### PR TITLE
feat(mobile): add OAuth email adapters

### DIFF
--- a/apps/mobile/__tests__/calendar/calendar-utils.test.ts
+++ b/apps/mobile/__tests__/calendar/calendar-utils.test.ts
@@ -143,6 +143,12 @@ describe("getBillsForDate", () => {
     expect(getBillsForDate([bill], new Date(2026, 3, 22))).toEqual([]);
   });
 
+  test("excludes bill with unknown frequency", () => {
+    // biome-ignore lint/suspicious/noExplicitAny: testing unknown frequency branch
+    const bill = makeBill({ frequency: "unknown" as any });
+    expect(getBillsForDate([bill], new Date(2026, 0, 15))).toEqual([]);
+  });
+
   // BUG 1a: monthly bill starting Jan 31 should match Apr 30 (last valid day)
   test("monthly bill day-31 matches on Apr 30 (day overflow clamped)", () => {
     const bill = makeBill({ startDate: new Date(2025, 0, 31) }); // Jan 31

--- a/apps/mobile/__tests__/email-capture/gmail-adapter.test.ts
+++ b/apps/mobile/__tests__/email-capture/gmail-adapter.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetItemAsync = vi.fn();
+const mockSetItemAsync = vi.fn();
+const mockDeleteItemAsync = vi.fn();
+
+vi.mock("expo-secure-store", () => ({
+  getItemAsync: (...args: unknown[]) => mockGetItemAsync(...args),
+  setItemAsync: (...args: unknown[]) => mockSetItemAsync(...args),
+  deleteItemAsync: (...args: unknown[]) => mockDeleteItemAsync(...args),
+}));
+
+const mockOpenAuthSession = vi.fn();
+
+vi.mock("expo-web-browser", () => ({
+  openAuthSessionAsync: (...args: unknown[]) => mockOpenAuthSession(...args),
+}));
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+import {
+  connectGmail,
+  disconnectGmail,
+  fetchGmailEmails,
+  isGmailConnected,
+} from "@/features/email-capture/services/gmail-adapter";
+
+describe("gmail adapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("isGmailConnected", () => {
+    it("returns true when token exists", async () => {
+      mockGetItemAsync.mockResolvedValueOnce("access-token");
+      expect(await isGmailConnected()).toBe(true);
+      expect(mockGetItemAsync).toHaveBeenCalledWith("email-gmail-token");
+    });
+
+    it("returns false when no token", async () => {
+      mockGetItemAsync.mockResolvedValueOnce(null);
+      expect(await isGmailConnected()).toBe(false);
+    });
+  });
+
+  describe("connectGmail", () => {
+    it("returns email on successful OAuth flow", async () => {
+      mockOpenAuthSession.mockResolvedValueOnce({
+        type: "success",
+        url: "fidy://email/callback?code=auth-code",
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            access_token: "gmail-access",
+            refresh_token: "gmail-refresh",
+          }),
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ emailAddress: "user@gmail.com" }),
+      });
+
+      const result = await connectGmail("test-client-id");
+      expect(result).toEqual({ success: true, email: "user@gmail.com" });
+      expect(mockSetItemAsync).toHaveBeenCalledWith("email-gmail-token", "gmail-access");
+      expect(mockSetItemAsync).toHaveBeenCalledWith("email-gmail-refresh-token", "gmail-refresh");
+    });
+
+    it("returns error when user dismisses browser", async () => {
+      mockOpenAuthSession.mockResolvedValueOnce({ type: "dismiss" });
+
+      const result = await connectGmail("test-client-id");
+      expect(result).toEqual({ success: false, error: "cancelled" });
+    });
+
+    it("returns error when token exchange fails", async () => {
+      mockOpenAuthSession.mockResolvedValueOnce({
+        type: "success",
+        url: "fidy://email/callback?code=auth-code",
+      });
+
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 400 });
+
+      const result = await connectGmail("test-client-id");
+      expect(result).toEqual({ success: false, error: "token_exchange_failed" });
+    });
+  });
+
+  describe("disconnectGmail", () => {
+    it("deletes tokens from secure store", async () => {
+      await disconnectGmail();
+      expect(mockDeleteItemAsync).toHaveBeenCalledWith("email-gmail-token");
+      expect(mockDeleteItemAsync).toHaveBeenCalledWith("email-gmail-refresh-token");
+    });
+  });
+
+  describe("fetchGmailEmails", () => {
+    it("fetches and maps emails to RawEmail format", async () => {
+      mockGetItemAsync.mockResolvedValueOnce("access-token");
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ messages: [{ id: "msg-1" }] }),
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            id: "msg-1",
+            payload: {
+              headers: [
+                { name: "From", value: "bank@example.com" },
+                { name: "Subject", value: "Transaction Alert" },
+                { name: "Date", value: "Thu, 05 Mar 2026 10:00:00 +0000" },
+              ],
+              parts: [{ mimeType: "text/plain", body: { data: "SGVsbG8gV29ybGQ" } }],
+            },
+          }),
+      });
+
+      const emails = await fetchGmailEmails("2026-03-01T00:00:00Z", ["bank@example.com"]);
+
+      expect(emails).toHaveLength(1);
+      expect(emails[0]).toMatchObject({
+        externalId: "msg-1",
+        from: "bank@example.com",
+        subject: "Transaction Alert",
+        provider: "gmail",
+      });
+    });
+
+    it("returns empty array when no messages found", async () => {
+      mockGetItemAsync.mockResolvedValueOnce("access-token");
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      const emails = await fetchGmailEmails("2026-03-01T00:00:00Z", ["bank@example.com"]);
+      expect(emails).toEqual([]);
+    });
+
+    it("returns empty array when not connected", async () => {
+      mockGetItemAsync.mockResolvedValueOnce(null);
+
+      const emails = await fetchGmailEmails("2026-03-01T00:00:00Z", ["bank@example.com"]);
+      expect(emails).toEqual([]);
+    });
+  });
+});

--- a/apps/mobile/__tests__/email-capture/gmail-adapter.test.ts
+++ b/apps/mobile/__tests__/email-capture/gmail-adapter.test.ts
@@ -26,6 +26,8 @@ import {
   isGmailConnected,
 } from "@/features/email-capture/services/gmail-adapter";
 
