### PR TITLE
refactor(mobile): eliminate side effects from core logic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,3 +18,14 @@ Tools already chosen:
 - Drizzle ORM
 - Zod
 - date-fns
+
+## Code Style: Functional Programming
+
+All code in the financial core (`lib/`, schemas, utils) MUST follow functional programming patterns. Infrastructure edges (stores, hooks, DB clients) are exempt where idiomatic React/Zustand patterns require it.
+
+- No mutable variables (`let`, `var`) in pure logic — use `const` only
+- No `.push()` accumulation — use `.map()`, `.filter()`, `.reduce()`, `Array.from()`
+- No parameter reassignment — create new `const` bindings instead
+- No `while`/`for` loops — use declarative alternatives or recursion
+- Separate pure functions from side effects: pure logic in `lib/`, effects in stores/hooks
+- Pure functions take all dependencies as parameters (no reaching into module state)

--- a/apps/mobile/__tests__/calendar/calendar-utils.test.ts
+++ b/apps/mobile/__tests__/calendar/calendar-utils.test.ts
@@ -229,6 +229,7 @@ describe("getNextOccurrence", () => {
     expect(next.getDate()).toBe(28); // Clamped
   });
 
+
   // Bill due today should not skip to next period when called mid-day
   test("monthly bill due today returns today even when called in the afternoon", () => {
     const bill = makeBill({ startDate: new Date(2025, 0, 15) }); // 15th monthly

--- a/apps/mobile/__tests__/calendar/calendar-utils.test.ts
+++ b/apps/mobile/__tests__/calendar/calendar-utils.test.ts
@@ -229,7 +229,6 @@ describe("getNextOccurrence", () => {
     expect(next.getDate()).toBe(28); // Clamped
   });
 
-
   // Bill due today should not skip to next period when called mid-day
   test("monthly bill due today returns today even when called in the afternoon", () => {
     const bill = makeBill({ startDate: new Date(2025, 0, 15) }); // 15th monthly

--- a/apps/mobile/__tests__/transactions/build-transaction.test.ts
+++ b/apps/mobile/__tests__/transactions/build-transaction.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildTransaction,
+  toStoredTransaction,
+  toTransactionRow,
+} from "@/features/transactions/lib/build-transaction";
+import type { StoredTransaction } from "@/features/transactions/schema";
+
+const NOW = new Date(2026, 2, 5, 12, 0, 0);
+
+describe("buildTransaction", () => {
+  const validInput = {
+    type: "expense" as const,
+    digits: "1234",
+    categoryId: "food" as const,
+    description: "Lunch",
+    date: new Date(2026, 2, 5),
+  };
+
+  test("returns success with valid input", () => {
+    const result = buildTransaction(validInput, "user-1", "tx-1", NOW);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.transaction.id).toBe("tx-1");
+    expect(result.transaction.userId).toBe("user-1");
+    expect(result.transaction.amountCents).toBe(1234);
+    expect(result.transaction.categoryId).toBe("food");
+    expect(result.transaction.createdAt).toBe(NOW);
+    expect(result.transaction.updatedAt).toBe(NOW);
+    expect(result.transaction.deletedAt).toBeNull();
+  });
+
+  test("returns error for zero amount", () => {
+    const result = buildTransaction({ ...validInput, digits: "0" }, "user-1", "tx-2", NOW);
+    expect(result.success).toBe(false);
+  });
+
+  test("defaults categoryId to 'other' when null", () => {
+    const result = buildTransaction({ ...validInput, categoryId: null }, "user-1", "tx-3", NOW);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.transaction.categoryId).toBe("other");
+  });
+
+  test("returns error for non-numeric digits", () => {
+    const result = buildTransaction({ ...validInput, digits: "abc" }, "user-1", "tx-4", NOW);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("toStoredTransaction / toTransactionRow round-trip", () => {
+  const stored: StoredTransaction = {
+    id: "tx-rt",
+    userId: "user-1",
+    type: "income",
+    amountCents: 5000,
+    categoryId: "income",
+    description: "Monthly",
+    date: new Date(2026, 2, 1),
+    createdAt: new Date(2026, 2, 1, 10, 0, 0),
+    updatedAt: new Date(2026, 2, 1, 10, 0, 0),
+    deletedAt: null,
+  };
+
+  test("toTransactionRow produces correct DB row", () => {
+    const row = toTransactionRow(stored);
+    expect(row.id).toBe("tx-rt");
+    expect(row.userId).toBe("user-1");
+    expect(row.type).toBe("income");
+    expect(row.amountCents).toBe(5000);
+    expect(row.date).toBe("2026-03-01");
+    expect(typeof row.createdAt).toBe("string");
+  });
+
+  test("toStoredTransaction reverses toTransactionRow", () => {
+    const row = toTransactionRow(stored);
+    const roundTripped = toStoredTransaction(row);
+    expect(roundTripped.id).toBe(stored.id);
+    expect(roundTripped.userId).toBe(stored.userId);
+    expect(roundTripped.type).toBe(stored.type);
+    expect(roundTripped.amountCents).toBe(stored.amountCents);
+    expect(roundTripped.categoryId).toBe(stored.categoryId);
+    expect(roundTripped.description).toBe(stored.description);
+    expect(roundTripped.date.getFullYear()).toBe(stored.date.getFullYear());
+    expect(roundTripped.date.getMonth()).toBe(stored.date.getMonth());
+    expect(roundTripped.date.getDate()).toBe(stored.date.getDate());
+    expect(roundTripped.deletedAt).toBeNull();
+  });
+});

--- a/apps/mobile/features/calendar/components/CalendarGrid.tsx
+++ b/apps/mobile/features/calendar/components/CalendarGrid.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { StyleSheet, Text, View } from "react-native";
 import { useThemeColor } from "@/shared/hooks/use-theme-color";
+import type { CalendarDay } from "../lib/calendar-utils";
 import { getBillsForDate, getMonthGrid, WEEKDAY_LABELS } from "../lib/calendar-utils";
 import type { Bill } from "../schema";
 import { CalendarDayCell } from "./CalendarDayCell";
@@ -17,18 +18,16 @@ export function CalendarGrid({ currentMonth, bills, onBillPress }: Props) {
 
   const grid = useMemo(() => getMonthGrid(year, month), [year, month]);
 
-  const billsByDate = useMemo(() => {
-    const map = new Map<string, Bill[]>();
-    for (const week of grid) {
-      for (const cell of week) {
-        if (cell.date) {
-          const key = cell.date.toISOString();
-          map.set(key, getBillsForDate(bills, cell.date));
-        }
-      }
-    }
-    return map;
-  }, [grid, bills]);
+  const billsByDate = useMemo(
+    () =>
+      new Map(
+        grid
+          .flat()
+          .filter((cell): cell is CalendarDay & { date: Date } => cell.date !== null)
+          .map((cell) => [cell.date.toISOString(), getBillsForDate(bills, cell.date)] as const)
+      ),
+    [grid, bills]
+  );
 
   const borderColor = useThemeColor("borderSubtle");
   const cardBg = useThemeColor("card");

--- a/apps/mobile/features/calendar/lib/calendar-utils.ts
+++ b/apps/mobile/features/calendar/lib/calendar-utils.ts
@@ -1,6 +1,7 @@
 import {
   addDays,
   addWeeks,
+  differenceInCalendarDays,
   differenceInWeeks,
   format,
   getDay,
@@ -37,24 +38,15 @@ export function getMonthGrid(year: number, month: number): CalendarDay[][] {
   const totalCells = startOffset + daysInMonth;
   const numWeeks = Math.ceil(totalCells / 7);
 
-  const grid: CalendarDay[][] = [];
-
-  for (let week = 0; week < numWeeks; week++) {
-    const row: CalendarDay[] = [];
-    for (let dayOfWeek = 0; dayOfWeek < 7; dayOfWeek++) {
+  return Array.from({ length: numWeeks }, (_, week) =>
+    Array.from({ length: 7 }, (_, dayOfWeek) => {
       const cellIndex = week * 7 + dayOfWeek;
       const dayNum = cellIndex - startOffset + 1;
-
-      if (dayNum < 1 || dayNum > daysInMonth) {
-        row.push({ day: null, date: null });
-      } else {
-        row.push({ day: dayNum, date: new Date(year, month, dayNum) });
-      }
-    }
-    grid.push(row);
-  }
-
-  return grid;
+      return dayNum < 1 || dayNum > daysInMonth
+        ? { day: null, date: null }
+        : { day: dayNum, date: new Date(year, month, dayNum) };
+    })
+  );
 }
 
 /**
@@ -98,32 +90,32 @@ export function formatMonthYear(date: Date): string {
 export function getNextOccurrence(bill: Bill, from: Date): Date {
   const start = bill.startDate;
   // Normalize to midnight so a bill due today isn't skipped
-  from = startOfDay(from);
+  const normalizedFrom = startOfDay(from);
   switch (bill.frequency) {
     case "weekly": {
-      const dayDiff = (getDay(start) - getDay(from) + 7) % 7;
-      const next = addDays(from, dayDiff === 0 ? 0 : dayDiff);
-      return next >= from ? next : addWeeks(next, 1);
+      const dayDiff = (getDay(start) - getDay(normalizedFrom) + 7) % 7;
+      const next = addDays(normalizedFrom, dayDiff === 0 ? 0 : dayDiff);
+      return next >= normalizedFrom ? next : addWeeks(next, 1);
     }
     case "biweekly": {
-      let next = start;
-      while (next < from) next = addWeeks(next, 2);
-      return next;
+      const daysDiff = differenceInCalendarDays(normalizedFrom, start);
+      const periods = daysDiff <= 0 ? 0 : Math.ceil(daysDiff / 14);
+      return addWeeks(start, periods * 2);
     }
     case "monthly": {
       const day = start.getDate();
-      const y = from.getFullYear();
-      const m = from.getMonth();
+      const y = normalizedFrom.getFullYear();
+      const m = normalizedFrom.getMonth();
       const candidate = new Date(y, m, clampDay(day, y, m));
-      if (candidate >= from) return candidate;
+      if (candidate >= normalizedFrom) return candidate;
       return new Date(y, m + 1, clampDay(day, y, m + 1));
     }
     case "yearly": {
       const day = start.getDate();
       const sm = start.getMonth();
-      const y = from.getFullYear();
+      const y = normalizedFrom.getFullYear();
       const candidate = new Date(y, sm, clampDay(day, y, sm));
-      if (candidate >= from) return candidate;
+      if (candidate >= normalizedFrom) return candidate;
       return new Date(y + 1, sm, clampDay(day, y + 1, sm));
     }
   }

--- a/apps/mobile/features/dashboard/lib/compute-arcs.ts
+++ b/apps/mobile/features/dashboard/lib/compute-arcs.ts
@@ -16,21 +16,16 @@ export const computeRadius = (size: number, strokeWidth: number): number =>
 export const computeCircumference = (size: number, strokeWidth: number): number =>
   2 * Math.PI * computeRadius(size, strokeWidth);
 
-export const computeArcs = (
-  segments: readonly Segment[],
-  circumference: number
-): readonly Arc[] => {
-  const arcs: Arc[] = [];
-  let accumulated = 0;
-  for (const segment of segments) {
+export const computeArcs = (segments: readonly Segment[], circumference: number): readonly Arc[] =>
+  segments.map((segment, i) => {
     const dash = (circumference * segment.percentage) / 100;
-    arcs.push({
+    const precedingRotation = segments
+      .slice(0, i)
+      .reduce((sum, s) => sum + (s.percentage / 100) * 360, 0);
+    return {
       offset: circumference - dash,
       dash,
-      rotation: accumulated - 90,
+      rotation: precedingRotation - 90,
       color: segment.color,
-    });
-    accumulated += (dash / circumference) * 360;
-  }
-  return arcs;
-};
+    };
+  });

--- a/apps/mobile/features/sync/services/syncEngine.ts
+++ b/apps/mobile/features/sync/services/syncEngine.ts
@@ -51,6 +51,10 @@ function toSupabaseRow(row: {
   };
 }
 
+function shouldUpdateLocal(serverUpdatedAt: string, localUpdatedAt: string | undefined): boolean {
+  return !localUpdatedAt || serverUpdatedAt > localUpdatedAt;
+}
+
 function fromSupabaseRow(row: SupabaseTransactionRow) {
   return {
     id: row.id,
@@ -66,6 +70,20 @@ function fromSupabaseRow(row: SupabaseTransactionRow) {
   };
 }
 
+async function processEntry(
+  db: AnyDb,
+  supabase: SupabaseClient,
+  entry: { id: string; tableName: string; rowId: string }
+): Promise<string | null> {
+  if (entry.tableName !== "transactions") return null;
+
+  const row = await getTransactionById(db, entry.rowId);
+  if (!row) return entry.id;
+
+  const { error } = await supabase.from("transactions").upsert(toSupabaseRow(row));
+  return error ? null : entry.id;
+}
+
 export async function syncPush(
   db: AnyDb,
   supabase: SupabaseClient,
@@ -74,27 +92,12 @@ export async function syncPush(
   const entries = await getQueuedSyncEntries(db);
   if (entries.length === 0) return;
 
-  const processedIds: string[] = [];
-
-  for (const entry of entries) {
-    try {
-      if (entry.tableName === "transactions") {
-        const row = await getTransactionById(db, entry.rowId);
-        if (!row) {
-          processedIds.push(entry.id);
-          continue;
-        }
-
-        const { error } = await supabase.from("transactions").upsert(toSupabaseRow(row));
-
-        if (!error) {
-          processedIds.push(entry.id);
-        }
-      }
-    } catch {
-      // Keep in queue for retry
-    }
-  }
+  const results = await Promise.allSettled(entries.map((e) => processEntry(db, supabase, e)));
+  const processedIds = results
+    .filter(
+      (r): r is PromiseFulfilledResult<string> => r.status === "fulfilled" && r.value !== null
+    )
+    .map((r) => r.value);
 
   if (processedIds.length > 0) {
     await clearSyncEntries(db, processedIds);
@@ -108,11 +111,8 @@ export async function syncPull(
 ): Promise<boolean> {
   const lastSyncAt = await getSyncMeta(db, LAST_SYNC_AT);
 
-  let query = supabase.from("transactions").select("*").eq("user_id", userId);
-
-  if (lastSyncAt) {
-    query = query.gte("updated_at", lastSyncAt);
-  }
+  const baseQuery = supabase.from("transactions").select("*").eq("user_id", userId);
+  const query = lastSyncAt ? baseQuery.gte("updated_at", lastSyncAt) : baseQuery;
 
   const { data, error } = await query.order("updated_at", { ascending: true }).limit(1000);
   if (error || !data) return false;
@@ -122,7 +122,7 @@ export async function syncPull(
   for (const serverRow of rows) {
     const localRow = await getTransactionById(db, serverRow.id);
 
-    if (!localRow || serverRow.updated_at > localRow.updatedAt) {
+    if (shouldUpdateLocal(serverRow.updated_at, localRow?.updatedAt)) {
       await upsertTransaction(db, fromSupabaseRow(serverRow));
     }
   }

--- a/apps/mobile/features/transactions/lib/build-transaction.ts
+++ b/apps/mobile/features/transactions/lib/build-transaction.ts
@@ -1,0 +1,84 @@
+import { parseIsoDate, toIsoDate } from "@/shared/lib/format-date";
+import type { CreateTransactionInput, StoredTransaction, TransactionType } from "../schema";
+import { createTransactionSchema } from "../schema";
+import type { CategoryId } from "./categories";
+import { amountToCents } from "./format-amount";
+import type { TransactionRow } from "./repository";
+
+type BuildInput = {
+  type: TransactionType;
+  digits: string;
+  categoryId: CategoryId | null;
+  description: string;
+  date: Date;
+};
+
+export function buildTransaction(
+  input: BuildInput,
+  userId: string,
+  id: string,
+  now: Date
+): { success: true; transaction: StoredTransaction } | { success: false; error: string } {
+  const amountCents = amountToCents(input.digits);
+
+  const raw: CreateTransactionInput = {
+    type: input.type,
+    amountCents,
+    categoryId: input.categoryId ?? "other",
+    description: input.description || undefined,
+    date: input.date,
+  };
+
+  const result = createTransactionSchema.safeParse(raw);
+  if (!result.success) {
+    return {
+      success: false,
+      error: result.error.issues[0]?.message ?? "Invalid input",
+    };
+  }
+
+  return {
+    success: true,
+    transaction: {
+      id,
+      userId,
+      type: result.data.type,
+      amountCents: result.data.amountCents,
+      categoryId: result.data.categoryId as CategoryId,
+      description: result.data.description ?? "",
+      date: result.data.date,
+      createdAt: now,
+      updatedAt: now,
+      deletedAt: null,
+    },
+  };
+}
+
+export function toStoredTransaction(row: TransactionRow): StoredTransaction {
+  return {
+    id: row.id,
+    userId: row.userId,
+    type: row.type as TransactionType,
+    amountCents: row.amountCents,
+    categoryId: row.categoryId as CategoryId,
+    description: row.description ?? "",
+    date: parseIsoDate(row.date),
+    createdAt: new Date(row.createdAt),
+    updatedAt: new Date(row.updatedAt),
+    deletedAt: row.deletedAt ? new Date(row.deletedAt) : null,
+  };
+}
+
+export function toTransactionRow(tx: StoredTransaction): TransactionRow {
+  return {
+    id: tx.id,
+    userId: tx.userId,
+    type: tx.type,
+    amountCents: tx.amountCents,
+    categoryId: tx.categoryId,
+    description: tx.description || null,
+    date: toIsoDate(tx.date),
+    createdAt: tx.createdAt.toISOString(),
+    updatedAt: tx.updatedAt.toISOString(),
+  };
+}

--- a/apps/mobile/features/transactions/store.ts
+++ b/apps/mobile/features/transactions/store.ts
@@ -1,17 +1,15 @@
 import { create } from "zustand";
 import type { AnyDb } from "@/shared/db/client";
-import { parseIsoDate, toIsoDate } from "@/shared/lib/format-date";
 import { generateId } from "@/shared/lib/generate-id";
+import { buildTransaction, toStoredTransaction, toTransactionRow } from "./lib/build-transaction";
 import type { CategoryId } from "./lib/categories";
-import { amountToCents } from "./lib/format-amount";
 import {
   enqueueSync,
   getAllTransactions,
   insertTransaction,
   softDeleteTransaction,
 } from "./lib/repository";
-import type { CreateTransactionInput, StoredTransaction, TransactionType } from "./schema";
-import { createTransactionSchema } from "./schema";
+import type { StoredTransaction, TransactionType } from "./schema";
 
 type SheetStep = 1 | 2;
 
@@ -91,50 +89,23 @@ export const useTransactionStore = create<AddTransactionState & AddTransactionAc
       }
 
       const { type, digits, categoryId, description, date } = get();
-      const amountCents = amountToCents(digits);
+      const id = generateId("tx");
+      const now = new Date();
 
-      const input: CreateTransactionInput = {
-        type,
-        amountCents,
-        categoryId: categoryId ?? "other",
-        description: description || undefined,
-        date,
-      };
-
-      const result = createTransactionSchema.safeParse(input);
+      const result = buildTransaction(
+        { type, digits, categoryId, description, date },
+        userIdRef,
+        id,
+        now
+      );
       if (!result.success) {
-        return {
-          success: false as const,
-          error: result.error.issues[0]?.message ?? "Invalid input",
-        };
+        return { success: false as const, error: result.error };
       }
 
-      const now = new Date();
-      const transaction: StoredTransaction = {
-        id: generateId("tx"),
-        userId: userIdRef,
-        type: result.data.type,
-        amountCents: result.data.amountCents,
-        categoryId: result.data.categoryId as CategoryId,
-        description: result.data.description ?? "",
-        date: result.data.date,
-        createdAt: now,
-        updatedAt: now,
-        deletedAt: null,
-      };
+      const { transaction } = result;
 
       try {
-        await insertTransaction(dbRef, {
-          id: transaction.id,
-          userId: transaction.userId,
-          type: transaction.type,
-          amountCents: transaction.amountCents,
-          categoryId: transaction.categoryId,
-          description: transaction.description || null,
-          date: toIsoDate(transaction.date),
-          createdAt: transaction.createdAt.toISOString(),
-          updatedAt: transaction.updatedAt.toISOString(),
-        });
+        await insertTransaction(dbRef, toTransactionRow(transaction));
 
         await enqueueSync(dbRef, {
           id: generateId("sq"),
@@ -158,19 +129,7 @@ export const useTransactionStore = create<AddTransactionState & AddTransactionAc
       if (!dbRef || !userIdRef) return;
       try {
         const rows = await getAllTransactions(dbRef, userIdRef);
-        const transactions: StoredTransaction[] = rows.map((row) => ({
-          id: row.id,
-          userId: row.userId,
-          type: row.type as TransactionType,
-          amountCents: row.amountCents,
-          categoryId: row.categoryId as CategoryId,
-          description: row.description ?? "",
-          date: parseIsoDate(row.date),
-          createdAt: new Date(row.createdAt),
-          updatedAt: new Date(row.updatedAt),
-          deletedAt: row.deletedAt ? new Date(row.deletedAt) : null,
-        }));
-        set({ transactions });
+        set({ transactions: rows.map(toStoredTransaction) });
       } catch {
         // DB read failed — keep existing in-memory state
       }


### PR DESCRIPTION
- compute-arcs: replace for-loop with pure .map()
- calendar-utils: Array.from grid, fix param reassignment, eliminate while-loop
- transactions/store: extract buildTransaction, toStoredTransaction, toTransactionRow
- syncEngine: const query, shouldUpdateLocal predicate, Promise.allSettled
- CalendarGrid: declarative Map construction in useMemo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored mobile core logic to remove side effects and use pure, declarative functions, and documented FP code style rules to enforce them. Improves reliability, testability, and keeps UI state consistent.

- **Refactors**
  - Transactions: extracted buildTransaction, toStoredTransaction, toTransactionRow; store uses them; added unit tests.
  - Calendar: getMonthGrid via Array.from; getNextOccurrence without mutation; CalendarGrid builds billsByDate declaratively.
  - Dashboard: computeArcs now a pure map with rotation derived from prior segments.
  - Sync: constant query composition; shouldUpdateLocal predicate; push uses Promise.allSettled with per-entry processing.

<sup>Written for commit 649ae18092185f6f6f9ff9fbfa4b342e38c691d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

