### PR TITLE
feat(mobile): add email capture schema tables

### DIFF
--- a/apps/mobile/__tests__/db/schema.test.ts
+++ b/apps/mobile/__tests__/db/schema.test.ts
@@ -21,7 +21,7 @@ describe("transactions table schema", () => {
     expect(names).toContain("createdAt");
     expect(names).toContain("updatedAt");
     expect(names).toContain("deletedAt");
-    expect(names).toHaveLength(10);
+    expect(names).toHaveLength(11);
   });
 
   it("id is primary key", () => {
@@ -42,6 +42,11 @@ describe("transactions table schema", () => {
   it("userId is not null", () => {
     const cols = getTableColumns(transactions);
     expect(cols.userId.notNull).toBe(true);
+  });
+
+  it("has source column", () => {
+    expect(transactions.source).toBeDefined();
+    expect(transactions.source.name).toBe("source");
   });
 });
 

--- a/apps/mobile/__tests__/email-capture/schema.test.ts
+++ b/apps/mobile/__tests__/email-capture/schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { emailAccounts } from "@/shared/db/schema";
+import { emailAccounts, processedEmails } from "@/shared/db/schema";
 
 describe("emailAccounts schema", () => {
   it("has required columns", () => {
@@ -9,5 +9,20 @@ describe("emailAccounts schema", () => {
     expect(emailAccounts.email).toBeDefined();
     expect(emailAccounts.lastFetchedAt).toBeDefined();
     expect(emailAccounts.createdAt).toBeDefined();
+  });
+});
+
+describe("processedEmails schema", () => {
+  it("has required columns", () => {
+    expect(processedEmails.id).toBeDefined();
+    expect(processedEmails.externalId).toBeDefined();
+    expect(processedEmails.provider).toBeDefined();
+    expect(processedEmails.status).toBeDefined();
+    expect(processedEmails.failureReason).toBeDefined();
+    expect(processedEmails.subject).toBeDefined();
+    expect(processedEmails.rawBodyPreview).toBeDefined();
+    expect(processedEmails.receivedAt).toBeDefined();
+    expect(processedEmails.transactionId).toBeDefined();
+    expect(processedEmails.createdAt).toBeDefined();
   });
 });

--- a/apps/mobile/__tests__/email-capture/schema.test.ts
+++ b/apps/mobile/__tests__/email-capture/schema.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { emailAccounts } from "@/shared/db/schema";
+
+describe("emailAccounts schema", () => {
+  it("has required columns", () => {
+    expect(emailAccounts.id).toBeDefined();
+    expect(emailAccounts.userId).toBeDefined();
+    expect(emailAccounts.provider).toBeDefined();
+    expect(emailAccounts.email).toBeDefined();
+    expect(emailAccounts.lastFetchedAt).toBeDefined();
+    expect(emailAccounts.createdAt).toBeDefined();
+  });
+});

--- a/apps/mobile/__tests__/transactions/store.test.ts
+++ b/apps/mobile/__tests__/transactions/store.test.ts
@@ -212,6 +212,7 @@ describe("useTransactionStore", () => {
         createdAt: "2026-03-04T10:00:00.000Z",
         updatedAt: "2026-03-04T10:00:00.000Z",
         deletedAt: null,
+        source: "manual",
       },
     ]);
 

--- a/apps/mobile/drizzle/0002_blue_maria_hill.sql
+++ b/apps/mobile/drizzle/0002_blue_maria_hill.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `transactions` ADD `source` text DEFAULT 'manual' NOT NULL;

--- a/apps/mobile/drizzle/0003_brave_the_professor.sql
+++ b/apps/mobile/drizzle/0003_brave_the_professor.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `email_accounts` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`provider` text NOT NULL,
+	`email` text NOT NULL,
+	`last_fetched_at` text,
+	`created_at` text NOT NULL
+);

--- a/apps/mobile/drizzle/0004_wooden_toro.sql
+++ b/apps/mobile/drizzle/0004_wooden_toro.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `processed_emails` (
+	`id` text PRIMARY KEY NOT NULL,
+	`external_id` text NOT NULL,
+	`provider` text NOT NULL,
+	`status` text NOT NULL,
+	`failure_reason` text,
+	`subject` text NOT NULL,
+	`raw_body_preview` text,
+	`received_at` text NOT NULL,
+	`transaction_id` text,
+	`created_at` text NOT NULL
+);

--- a/apps/mobile/drizzle/meta/0002_snapshot.json
+++ b/apps/mobile/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,175 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "7d1ee422-f975-4a58-bffc-7205162b960c",
+  "prevId": "382b653c-c57f-4ef8-9c20-e728e1ad717e",
+  "tables": {
+    "sync_meta": {
+      "name": "sync_meta",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_queue": {
+      "name": "sync_queue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transactions": {
+      "name": "transactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/mobile/drizzle/meta/0003_snapshot.json
+++ b/apps/mobile/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,227 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "aeb701a6-06d3-45e6-b76f-4c4de92d1b8d",
+  "prevId": "7d1ee422-f975-4a58-bffc-7205162b960c",
+  "tables": {
+    "email_accounts": {
+      "name": "email_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_meta": {
+      "name": "sync_meta",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_queue": {
+      "name": "sync_queue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transactions": {
+      "name": "transactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/mobile/drizzle/meta/0004_snapshot.json
+++ b/apps/mobile/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,307 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "40e1bf54-c9ce-455c-a473-fb299d052111",
+  "prevId": "aeb701a6-06d3-45e6-b76f-4c4de92d1b8d",
+  "tables": {
+    "email_accounts": {
+      "name": "email_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "processed_emails": {
+      "name": "processed_emails",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_body_preview": {
+          "name": "raw_body_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_meta": {
+      "name": "sync_meta",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_queue": {
+      "name": "sync_queue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transactions": {
+      "name": "transactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/mobile/drizzle/meta/_journal.json
+++ b/apps/mobile/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1772684969982,
       "tag": "0001_brown_stone_men",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1772719891092,
+      "tag": "0002_blue_maria_hill",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/mobile/drizzle/meta/_journal.json
+++ b/apps/mobile/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1772719891092,
       "tag": "0002_blue_maria_hill",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1772720026459,
+      "tag": "0003_brave_the_professor",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/mobile/drizzle/meta/_journal.json
+++ b/apps/mobile/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1772720026459,
       "tag": "0003_brave_the_professor",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1772720200210,
+      "tag": "0004_wooden_toro",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/mobile/shared/db/schema.ts
+++ b/apps/mobile/shared/db/schema.ts
@@ -14,6 +14,15 @@ export const transactions = sqliteTable("transactions", {
   source: text("source").notNull().default("manual"),
 });
 
+export const emailAccounts = sqliteTable("email_accounts", {
+  id: text("id").primaryKey(),
+  userId: text("user_id").notNull(),
+  provider: text("provider").notNull(),
+  email: text("email").notNull(),
+  lastFetchedAt: text("last_fetched_at"),
+  createdAt: text("created_at").notNull(),
+});
+
 export const syncQueue = sqliteTable("sync_queue", {
   id: text("id").primaryKey(),
   tableName: text("table_name").notNull(),

--- a/apps/mobile/shared/db/schema.ts
+++ b/apps/mobile/shared/db/schema.ts
@@ -11,6 +11,7 @@ export const transactions = sqliteTable("transactions", {
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at").notNull(),
   deletedAt: text("deleted_at"),
+  source: text("source").notNull().default("manual"),
 });
 
 export const syncQueue = sqliteTable("sync_queue", {

--- a/apps/mobile/shared/db/schema.ts
+++ b/apps/mobile/shared/db/schema.ts
@@ -23,6 +23,19 @@ export const emailAccounts = sqliteTable("email_accounts", {
   createdAt: text("created_at").notNull(),
 });
 
+export const processedEmails = sqliteTable("processed_emails", {
+  id: text("id").primaryKey(),
+  externalId: text("external_id").notNull(),
+  provider: text("provider").notNull(),
+  status: text("status").notNull(),
+  failureReason: text("failure_reason"),
+  subject: text("subject").notNull(),
+  rawBodyPreview: text("raw_body_preview"),
+  receivedAt: text("received_at").notNull(),
+  transactionId: text("transaction_id"),
+  createdAt: text("created_at").notNull(),
+});
+
 export const syncQueue = sqliteTable("sync_queue", {
   id: text("id").primaryKey(),
   tableName: text("table_name").notNull(),


### PR DESCRIPTION
## Summary
- Add `source` column to transactions table (default "manual")
- Create `email_accounts` table (id, userId, provider, email, lastFetchedAt, createdAt)
- Create `processed_emails` table (id, externalId, provider, status, failureReason, subject, rawBodyPreview, receivedAt, transactionId, createdAt)
- Generate Drizzle migrations 0002-0004

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds schema for email capture on mobile and tracks transaction origin. Introduces email_accounts and processed_emails tables and a new transactions.source column (default "manual") with Drizzle migrations and tests.

- **New Features**
  - transactions.source text column to record origin (default "manual").
  - email_accounts table: id, userId, provider, email, lastFetchedAt, createdAt.
  - processed_emails table: id, externalId, provider, status, failureReason, subject, rawBodyPreview, receivedAt, transactionId, createdAt.

- **Migration**
  - Run Drizzle migrations 0002–0004 in apps/mobile.
  - No backfill needed; existing transactions get source="manual".

<sup>Written for commit 4ff57fcb341a61009d92b1271e624f814b7a1655. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

