### PR TITLE
fix(mobile): fix coin position on Android and SQL bundling

### DIFF
--- a/apps/mobile/babel.config.js
+++ b/apps/mobile/babel.config.js
@@ -2,6 +2,6 @@ module.exports = (api) => {
   api.cache(true);
   return {
     presets: [["babel-preset-expo", { jsxImportSource: "nativewind" }], "nativewind/babel"],
-    plugins: ["babel-plugin-inline-import"],
+    plugins: [["inline-import", { extensions: [".sql"] }]],
   };
 };

--- a/apps/mobile/shared/components/FidyLogo.tsx
+++ b/apps/mobile/shared/components/FidyLogo.tsx
@@ -1,4 +1,4 @@
-import { Text, useColorScheme, View } from "react-native";
+import { Platform, Text, useColorScheme, View } from "react-native";
 
 interface FidyLogoProps {
   size?: "default" | "small";
@@ -10,9 +10,9 @@ export function FidyLogo({ size = "default" }: FidyLogoProps) {
 
   const isSmall = size === "small";
   const fontSize = isSmall ? 32 : 64;
-  const coinSize = isSmall ? 8 : 14;
-  const coinTop = 0;
-  const coinLeft = isSmall ? 10 : 21;
+  const coinSize = isSmall ? 8 : Platform.OS === "android" ? 15 : 14;
+  const coinTop = Platform.OS === "android" ? (isSmall ? 3 : 8) : 0;
+  const coinLeft = Platform.OS === "android" ? (isSmall ? 13 : 27) : isSmall ? 10 : 21;
 
   const textColor = isDark ? "#F0F0F0" : "#1A1A1A";
   const coinBg = isDark ? "#8BC34A" : "#7CB243";
@@ -27,6 +27,7 @@ export function FidyLogo({ size = "default" }: FidyLogoProps) {
           fontSize,
           color: textColor,
           lineHeight: fontSize * 1.2,
+          ...(Platform.OS === "android" && { includeFontPadding: false }),
         }}
       >
         fidy
@@ -52,6 +53,7 @@ export function FidyLogo({ size = "default" }: FidyLogoProps) {
             fontSize: isSmall ? 4 : 7,
             color: dollarColor,
             lineHeight: isSmall ? 6 : 9,
+            ...(Platform.OS === "android" && { includeFontPadding: false }),
           }}
         >
           $


### PR DESCRIPTION
- Add platform-specific coin offset and size for Android
- Disable includeFontPadding on Android for consistent text layout
- Configure babel-plugin-inline-import with .sql extension

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes FidyLogo coin alignment on Android and enables bundling of .sql files. Improves logo rendering consistency and lets SQL queries be inlined at build time.

- **Bug Fixes**
  - Added Android-specific coin size and offsets in FidyLogo.
  - Disabled includeFontPadding for logo text and dollar sign on Android.

- **Dependencies**
  - Configured inline-import Babel plugin to process .sql extensions.

<sup>Written for commit b2431ad99ce6d5ed7ae8a5526f2bd94d3398cbae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

