### PR TITLE
feat(mobile): add email capture store

### DIFF
--- a/apps/mobile/__tests__/email-capture/repository.test.ts
+++ b/apps/mobile/__tests__/email-capture/repository.test.ts
@@ -1,0 +1,159 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: mock db needs flexible typing
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockValues = vi.fn().mockReturnThis();
+const mockInsert = vi.fn(() => ({ values: mockValues }));
+const mockSelect = vi.fn().mockReturnThis();
+const mockFrom = vi.fn().mockReturnThis();
+const mockWhere = vi.fn().mockReturnThis();
+const mockOrderBy = vi.fn().mockResolvedValue([]);
+const mockDelete = vi.fn().mockReturnThis();
+const mockDeleteWhere = vi.fn().mockResolvedValue([]);
+const mockUpdate = vi.fn().mockReturnThis();
+const mockSet = vi.fn().mockReturnThis();
+const mockUpdateWhere = vi.fn().mockResolvedValue([]);
+
+const mockDb = {
+  insert: mockInsert,
+  select: mockSelect,
+  from: mockFrom,
+  where: mockWhere,
+  orderBy: mockOrderBy,
+  delete: mockDelete,
+  update: mockUpdate,
+} as any;
+
+describe("email capture repository", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValues.mockReturnThis();
+    mockSelect.mockReturnValue({ from: mockFrom });
+    mockFrom.mockReturnValue({ where: mockWhere, orderBy: mockOrderBy });
+    mockWhere.mockReturnValue({ orderBy: mockOrderBy });
+    mockDelete.mockReturnValue({ where: mockDeleteWhere });
+    mockUpdate.mockReturnValue({ set: mockSet });
+    mockSet.mockReturnValue({ where: mockUpdateWhere });
+    mockInsert.mockReturnValue({ values: mockValues });
+  });
+
+  it("insertEmailAccount calls db.insert with correct row", async () => {
+    const { insertEmailAccount } = await import("@/features/email-capture/lib/repository");
+
+    await insertEmailAccount(mockDb, {
+      id: "ea-1",
+      userId: "user-1",
+      provider: "gmail",
+      email: "test@gmail.com",
+      lastFetchedAt: null,
+      createdAt: "2026-03-05T10:00:00Z",
+    });
+
+    expect(mockInsert).toHaveBeenCalled();
+    expect(mockValues).toHaveBeenCalledWith({
+      id: "ea-1",
+      userId: "user-1",
+      provider: "gmail",
+      email: "test@gmail.com",
+      lastFetchedAt: null,
+      createdAt: "2026-03-05T10:00:00Z",
+    });
+  });
+
+  it("getEmailAccounts returns accounts for userId", async () => {
+    const mockRows = [{ id: "ea-1", userId: "user-1", provider: "gmail", email: "test@gmail.com" }];
+    mockWhere.mockResolvedValueOnce(mockRows);
+
+    const { getEmailAccounts } = await import("@/features/email-capture/lib/repository");
+    const result = await getEmailAccounts(mockDb, "user-1");
+
+    expect(mockSelect).toHaveBeenCalled();
+    expect(mockFrom).toHaveBeenCalled();
+    expect(mockWhere).toHaveBeenCalled();
+    expect(result).toEqual(mockRows);
+  });
+
+  it("deleteEmailAccount deletes by id", async () => {
+    const { deleteEmailAccount } = await import("@/features/email-capture/lib/repository");
+
+    await deleteEmailAccount(mockDb, "ea-1");
+
+    expect(mockDelete).toHaveBeenCalled();
+    expect(mockDeleteWhere).toHaveBeenCalled();
+  });
+
+  it("updateLastFetchedAt updates the timestamp", async () => {
+    const { updateLastFetchedAt } = await import("@/features/email-capture/lib/repository");
+
+    await updateLastFetchedAt(mockDb, "ea-1", "2026-03-05T12:00:00Z");
+
+    expect(mockUpdate).toHaveBeenCalled();
+    expect(mockSet).toHaveBeenCalledWith({ lastFetchedAt: "2026-03-05T12:00:00Z" });
+    expect(mockUpdateWhere).toHaveBeenCalled();
+  });
+
+  it("insertProcessedEmail calls db.insert", async () => {
+    const { insertProcessedEmail } = await import("@/features/email-capture/lib/repository");
+
+    await insertProcessedEmail(mockDb, {
+      id: "pe-1",
+      externalId: "msg-123",
+      provider: "gmail",
+      status: "success",
+      failureReason: null,
+      subject: "Compra aprobada",
+      rawBodyPreview: "Su compra...",
+      receivedAt: "2026-03-05T10:00:00Z",
+      transactionId: "tx-1",
+      createdAt: "2026-03-05T10:00:00Z",
+    });
+
+    expect(mockInsert).toHaveBeenCalled();
+    expect(mockValues).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "pe-1", externalId: "msg-123", status: "success" })
+    );
+  });
+
+  it("getProcessedEmailByExternalId returns matching row", async () => {
+    const mockRow = { id: "pe-1", externalId: "msg-123", status: "success" };
+    mockWhere.mockResolvedValueOnce([mockRow]);
+
+    const { getProcessedEmailByExternalId } = await import(
+      "@/features/email-capture/lib/repository"
+    );
+    const result = await getProcessedEmailByExternalId(mockDb, "msg-123");
+
+    expect(result).toEqual(mockRow);
+  });
+
+  it("getProcessedEmailByExternalId returns null when not found", async () => {
+    mockWhere.mockResolvedValueOnce([]);
+
+    const { getProcessedEmailByExternalId } = await import(
+      "@/features/email-capture/lib/repository"
+    );
+    const result = await getProcessedEmailByExternalId(mockDb, "nonexistent");
+
+    expect(result).toBeNull();
+  });
+
+  it("getFailedEmails returns emails with failed status", async () => {
+    const mockRows = [{ id: "pe-1", status: "failed", subject: "Could not parse" }];
+    mockWhere.mockReturnValueOnce({ orderBy: mockOrderBy });
+    mockOrderBy.mockResolvedValueOnce(mockRows);
+
+    const { getFailedEmails } = await import("@/features/email-capture/lib/repository");
+    const result = await getFailedEmails(mockDb);
+
+    expect(mockSelect).toHaveBeenCalled();
+    expect(result).toEqual(mockRows);
+  });
+
+  it("dismissProcessedEmail deletes by id", async () => {
+    const { dismissProcessedEmail } = await import("@/features/email-capture/lib/repository");
+
+    await dismissProcessedEmail(mockDb, "pe-1");
+
+    expect(mockDelete).toHaveBeenCalled();
+    expect(mockDeleteWhere).toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/features/email-capture/lib/repository", () => ({
+  getEmailAccounts: vi.fn().mockResolvedValue([]),
+  insertEmailAccount: vi.fn(),
+  deleteEmailAccount: vi.fn(),
+  getFailedEmails: vi.fn().mockResolvedValue([]),
+  dismissProcessedEmail: vi.fn(),
+}));
+
+import {
+  deleteEmailAccount,
+  dismissProcessedEmail,
+  getEmailAccounts,
+  getFailedEmails,
+} from "@/features/email-capture/lib/repository";
+import { useEmailCaptureStore } from "@/features/email-capture/store";
+
+// biome-ignore lint/suspicious/noExplicitAny: mock db needs flexible typing
+const mockDb = {} as any;
+const mockUserId = "user-1";
+
+describe("useEmailCaptureStore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useEmailCaptureStore.getState().initStore(mockDb, mockUserId);
+    useEmailCaptureStore.setState({
+      accounts: [],
+      failedEmails: [],
+      failedCount: 0,
+      isFetching: false,
+      bannerDismissed: false,
+    });
+  });
+
+  it("starts with empty state", () => {
+    const state = useEmailCaptureStore.getState();
+    expect(state.accounts).toEqual([]);
+    expect(state.failedEmails).toEqual([]);
+    expect(state.failedCount).toBe(0);
+    expect(state.isFetching).toBe(false);
+    expect(state.bannerDismissed).toBe(false);
+  });
+
+  it("loadAccounts fetches from DB and sets state", async () => {
+    const mockAccounts = [
+      {
+        id: "ea-1",
+        userId: mockUserId,
+        provider: "gmail",
+        email: "test@gmail.com",
+        lastFetchedAt: null,
+        createdAt: "2026-03-05T10:00:00Z",
+      },
+    ];
+    vi.mocked(getEmailAccounts).mockResolvedValueOnce(mockAccounts);
+
+    await useEmailCaptureStore.getState().loadAccounts();
+
+    expect(getEmailAccounts).toHaveBeenCalledWith(mockDb, mockUserId);
+    expect(useEmailCaptureStore.getState().accounts).toEqual(mockAccounts);
+  });
+
+  it("loadFailedEmails fetches from DB and sets state", async () => {
+    const mockFailed = [
+      {
+        id: "pe-1",
+        externalId: "msg-1",
+        provider: "gmail",
+        status: "failed",
+        failureReason: "parse error",
+        subject: "Compra",
+        rawBodyPreview: null,
+        receivedAt: "2026-03-05T10:00:00Z",
+        transactionId: null,
+        createdAt: "2026-03-05T10:00:00Z",
+      },
+    ];
+    vi.mocked(getFailedEmails).mockResolvedValueOnce(mockFailed);
+
+    await useEmailCaptureStore.getState().loadFailedEmails();
+
+    expect(getFailedEmails).toHaveBeenCalledWith(mockDb);
+    expect(useEmailCaptureStore.getState().failedEmails).toEqual(mockFailed);
+    expect(useEmailCaptureStore.getState().failedCount).toBe(1);
+  });
+
+  it("dismissBanner sets bannerDismissed to true", () => {
+    useEmailCaptureStore.getState().dismissBanner();
+    expect(useEmailCaptureStore.getState().bannerDismissed).toBe(true);
+  });
+
+  it("dismissFailedEmail removes from DB and state", async () => {
+    useEmailCaptureStore.setState({
+      failedEmails: [
+        {
+          id: "pe-1",
+          externalId: "msg-1",
+          provider: "gmail",
+          status: "failed",
+          failureReason: null,
+          subject: "Test",
+          rawBodyPreview: null,
+          receivedAt: "2026-03-05T10:00:00Z",
+          transactionId: null,
+          createdAt: "2026-03-05T10:00:00Z",
+        },
+      ],
+      failedCount: 1,
+    });
+
+    await useEmailCaptureStore.getState().dismissFailedEmail("pe-1");
+
+    expect(dismissProcessedEmail).toHaveBeenCalledWith(mockDb, "pe-1");
+    expect(useEmailCaptureStore.getState().failedEmails).toHaveLength(0);
+    expect(useEmailCaptureStore.getState().failedCount).toBe(0);
+  });
+
+  it("disconnectEmail removes from DB and state", async () => {
+    useEmailCaptureStore.setState({
+      accounts: [
+        {
+          id: "ea-1",
+          userId: mockUserId,
+          provider: "gmail",
+          email: "test@gmail.com",
+          lastFetchedAt: null,
+          createdAt: "2026-03-05T10:00:00Z",
+        },
+      ],
+    });
+
+    await useEmailCaptureStore.getState().disconnectEmail("ea-1");
+
+    expect(deleteEmailAccount).toHaveBeenCalledWith(mockDb, "ea-1");
+    expect(useEmailCaptureStore.getState().accounts).toHaveLength(0);
+  });
+});

