### PR TITLE
feat(mobile): add email capture types and bank senders

### DIFF
--- a/apps/mobile/__tests__/email-capture/bank-senders.test.ts
+++ b/apps/mobile/__tests__/email-capture/bank-senders.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from "vitest";
 import { DEFAULT_BANK_SENDERS, isBankSender } from "@/features/email-capture/lib/bank-senders";
 
 describe("bank senders", () => {
-  it("has default Colombian bank senders", () => {
+  it("has default verified bank senders", () => {
     expect(DEFAULT_BANK_SENDERS.length).toBeGreaterThan(0);
     expect(DEFAULT_BANK_SENDERS).toContainEqual(
-      expect.objectContaining({ email: "notificaciones@bancolombia.com.co" })
+      expect.objectContaining({ email: "davibankinforma@davibank.com" })
     );
   });
 
   it("isBankSender returns true for known senders", () => {
-    expect(isBankSender("notificaciones@bancolombia.com.co", DEFAULT_BANK_SENDERS)).toBe(true);
+    expect(isBankSender("davibankinforma@davibank.com", DEFAULT_BANK_SENDERS)).toBe(true);
   });
 
   it("isBankSender returns false for unknown senders", () => {
@@ -18,6 +18,6 @@ describe("bank senders", () => {
   });
 
   it("isBankSender is case-insensitive", () => {
-    expect(isBankSender("Notificaciones@Bancolombia.com.co", DEFAULT_BANK_SENDERS)).toBe(true);
+    expect(isBankSender("BBVA@BBVANET.COM.CO", DEFAULT_BANK_SENDERS)).toBe(true);
   });
 });

--- a/apps/mobile/__tests__/email-capture/bank-senders.test.ts
+++ b/apps/mobile/__tests__/email-capture/bank-senders.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_BANK_SENDERS, isBankSender } from "@/features/email-capture/lib/bank-senders";
+
+describe("bank senders", () => {
+  it("has default Colombian bank senders", () => {
+    expect(DEFAULT_BANK_SENDERS.length).toBeGreaterThan(0);
+    expect(DEFAULT_BANK_SENDERS).toContainEqual(
+      expect.objectContaining({ email: "notificaciones@bancolombia.com.co" })
+    );
+  });
+
+  it("isBankSender returns true for known senders", () => {
+    expect(isBankSender("notificaciones@bancolombia.com.co", DEFAULT_BANK_SENDERS)).toBe(true);
+  });
+
+  it("isBankSender returns false for unknown senders", () => {
+    expect(isBankSender("promo@random.com", DEFAULT_BANK_SENDERS)).toBe(false);
+  });
+
+  it("isBankSender is case-insensitive", () => {
+    expect(isBankSender("Notificaciones@Bancolombia.com.co", DEFAULT_BANK_SENDERS)).toBe(true);
+  });
+});

--- a/apps/mobile/__tests__/email-capture/types.test.ts
+++ b/apps/mobile/__tests__/email-capture/types.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  emailProviderSchema,
+  processedEmailStatusSchema,
+  rawEmailSchema,
+} from "@/features/email-capture/schema";
+
+describe("email capture schemas", () => {
+  it("validates a raw email", () => {
+    const valid = rawEmailSchema.safeParse({
+      externalId: "msg-123",
+      from: "notificaciones@bancolombia.com.co",
+      subject: "Compra aprobada",
+      body: "Su compra por $50,000 en EXITO fue aprobada",
+      receivedAt: "2026-03-05T10:00:00Z",
+      provider: "gmail",
+    });
+    expect(valid.success).toBe(true);
+  });
+
+  it("rejects invalid provider", () => {
+    const invalid = rawEmailSchema.safeParse({
+      externalId: "msg-123",
+      from: "test@test.com",
+      subject: "Test",
+      body: "Body",
+      receivedAt: "2026-03-05T10:00:00Z",
+      provider: "yahoo",
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it("validates email provider", () => {
+    expect(emailProviderSchema.safeParse("gmail").success).toBe(true);
+    expect(emailProviderSchema.safeParse("outlook").success).toBe(true);
+    expect(emailProviderSchema.safeParse("yahoo").success).toBe(false);
+  });
+
+  it("validates processed email status", () => {
+    expect(processedEmailStatusSchema.safeParse("success").success).toBe(true);
+    expect(processedEmailStatusSchema.safeParse("failed").success).toBe(true);
+    expect(processedEmailStatusSchema.safeParse("skipped_duplicate").success).toBe(true);
+    expect(processedEmailStatusSchema.safeParse("pending").success).toBe(false);
+  });
+});

--- a/apps/mobile/__tests__/email-capture/types.test.ts
+++ b/apps/mobile/__tests__/email-capture/types.test.ts
@@ -9,7 +9,7 @@ describe("email capture schemas", () => {
   it("validates a raw email", () => {
     const valid = rawEmailSchema.safeParse({
       externalId: "msg-123",
-      from: "notificaciones@bancolombia.com.co",
+      from: "alertasynotificaciones@notificacionesbancolombia.com",
       subject: "Compra aprobada",
       body: "Su compra por $50,000 en EXITO fue aprobada",
       receivedAt: "2026-03-05T10:00:00Z",

--- a/apps/mobile/features/email-capture/lib/bank-senders.ts
+++ b/apps/mobile/features/email-capture/lib/bank-senders.ts
@@ -4,13 +4,9 @@ export type BankSender = {
 };
 
 export const DEFAULT_BANK_SENDERS: readonly BankSender[] = [
-  { bank: "Bancolombia", email: "notificaciones@bancolombia.com.co" },
-  { bank: "Nequi", email: "nequi@bancolombia.com.co" },
-  { bank: "Davivienda", email: "alertas@davivienda.com" },
-  { bank: "Daviplata", email: "notificaciones@daviplata.com" },
-  { bank: "BBVA", email: "notificaciones@bbva.com.co" },
-  { bank: "Banco de Bogota", email: "alertas@bancodebogota.com.co" },
-  { bank: "Scotiabank Colpatria", email: "alertas@colpatria.com" },
+  { bank: "Davibank", email: "davibankinforma@davibank.com" },
+  { bank: "BBVA", email: "BBVA@bbvanet.com.co" },
+  { bank: "Rappi", email: "noreply@rappicard.co" },
 ] as const;
 
 export function isBankSender(from: string, senders: readonly BankSender[]): boolean {

--- a/apps/mobile/features/email-capture/lib/bank-senders.ts
+++ b/apps/mobile/features/email-capture/lib/bank-senders.ts
@@ -1,0 +1,19 @@
+export type BankSender = {
+  readonly bank: string;
+  readonly email: string;
+};
+
+export const DEFAULT_BANK_SENDERS: readonly BankSender[] = [
+  { bank: "Bancolombia", email: "notificaciones@bancolombia.com.co" },
+  { bank: "Nequi", email: "nequi@bancolombia.com.co" },
+  { bank: "Davivienda", email: "alertas@davivienda.com" },
+  { bank: "Daviplata", email: "notificaciones@daviplata.com" },
+  { bank: "BBVA", email: "notificaciones@bbva.com.co" },
+  { bank: "Banco de Bogota", email: "alertas@bancodebogota.com.co" },
+  { bank: "Scotiabank Colpatria", email: "alertas@colpatria.com" },
+] as const;
+
+export function isBankSender(from: string, senders: readonly BankSender[]): boolean {
+  const normalized = from.toLowerCase();
+  return senders.some((s) => s.email.toLowerCase() === normalized);
+}

--- a/apps/mobile/features/email-capture/schema.ts
+++ b/apps/mobile/features/email-capture/schema.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+export const emailProviderSchema = z.enum(["gmail", "outlook"]);
+export type EmailProvider = z.infer<typeof emailProviderSchema>;
+
+export const processedEmailStatusSchema = z.enum(["success", "failed", "skipped_duplicate"]);
+export type ProcessedEmailStatus = z.infer<typeof processedEmailStatusSchema>;
+
+export const rawEmailSchema = z.object({
+  externalId: z.string(),
+  from: z.string().email(),
+  subject: z.string(),
+  body: z.string(),
+  receivedAt: z.string(),
+  provider: emailProviderSchema,
+});
+export type RawEmail = z.infer<typeof rawEmailSchema>;
+
+export const transactionSourceSchema = z.enum(["manual", "email_gmail", "email_outlook"]);
+export type TransactionSource = z.infer<typeof transactionSourceSchema>;


### PR DESCRIPTION
## Summary
- Add Zod schemas: rawEmail, emailProvider, processedEmailStatus, transactionSource
- Add DEFAULT_BANK_SENDERS list for Colombian banks
- Add pure isBankSender function (case-insensitive matching)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Zod schemas for email capture and a verified list of Colombian bank sender emails with a case-insensitive matcher. This standardizes email parsing and improves detection of bank-originated emails.

- **New Features**
  - Schemas: emailProvider (gmail|outlook), processedEmailStatus (success|failed|skipped_duplicate), rawEmail, transactionSource (manual|email_gmail|email_outlook).
  - Bank senders: DEFAULT_BANK_SENDERS now includes verified emails for Davibank, BBVA, and Rappi.
  - Matching: isBankSender(from, senders) with case-insensitive exact email checks.
  - Tests: coverage for schema validation and bank sender matching.

- **Bug Fixes**
  - Use only verified bank sender emails; removed unverified entries pending confirmation.

<sup>Written for commit 9244245b7d602945319b582fa6e352e1cbc13e87. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

