### PR TITLE
feat(mobile): add sync schema, user-scoped DB, and sync queue

### DIFF
--- a/apps/mobile/__tests__/db/client.test.ts
+++ b/apps/mobile/__tests__/db/client.test.ts
@@ -17,31 +17,51 @@ describe("getDb", () => {
     resetDb();
   });
 
-  it("returns a drizzle instance", () => {
-    const db = getDb();
+  it("returns a drizzle instance for a given userId", () => {
+    const db = getDb("user-123");
     expect(db).toBeDefined();
     expect(db).toHaveProperty("_", "drizzle-instance");
   });
 
-  it("returns the same instance on subsequent calls (singleton)", () => {
-    const db1 = getDb();
-    const db2 = getDb();
+  it("returns the same instance on subsequent calls with same userId", () => {
+    const db1 = getDb("user-123");
+    const db2 = getDb("user-123");
     expect(db1).toBe(db2);
   });
 
-  it("opens database with correct name", () => {
-    getDb();
-    expect(openDatabaseSync).toHaveBeenCalledWith("fidy.db");
+  it("opens database with user-scoped name", () => {
+    getDb("user-123");
+    expect(openDatabaseSync).toHaveBeenCalledWith("fidy-user-123.db");
   });
 
-  it("sets SQLCipher encryption key after opening", () => {
+  it("sets SQLCipher encryption key derived from userId", () => {
     const mockExecSync = vi.fn();
     vi.mocked(openDatabaseSync).mockReturnValueOnce({
       execSync: mockExecSync,
       closeSync: vi.fn(),
     } as unknown as ReturnType<typeof openDatabaseSync>);
 
-    getDb();
+    getDb("user-123");
     expect(mockExecSync).toHaveBeenCalledWith(expect.stringContaining("PRAGMA key"));
+  });
+
+  it("resets and closes the connection on resetDb", () => {
+    const mockCloseSync = vi.fn();
+    vi.mocked(openDatabaseSync).mockReturnValueOnce({
+      execSync: vi.fn(),
+      closeSync: mockCloseSync,
+    } as unknown as ReturnType<typeof openDatabaseSync>);
+
+    getDb("user-123");
+    resetDb();
+    expect(mockCloseSync).toHaveBeenCalled();
+
+    getDb("user-456");
+    expect(openDatabaseSync).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws when called with a different userId without resetDb", () => {
+    getDb("user-123");
+    expect(() => getDb("user-456")).toThrow("Call resetDb() first");
   });
 });

--- a/apps/mobile/__tests__/db/schema.test.ts
+++ b/apps/mobile/__tests__/db/schema.test.ts
@@ -1,6 +1,6 @@
 import { getTableColumns, getTableName } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
-import { transactions } from "@/shared/db/schema";
+import { syncMeta, syncQueue, transactions } from "@/shared/db/schema";
 
 describe("transactions table schema", () => {
   it("is named 'transactions'", () => {
@@ -12,13 +12,16 @@ describe("transactions table schema", () => {
     const names = Object.keys(cols);
 
     expect(names).toContain("id");
+    expect(names).toContain("userId");
     expect(names).toContain("type");
     expect(names).toContain("amountCents");
     expect(names).toContain("categoryId");
     expect(names).toContain("description");
     expect(names).toContain("date");
     expect(names).toContain("createdAt");
-    expect(names).toHaveLength(7);
+    expect(names).toContain("updatedAt");
+    expect(names).toContain("deletedAt");
+    expect(names).toHaveLength(10);
   });
 
   it("id is primary key", () => {
@@ -31,13 +34,51 @@ describe("transactions table schema", () => {
     expect(cols.description.notNull).toBe(false);
   });
 
-  it("amount_cents is not null", () => {
+  it("deletedAt is nullable (soft delete)", () => {
     const cols = getTableColumns(transactions);
-    expect(cols.amountCents.notNull).toBe(true);
+    expect(cols.deletedAt.notNull).toBe(false);
   });
 
-  it("type is not null", () => {
+  it("userId is not null", () => {
     const cols = getTableColumns(transactions);
-    expect(cols.type.notNull).toBe(true);
+    expect(cols.userId.notNull).toBe(true);
+  });
+});
+
+describe("syncQueue table schema", () => {
+  it("is named 'sync_queue'", () => {
+    expect(getTableName(syncQueue)).toBe("sync_queue");
+  });
+
+  it("has all required columns", () => {
+    const cols = getTableColumns(syncQueue);
+    const names = Object.keys(cols);
+
+    expect(names).toContain("id");
+    expect(names).toContain("tableName");
+    expect(names).toContain("rowId");
+    expect(names).toContain("operation");
+    expect(names).toContain("createdAt");
+    expect(names).toHaveLength(5);
+  });
+});
+
+describe("syncMeta table schema", () => {
+  it("is named 'sync_meta'", () => {
+    expect(getTableName(syncMeta)).toBe("sync_meta");
+  });
+
+  it("has key and value columns", () => {
+    const cols = getTableColumns(syncMeta);
+    const names = Object.keys(cols);
+
+    expect(names).toContain("key");
+    expect(names).toContain("value");
+    expect(names).toHaveLength(2);
+  });
+
+  it("key is primary key", () => {
+    const cols = getTableColumns(syncMeta);
+    expect(cols.key.primary).toBe(true);
   });
 });

--- a/apps/mobile/__tests__/transactions/repository.test.ts
+++ b/apps/mobile/__tests__/transactions/repository.test.ts
@@ -5,17 +5,23 @@ const mockValues = vi.fn().mockReturnThis();
 const mockInsert = vi.fn(() => ({ values: mockValues }));
 const mockSelect = vi.fn().mockReturnThis();
 const mockFrom = vi.fn().mockReturnThis();
+const mockWhere = vi.fn().mockReturnThis();
 const mockOrderBy = vi.fn().mockResolvedValue([]);
 const mockDelete = vi.fn().mockReturnThis();
-const mockWhere = vi.fn().mockResolvedValue([]);
+const mockDeleteWhere = vi.fn().mockResolvedValue([]);
+const mockUpdate = vi.fn().mockReturnThis();
+const mockSet = vi.fn().mockReturnThis();
+const mockUpdateWhere = vi.fn().mockResolvedValue([]);
+const mockOnConflictDoUpdate = vi.fn().mockResolvedValue([]);
 
 const mockDb = {
   insert: mockInsert,
   select: mockSelect,
   from: mockFrom,
+  where: mockWhere,
   orderBy: mockOrderBy,
   delete: mockDelete,
-  where: mockWhere,
+  update: mockUpdate,
 } as any;
 
 describe("transaction repository", () => {
@@ -23,8 +29,13 @@ describe("transaction repository", () => {
     vi.clearAllMocks();
     mockValues.mockReturnThis();
     mockSelect.mockReturnValue({ from: mockFrom });
-    mockFrom.mockReturnValue({ orderBy: mockOrderBy });
-    mockDelete.mockReturnValue({ where: mockWhere });
+    mockFrom.mockReturnValue({ where: mockWhere, orderBy: mockOrderBy });
+    mockWhere.mockReturnValue({ orderBy: mockOrderBy });
+    mockDelete.mockReturnValue({ where: mockDeleteWhere });
+    mockUpdate.mockReturnValue({ set: mockSet });
+    mockSet.mockReturnValue({ where: mockUpdateWhere });
+    mockInsert.mockReturnValue({ values: mockValues });
+    mockValues.mockReturnValue({ onConflictDoUpdate: mockOnConflictDoUpdate });
   });
 
   it("insertTransaction calls db.insert with correct row", async () => {
@@ -32,56 +43,152 @@ describe("transaction repository", () => {
 
     await insertTransaction(mockDb, {
       id: "tx-123",
+      userId: "user-1",
       type: "expense",
       amountCents: 4520,
       categoryId: "food",
       description: "Groceries",
       date: "2026-03-04",
       createdAt: "2026-03-04T10:00:00.000Z",
+      updatedAt: "2026-03-04T10:00:00.000Z",
     });
 
     expect(mockInsert).toHaveBeenCalled();
     expect(mockValues).toHaveBeenCalledWith({
       id: "tx-123",
+      userId: "user-1",
       type: "expense",
       amountCents: 4520,
       categoryId: "food",
       description: "Groceries",
       date: "2026-03-04",
       createdAt: "2026-03-04T10:00:00.000Z",
+      updatedAt: "2026-03-04T10:00:00.000Z",
     });
   });
 
-  it("getAllTransactions calls db.select().from().orderBy()", async () => {
+  it("getAllTransactions filters by userId and excludes deleted", async () => {
+    mockWhere.mockReturnValueOnce({ orderBy: mockOrderBy });
     const mockRows = [
       {
         id: "tx-1",
+        userId: "user-1",
         type: "expense",
         amountCents: 1000,
         categoryId: "food",
         description: null,
         date: "2026-03-04",
         createdAt: "2026-03-04T10:00:00.000Z",
+        updatedAt: "2026-03-04T10:00:00.000Z",
+        deletedAt: null,
       },
     ];
     mockOrderBy.mockResolvedValueOnce(mockRows);
 
     const { getAllTransactions } = await import("@/features/transactions/lib/repository");
-
-    const result = await getAllTransactions(mockDb);
+    const result = await getAllTransactions(mockDb, "user-1");
 
     expect(mockSelect).toHaveBeenCalled();
     expect(mockFrom).toHaveBeenCalled();
+    expect(mockWhere).toHaveBeenCalled();
     expect(mockOrderBy).toHaveBeenCalled();
     expect(result).toEqual(mockRows);
   });
 
-  it("deleteTransaction calls db.delete().where() with id", async () => {
-    const { deleteTransaction } = await import("@/features/transactions/lib/repository");
+  it("softDeleteTransaction sets deletedAt and updatedAt", async () => {
+    const { softDeleteTransaction } = await import("@/features/transactions/lib/repository");
 
-    await deleteTransaction(mockDb, "tx-123");
+    await softDeleteTransaction(mockDb, "tx-123");
 
-    expect(mockDelete).toHaveBeenCalled();
-    expect(mockWhere).toHaveBeenCalled();
+    expect(mockUpdate).toHaveBeenCalled();
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deletedAt: expect.any(String),
+        updatedAt: expect.any(String),
+      })
+    );
+    expect(mockUpdateWhere).toHaveBeenCalled();
+  });
+
+  it("enqueueSync inserts into sync_queue", async () => {
+    const { enqueueSync } = await import("@/features/transactions/lib/repository");
+
+    await enqueueSync(mockDb, {
+      id: "sq-1",
+      tableName: "transactions",
+      rowId: "tx-123",
+      operation: "insert",
+      createdAt: "2026-03-04T10:00:00.000Z",
+    });
+
+    expect(mockInsert).toHaveBeenCalled();
+    expect(mockValues).toHaveBeenCalledWith({
+      id: "sq-1",
+      tableName: "transactions",
+      rowId: "tx-123",
+      operation: "insert",
+      createdAt: "2026-03-04T10:00:00.000Z",
+    });
+  });
+
+  it("getQueuedSyncEntries returns all queue entries", async () => {
+    const mockEntries = [
+      { id: "sq-1", tableName: "transactions", rowId: "tx-1", operation: "insert" },
+    ];
+    mockFrom.mockResolvedValueOnce(mockEntries);
+
+    const { getQueuedSyncEntries } = await import("@/features/transactions/lib/repository");
+    const result = await getQueuedSyncEntries(mockDb);
+
+    expect(mockSelect).toHaveBeenCalled();
+    expect(result).toEqual(mockEntries);
+  });
+
+  it("clearSyncEntries deletes entries by id in a single query", async () => {
+    const { clearSyncEntries } = await import("@/features/transactions/lib/repository");
+
+    await clearSyncEntries(mockDb, ["sq-1", "sq-2"]);
+
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+    expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
+  });
+
+  it("clearSyncEntries does nothing for empty array", async () => {
+    const { clearSyncEntries } = await import("@/features/transactions/lib/repository");
+
+    await clearSyncEntries(mockDb, []);
+
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it("setSyncMeta upserts key-value pair", async () => {
+    const { setSyncMeta } = await import("@/features/transactions/lib/repository");
+
+    await setSyncMeta(mockDb, "last_sync_at", "2026-03-04T10:00:00.000Z");
+
+    expect(mockInsert).toHaveBeenCalled();
+    expect(mockValues).toHaveBeenCalledWith({
+      key: "last_sync_at",
+      value: "2026-03-04T10:00:00.000Z",
+    });
+    expect(mockOnConflictDoUpdate).toHaveBeenCalled();
+  });
+
+  it("getSyncMeta returns value for existing key", async () => {
+    mockWhere.mockResolvedValueOnce([{ key: "last_sync_at", value: "2026-03-04T10:00:00.000Z" }]);
+
+    const { getSyncMeta } = await import("@/features/transactions/lib/repository");
+    const result = await getSyncMeta(mockDb, "last_sync_at");
+
+    expect(result).toBe("2026-03-04T10:00:00.000Z");
+  });
+
+  it("getSyncMeta returns null for missing key", async () => {
+    mockWhere.mockResolvedValueOnce([]);
+
+    const { getSyncMeta } = await import("@/features/transactions/lib/repository");
+    const result = await getSyncMeta(mockDb, "nonexistent");
+
+    expect(result).toBeNull();
   });
 });

--- a/apps/mobile/__tests__/transactions/store.test.ts
+++ b/apps/mobile/__tests__/transactions/store.test.ts
@@ -3,23 +3,26 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("@/features/transactions/lib/repository", () => ({
   insertTransaction: vi.fn(),
   getAllTransactions: vi.fn().mockResolvedValue([]),
-  deleteTransaction: vi.fn(),
+  softDeleteTransaction: vi.fn(),
+  enqueueSync: vi.fn(),
 }));
 
 import {
-  deleteTransaction as deleteTransactionRepo,
+  enqueueSync,
   getAllTransactions,
   insertTransaction,
+  softDeleteTransaction,
 } from "@/features/transactions/lib/repository";
 import { useTransactionStore } from "@/features/transactions/store";
 
 // biome-ignore lint/suspicious/noExplicitAny: mock db needs flexible typing
 const mockDb = {} as any;
+const mockUserId = "user-1";
 
 describe("useTransactionStore", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useTransactionStore.getState().initStore(mockDb);
+    useTransactionStore.getState().initStore(mockDb, mockUserId);
     useTransactionStore.setState({
       isOpen: false,
       step: 1,
@@ -108,6 +111,9 @@ describe("useTransactionStore", () => {
       expect(result.transaction.categoryId).toBe("food");
       expect(result.transaction.description).toBe("Groceries");
       expect(result.transaction.type).toBe("expense");
+      expect(result.transaction.userId).toBe(mockUserId);
+      expect(result.transaction.updatedAt).toBeInstanceOf(Date);
+      expect(result.transaction.deletedAt).toBeNull();
     }
 
     expect(useTransactionStore.getState().transactions).toHaveLength(1);
@@ -117,6 +123,24 @@ describe("useTransactionStore", () => {
         amountCents: 4520,
         categoryId: "food",
         type: "expense",
+        userId: mockUserId,
+        updatedAt: expect.any(String),
+      })
+    );
+  });
+
+  it("saveTransaction enqueues sync entry after insert", async () => {
+    const store = useTransactionStore.getState();
+    store.setDigits("1000");
+    store.setCategoryId("food");
+
+    await store.saveTransaction();
+
+    expect(enqueueSync).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        tableName: "transactions",
+        operation: "insert",
       })
     );
   });
@@ -179,12 +203,15 @@ describe("useTransactionStore", () => {
     vi.mocked(getAllTransactions).mockResolvedValueOnce([
       {
         id: "tx-1",
+        userId: mockUserId,
         type: "expense",
         amountCents: 1000,
         categoryId: "food",
         description: "Lunch",
         date: "2026-03-04",
         createdAt: "2026-03-04T10:00:00.000Z",
+        updatedAt: "2026-03-04T10:00:00.000Z",
+        deletedAt: null,
       },
     ]);
 
@@ -193,12 +220,15 @@ describe("useTransactionStore", () => {
     const txs = useTransactionStore.getState().transactions;
     expect(txs).toHaveLength(1);
     expect(txs[0].id).toBe("tx-1");
+    expect(txs[0].userId).toBe(mockUserId);
     expect(txs[0].date).toBeInstanceOf(Date);
     expect(txs[0].createdAt).toBeInstanceOf(Date);
-    expect(getAllTransactions).toHaveBeenCalledWith(mockDb);
+    expect(txs[0].updatedAt).toBeInstanceOf(Date);
+    expect(txs[0].deletedAt).toBeNull();
+    expect(getAllTransactions).toHaveBeenCalledWith(mockDb, mockUserId);
   });
 
-  it("deleteTransaction removes from DB and state", async () => {
+  it("removeTransaction soft-deletes from DB, enqueues sync, and removes from state", async () => {
     const store = useTransactionStore.getState();
     store.setDigits("100");
     store.setCategoryId("food");
@@ -210,7 +240,15 @@ describe("useTransactionStore", () => {
     await useTransactionStore.getState().removeTransaction(txs[0].id);
 
     expect(useTransactionStore.getState().transactions).toHaveLength(0);
-    expect(deleteTransactionRepo).toHaveBeenCalledWith(mockDb, txs[0].id);
+    expect(softDeleteTransaction).toHaveBeenCalledWith(mockDb, txs[0].id);
+    expect(enqueueSync).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        tableName: "transactions",
+        rowId: txs[0].id,
+        operation: "delete",
+      })
+    );
   });
 
   it("saveTransaction returns error when DB insert fails", async () => {
@@ -228,7 +266,7 @@ describe("useTransactionStore", () => {
     expect(useTransactionStore.getState().transactions).toHaveLength(0);
   });
 
-  it("removeTransaction keeps UI state when DB delete fails", async () => {
+  it("removeTransaction keeps UI state when DB operation fails", async () => {
     const store = useTransactionStore.getState();
     store.setDigits("100");
     store.setCategoryId("food");
@@ -237,7 +275,7 @@ describe("useTransactionStore", () => {
     const txs = useTransactionStore.getState().transactions;
     expect(txs).toHaveLength(1);
 
-    vi.mocked(deleteTransactionRepo).mockRejectedValueOnce(new Error("db error"));
+    vi.mocked(softDeleteTransaction).mockRejectedValueOnce(new Error("db error"));
     await useTransactionStore.getState().removeTransaction(txs[0].id);
 
     expect(useTransactionStore.getState().transactions).toHaveLength(1);

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -19,8 +19,11 @@ import migrations from "../drizzle/migrations";
 
 SplashScreen.preventAutoHideAsync();
 
+// TODO: replace with auth user ID in Task 10
+const TEMP_USER_ID = "local-user";
+
 export default function RootLayout() {
-  const db = getDb();
+  const db = getDb(TEMP_USER_ID);
   const { success: migrationsReady, error: migrationsError } = useMigrations(db, migrations);
 
   const [fontsLoaded, fontsError] = useFonts({
@@ -32,7 +35,7 @@ export default function RootLayout() {
 
   useEffect(() => {
     if (migrationsReady) {
-      useTransactionStore.getState().initStore(db);
+      useTransactionStore.getState().initStore(db, TEMP_USER_ID);
       useTransactionStore
         .getState()
         .loadTransactions()

--- a/apps/mobile/drizzle/0001_brown_stone_men.sql
+++ b/apps/mobile/drizzle/0001_brown_stone_men.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `sync_meta` (
+	`key` text PRIMARY KEY NOT NULL,
+	`value` text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `sync_queue` (
+	`id` text PRIMARY KEY NOT NULL,
+	`table_name` text NOT NULL,
+	`row_id` text NOT NULL,
+	`operation` text NOT NULL,
+	`created_at` text NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE `transactions` ADD `user_id` text NOT NULL;--> statement-breakpoint
+ALTER TABLE `transactions` ADD `updated_at` text NOT NULL;--> statement-breakpoint
+ALTER TABLE `transactions` ADD `deleted_at` text;

--- a/apps/mobile/drizzle/meta/0001_snapshot.json
+++ b/apps/mobile/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,167 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "382b653c-c57f-4ef8-9c20-e728e1ad717e",
+  "prevId": "09cb8fc3-6257-43cb-919a-0defd963c6fd",
+  "tables": {
+    "sync_meta": {
+      "name": "sync_meta",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_queue": {
+      "name": "sync_queue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transactions": {
+      "name": "transactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/mobile/drizzle/meta/_journal.json
+++ b/apps/mobile/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1772637052608,
       "tag": "0000_smart_rachel_grey",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1772684969982,
+      "tag": "0001_brown_stone_men",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/mobile/drizzle/migrations.js
+++ b/apps/mobile/drizzle/migrations.js
@@ -1,10 +1,12 @@
 // @ts-nocheck
 import m0000 from "./0000_smart_rachel_grey.sql";
+import m0001 from "./0001_brown_stone_men.sql";
 import journal from "./meta/_journal.json";
 
 export default {
   journal,
   migrations: {
     m0000,
+    m0001,
   },
 };

--- a/apps/mobile/features/transactions/lib/repository.ts
+++ b/apps/mobile/features/transactions/lib/repository.ts
@@ -1,9 +1,9 @@
-import { desc, eq } from "drizzle-orm";
-import type { ExpoSQLiteDatabase } from "drizzle-orm/expo-sqlite";
-import { transactions } from "@/shared/db/schema";
+import { and, desc, eq, inArray, isNull } from "drizzle-orm";
+import type { AnyDb } from "@/shared/db/client";
+import { syncMeta, syncQueue, transactions } from "@/shared/db/schema";
 
-// biome-ignore lint/suspicious/noExplicitAny: drizzle generic varies by caller
-type AnyDb = ExpoSQLiteDatabase<any>;
+export type SyncOperation = "insert" | "update" | "delete";
+export type SyncTableName = "transactions";
 
 export type TransactionRow = typeof transactions.$inferInsert;
 
@@ -11,10 +11,56 @@ export async function insertTransaction(db: AnyDb, row: TransactionRow) {
   await db.insert(transactions).values(row);
 }
 
-export async function getAllTransactions(db: AnyDb) {
-  return db.select().from(transactions).orderBy(desc(transactions.date));
+export async function getAllTransactions(db: AnyDb, userId: string) {
+  return db
+    .select()
+    .from(transactions)
+    .where(and(eq(transactions.userId, userId), isNull(transactions.deletedAt)))
+    .orderBy(desc(transactions.date));
 }
 
-export async function deleteTransaction(db: AnyDb, id: string) {
-  await db.delete(transactions).where(eq(transactions.id, id));
+export async function softDeleteTransaction(db: AnyDb, id: string) {
+  const now = new Date().toISOString();
+  await db
+    .update(transactions)
+    .set({ deletedAt: now, updatedAt: now })
+    .where(eq(transactions.id, id));
+}
+
+export async function getTransactionById(db: AnyDb, id: string) {
+  const rows = await db.select().from(transactions).where(eq(transactions.id, id));
+  return rows[0] ?? null;
+}
+
+export type SyncQueueEntry = {
+  id: string;
+  tableName: SyncTableName;
+  rowId: string;
+  operation: SyncOperation;
+  createdAt: string;
+};
+
+export async function enqueueSync(db: AnyDb, entry: SyncQueueEntry) {
+  await db.insert(syncQueue).values(entry);
+}
+
+export async function getQueuedSyncEntries(db: AnyDb) {
+  return db.select().from(syncQueue);
+}
+
+export async function clearSyncEntries(db: AnyDb, ids: string[]) {
+  if (ids.length === 0) return;
+  await db.delete(syncQueue).where(inArray(syncQueue.id, ids));
+}
+
+export async function getSyncMeta(db: AnyDb, key: string) {
+  const rows = await db.select().from(syncMeta).where(eq(syncMeta.key, key));
+  return rows[0]?.value ?? null;
+}
+
+export async function setSyncMeta(db: AnyDb, key: string, value: string) {
+  await db
+    .insert(syncMeta)
+    .values({ key, value })
+    .onConflictDoUpdate({ target: syncMeta.key, set: { value } });
 }

--- a/apps/mobile/features/transactions/schema.ts
+++ b/apps/mobile/features/transactions/schema.ts
@@ -20,10 +20,13 @@ export type CreateTransactionInput = z.infer<typeof createTransactionSchema>;
 
 export type StoredTransaction = {
   readonly id: string;
+  readonly userId: string;
   readonly type: TransactionType;
   readonly amountCents: number;
   readonly categoryId: CategoryId;
   readonly description: string;
   readonly date: Date;
   readonly createdAt: Date;
+  readonly updatedAt: Date;
+  readonly deletedAt: Date | null;
 };

--- a/apps/mobile/features/transactions/store.ts
+++ b/apps/mobile/features/transactions/store.ts
@@ -1,21 +1,23 @@
 import { create } from "zustand";
 import type { AnyDb } from "@/shared/db/client";
 import { parseIsoDate, toIsoDate } from "@/shared/lib/format-date";
+import { generateId } from "@/shared/lib/generate-id";
 import type { CategoryId } from "./lib/categories";
 import { amountToCents } from "./lib/format-amount";
 import {
-  deleteTransaction as deleteTransactionRepo,
+  enqueueSync,
   getAllTransactions,
   insertTransaction,
+  softDeleteTransaction,
 } from "./lib/repository";
 import type { CreateTransactionInput, StoredTransaction, TransactionType } from "./schema";
 import { createTransactionSchema } from "./schema";
 
 type SheetStep = 1 | 2;
 
-// Module-level ref: Zustand doesn't serialize DB connections, so we keep it outside the store.
-// The repository layer stays pure (DB passed as param); this is the only impure bridge.
+// Module-level refs: Zustand doesn't serialize DB connections, so we keep them outside the store.
 let dbRef: AnyDb | null = null;
+let userIdRef: string | null = null;
 
 type AddTransactionState = {
   // Sheet visibility
@@ -34,7 +36,7 @@ type AddTransactionState = {
 };
 
 type AddTransactionActions = {
-  initStore: (db: AnyDb) => void;
+  initStore: (db: AnyDb, userId: string) => void;
   openSheet: () => void;
   closeSheet: () => void;
   setStep: (step: SheetStep) => void;
@@ -69,8 +71,9 @@ export const useTransactionStore = create<AddTransactionState & AddTransactionAc
     date: new Date(),
     transactions: [],
 
-    initStore: (db) => {
+    initStore: (db, userId) => {
       dbRef = db;
+      userIdRef = userId;
     },
 
     openSheet: () => set({ isOpen: true, ...INITIAL_FORM, date: new Date() }),
@@ -83,6 +86,10 @@ export const useTransactionStore = create<AddTransactionState & AddTransactionAc
     setDate: (date) => set({ date }),
 
     saveTransaction: async () => {
+      if (!dbRef || !userIdRef) {
+        return { success: false as const, error: "Store not initialized" };
+      }
+
       const { type, digits, categoryId, description, date } = get();
       const amountCents = amountToCents(digits);
 
@@ -102,28 +109,40 @@ export const useTransactionStore = create<AddTransactionState & AddTransactionAc
         };
       }
 
+      const now = new Date();
       const transaction: StoredTransaction = {
-        id: `tx-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+        id: generateId("tx"),
+        userId: userIdRef,
         type: result.data.type,
         amountCents: result.data.amountCents,
         categoryId: result.data.categoryId as CategoryId,
         description: result.data.description ?? "",
         date: result.data.date,
-        createdAt: new Date(),
+        createdAt: now,
+        updatedAt: now,
+        deletedAt: null,
       };
 
       try {
-        if (dbRef) {
-          await insertTransaction(dbRef, {
-            id: transaction.id,
-            type: transaction.type,
-            amountCents: transaction.amountCents,
-            categoryId: transaction.categoryId,
-            description: transaction.description || null,
-            date: toIsoDate(transaction.date),
-            createdAt: transaction.createdAt.toISOString(),
-          });
-        }
+        await insertTransaction(dbRef, {
+          id: transaction.id,
+          userId: transaction.userId,
+          type: transaction.type,
+          amountCents: transaction.amountCents,
+          categoryId: transaction.categoryId,
+          description: transaction.description || null,
+          date: toIsoDate(transaction.date),
+          createdAt: transaction.createdAt.toISOString(),
+          updatedAt: transaction.updatedAt.toISOString(),
+        });
+
+        await enqueueSync(dbRef, {
+          id: generateId("sq"),
+          tableName: "transactions",
+          rowId: transaction.id,
+          operation: "insert",
+          createdAt: now.toISOString(),
+        });
       } catch {
         return { success: false as const, error: "Failed to save transaction" };
       }
@@ -136,17 +155,20 @@ export const useTransactionStore = create<AddTransactionState & AddTransactionAc
     },
 
     loadTransactions: async () => {
-      if (!dbRef) return;
+      if (!dbRef || !userIdRef) return;
       try {
-        const rows = await getAllTransactions(dbRef);
+        const rows = await getAllTransactions(dbRef, userIdRef);
         const transactions: StoredTransaction[] = rows.map((row) => ({
           id: row.id,
+          userId: row.userId,
           type: row.type as TransactionType,
           amountCents: row.amountCents,
           categoryId: row.categoryId as CategoryId,
           description: row.description ?? "",
           date: parseIsoDate(row.date),
           createdAt: new Date(row.createdAt),
+          updatedAt: new Date(row.updatedAt),
+          deletedAt: row.deletedAt ? new Date(row.deletedAt) : null,
         }));
         set({ transactions });
       } catch {
@@ -157,9 +179,16 @@ export const useTransactionStore = create<AddTransactionState & AddTransactionAc
     removeTransaction: async (id) => {
       if (dbRef) {
         try {
-          await deleteTransactionRepo(dbRef, id);
+          await softDeleteTransaction(dbRef, id);
+          await enqueueSync(dbRef, {
+            id: generateId("sq"),
+            tableName: "transactions",
+            rowId: id,
+            operation: "delete",
+            createdAt: new Date().toISOString(),
+          });
         } catch {
-          // DB delete failed — keep UI state unchanged
+          // DB operation failed — keep UI state unchanged
           return;
         }
       }

--- a/apps/mobile/shared/db/client.ts
+++ b/apps/mobile/shared/db/client.ts
@@ -5,18 +5,21 @@ import { openDatabaseSync } from "expo-sqlite";
 // biome-ignore lint/suspicious/noExplicitAny: drizzle generic varies by caller
 export type AnyDb = ExpoSQLiteDatabase<any>;
 
-const DB_NAME = "fidy.db";
-// TODO: move to secure storage when auth is added
-const DB_KEY = "fidy-dev-key-2026";
-
 let db: ReturnType<typeof drizzle> | null = null;
 let sqliteRef: ReturnType<typeof openDatabaseSync> | null = null;
+let currentUserId: string | null = null;
 
-export function getDb() {
+export function getDb(userId: string) {
+  if (db && currentUserId !== userId) {
+    throw new Error(`DB already open for user "${currentUserId}". Call resetDb() first.`);
+  }
   if (!db) {
-    sqliteRef = openDatabaseSync(DB_NAME);
-    sqliteRef.execSync(`PRAGMA key = '${DB_KEY}'`);
+    const dbName = `fidy-${userId}.db`;
+    const dbKey = `fidy-key-${userId}`;
+    sqliteRef = openDatabaseSync(dbName);
+    sqliteRef.execSync(`PRAGMA key = '${dbKey}'`);
     db = drizzle(sqliteRef);
+    currentUserId = userId;
   }
   return db;
 }
@@ -27,5 +30,6 @@ export function resetDb() {
   } finally {
     sqliteRef = null;
     db = null;
+    currentUserId = null;
   }
 }

--- a/apps/mobile/shared/db/schema.ts
+++ b/apps/mobile/shared/db/schema.ts
@@ -2,10 +2,26 @@ import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
 export const transactions = sqliteTable("transactions", {
   id: text("id").primaryKey(),
+  userId: text("user_id").notNull(),
   type: text("type").notNull(),
   amountCents: integer("amount_cents").notNull(),
   categoryId: text("category_id").notNull(),
   description: text("description"),
   date: text("date").notNull(),
   createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+  deletedAt: text("deleted_at"),
+});
+
+export const syncQueue = sqliteTable("sync_queue", {
+  id: text("id").primaryKey(),
+  tableName: text("table_name").notNull(),
+  rowId: text("row_id").notNull(),
+  operation: text("operation").notNull(),
+  createdAt: text("created_at").notNull(),
+});
+
+export const syncMeta = sqliteTable("sync_meta", {
+  key: text("key").primaryKey(),
+  value: text("value").notNull(),
 });

--- a/apps/mobile/shared/lib/generate-id.ts
+++ b/apps/mobile/shared/lib/generate-id.ts
@@ -1,0 +1,3 @@
+export function generateId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+}


### PR DESCRIPTION
- Add `userId`, `updatedAt`, `deletedAt` sync columns to transactions table
- Add `syncQueue` and `syncMeta` tables with Drizzle migration
- Scope DB file name and encryption key per user (`getDb(userId)`)
- Update repository with soft delete, sync queue, and sync meta functions
- Update transaction store with user-scoped init, sync enqueue on save/remove
- Add `SyncOperation`/`SyncTableName` union types for type safety
- Extract `generateId` helper to eliminate copy-pasted ID generation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-user SQLite DB and a local sync system (schema + queue) for transactions. Enables soft deletes and tracks changes for future server sync.

- **New Features**
  - Transactions: add userId, updatedAt, deletedAt; implement soft delete.
  - Schema: add sync_queue and sync_meta with Drizzle migration.
  - DB: getDb(userId) opens a user-scoped DB name and encryption key; prevents switching users without resetDb(); resetDb() closes and resets.
  - Repository: filter by userId and exclude soft-deleted; add softDeleteTransaction; enqueue/get/clear sync entries; get/set sync meta; getTransactionById.
  - Store: initStore(db, userId); saveTransaction inserts and enqueues sync; removeTransaction soft-deletes and enqueues; load scoped to user.
  - Utils/Types: add generateId helper; add SyncOperation and SyncTableName unions.

- **Migration**
  - Run new Drizzle migration (m0001).
  - Update call sites to pass userId to getDb(userId).
  - Initialize the store with initStore(db, userId).

<sup>Written for commit e6a8d8ca8d507b18867e431b98994446291fe77b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