+const CLIENT_ID = "test-client-id";
+
 describe("gmail adapter", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -65,7 +67,7 @@ describe("gmail adapter", () => {
         json: () => Promise.resolve({ emailAddress: "user@gmail.com" }),
       });
 
-      const result = await connectGmail("test-client-id");
+      const result = await connectGmail(CLIENT_ID);
       expect(result).toEqual({ success: true, email: "user@gmail.com" });
       expect(mockSetItemAsync).toHaveBeenCalledWith("email-gmail-token", "gmail-access");
       expect(mockSetItemAsync).toHaveBeenCalledWith("email-gmail-refresh-token", "gmail-refresh");
@@ -74,7 +76,7 @@ describe("gmail adapter", () => {
     it("returns error when user dismisses browser", async () => {
       mockOpenAuthSession.mockResolvedValueOnce({ type: "dismiss" });
 
-      const result = await connectGmail("test-client-id");
+      const result = await connectGmail(CLIENT_ID);
       expect(result).toEqual({ success: false, error: "cancelled" });
     });
 
@@ -86,7 +88,7 @@ describe("gmail adapter", () => {
 
       mockFetch.mockResolvedValueOnce({ ok: false, status: 400 });
 
-      const result = await connectGmail("test-client-id");
+      const result = await connectGmail(CLIENT_ID);
       expect(result).toEqual({ success: false, error: "token_exchange_failed" });
     });
   });
@@ -101,7 +103,9 @@ describe("gmail adapter", () => {
 
   describe("fetchGmailEmails", () => {
     it("fetches and maps emails to RawEmail format", async () => {
+      // getValidToken: getItemAsync returns token, profile check succeeds
       mockGetItemAsync.mockResolvedValueOnce("access-token");
+      mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -124,7 +128,9 @@ describe("gmail adapter", () => {
           }),
       });
 
-      const emails = await fetchGmailEmails("2026-03-01T00:00:00Z", ["bank@example.com"]);
+      const emails = await fetchGmailEmails(CLIENT_ID, "2026-03-01T00:00:00Z", [
+        "bank@example.com",
+      ]);
 
       expect(emails).toHaveLength(1);
       expect(emails[0]).toMatchObject({
@@ -135,22 +141,144 @@ describe("gmail adapter", () => {
       });
     });
 
+    it("refreshes expired token and retries", async () => {
+      // getValidToken: token exists but profile check fails (expired)
+      mockGetItemAsync.mockResolvedValueOnce("expired-token");
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 401 });
+      // refresh token exists
+      mockGetItemAsync.mockResolvedValueOnce("refresh-token");
+      // refresh succeeds
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ access_token: "new-token" }),
+      });
+
+      // list messages
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ messages: [{ id: "msg-1" }] }),
+      });
+
+      // get message
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            id: "msg-1",
+            payload: {
+              headers: [
+                { name: "From", value: "bank@example.com" },
+                { name: "Subject", value: "Alerta" },
+                { name: "Date", value: "Thu, 05 Mar 2026 10:00:00 +0000" },
+              ],
+              parts: [{ mimeType: "text/plain", body: { data: "dGVzdA" } }],
+            },
+          }),
+      });
+
+      const emails = await fetchGmailEmails(CLIENT_ID, "2026-03-01T00:00:00Z", [
+        "bank@example.com",
+      ]);
+
+      expect(emails).toHaveLength(1);
+      expect(mockSetItemAsync).toHaveBeenCalledWith("email-gmail-token", "new-token");
+    });
+
+    it("decodes UTF-8 body correctly", async () => {
+      mockGetItemAsync.mockResolvedValueOnce("access-token");
+      mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+
+      // "Compra aprobada por $50.000 en ÉXITO" in base64url
+      const utf8Text = "Compra aprobada por $50.000 en ÉXITO";
+      const encoded = Buffer.from(utf8Text, "utf-8")
+        .toString("base64")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ messages: [{ id: "msg-utf8" }] }),
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            id: "msg-utf8",
+            payload: {
+              headers: [
+                { name: "From", value: "bank@example.com" },
+                { name: "Subject", value: "Compra" },
+                { name: "Date", value: "Thu, 05 Mar 2026 10:00:00 +0000" },
+              ],
+              parts: [{ mimeType: "text/plain", body: { data: encoded } }],
+            },
+          }),
+      });
+
+      const emails = await fetchGmailEmails(CLIENT_ID, "2026-03-01T00:00:00Z", [
+        "bank@example.com",
+      ]);
+
+      expect(emails[0].body).toBe(utf8Text);
+    });
+
+    it("handles invalid date header gracefully", async () => {
+      mockGetItemAsync.mockResolvedValueOnce("access-token");
+      mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ messages: [{ id: "msg-bad-date" }] }),
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            id: "msg-bad-date",
+            payload: {
+              headers: [
+                { name: "From", value: "bank@example.com" },
+                { name: "Subject", value: "Alert" },
+                { name: "Date", value: "not-a-date" },
+              ],
+              parts: [{ mimeType: "text/plain", body: { data: "dGVzdA" } }],
+            },
+          }),
+      });
+
+      const emails = await fetchGmailEmails(CLIENT_ID, "2026-03-01T00:00:00Z", [
+        "bank@example.com",
+      ]);
+
+      expect(emails).toHaveLength(1);
+      expect(emails[0].receivedAt).toBeDefined();
+      expect(() => new Date(emails[0].receivedAt)).not.toThrow();
+    });
+
     it("returns empty array when no messages found", async () => {
       mockGetItemAsync.mockResolvedValueOnce("access-token");
+      mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({}),
       });
 
-      const emails = await fetchGmailEmails("2026-03-01T00:00:00Z", ["bank@example.com"]);
+      const emails = await fetchGmailEmails(CLIENT_ID, "2026-03-01T00:00:00Z", [
+        "bank@example.com",
+      ]);
       expect(emails).toEqual([]);
     });
 
     it("returns empty array when not connected", async () => {
       mockGetItemAsync.mockResolvedValueOnce(null);
 
-      const emails = await fetchGmailEmails("2026-03-01T00:00:00Z", ["bank@example.com"]);
+      const emails = await fetchGmailEmails(CLIENT_ID, "2026-03-01T00:00:00Z", [
+        "bank@example.com",
+      ]);
       expect(emails).toEqual([]);
     });
   });

--- a/apps/mobile/__tests__/email-capture/gmail-adapter.test.ts
+++ b/apps/mobile/__tests__/email-capture/gmail-adapter.test.ts
@@ -141,16 +141,16 @@ describe("gmail adapter", () => {
       });
     });
 
