### PR TITLE
fix(mobile): redirect after OAuth sign-in

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -8,7 +8,7 @@ import {
 } from "@expo-google-fonts/poppins";
 import { useMigrations } from "drizzle-orm/expo-sqlite/migrator";
 import { useFonts } from "expo-font";
-import { Stack } from "expo-router";
+import { Redirect, Stack } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
 import { useEffect } from "react";
@@ -43,11 +43,7 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: string }) {
     }
   }, [migrationsReady, migrationsError]);
 
-  if (!migrationsReady && !migrationsError) {
-    return null;
-  }
-
-  return <Stack.Screen name="(tabs)" />;
+  return null;
 }
 
 export default function RootLayout() {
@@ -87,12 +83,17 @@ export default function RootLayout() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <Stack screenOptions={{ headerShown: false }}>
-        {db && userId ? (
-          <AuthenticatedShell db={db} userId={userId} />
-        ) : (
-          <Stack.Screen name="(auth)" />
-        )}
+        <Stack.Screen name="(auth)" />
+        <Stack.Screen name="(tabs)" />
       </Stack>
+      {db && userId ? (
+        <>
+          <AuthenticatedShell db={db} userId={userId} />
+          <Redirect href="/(tabs)" />
+        </>
+      ) : (
+        <Redirect href="/(auth)" />
+      )}
       <StatusBar style="auto" />
     </GestureHandlerRootView>
   );


### PR DESCRIPTION
- Use Redirect component for auth-gated navigation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes post-OAuth navigation on mobile by using expo-router Redirect to route users based on auth state. Authenticated users go to /(tabs); others go to /(auth), with both routes registered to avoid blank screens during migrations.

<sup>Written for commit a6e50170302a724e19b669b872a28d1ae8b7ebf3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

