### PR TITLE
ci(coverage): add 80% coverage gate to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,8 @@ jobs:
           bun-version: latest
       - name: Install dependencies
         run: bun install --frozen-lockfile
-      - name: Run tests
-        run: bun test --passWithNoTests
+      - name: Run tests with coverage
+        run: bun test --coverage --passWithNoTests
 
   security-sca:
     name: Security (SCA)

--- a/apps/mobile/bunfig.toml
+++ b/apps/mobile/bunfig.toml
@@ -1,0 +1,3 @@
+[test]
+preload = ["./__tests__/setup.ts"]
+coverageThreshold = 0.8


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enforce a minimum 80% test coverage in CI for the mobile app. CI now runs tests with coverage, and apps/mobile/bunfig.toml sets coverageThreshold=0.8 with the test preload configured.

<sup>Written for commit f82a1f9ae3b14d18fdfd74be3240f7953815c59c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