-    it("refreshes expired token and retries", async () => {
+    it("refreshes expired token and persists rotated refresh token", async () => {
       // getValidToken: token exists but profile check fails (expired)
       mockGetItemAsync.mockResolvedValueOnce("expired-token");
       mockFetch.mockResolvedValueOnce({ ok: false, status: 401 });
       // refresh token exists
       mockGetItemAsync.mockResolvedValueOnce("refresh-token");
-      // refresh succeeds
+      // refresh succeeds with rotated refresh token
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve({ access_token: "new-token" }),
+        json: () => Promise.resolve({ access_token: "new-token", refresh_token: "new-refresh" }),
       });
 
       // list messages
@@ -182,6 +182,7 @@ describe("gmail adapter", () => {
 
       expect(emails).toHaveLength(1);
       expect(mockSetItemAsync).toHaveBeenCalledWith("email-gmail-token", "new-token");
+      expect(mockSetItemAsync).toHaveBeenCalledWith("email-gmail-refresh-token", "new-refresh");
     });
 
     it("decodes UTF-8 body correctly", async () => {

--- a/apps/mobile/__tests__/email-capture/outlook-adapter.test.ts
+++ b/apps/mobile/__tests__/email-capture/outlook-adapter.test.ts
@@ -187,16 +187,16 @@ describe("outlook adapter", () => {
       });
     });
 
-    it("refreshes expired token and retries", async () => {
+    it("refreshes expired token and persists rotated refresh token", async () => {
       // getValidToken: token exists but profile check fails
       mockGetItemAsync.mockResolvedValueOnce("expired-token");
       mockFetch.mockResolvedValueOnce({ ok: false, status: 401 });
       // refresh token exists
       mockGetItemAsync.mockResolvedValueOnce("refresh-token");
-      // refresh succeeds
+      // refresh succeeds with rotated refresh token
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve({ access_token: "new-token" }),
+        json: () => Promise.resolve({ access_token: "new-token", refresh_token: "new-refresh" }),
       });
 
       mockFetch.mockResolvedValueOnce({
@@ -221,6 +221,7 @@ describe("outlook adapter", () => {
 
       expect(emails).toHaveLength(1);
       expect(mockSetItemAsync).toHaveBeenCalledWith("email-outlook-token", "new-token");
+      expect(mockSetItemAsync).toHaveBeenCalledWith("email-outlook-refresh-token", "new-refresh");
     });
 
     it("returns empty array when no messages found", async () => {

--- a/apps/mobile/__tests__/email-capture/outlook-adapter.test.ts
+++ b/apps/mobile/__tests__/email-capture/outlook-adapter.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetItemAsync = vi.fn();
+const mockSetItemAsync = vi.fn();
+const mockDeleteItemAsync = vi.fn();
+
+vi.mock("expo-secure-store", () => ({
+  getItemAsync: (...args: unknown[]) => mockGetItemAsync(...args),
+  setItemAsync: (...args: unknown[]) => mockSetItemAsync(...args),
+  deleteItemAsync: (...args: unknown[]) => mockDeleteItemAsync(...args),
+}));
+
+const mockOpenAuthSession = vi.fn();
+
+vi.mock("expo-web-browser", () => ({
+  openAuthSessionAsync: (...args: unknown[]) => mockOpenAuthSession(...args),
+}));
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+import {
+  connectOutlook,
+  disconnectOutlook,
+  fetchOutlookEmails,
+  isOutlookConnected,
+} from "@/features/email-capture/services/outlook-adapter";
+
+describe("outlook adapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("isOutlookConnected", () => {
+    it("returns true when token exists", async () => {
+      mockGetItemAsync.mockResolvedValueOnce("access-token");
+      expect(await isOutlookConnected()).toBe(true);
+      expect(mockGetItemAsync).toHaveBeenCalledWith("email-outlook-token");
+    });
+
+    it("returns false when no token", async () => {
+      mockGetItemAsync.mockResolvedValueOnce(null);
+      expect(await isOutlookConnected()).toBe(false);
+    });
+  });
+
+  describe("connectOutlook", () => {
+    it("returns email on successful OAuth flow", async () => {
+      mockOpenAuthSession.mockResolvedValueOnce({
+        type: "success",
+        url: "fidy://email/callback?code=auth-code",
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            access_token: "outlook-access",
+            refresh_token: "outlook-refresh",
+          }),
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ mail: "user@outlook.com" }),
+      });
+
+      const result = await connectOutlook("test-client-id");
+      expect(result).toEqual({ success: true, email: "user@outlook.com" });
+      expect(mockSetItemAsync).toHaveBeenCalledWith("email-outlook-token", "outlook-access");
+      expect(mockSetItemAsync).toHaveBeenCalledWith(
+        "email-outlook-refresh-token",
+        "outlook-refresh"
+      );
+    });
+
+    it("returns error when user dismisses browser", async () => {
+      mockOpenAuthSession.mockResolvedValueOnce({ type: "dismiss" });
+
+      const result = await connectOutlook("test-client-id");
+      expect(result).toEqual({ success: false, error: "cancelled" });
+    });
+
+    it("returns error when token exchange fails", async () => {
+      mockOpenAuthSession.mockResolvedValueOnce({
+        type: "success",
+        url: "fidy://email/callback?code=auth-code",
+      });
+
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 400 });
+
+      const result = await connectOutlook("test-client-id");
+      expect(result).toEqual({ success: false, error: "token_exchange_failed" });
+    });
+  });
+
+  describe("disconnectOutlook", () => {
+    it("deletes tokens from secure store", async () => {
+      await disconnectOutlook();
+      expect(mockDeleteItemAsync).toHaveBeenCalledWith("email-outlook-token");
+      expect(mockDeleteItemAsync).toHaveBeenCalledWith("email-outlook-refresh-token");
+    });
+  });
+
+  describe("fetchOutlookEmails", () => {
+    it("fetches and maps emails to RawEmail format", async () => {
+      mockGetItemAsync.mockResolvedValueOnce("access-token");
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            value: [
+              {
+                id: "msg-1",
+                subject: "Transaction Alert",
+                from: { emailAddress: { address: "bank@example.com" } },
+                body: { content: "Your purchase of $50,000" },
+                receivedDateTime: "2026-03-05T10:00:00Z",
+              },
+            ],
+          }),
+      });
+
+      const emails = await fetchOutlookEmails("2026-03-01T00:00:00Z", ["bank@example.com"]);
+
+      expect(emails).toHaveLength(1);
+      expect(emails[0]).toMatchObject({
+        externalId: "msg-1",
+        from: "bank@example.com",
+        subject: "Transaction Alert",
+        provider: "outlook",
+      });
+    });
+
+    it("returns empty array when no messages found", async () => {
+      mockGetItemAsync.mockResolvedValueOnce("access-token");
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ value: [] }),
+      });
+
+      const emails = await fetchOutlookEmails("2026-03-01T00:00:00Z", ["bank@example.com"]);
+      expect(emails).toEqual([]);
+    });
+
+    it("returns empty array when not connected", async () => {
+      mockGetItemAsync.mockResolvedValueOnce(null);
+
+      const emails = await fetchOutlookEmails("2026-03-01T00:00:00Z", ["bank@example.com"]);
+      expect(emails).toEqual([]);
+    });
+  });
+});

--- a/apps/mobile/__tests__/email-capture/outlook-adapter.test.ts
+++ b/apps/mobile/__tests__/email-capture/outlook-adapter.test.ts
@@ -26,6 +26,8 @@ import {
   isOutlookConnected,
 } from "@/features/email-capture/services/outlook-adapter";
 
