### PR TITLE
chore(ci): add GitHub Actions CI pipeline and fix all quality issues

### DIFF
--- a/.claude/skills/commiting-changes/SKILL.md
+++ b/.claude/skills/commiting-changes/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: commiting-changes
+description: Run all CI checks locally and commit if everything passes. Use this before every commit.
+---
+
+Before committing any changes, you MUST run every CI job locally in this order. If any step fails, stop, fix the issue, and start over from step 1.
+
+## Step 1 — Lint
+
+```bash
+bunx biome check .
+bun run --cwd apps/mobile lint
+```
+
+## Step 2 — Type Check
+
+```bash
+bun run --cwd packages/types typecheck
+bun run --cwd packages/schemas typecheck
+bun run --cwd packages/utils typecheck
+bun run --cwd apps/mobile typecheck
+```
+
+## Step 3 — Tests
+
+```bash
+bun test --passWithNoTests
+```
+
+## Step 4 — Commit
+
+Only proceed here if all steps above passed with no errors.
+
+Stage the relevant files and commit following these rules enforced by lefthook:
+
+**Header format** (required):
+```
+type(scope): message
+```
+- `type` must be one of: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`, `perf`, `ci`
+- `scope` is required (e.g. `mobile`, `ci`, `auth`)
+- Example: `feat(auth): add login screen`
+
+**Body format** (optional):
+- If a body is included, every line must be a bullet point starting with `- `
+- No prose paragraphs
+
+**Never include** `Co-Authored-By` lines.
+
+## Conventions
+
+- All devDependencies must use **exact pinned versions** (no `^` or `~`). When adding a new package, use `bun add -d -E <package>` to pin exactly.
+- When fixing issues after an initial commit, use `git commit --amend --no-edit` to fold the fix into the previous commit instead of creating a new one. Then force push with `git push --force`.

--- a/.claude/skills/committing-changes/SKILL.md
+++ b/.claude/skills/committing-changes/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: commiting-changes
+name: committing-changes
 description: Run all CI checks locally and commit if everything passes. Use this before every commit.
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,92 @@
+name: CI
+
+on:
+  push:
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Biome check
+        run: bunx biome check .
+      - name: Mobile ESLint
+        run: bun run --cwd apps/mobile lint
+
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Check shared packages
+        run: |
+          bun run --cwd packages/types typecheck
+          bun run --cwd packages/schemas typecheck
+          bun run --cwd packages/utils typecheck
+      - name: Check mobile app
+        run: bun run --cwd apps/mobile typecheck
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Run tests
+        run: bun test --passWithNoTests
+
+  security-sca:
+    name: Security (SCA)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Snyk dependency scan
+        uses: snyk/actions/node@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --all-projects --severity-threshold=high
+
+  security-sast:
+    name: Security (SAST + Secrets)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Both scanners need full git history
+      - name: Gitleaks — pattern-based secret scan
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: TruffleHog — verified secret scan
+        uses: trufflesecurity/trufflehog@main
+        with:
+          extra_args: --only-verified
+      - name: Semgrep SAST
+        uses: semgrep/semgrep-action@v1
+        with:
+          config: >-
+            p/owasp-top-ten
+            p/react
+            p/typescript
+            p/secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Snyk dependency scan
-        uses: snyk/actions/node@master
+        uses: snyk/actions/node@9adf32b1121593767fc3c057af55b55db032dc04 # master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: TruffleHog — verified secret scan
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@041f07e9df901a1038a528e5525b0226d04dd5ea # v3.93.6
         with:
           extra_args: --only-verified
       - name: Semgrep SAST

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 The role of this file is to describe common mistakes and confusion points that agents might encounter as they work in this project. If you ever encounter something in the project that surprises you, please alert the developer working with you and indicate that this is the case in this CLAUDE.md file to help prevent future agents from having the same issue
 
+## Committing Changes
+
+Before committing, use the `commiting-changes` skill.
+
 ## Tech Stack
 
 This is a greenfield project, so you are allowed to use any tool you think is best for solving the problem.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ The role of this file is to describe common mistakes and confusion points that a
 
 ## Committing Changes
 
-Before committing, use the `commiting-changes` skill.
+Before committing, use the `committing-changes` skill.
 
 ## Tech Stack
 

--- a/apps/mobile/nativewind-env.d.ts
+++ b/apps/mobile/nativewind-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="nativewind/types" />

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -9,6 +9,7 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "lint": "expo lint",
+    "typecheck": "tsc --noEmit",
     "test": "bun test"
   },
   "dependencies": {

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
+    "types": ["bun-types"],
     "paths": {
       "@/*": ["./*"],
       "@fidy/types": ["../../packages/types/src/index.ts"],
@@ -9,5 +10,5 @@
       "@fidy/utils": ["../../packages/utils/src/index.ts"]
     }
   },
-  "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts"]
+  "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts", "nativewind-env.d.ts"]
 }

--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,15 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": ["**", "!**/node_modules", "!**/.expo", "!**/dist", "!**/build", "!**/.next"]
+    "includes": [
+      "**",
+      "!**/node_modules",
+      "!**/.expo",
+      "!**/dist",
+      "!**/build",
+      "!**/.next",
+      "!.claude"
+    ]
   },
   "formatter": {
     "enabled": true,
@@ -50,5 +58,22 @@
       "enabled": true,
       "indentWidth": 2
     }
-  }
+  },
+  "css": {
+    "linter": {
+      "enabled": true
+    }
+  },
+  "overrides": [
+    {
+      "includes": ["**/*.css"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noUnknownAtRules": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "fidy",
       "devDependencies": {
         "@biomejs/biome": "2.4.4",
+        "bun-types": "^1.3.10",
         "lefthook": "2.1.1",
         "typescript": "5.9.2",
       },
@@ -712,6 +713,8 @@
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.4",
+    "bun-types": "1.3.10",
     "lefthook": "2.1.1",
     "typescript": "5.9.2"
   }

--- a/packages/schemas/tsconfig.json
+++ b/packages/schemas/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
- Add CI workflow triggering on every branch push with Lint, Type Check, Test, Security (SCA), and Security (SAST + Secrets) jobs
- Add typecheck script to apps/mobile/package.json
- Exclude .claude/ from Biome and disable noUnknownAtRules for CSS to allow @tailwind directives
- Add tsconfig.json to each package for TypeScript project references
- Add bun-types to resolve bun:test and process type declarations
- Add nativewind-env.d.ts to enable className prop on React Native components
- Add commiting-changes skill to enforce local CI checks before every commit
- Update CLAUDE.md to reference the commiting-changes skill

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions CI that runs on every push for linting, type checks, tests, and security scans. Standardizes TypeScript configs and local checks so contributors can match CI locally.

- **New Features**
  - CI workflow with jobs: Lint (Biome + mobile ESLint), Type Check (packages + mobile), Test (bun test with passWithNoTests), Security SCA (Snyk), and SAST + Secrets (Semgrep, Gitleaks, TruffleHog).
  - New committing-changes skill to run checks locally before committing; linked from CLAUDE.md with commit rules and exact devDependency pinning.

- **Refactors**
  - TS project refs for packages (types, schemas, utils) and a typecheck script for apps/mobile.
  - Improved typings: repo-wide bun-types and nativewind types for mobile; updated mobile tsconfig types/paths/includes.
  - Biome tweaks: exclude .claude and allow @tailwind by disabling noUnknownAtRules for CSS.

<sup>Written for commit 5fce6a181c8c01b543e685bffd26e8d8c9423dc8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