--- a/apps/mobile/features/email-capture/lib/repository.ts
+++ b/apps/mobile/features/email-capture/lib/repository.ts
@@ -1,0 +1,46 @@
+import { desc, eq } from "drizzle-orm";
+import type { AnyDb } from "@/shared/db/client";
+import { emailAccounts, processedEmails } from "@/shared/db/schema";
+
+export type EmailAccountRow = typeof emailAccounts.$inferInsert;
+export type ProcessedEmailRow = typeof processedEmails.$inferInsert;
+
+export async function insertEmailAccount(db: AnyDb, row: EmailAccountRow) {
+  await db.insert(emailAccounts).values(row);
+}
+
+export async function getEmailAccounts(db: AnyDb, userId: string) {
+  return db.select().from(emailAccounts).where(eq(emailAccounts.userId, userId));
+}
+
+export async function deleteEmailAccount(db: AnyDb, id: string) {
+  await db.delete(emailAccounts).where(eq(emailAccounts.id, id));
+}
+
+export async function updateLastFetchedAt(db: AnyDb, id: string, timestamp: string) {
+  await db.update(emailAccounts).set({ lastFetchedAt: timestamp }).where(eq(emailAccounts.id, id));
+}
+
+export async function insertProcessedEmail(db: AnyDb, row: ProcessedEmailRow) {
+  await db.insert(processedEmails).values(row);
+}
+
+export async function getProcessedEmailByExternalId(db: AnyDb, externalId: string) {
+  const rows = await db
+    .select()
+    .from(processedEmails)
+    .where(eq(processedEmails.externalId, externalId));
+  return rows[0] ?? null;
+}
+
+export async function getFailedEmails(db: AnyDb) {
+  return db
+    .select()
+    .from(processedEmails)
+    .where(eq(processedEmails.status, "failed"))
+    .orderBy(desc(processedEmails.receivedAt));
+}
+
+export async function dismissProcessedEmail(db: AnyDb, id: string) {
+  await db.delete(processedEmails).where(eq(processedEmails.id, id));
+}

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -1,0 +1,76 @@
+import { create } from "zustand";
+import type { AnyDb } from "@/shared/db/client";
+import type { EmailAccountRow, ProcessedEmailRow } from "./lib/repository";
+import {
+  deleteEmailAccount,
+  dismissProcessedEmail,
+  getEmailAccounts,
+  getFailedEmails,
+} from "./lib/repository";
+
+let dbRef: AnyDb | null = null;
+let userIdRef: string | null = null;
+
+type EmailCaptureState = {
+  accounts: EmailAccountRow[];
+  failedEmails: ProcessedEmailRow[];
+  failedCount: number;
+  isFetching: boolean;
+  bannerDismissed: boolean;
+};
+
+type EmailCaptureActions = {
+  initStore: (db: AnyDb, userId: string) => void;
+  loadAccounts: () => Promise<void>;
+  loadFailedEmails: () => Promise<void>;
+  dismissBanner: () => void;
+  dismissFailedEmail: (id: string) => Promise<void>;
+  connectEmail: () => void;
+  disconnectEmail: (id: string) => Promise<void>;
+};
+
+export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActions>((set, get) => ({
+  accounts: [],
+  failedEmails: [],
+  failedCount: 0,
+  isFetching: false,
+  bannerDismissed: false,
+
+  initStore: (db, userId) => {
+    dbRef = db;
+    userIdRef = userId;
+  },
+
+  loadAccounts: async () => {
+    if (!dbRef || !userIdRef) return;
+    const accounts = await getEmailAccounts(dbRef, userIdRef);
+    set({ accounts });
+  },
+
+  loadFailedEmails: async () => {
+    if (!dbRef) return;
+    const failedEmails = await getFailedEmails(dbRef);
+    set({ failedEmails, failedCount: failedEmails.length });
+  },
+
+  dismissBanner: () => set({ bannerDismissed: true }),
+
+  dismissFailedEmail: async (id) => {
+    if (!dbRef) return;
+    await dismissProcessedEmail(dbRef, id);
+    const updated = get().failedEmails.filter((e) => e.id !== id);
+    set({ failedEmails: updated, failedCount: updated.length });
+  },
+
+  connectEmail: () => {
+    // Stub — will be implemented when OAuth flow is added
+  },
+
+  disconnectEmail: async (id) => {
+    if (!dbRef) return;
+    await deleteEmailAccount(dbRef, id);
+    set((state) => ({
+      accounts: state.accounts.filter((a) => a.id !== id),
+    }));
+  },
+}));


### PR DESCRIPTION
- Zustand store with accounts, failedEmails state
- Actions: load, dismiss, connect/disconnect
- TDD: 6 tests for store behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the email capture data layer for mobile: a Drizzle repository and a Zustand store to manage linked email accounts and failed emails. Supports fetching/dismissing failed items and disconnecting accounts; connect flow is stubbed.

- **New Features**
  - Repository: CRUD for email_accounts and processed_emails; helpers updateLastFetchedAt, getProcessedEmailByExternalId, getFailedEmails, dismissProcessedEmail.
  - Store: state for accounts, failedEmails, failedCount, isFetching, bannerDismissed; actions initStore, loadAccounts, loadFailedEmails, dismissBanner, dismissFailedEmail, disconnectEmail; connectEmail is a stub.
  - Tests: unit tests for repository and store behaviors.

<sup>Written for commit a3aba48392bb91efea323423f90706685dbf4610. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