+const CLIENT_ID = "test-client-id";
+
 describe("outlook adapter", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -65,7 +67,7 @@ describe("outlook adapter", () => {
         json: () => Promise.resolve({ mail: "user@outlook.com" }),
       });
 
-      const result = await connectOutlook("test-client-id");
+      const result = await connectOutlook(CLIENT_ID);
       expect(result).toEqual({ success: true, email: "user@outlook.com" });
       expect(mockSetItemAsync).toHaveBeenCalledWith("email-outlook-token", "outlook-access");
       expect(mockSetItemAsync).toHaveBeenCalledWith(
@@ -74,10 +76,58 @@ describe("outlook adapter", () => {
       );
     });
 
+    it("falls back to userPrincipalName when mail is null", async () => {
+      mockOpenAuthSession.mockResolvedValueOnce({
+        type: "success",
+        url: "fidy://email/callback?code=auth-code",
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            access_token: "outlook-access",
+            refresh_token: "outlook-refresh",
+          }),
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ mail: null, userPrincipalName: "user@live.com" }),
+      });
+
+      const result = await connectOutlook(CLIENT_ID);
+      expect(result).toEqual({ success: true, email: "user@live.com" });
+    });
+
+    it("returns error when no email found in profile", async () => {
+      mockOpenAuthSession.mockResolvedValueOnce({
+        type: "success",
+        url: "fidy://email/callback?code=auth-code",
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            access_token: "outlook-access",
+            refresh_token: "outlook-refresh",
+          }),
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ mail: null, userPrincipalName: null }),
+      });
+
+      const result = await connectOutlook(CLIENT_ID);
+      expect(result).toEqual({ success: false, error: "no_email_found" });
+    });
+
     it("returns error when user dismisses browser", async () => {
       mockOpenAuthSession.mockResolvedValueOnce({ type: "dismiss" });
 
-      const result = await connectOutlook("test-client-id");
+      const result = await connectOutlook(CLIENT_ID);
       expect(result).toEqual({ success: false, error: "cancelled" });
     });
 
@@ -89,7 +139,7 @@ describe("outlook adapter", () => {
 
       mockFetch.mockResolvedValueOnce({ ok: false, status: 400 });
 
-      const result = await connectOutlook("test-client-id");
+      const result = await connectOutlook(CLIENT_ID);
       expect(result).toEqual({ success: false, error: "token_exchange_failed" });
     });
   });
@@ -104,7 +154,9 @@ describe("outlook adapter", () => {
 
   describe("fetchOutlookEmails", () => {
     it("fetches and maps emails to RawEmail format", async () => {
+      // getValidToken: token exists, profile check succeeds
       mockGetItemAsync.mockResolvedValueOnce("access-token");
+      mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -122,7 +174,9 @@ describe("outlook adapter", () => {
           }),
       });
 
-      const emails = await fetchOutlookEmails("2026-03-01T00:00:00Z", ["bank@example.com"]);
+      const emails = await fetchOutlookEmails(CLIENT_ID, "2026-03-01T00:00:00Z", [
+        "bank@example.com",
+      ]);
 
       expect(emails).toHaveLength(1);
       expect(emails[0]).toMatchObject({
@@ -133,22 +187,63 @@ describe("outlook adapter", () => {
       });
     });
 
+    it("refreshes expired token and retries", async () => {
+      // getValidToken: token exists but profile check fails
+      mockGetItemAsync.mockResolvedValueOnce("expired-token");
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 401 });
+      // refresh token exists
+      mockGetItemAsync.mockResolvedValueOnce("refresh-token");
+      // refresh succeeds
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ access_token: "new-token" }),
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            value: [
+              {
+                id: "msg-1",
+                subject: "Alerta",
+                from: { emailAddress: { address: "bank@example.com" } },
+                body: { content: "Compra" },
+                receivedDateTime: "2026-03-05T10:00:00Z",
+              },
+            ],
+          }),
+      });
+
+      const emails = await fetchOutlookEmails(CLIENT_ID, "2026-03-01T00:00:00Z", [
+        "bank@example.com",
+      ]);
+
+      expect(emails).toHaveLength(1);
+      expect(mockSetItemAsync).toHaveBeenCalledWith("email-outlook-token", "new-token");
+    });
+
     it("returns empty array when no messages found", async () => {
       mockGetItemAsync.mockResolvedValueOnce("access-token");
+      mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ value: [] }),
       });
 
-      const emails = await fetchOutlookEmails("2026-03-01T00:00:00Z", ["bank@example.com"]);
+      const emails = await fetchOutlookEmails(CLIENT_ID, "2026-03-01T00:00:00Z", [
+        "bank@example.com",
+      ]);
       expect(emails).toEqual([]);
     });
 
     it("returns empty array when not connected", async () => {
       mockGetItemAsync.mockResolvedValueOnce(null);
 
-      const emails = await fetchOutlookEmails("2026-03-01T00:00:00Z", ["bank@example.com"]);
+      const emails = await fetchOutlookEmails(CLIENT_ID, "2026-03-01T00:00:00Z", [
+        "bank@example.com",
+      ]);
       expect(emails).toEqual([]);
     });
   });

--- a/apps/mobile/__tests__/email-capture/repository.test.ts
+++ b/apps/mobile/__tests__/email-capture/repository.test.ts
@@ -59,6 +59,25 @@ describe("email capture repository", () => {
     });
   });
 
