### PR TITLE
ci(workflow): exclude main from CI and update commit skill

### DIFF
--- a/.claude/skills/committing-changes/SKILL.md
+++ b/.claude/skills/committing-changes/SKILL.md
@@ -5,6 +5,14 @@ description: Run all CI checks locally and commit if everything passes. Use this
 
 Before committing any changes, you MUST run every CI job locally in this order. If any step fails, stop, fix the issue, and start over from step 1.
 
+## Step 0 — Pull Rebase
+
+```bash
+git pull --rebase origin main
+```
+
+Ensure your branch is up to date with the main branch before running checks or committing.
+
 ## Step 1 — Lint
 
 ```bash
@@ -39,13 +47,23 @@ type(scope): message
 ```
 - `type` must be one of: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`, `perf`, `ci`
 - `scope` is required (e.g. `mobile`, `ci`, `auth`)
-- Example: `feat(auth): add login screen`
+- **Keep the header short and high-level** (under 50 chars after the scope). No implementation details.
+- Example: `ci(workflow): exclude main from CI triggers`
 
 **Body format** (optional):
 - If a body is included, every line must be a bullet point starting with `- `
+- **Keep bullet points concise** — a few words each, no full sentences
 - No prose paragraphs
 
 **Never include** `Co-Authored-By` lines.
+
+## Step 5 — Push
+
+Always push after committing. Never create a pull request.
+
+```bash
+git push -u origin <branch-name>
+```
 
 ## Conventions
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches-ignore:
+      - main
 
 jobs:
   lint:


### PR DESCRIPTION
- Skip CI on pushes to main
- Add rebase step to commit skill
- Add push step to commit skill
- Enforce concise commit messages

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop running CI on pushes to main. Update the commit skill to require rebasing from main, concise commit messages, and pushing after commit.

- **Refactors**
  - CI workflow now ignores pushes to main.
  - Commit skill: added Step 0 (git pull --rebase origin main), enforced short headers and concise bullets, and added Step 5 (push after commit).

<sup>Written for commit 508c84e40bc02656384d5cea971b5a417928ec09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

