### PR TITLE
ci(workflow): run CI on PRs, update commit skill

### DIFF
--- a/.claude/skills/committing-changes/SKILL.md
+++ b/.claude/skills/committing-changes/SKILL.md
@@ -8,7 +8,7 @@ Before committing any changes, you MUST run every CI job locally in this order. 
 ## Step 0 — Pull Rebase
 
 ```bash
-git pull --rebase origin main
+git pull --rebase --autostash origin main
 ```
 
 Ensure your branch is up to date with the main branch before running checks or committing.
@@ -32,7 +32,7 @@ bun run --cwd apps/mobile typecheck
 ## Step 3 — Tests
 
 ```bash
-bun test --passWithNoTests
+cd apps/mobile && npx vitest run
 ```
 
 ## Step 4 — Commit
@@ -68,4 +68,4 @@ git push -u origin <branch-name>
 ## Conventions
 
 - All devDependencies must use **exact pinned versions** (no `^` or `~`). When adding a new package, use `bun add -d -E <package>` to pin exactly.
-- When fixing issues after an initial commit, use `git commit --amend --no-edit` to fold the fix into the previous commit instead of creating a new one. Then force push with `git push --force`.
+- When fixing issues after a PR review, create a new commit (do not amend). This keeps the review history clear and avoids force pushes.

--- a/.claude/skills/committing-changes/SKILL.md
+++ b/.claude/skills/committing-changes/SKILL.md
@@ -65,10 +65,12 @@ Push to the feature branch after committing. Main is protected — direct pushes
 git push -u origin <branch-name>
 ```
 
-Then create a pull request targeting `main`. The PR title and body **must match the commit message exactly** (header → title, body → description):
+Then create a pull request targeting `main`. The PR title and body **must match the commit message exactly** (header → title, body → description). Do NOT use `--fill` — it breaks with multiple commits. Instead, explicitly pass the commit message:
 
 ```bash
-gh pr create --fill
+TITLE=$(git log -1 --format=%s)
+BODY=$(git log -1 --format=%b)
+gh pr create --title "$TITLE" --body "$BODY"
 ```
 
 ## Conventions

--- a/.claude/skills/committing-changes/SKILL.md
+++ b/.claude/skills/committing-changes/SKILL.md
@@ -57,12 +57,18 @@ type(scope): message
 
 **Never include** `Co-Authored-By` lines.
 
-## Step 5 — Push
+## Step 5 — Push & PR
 
-Always push after committing. Never create a pull request.
+Push to the feature branch after committing. Main is protected — direct pushes are not allowed.
 
 ```bash
 git push -u origin <branch-name>
+```
+
+Then create a pull request targeting `main`. The PR title and body **must match the commit message exactly** (header → title, body → description):
+
+```bash
+gh pr create --fill
 ```
 
 ## Conventions

--- a/.claude/skills/committing-changes/SKILL.md
+++ b/.claude/skills/committing-changes/SKILL.md
@@ -73,6 +73,25 @@ BODY=$(git log -1 --format=%b)
 gh pr create --title "$TITLE" --body "$BODY"
 ```
 
+## Step 6 — Merge (only when the user explicitly asks)
+
+**NEVER merge on your own.** Only run this step when the user tells you to merge.
+
+Use squash merge so the merge commit on `main` matches the PR title and body:
+
+```bash
+PR_NUM=$(gh pr view --json number -q .number)
+TITLE=$(gh pr view "$PR_NUM" --json title -q .title)
+BODY=$(gh pr view "$PR_NUM" --json body -q .body)
+gh pr merge "$PR_NUM" --squash --subject "$TITLE" --body "$BODY"
+```
+
+After merging, switch back to `main` and pull:
+
+```bash
+git checkout main && git pull
+```
+
 ## Conventions
 
 - All devDependencies must use **exact pinned versions** (no `^` or `~`). When adding a new package, use `bun add -d -E <package>` to pin exactly.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
 on:
-  push:
-    branches-ignore:
+  pull_request:
+    branches:
       - main
 
 jobs:


### PR DESCRIPTION
- Trigger CI on pull_request to main
- Use --autostash on pull rebase
- Use npx vitest run for tests
- Require PR to main, no direct push
- PR title/body must match commit message