+  it("getEmailAccount returns single account by id", async () => {
+    const mockRow = { id: "ea-1", userId: "user-1", provider: "gmail", email: "test@gmail.com" };
+    mockWhere.mockResolvedValueOnce([mockRow]);
+
+    const { getEmailAccount } = await import("@/features/email-capture/lib/repository");
+    const result = await getEmailAccount(mockDb, "ea-1");
+
+    expect(result).toEqual(mockRow);
+  });
+
+  it("getEmailAccount returns null when not found", async () => {
+    mockWhere.mockResolvedValueOnce([]);
+
+    const { getEmailAccount } = await import("@/features/email-capture/lib/repository");
+    const result = await getEmailAccount(mockDb, "nonexistent");
+
+    expect(result).toBeNull();
+  });
+
   it("getEmailAccounts returns accounts for userId", async () => {
     const mockRows = [{ id: "ea-1", userId: "user-1", provider: "gmail", email: "test@gmail.com" }];
     mockWhere.mockResolvedValueOnce(mockRows);

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -8,12 +8,27 @@ vi.mock("@/features/email-capture/lib/repository", () => ({
   dismissProcessedEmail: vi.fn(),
 }));
 
+vi.mock("@/features/email-capture/services/gmail-adapter", () => ({
+  connectGmail: vi.fn(),
+}));
+
+vi.mock("@/features/email-capture/services/outlook-adapter", () => ({
+  connectOutlook: vi.fn(),
+}));
+
+vi.mock("@/shared/lib/generate-id", () => ({
+  generateId: vi.fn(() => "ea-generated"),
+}));
+
 import {
   deleteEmailAccount,
   dismissProcessedEmail,
   getEmailAccounts,
   getFailedEmails,
+  insertEmailAccount,
 } from "@/features/email-capture/lib/repository";
+import { connectGmail } from "@/features/email-capture/services/gmail-adapter";
+import { connectOutlook } from "@/features/email-capture/services/outlook-adapter";
 import { useEmailCaptureStore } from "@/features/email-capture/store";
 
 // biome-ignore lint/suspicious/noExplicitAny: mock db needs flexible typing
@@ -114,6 +129,51 @@ describe("useEmailCaptureStore", () => {
     expect(dismissProcessedEmail).toHaveBeenCalledWith(mockDb, "pe-1");
     expect(useEmailCaptureStore.getState().failedEmails).toHaveLength(0);
     expect(useEmailCaptureStore.getState().failedCount).toBe(0);
+  });
+
+  it("connectEmail calls Gmail adapter and saves account", async () => {
+    vi.mocked(connectGmail).mockResolvedValueOnce({
+      success: true,
+      email: "user@gmail.com",
+    });
+
+    await useEmailCaptureStore.getState().connectEmail("gmail", "client-id");
+
+    expect(connectGmail).toHaveBeenCalledWith("client-id");
+    expect(insertEmailAccount).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        provider: "gmail",
+        email: "user@gmail.com",
+        userId: mockUserId,
+      })
+    );
+    expect(useEmailCaptureStore.getState().accounts).toHaveLength(1);
+  });
+
+  it("connectEmail calls Outlook adapter for outlook provider", async () => {
+    vi.mocked(connectOutlook).mockResolvedValueOnce({
+      success: true,
+      email: "user@outlook.com",
+    });
+
+    await useEmailCaptureStore.getState().connectEmail("outlook", "client-id");
+
+    expect(connectOutlook).toHaveBeenCalledWith("client-id");
+    expect(insertEmailAccount).toHaveBeenCalled();
+    expect(useEmailCaptureStore.getState().accounts).toHaveLength(1);
+  });
+
+  it("connectEmail does not save account on failure", async () => {
+    vi.mocked(connectGmail).mockResolvedValueOnce({
+      success: false,
+      error: "cancelled",
+    });
+
+    await useEmailCaptureStore.getState().connectEmail("gmail", "client-id");
+
+    expect(insertEmailAccount).not.toHaveBeenCalled();
+    expect(useEmailCaptureStore.getState().accounts).toHaveLength(0);
   });
 
   it("disconnectEmail removes from DB and state", async () => {

--- a/apps/mobile/__tests__/transactions/build-transaction.test.ts
+++ b/apps/mobile/__tests__/transactions/build-transaction.test.ts
@@ -48,6 +48,43 @@ describe("buildTransaction", () => {
   });
 });
 
+describe("toStoredTransaction branch coverage", () => {
+  test("handles null description by defaulting to empty string", () => {
+    const row = {
+      id: "tx-nd",
+      userId: "user-1",
+      type: "expense",
+      amountCents: 500,
+      categoryId: "food",
+      description: null,
+      date: "2026-03-01",
+      createdAt: "2026-03-01T10:00:00.000Z",
+      updatedAt: "2026-03-01T10:00:00.000Z",
+      deletedAt: null,
+    };
+    const result = toStoredTransaction(row);
+    expect(result.description).toBe("");
+  });
+
+  test("handles non-null deletedAt by converting to Date", () => {
+    const row = {
+      id: "tx-da",
+      userId: "user-1",
+      type: "expense",
+      amountCents: 500,
+      categoryId: "food",
+      description: "Test",
+      date: "2026-03-01",
+      createdAt: "2026-03-01T10:00:00.000Z",
+      updatedAt: "2026-03-01T10:00:00.000Z",
+      deletedAt: "2026-03-02T10:00:00.000Z",
+    };
+    const result = toStoredTransaction(row);
+    expect(result.deletedAt).toBeInstanceOf(Date);
+    expect(result.deletedAt?.toISOString()).toBe("2026-03-02T10:00:00.000Z");
+  });
+});
+
 describe("toStoredTransaction / toTransactionRow round-trip", () => {
   const stored: StoredTransaction = {
     id: "tx-rt",

--- a/apps/mobile/__tests__/transactions/repository.test.ts
+++ b/apps/mobile/__tests__/transactions/repository.test.ts
@@ -183,6 +183,67 @@ describe("transaction repository", () => {
     expect(result).toBe("2026-03-04T10:00:00.000Z");
   });
 
+  it("getTransactionById returns the row when found", async () => {
+    const mockRow = {
+      id: "tx-1",
+      userId: "user-1",
+      type: "expense",
+      amountCents: 1000,
+      categoryId: "food",
+      description: null,
+      date: "2026-03-04",
+      createdAt: "2026-03-04T10:00:00.000Z",
+      updatedAt: "2026-03-04T10:00:00.000Z",
+      deletedAt: null,
+    };
+    mockWhere.mockResolvedValueOnce([mockRow]);
+
+    const { getTransactionById } = await import("@/features/transactions/lib/repository");
+    const result = await getTransactionById(mockDb, "tx-1");
+
+    expect(mockSelect).toHaveBeenCalled();
+    expect(result).toEqual(mockRow);
+  });
+
+  it("getTransactionById returns null when not found", async () => {
+    mockWhere.mockResolvedValueOnce([]);
+
+    const { getTransactionById } = await import("@/features/transactions/lib/repository");
+    const result = await getTransactionById(mockDb, "tx-nonexistent");
+
+    expect(result).toBeNull();
+  });
+
+  it("upsertTransaction calls insert with onConflictDoUpdate", async () => {
+    const { upsertTransaction } = await import("@/features/transactions/lib/repository");
+
+    const row = {
+      id: "tx-1",
+      userId: "user-1",
+      type: "expense" as const,
+      amountCents: 2000,
+      categoryId: "food",
+      description: "Updated",
+      date: "2026-03-04",
+      createdAt: "2026-03-04T10:00:00.000Z",
+      updatedAt: "2026-03-04T12:00:00.000Z",
+    };
+
+    await upsertTransaction(mockDb, row);
+
+    expect(mockInsert).toHaveBeenCalled();
+    expect(mockValues).toHaveBeenCalledWith(row);
+    expect(mockOnConflictDoUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        set: expect.objectContaining({
+          type: row.type,
+          amountCents: row.amountCents,
+          description: row.description,
+        }),
+      })
+    );
+  });
+
   it("getSyncMeta returns null for missing key", async () => {
     mockWhere.mockResolvedValueOnce([]);
 

--- a/apps/mobile/__tests__/transactions/store.test.ts
+++ b/apps/mobile/__tests__/transactions/store.test.ts
@@ -35,6 +35,14 @@ describe("useTransactionStore", () => {
     });
   });
 
+  it("saveTransaction returns error when store is not initialized", async () => {
+    // Reset module-level refs by creating a fresh store state without initStore
+    // biome-ignore lint/suspicious/noExplicitAny: testing uninitialized store guard
+    useTransactionStore.getState().initStore(null as any, null as any);
+    const result = await useTransactionStore.getState().saveTransaction();
+    expect(result).toEqual({ success: false, error: "Store not initialized" });
+  });
+
   it("starts closed with default form values", () => {
     const state = useTransactionStore.getState();
     expect(state.isOpen).toBe(false);

--- a/apps/mobile/features/email-capture/lib/repository.ts
+++ b/apps/mobile/features/email-capture/lib/repository.ts
@@ -9,6 +9,11 @@ export async function insertEmailAccount(db: AnyDb, row: EmailAccountRow) {
   await db.insert(emailAccounts).values(row);
 }
 
+export async function getEmailAccount(db: AnyDb, id: string) {
+  const rows = await db.select().from(emailAccounts).where(eq(emailAccounts.id, id));
+  return rows[0] ?? null;
+}
+
 export async function getEmailAccounts(db: AnyDb, userId: string) {
   return db.select().from(emailAccounts).where(eq(emailAccounts.userId, userId));
 }

--- a/apps/mobile/features/email-capture/services/gmail-adapter.ts
+++ b/apps/mobile/features/email-capture/services/gmail-adapter.ts
@@ -42,6 +42,9 @@ async function getValidToken(clientId: string): Promise<string | null> {
 
   const data = await refreshResponse.json();
   await SecureStore.setItemAsync(TOKEN_KEY, data.access_token);
+  if (data.refresh_token) {
+    await SecureStore.setItemAsync(REFRESH_TOKEN_KEY, data.refresh_token);
+  }
   return data.access_token;
 }
 

--- a/apps/mobile/features/email-capture/services/gmail-adapter.ts
+++ b/apps/mobile/features/email-capture/services/gmail-adapter.ts
@@ -1,0 +1,173 @@
+import * as SecureStore from "expo-secure-store";
+import type { RawEmail } from "../schema";
+
+const TOKEN_KEY = "email-gmail-token";
+const REFRESH_TOKEN_KEY = "email-gmail-refresh-token";
+const REDIRECT_URI = "fidy://email/callback";
+const AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
+const TOKEN_URL = "https://oauth2.googleapis.com/token";
+const SCOPE = "https://www.googleapis.com/auth/gmail.readonly";
+
+type ConnectResult = { success: true; email: string } | { success: false; error: string };
+
+export async function isGmailConnected(): Promise<boolean> {
+  const token = await SecureStore.getItemAsync(TOKEN_KEY);
+  return token != null;
+}
+
+export async function connectGmail(clientId: string): Promise<ConnectResult> {
+  const { openAuthSessionAsync } = await import("expo-web-browser");
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: REDIRECT_URI,
+    response_type: "code",
+    scope: SCOPE,
+    access_type: "offline",
+    prompt: "consent",
+  });
+
+  const result = await openAuthSessionAsync(`${AUTH_URL}?${params}`, REDIRECT_URI);
+
+  if (result.type !== "success" || !result.url) {
+    return { success: false, error: "cancelled" };
+  }
+
+  const code = new URL(result.url).searchParams.get("code");
+  if (!code) {
+    return { success: false, error: "no_code" };
+  }
+
+  const tokenResponse = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      code,
+      client_id: clientId,
+      redirect_uri: REDIRECT_URI,
+      grant_type: "authorization_code",
+    }).toString(),
+  });
+
+  if (!tokenResponse.ok) {
+    return { success: false, error: "token_exchange_failed" };
+  }
+
+  const tokens = await tokenResponse.json();
+  await SecureStore.setItemAsync(TOKEN_KEY, tokens.access_token);
+  if (tokens.refresh_token) {
+    await SecureStore.setItemAsync(REFRESH_TOKEN_KEY, tokens.refresh_token);
+  }
+
+  const profileResponse = await fetch("https://gmail.googleapis.com/gmail/v1/users/me/profile", {
+    headers: { Authorization: `Bearer ${tokens.access_token}` },
+  });
+
+  if (!profileResponse.ok) {
+    return { success: false, error: "profile_fetch_failed" };
+  }
+
+  const profile = await profileResponse.json();
+  return { success: true, email: profile.emailAddress };
+}
+
+export async function disconnectGmail(): Promise<void> {
+  await SecureStore.deleteItemAsync(TOKEN_KEY);
+  await SecureStore.deleteItemAsync(REFRESH_TOKEN_KEY);
+}
+
+export async function fetchGmailEmails(since: string, senderEmails: string[]): Promise<RawEmail[]> {
+  const token = await SecureStore.getItemAsync(TOKEN_KEY);
+  if (!token) return [];
+
+  const epoch = Math.floor(new Date(since).getTime() / 1000);
+  const fromQuery = senderEmails.map((e) => `from:${e}`).join(" OR ");
+  const query = `(${fromQuery}) after:${epoch}`;
+
+  const listResponse = await fetch(
+    `https://gmail.googleapis.com/gmail/v1/users/me/messages?q=${encodeURIComponent(query)}`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+
+  if (!listResponse.ok) return [];
+
+  const listData = await listResponse.json();
+  const messageIds: string[] = (listData.messages ?? []).map((m: { id: string }) => m.id);
+
+  if (messageIds.length === 0) return [];
+
+  const emails: RawEmail[] = [];
+
+  for (const id of messageIds) {
+    const msgResponse = await fetch(
+      `https://gmail.googleapis.com/gmail/v1/users/me/messages/${id}?format=full`,
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
+
+    if (!msgResponse.ok) continue;
+
+    const msg = await msgResponse.json();
+    const parsed = parseGmailMessage(id, msg);
+    if (parsed) emails.push(parsed);
+  }
+
+  return emails;
+}
+
+type GmailHeader = { name: string; value: string };
+type GmailPart = { mimeType: string; body?: { data?: string }; parts?: GmailPart[] };
+type GmailPayload = { headers: GmailHeader[]; parts?: GmailPart[]; body?: { data?: string } };
+
+function getHeader(headers: GmailHeader[], name: string): string {
+  return headers.find((h) => h.name.toLowerCase() === name.toLowerCase())?.value ?? "";
+}
+
+function extractPlainText(payload: GmailPayload): string {
+  if (payload.body?.data) {
+    return decodeBase64Url(payload.body.data);
+  }
+  if (payload.parts) {
+    for (const part of payload.parts) {
+      if (part.mimeType === "text/plain" && part.body?.data) {
+        return decodeBase64Url(part.body.data);
+      }
+    }
+    for (const part of payload.parts) {
+      if (part.parts) {
+        const nested = extractPlainText({
+          headers: [],
+          parts: part.parts,
+        });
+        if (nested) return nested;
+      }
+    }
+  }
+  return "";
+}
+
+function decodeBase64Url(data: string): string {
+  const base64 = data.replace(/-/g, "+").replace(/_/g, "/");
+  return atob(base64);
+}
+
+function parseGmailMessage(id: string, msg: { payload: GmailPayload }): RawEmail | null {
+  const headers = msg.payload.headers;
+  const from = getHeader(headers, "From");
+  const subject = getHeader(headers, "Subject");
+  const dateStr = getHeader(headers, "Date");
+  const body = extractPlainText(msg.payload);
+
+  if (!from || !subject) return null;
+
+  const emailMatch = from.match(/<(.+?)>/) ?? [null, from];
+  const emailAddress = emailMatch[1] ?? from;
+
+  return {
+    externalId: id,
+    from: emailAddress,
+    subject,
+    body,
+    receivedAt: new Date(dateStr).toISOString(),
+    provider: "gmail",
+  };
+}

--- a/apps/mobile/features/email-capture/services/gmail-adapter.ts
+++ b/apps/mobile/features/email-capture/services/gmail-adapter.ts
@@ -15,6 +15,36 @@ export async function isGmailConnected(): Promise<boolean> {
   return token != null;
 }
 
+async function getValidToken(clientId: string): Promise<string | null> {
+  const token = await SecureStore.getItemAsync(TOKEN_KEY);
+  if (!token) return null;
+
+  const testResponse = await fetch("https://gmail.googleapis.com/gmail/v1/users/me/profile", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (testResponse.ok) return token;
+
+  const refreshToken = await SecureStore.getItemAsync(REFRESH_TOKEN_KEY);
+  if (!refreshToken) return null;
+
+  const refreshResponse = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: clientId,
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }).toString(),
+  });
+
+  if (!refreshResponse.ok) return null;
+
+  const data = await refreshResponse.json();
+  await SecureStore.setItemAsync(TOKEN_KEY, data.access_token);
+  return data.access_token;
+}
+
 export async function connectGmail(clientId: string): Promise<ConnectResult> {
   const { openAuthSessionAsync } = await import("expo-web-browser");
 
@@ -76,8 +106,12 @@ export async function disconnectGmail(): Promise<void> {
   await SecureStore.deleteItemAsync(REFRESH_TOKEN_KEY);
 }
 
-export async function fetchGmailEmails(since: string, senderEmails: string[]): Promise<RawEmail[]> {
-  const token = await SecureStore.getItemAsync(TOKEN_KEY);
+export async function fetchGmailEmails(
+  clientId: string,
+  since: string,
+  senderEmails: string[]
+): Promise<RawEmail[]> {
+  const token = await getValidToken(clientId);
   if (!token) return [];
 
   const epoch = Math.floor(new Date(since).getTime() / 1000);
@@ -147,7 +181,9 @@ function extractPlainText(payload: GmailPayload): string {
 
 function decodeBase64Url(data: string): string {
   const base64 = data.replace(/-/g, "+").replace(/_/g, "/");
-  return atob(base64);
+  const binary = atob(base64);
+  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
 }
 
 function parseGmailMessage(id: string, msg: { payload: GmailPayload }): RawEmail | null {
@@ -162,12 +198,17 @@ function parseGmailMessage(id: string, msg: { payload: GmailPayload }): RawEmail
   const emailMatch = from.match(/<(.+?)>/) ?? [null, from];
   const emailAddress = emailMatch[1] ?? from;
 
+  const parsedDate = new Date(dateStr);
+  const receivedAt = Number.isNaN(parsedDate.getTime())
+    ? new Date().toISOString()
+    : parsedDate.toISOString();
+
   return {
     externalId: id,
     from: emailAddress,
     subject,
     body,
-    receivedAt: new Date(dateStr).toISOString(),
+    receivedAt,
     provider: "gmail",
   };
 }

--- a/apps/mobile/features/email-capture/services/outlook-adapter.ts
+++ b/apps/mobile/features/email-capture/services/outlook-adapter.ts
@@ -1,0 +1,116 @@
+import * as SecureStore from "expo-secure-store";
+import type { RawEmail } from "../schema";
+
+const TOKEN_KEY = "email-outlook-token";
+const REFRESH_TOKEN_KEY = "email-outlook-refresh-token";
+const REDIRECT_URI = "fidy://email/callback";
+const AUTH_URL = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize";
+const TOKEN_URL = "https://login.microsoftonline.com/common/oauth2/v2.0/token";
+const SCOPE = "Mail.Read";
+
+type ConnectResult = { success: true; email: string } | { success: false; error: string };
+
+export async function isOutlookConnected(): Promise<boolean> {
+  const token = await SecureStore.getItemAsync(TOKEN_KEY);
+  return token != null;
+}
+
+export async function connectOutlook(clientId: string): Promise<ConnectResult> {
+  const { openAuthSessionAsync } = await import("expo-web-browser");
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: REDIRECT_URI,
+    response_type: "code",
+    scope: `${SCOPE} User.Read`,
+    prompt: "consent",
+  });
+
+  const result = await openAuthSessionAsync(`${AUTH_URL}?${params}`, REDIRECT_URI);
+
+  if (result.type !== "success" || !result.url) {
+    return { success: false, error: "cancelled" };
+  }
+
+  const code = new URL(result.url).searchParams.get("code");
+  if (!code) {
+    return { success: false, error: "no_code" };
+  }
+
+  const tokenResponse = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      code,
+      client_id: clientId,
+      redirect_uri: REDIRECT_URI,
+      grant_type: "authorization_code",
+      scope: `${SCOPE} User.Read`,
+    }).toString(),
+  });
+
+  if (!tokenResponse.ok) {
+    return { success: false, error: "token_exchange_failed" };
+  }
+
+  const tokens = await tokenResponse.json();
+  await SecureStore.setItemAsync(TOKEN_KEY, tokens.access_token);
+  if (tokens.refresh_token) {
+    await SecureStore.setItemAsync(REFRESH_TOKEN_KEY, tokens.refresh_token);
+  }
+
+  const profileResponse = await fetch("https://graph.microsoft.com/v1.0/me", {
+    headers: { Authorization: `Bearer ${tokens.access_token}` },
+  });
+
+  if (!profileResponse.ok) {
+    return { success: false, error: "profile_fetch_failed" };
+  }
+
+  const profile = await profileResponse.json();
+  return { success: true, email: profile.mail };
+}
+
+export async function disconnectOutlook(): Promise<void> {
+  await SecureStore.deleteItemAsync(TOKEN_KEY);
+  await SecureStore.deleteItemAsync(REFRESH_TOKEN_KEY);
+}
+
+export async function fetchOutlookEmails(
+  since: string,
+  senderEmails: string[]
+): Promise<RawEmail[]> {
+  const token = await SecureStore.getItemAsync(TOKEN_KEY);
+  if (!token) return [];
+
+  const senderFilter = senderEmails.map((e) => `from/emailAddress/address eq '${e}'`).join(" or ");
+  const dateFilter = `receivedDateTime ge ${since}`;
+  const filter = `(${senderFilter}) and ${dateFilter}`;
+
+  const response = await fetch(
+    `https://graph.microsoft.com/v1.0/me/messages?$filter=${encodeURIComponent(filter)}&$select=id,subject,body,from,receivedDateTime`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+
+  if (!response.ok) return [];
+
+  const data = await response.json();
+  const messages: OutlookMessage[] = data.value ?? [];
+
+  return messages.map((msg) => ({
+    externalId: msg.id,
+    from: msg.from.emailAddress.address,
+    subject: msg.subject,
+    body: msg.body.content,
+    receivedAt: msg.receivedDateTime,
+    provider: "outlook" as const,
+  }));
+}
+
+type OutlookMessage = {
+  id: string;
+  subject: string;
+  from: { emailAddress: { address: string } };
+  body: { content: string };
+  receivedDateTime: string;
+};

--- a/apps/mobile/features/email-capture/services/outlook-adapter.ts
+++ b/apps/mobile/features/email-capture/services/outlook-adapter.ts
@@ -15,6 +15,37 @@ export async function isOutlookConnected(): Promise<boolean> {
   return token != null;
 }
 
+async function getValidToken(clientId: string): Promise<string | null> {
+  const token = await SecureStore.getItemAsync(TOKEN_KEY);
+  if (!token) return null;
+
+  const testResponse = await fetch("https://graph.microsoft.com/v1.0/me", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (testResponse.ok) return token;
+
+  const refreshToken = await SecureStore.getItemAsync(REFRESH_TOKEN_KEY);
+  if (!refreshToken) return null;
+
+  const refreshResponse = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: clientId,
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      scope: `${SCOPE} User.Read`,
+    }).toString(),
+  });
+
+  if (!refreshResponse.ok) return null;
+
+  const data = await refreshResponse.json();
+  await SecureStore.setItemAsync(TOKEN_KEY, data.access_token);
+  return data.access_token;
+}
+
 export async function connectOutlook(clientId: string): Promise<ConnectResult> {
   const { openAuthSessionAsync } = await import("expo-web-browser");
 
@@ -68,7 +99,11 @@ export async function connectOutlook(clientId: string): Promise<ConnectResult> {
   }
 
   const profile = await profileResponse.json();
-  return { success: true, email: profile.mail };
+  const email = profile.mail || profile.userPrincipalName;
+  if (!email) {
+    return { success: false, error: "no_email_found" };
+  }
+  return { success: true, email };
 }
 
 export async function disconnectOutlook(): Promise<void> {
@@ -77,10 +112,11 @@ export async function disconnectOutlook(): Promise<void> {
 }
 
 export async function fetchOutlookEmails(
+  clientId: string,
   since: string,
   senderEmails: string[]
 ): Promise<RawEmail[]> {
-  const token = await SecureStore.getItemAsync(TOKEN_KEY);
+  const token = await getValidToken(clientId);
   if (!token) return [];
 
   const senderFilter = senderEmails.map((e) => `from/emailAddress/address eq '${e}'`).join(" or ");

--- a/apps/mobile/features/email-capture/services/outlook-adapter.ts
+++ b/apps/mobile/features/email-capture/services/outlook-adapter.ts
@@ -119,8 +119,11 @@ export async function fetchOutlookEmails(
   const token = await getValidToken(clientId);
   if (!token) return [];
 
-  const senderFilter = senderEmails.map((e) => `from/emailAddress/address eq '${e}'`).join(" or ");
-  const dateFilter = `receivedDateTime ge ${since}`;
+  const sanitize = (e: string) => e.replace(/'/g, "''");
+  const senderFilter = senderEmails
+    .map((e) => `from/emailAddress/address eq '${sanitize(e)}'`)
+    .join(" or ");
+  const dateFilter = `receivedDateTime ge '${since}'`;
   const filter = `(${senderFilter}) and ${dateFilter}`;
 
   const response = await fetch(

--- a/apps/mobile/features/email-capture/services/outlook-adapter.ts
+++ b/apps/mobile/features/email-capture/services/outlook-adapter.ts
@@ -43,6 +43,9 @@ async function getValidToken(clientId: string): Promise<string | null> {
 
   const data = await refreshResponse.json();
   await SecureStore.setItemAsync(TOKEN_KEY, data.access_token);
+  if (data.refresh_token) {
+    await SecureStore.setItemAsync(REFRESH_TOKEN_KEY, data.refresh_token);
+  }
   return data.access_token;
 }
 

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -1,12 +1,17 @@
 import { create } from "zustand";
 import type { AnyDb } from "@/shared/db/client";
+import { generateId } from "@/shared/lib/generate-id";
 import type { EmailAccountRow, ProcessedEmailRow } from "./lib/repository";
 import {
   deleteEmailAccount,
   dismissProcessedEmail,
   getEmailAccounts,
   getFailedEmails,
+  insertEmailAccount,
 } from "./lib/repository";
+import type { EmailProvider } from "./schema";
+import { connectGmail } from "./services/gmail-adapter";
+import { connectOutlook } from "./services/outlook-adapter";
 
 let dbRef: AnyDb | null = null;
 let userIdRef: string | null = null;
@@ -25,7 +30,7 @@ type EmailCaptureActions = {
   loadFailedEmails: () => Promise<void>;
   dismissBanner: () => void;
   dismissFailedEmail: (id: string) => Promise<void>;
-  connectEmail: () => void;
+  connectEmail: (provider: EmailProvider, clientId: string) => Promise<void>;
   disconnectEmail: (id: string) => Promise<void>;
 };
 
@@ -62,8 +67,25 @@ export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActio
     set({ failedEmails: updated, failedCount: updated.length });
   },
 
-  connectEmail: () => {
-    // Stub — will be implemented when OAuth flow is added
+  connectEmail: async (provider, clientId) => {
+    if (!dbRef || !userIdRef) return;
+
+    const result =
+      provider === "gmail" ? await connectGmail(clientId) : await connectOutlook(clientId);
+
+    if (!result.success) return;
+
+    const row: EmailAccountRow = {
+      id: generateId("ea"),
+      userId: userIdRef,
+      provider,
+      email: result.email,
+      lastFetchedAt: null,
+      createdAt: new Date().toISOString(),
+    };
+
+    await insertEmailAccount(dbRef, row);
+    set((state) => ({ accounts: [...state.accounts, row] }));
   },
 
   disconnectEmail: async (id) => {


### PR DESCRIPTION
- Gmail adapter with OAuth, token storage, email fetch
- Outlook adapter with Graph API integration
- 18 tests covering connect, disconnect, fetch flows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OAuth email adapters for Gmail and Outlook so users can connect accounts and fetch messages for email capture. The store now runs the OAuth flow, saves accounts, refreshes tokens, and safely parses messages.

- **New Features**
  - Gmail/Outlook adapters: OAuth + SecureStore; fetch by sender since date; map to RawEmail; UTF-8 decoding; safe Date parsing; Outlook email fallback (UPN).
  - Store/repo: connectEmail wired to adapters and inserts accounts; added getEmailAccount; expanded tests for adapters and branch coverage (calendar unknown frequency; transactions init guard/getById/upsert/null description/deletedAt).

- **Bug Fixes**
  - Outlook OData filter hardened: escape single quotes and quote ISO date.
  - Persist rotated refresh tokens in Gmail/Outlook adapters to prevent disconnects.

<sup>Written for commit 46f69057546f5248c8a11ba6cea2ed074a6e7b3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

