### PR TITLE
fix(mobile): address code review feedback

### DIFF
--- a/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
@@ -1,0 +1,239 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: mock db needs flexible typing
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BankSender } from "@/features/email-capture/lib/bank-senders";
+import type { RawEmail } from "@/features/email-capture/schema";
+
+const mockGetProcessedEmailByExternalId = vi.fn();
+const mockInsertProcessedEmail = vi.fn();
+const mockInsertTransaction = vi.fn();
+const mockEnqueueSync = vi.fn();
+
+vi.mock("@/features/email-capture/lib/repository", () => ({
+  getProcessedEmailByExternalId: (...args: unknown[]) => mockGetProcessedEmailByExternalId(...args),
+  insertProcessedEmail: (...args: unknown[]) => mockInsertProcessedEmail(...args),
+}));
+
+vi.mock("@/features/transactions/lib/repository", () => ({
+  insertTransaction: (...args: unknown[]) => mockInsertTransaction(...args),
+  enqueueSync: (...args: unknown[]) => mockEnqueueSync(...args),
+}));
+
+const mockGenerateId = vi.fn();
+vi.mock("@/shared/lib/generate-id", () => ({
+  generateId: (...args: unknown[]) => mockGenerateId(...args),
+}));
+
+import { processEmails } from "@/features/email-capture/services/email-pipeline";
+
+const mockDb = {} as any;
+const USER_ID = "user-1";
+
+const SENDERS: BankSender[] = [
+  { bank: "Bancolombia", email: "notificaciones@bancolombia.com.co" },
+  { bank: "BBVA", email: "bbva@bbvanet.com.co" },
+];
+
+function makeRawEmail(overrides: Partial<RawEmail> = {}): RawEmail {
+  return {
+    externalId: "ext-1",
+    from: "notificaciones@bancolombia.com.co",
+    subject: "Compra aprobada",
+    body: "Su compra por $50.000 fue aprobada",
+    receivedAt: "2026-03-05T10:00:00Z",
+    provider: "gmail",
+    ...overrides,
+  };
+}
+
+describe("email processing pipeline", () => {
+  let idCounter: number;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    idCounter = 0;
+    mockGenerateId.mockImplementation((prefix: string) => {
+      idCounter++;
+      return `${prefix}-${idCounter}`;
+    });
+    mockGetProcessedEmailByExternalId.mockResolvedValue(null);
+    mockInsertProcessedEmail.mockResolvedValue(undefined);
+    mockInsertTransaction.mockResolvedValue(undefined);
+    mockEnqueueSync.mockResolvedValue(undefined);
+  });
+
+  it("filters out emails from unknown senders", async () => {
+    const emails = [makeRawEmail({ from: "promo@random.com" })];
+    const parseFn = vi.fn();
+
+    const result = await processEmails(mockDb, USER_ID, emails, SENDERS, parseFn);
+
+    expect(parseFn).not.toHaveBeenCalled();
+    expect(result.filtered).toBe(1);
+    expect(result.saved).toBe(0);
+  });
+
+  it("skips already processed emails", async () => {
+    mockGetProcessedEmailByExternalId.mockResolvedValueOnce({
+      id: "pe-1",
+      externalId: "ext-1",
+      status: "success",
+    });
+
+    const emails = [makeRawEmail()];
+    const parseFn = vi.fn();
+
+    const result = await processEmails(mockDb, USER_ID, emails, SENDERS, parseFn);
+
+    expect(parseFn).not.toHaveBeenCalled();
+    expect(result.skippedDuplicate).toBe(1);
+  });
+
+  it("marks email as failed when parseFn returns null", async () => {
+    const emails = [makeRawEmail()];
+    const parseFn = vi.fn().mockResolvedValue(null);
+
+    const result = await processEmails(mockDb, USER_ID, emails, SENDERS, parseFn);
+
+    expect(result.failed).toBe(1);
+    expect(result.saved).toBe(0);
+    expect(mockInsertProcessedEmail).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        externalId: "ext-1",
+        status: "failed",
+        failureReason: "parse_failed",
+      })
+    );
+  });
+
+  it("saves transaction and marks email as success when parseFn returns data", async () => {
+    const emails = [makeRawEmail()];
+    const parseFn = vi.fn().mockResolvedValue({
+      type: "expense",
+      amountCents: 5000000,
+      categoryId: "other",
+      description: "Compra en Exito",
+      date: "2026-03-05",
+    });
+
+    const result = await processEmails(mockDb, USER_ID, emails, SENDERS, parseFn);
+
+    expect(result.saved).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(mockInsertTransaction).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        userId: USER_ID,
+        type: "expense",
+        amountCents: 5000000,
+        source: "email_gmail",
+      })
+    );
+    expect(mockEnqueueSync).toHaveBeenCalled();
+    expect(mockInsertProcessedEmail).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        externalId: "ext-1",
+        status: "success",
+      })
+    );
+  });
+
+  it("marks email as failed when Zod validation fails", async () => {
+    const emails = [makeRawEmail()];
+    const parseFn = vi.fn().mockResolvedValue({
+      type: "expense",
+      amountCents: -100,
+      categoryId: "other",
+      description: "Bad",
+      date: "2026-03-05",
+    });
+
+    const result = await processEmails(mockDb, USER_ID, emails, SENDERS, parseFn);
+
+    expect(result.failed).toBe(1);
+    expect(result.saved).toBe(0);
+    expect(mockInsertProcessedEmail).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        status: "failed",
+        failureReason: expect.stringContaining("validation"),
+      })
+    );
+  });
+
+  it("processes multiple emails in a batch", async () => {
+    const emails = [
+      makeRawEmail({ externalId: "ext-1" }),
+      makeRawEmail({ externalId: "ext-2", from: "promo@random.com" }),
+      makeRawEmail({ externalId: "ext-3" }),
+    ];
+
+    const parseFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        type: "expense",
+        amountCents: 5000000,
+        categoryId: "other",
+        description: "Compra 1",
+        date: "2026-03-05",
+      })
+      .mockResolvedValueOnce(null);
+
+    const result = await processEmails(mockDb, USER_ID, emails, SENDERS, parseFn);
+
+    expect(result.filtered).toBe(1);
+    expect(result.saved).toBe(1);
+    expect(result.failed).toBe(1);
+    expect(parseFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("sets source to email_outlook for outlook provider", async () => {
+    const emails = [makeRawEmail({ provider: "outlook" })];
+    const parseFn = vi.fn().mockResolvedValue({
+      type: "income",
+      amountCents: 100000,
+      categoryId: "salary",
+      description: "Deposito",
+      date: "2026-03-05",
+    });
+
+    const result = await processEmails(mockDb, USER_ID, emails, SENDERS, parseFn);
+
+    expect(result.saved).toBe(1);
+    expect(mockInsertTransaction).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({ source: "email_outlook" })
+    );
+  });
+
+  it("marks email as failed when parseFn throws", async () => {
+    const emails = [makeRawEmail()];
+    const parseFn = vi.fn().mockRejectedValue(new Error("LLM timeout"));
+
+    const result = await processEmails(mockDb, USER_ID, emails, SENDERS, parseFn);
+
+    expect(result.failed).toBe(1);
+    expect(result.saved).toBe(0);
+    expect(mockInsertProcessedEmail).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        status: "failed",
+        failureReason: "parse_error",
+      })
+    );
+  });
+
+  it("returns zero counts for empty input", async () => {
+    const parseFn = vi.fn();
+
+    const result = await processEmails(mockDb, USER_ID, [], SENDERS, parseFn);
+
+    expect(result).toEqual({
+      filtered: 0,
+      skippedDuplicate: 0,
+      saved: 0,
+      failed: 0,
+    });
+  });
+});

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -6,14 +6,23 @@ vi.mock("@/features/email-capture/lib/repository", () => ({
   deleteEmailAccount: vi.fn(),
   getFailedEmails: vi.fn().mockResolvedValue([]),
   dismissProcessedEmail: vi.fn(),
+  updateLastFetchedAt: vi.fn(),
 }));
 
 vi.mock("@/features/email-capture/services/gmail-adapter", () => ({
   connectGmail: vi.fn(),
+  fetchGmailEmails: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock("@/features/email-capture/services/outlook-adapter", () => ({
   connectOutlook: vi.fn(),
+  fetchOutlookEmails: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/features/email-capture/services/email-pipeline", () => ({
+  processEmails: vi
+    .fn()
+    .mockResolvedValue({ filtered: 0, skippedDuplicate: 0, saved: 0, failed: 0 }),
 }));
 
 vi.mock("@/shared/lib/generate-id", () => ({
@@ -26,9 +35,14 @@ import {
   getEmailAccounts,
   getFailedEmails,
   insertEmailAccount,
+  updateLastFetchedAt,
 } from "@/features/email-capture/lib/repository";
-import { connectGmail } from "@/features/email-capture/services/gmail-adapter";
-import { connectOutlook } from "@/features/email-capture/services/outlook-adapter";
+import { processEmails } from "@/features/email-capture/services/email-pipeline";
+import { connectGmail, fetchGmailEmails } from "@/features/email-capture/services/gmail-adapter";
+import {
+  connectOutlook,
+  fetchOutlookEmails,
+} from "@/features/email-capture/services/outlook-adapter";
 import { useEmailCaptureStore } from "@/features/email-capture/store";
 
 // biome-ignore lint/suspicious/noExplicitAny: mock db needs flexible typing
@@ -194,5 +208,90 @@ describe("useEmailCaptureStore", () => {
 
     expect(deleteEmailAccount).toHaveBeenCalledWith(mockDb, "ea-1");
     expect(useEmailCaptureStore.getState().accounts).toHaveLength(0);
+  });
+
+  describe("fetchAndProcess", () => {
+    it("fetches Gmail emails and runs pipeline", async () => {
+      useEmailCaptureStore.setState({
+        accounts: [
+          {
+            id: "ea-1",
+            userId: mockUserId,
+            provider: "gmail",
+            email: "test@gmail.com",
+            lastFetchedAt: null,
+            createdAt: "2026-03-05T10:00:00Z",
+          },
+        ],
+      });
+
+      const mockRawEmails = [
+        {
+          externalId: "ext-1",
+          from: "bank@example.com",
+          subject: "Alert",
+          body: "body",
+          receivedAt: "2026-03-05T10:00:00Z",
+          provider: "gmail" as const,
+        },
+      ];
+      vi.mocked(fetchGmailEmails).mockResolvedValueOnce(mockRawEmails);
+      vi.mocked(processEmails).mockResolvedValueOnce({
+        filtered: 0,
+        skippedDuplicate: 0,
+        saved: 1,
+        failed: 0,
+      });
+      vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
+
+      await useEmailCaptureStore.getState().fetchAndProcess("gmail-client-id", "outlook-client-id");
+
+      expect(fetchGmailEmails).toHaveBeenCalled();
+      expect(processEmails).toHaveBeenCalled();
+      expect(updateLastFetchedAt).toHaveBeenCalled();
+      expect(useEmailCaptureStore.getState().isFetching).toBe(false);
+    });
+
+    it("fetches Outlook emails for outlook accounts", async () => {
+      useEmailCaptureStore.setState({
+        accounts: [
+          {
+            id: "ea-2",
+            userId: mockUserId,
+            provider: "outlook",
+            email: "test@outlook.com",
+            lastFetchedAt: null,
+            createdAt: "2026-03-05T10:00:00Z",
+          },
+        ],
+      });
+
+      vi.mocked(fetchOutlookEmails).mockResolvedValueOnce([]);
+      vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
+
+      await useEmailCaptureStore.getState().fetchAndProcess("gmail-client-id", "outlook-client-id");
+
+      expect(fetchOutlookEmails).toHaveBeenCalled();
+    });
+
+    it("sets isFetching during execution", async () => {
+      useEmailCaptureStore.setState({ accounts: [] });
+      vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
+
+      const promise = useEmailCaptureStore.getState().fetchAndProcess("g", "o");
+      expect(useEmailCaptureStore.getState().isFetching).toBe(true);
+
+      await promise;
+      expect(useEmailCaptureStore.getState().isFetching).toBe(false);
+    });
+
+    it("does nothing when db or userId is not set", async () => {
+      useEmailCaptureStore.getState().initStore(null as any, null as any);
+
+      await useEmailCaptureStore.getState().fetchAndProcess("g", "o");
+
+      expect(fetchGmailEmails).not.toHaveBeenCalled();
+      expect(fetchOutlookEmails).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -293,5 +293,45 @@ describe("useEmailCaptureStore", () => {
       expect(fetchGmailEmails).not.toHaveBeenCalled();
       expect(fetchOutlookEmails).not.toHaveBeenCalled();
     });
+
+    it("skips when already fetching", async () => {
+      useEmailCaptureStore.setState({ isFetching: true, accounts: [] });
+
+      await useEmailCaptureStore.getState().fetchAndProcess("g", "o");
+
+      expect(fetchGmailEmails).not.toHaveBeenCalled();
+    });
+
+    it("continues processing other accounts when one fails", async () => {
+      useEmailCaptureStore.setState({
+        accounts: [
+          {
+            id: "ea-1",
+            userId: mockUserId,
+            provider: "gmail",
+            email: "test@gmail.com",
+            lastFetchedAt: null,
+            createdAt: "2026-03-05T10:00:00Z",
+          },
+          {
+            id: "ea-2",
+            userId: mockUserId,
+            provider: "outlook",
+            email: "test@outlook.com",
+            lastFetchedAt: null,
+            createdAt: "2026-03-05T10:00:00Z",
+          },
+        ],
+      });
+
+      vi.mocked(fetchGmailEmails).mockRejectedValueOnce(new Error("network error"));
+      vi.mocked(fetchOutlookEmails).mockResolvedValueOnce([]);
+      vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
+
+      await useEmailCaptureStore.getState().fetchAndProcess("g", "o");
+
+      expect(fetchOutlookEmails).toHaveBeenCalled();
+      expect(useEmailCaptureStore.getState().isFetching).toBe(false);
+    });
   });
 });

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -295,7 +295,19 @@ describe("useEmailCaptureStore", () => {
     });
 
     it("skips when already fetching", async () => {
-      useEmailCaptureStore.setState({ isFetching: true, accounts: [] });
+      useEmailCaptureStore.setState({
+        isFetching: true,
+        accounts: [
+          {
+            id: "ea-1",
+            userId: mockUserId,
+            provider: "gmail",
+            email: "test@gmail.com",
+            lastFetchedAt: null,
+            createdAt: "2026-03-05T10:00:00Z",
+          },
+        ],
+      });
 
       await useEmailCaptureStore.getState().fetchAndProcess("g", "o");
 

--- a/apps/mobile/features/email-capture/services/email-pipeline.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline.ts
@@ -1,0 +1,145 @@
+import { z } from "zod";
+import { enqueueSync, insertTransaction } from "@/features/transactions/lib/repository";
+import type { AnyDb } from "@/shared/db/client";
+import { generateId } from "@/shared/lib/generate-id";
+import type { BankSender } from "../lib/bank-senders";
+import { isBankSender } from "../lib/bank-senders";
+import { getProcessedEmailByExternalId, insertProcessedEmail } from "../lib/repository";
+import type { RawEmail } from "../schema";
+
+export type ParsedTransaction = {
+  type: "expense" | "income";
+  amountCents: number;
+  categoryId: string;
+  description: string;
+  date: string;
+};
+
+export type PipelineResult = {
+  filtered: number;
+  skippedDuplicate: number;
+  saved: number;
+  failed: number;
+};
+
+const parsedTransactionSchema = z.object({
+  type: z.enum(["expense", "income"]),
+  amountCents: z.number().int().positive(),
+  categoryId: z.string().min(1),
+  description: z.string(),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+});
+
+export async function processEmails(
+  db: AnyDb,
+  userId: string,
+  rawEmails: RawEmail[],
+  senders: readonly BankSender[],
+  parseFn: (body: string) => Promise<ParsedTransaction | null>
+): Promise<PipelineResult> {
+  const result: PipelineResult = {
+    filtered: 0,
+    skippedDuplicate: 0,
+    saved: 0,
+    failed: 0,
+  };
+
+  for (const email of rawEmails) {
+    if (!isBankSender(email.from, senders)) {
+      result.filtered++;
+      continue;
+    }
+
+    const existing = await getProcessedEmailByExternalId(db, email.externalId);
+    if (existing) {
+      result.skippedDuplicate++;
+      continue;
+    }
+
+    let parsed: ParsedTransaction | null = null;
+    let parseError = false;
+
+    try {
+      parsed = await parseFn(email.body);
+    } catch {
+      parseError = true;
+    }
+
+    if (!parsed) {
+      result.failed++;
+      await insertProcessedEmail(db, {
+        id: generateId("pe"),
+        externalId: email.externalId,
+        provider: email.provider,
+        status: "failed",
+        failureReason: parseError ? "parse_error" : "parse_failed",
+        subject: email.subject,
+        rawBodyPreview: email.body.slice(0, 500),
+        receivedAt: email.receivedAt,
+        transactionId: null,
+        createdAt: new Date().toISOString(),
+      });
+      continue;
+    }
+
+    const validation = parsedTransactionSchema.safeParse(parsed);
+    if (!validation.success) {
+      result.failed++;
+      await insertProcessedEmail(db, {
+        id: generateId("pe"),
+        externalId: email.externalId,
+        provider: email.provider,
+        status: "failed",
+        failureReason: `validation: ${validation.error.issues[0]?.message ?? "invalid"}`,
+        subject: email.subject,
+        rawBodyPreview: email.body.slice(0, 500),
+        receivedAt: email.receivedAt,
+        transactionId: null,
+        createdAt: new Date().toISOString(),
+      });
+      continue;
+    }
+
+    const source = email.provider === "gmail" ? "email_gmail" : "email_outlook";
+    const txId = generateId("tx");
+    const now = new Date().toISOString();
+
+    await insertTransaction(db, {
+      id: txId,
+      userId,
+      type: parsed.type,
+      amountCents: parsed.amountCents,
+      categoryId: parsed.categoryId,
+      description: parsed.description,
+      date: parsed.date,
+      source,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await enqueueSync(db, {
+      id: generateId("sq"),
+      tableName: "transactions",
+      rowId: txId,
+      operation: "insert",
+      createdAt: now,
+    });
+
+    await insertProcessedEmail(db, {
+      id: generateId("pe"),
+      externalId: email.externalId,
+      provider: email.provider,
+      status: "success",
+      failureReason: null,
+      subject: email.subject,
+      rawBodyPreview: email.body.slice(0, 500),
+      receivedAt: email.receivedAt,
+      transactionId: txId,
+      createdAt: now,
+    });
+
+    result.saved++;
+  }
+
+  return result;
+}

--- a/apps/mobile/features/email-capture/services/email-pipeline.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline.ts
@@ -100,18 +100,21 @@ export async function processEmails(
       continue;
     }
 
+    const validated = validation.data;
     const source = email.provider === "gmail" ? "email_gmail" : "email_outlook";
     const txId = generateId("tx");
     const now = new Date().toISOString();
 
+    // TODO: Step 5 — deduplicate by amount + date + description (deferred)
+
     await insertTransaction(db, {
       id: txId,
       userId,
-      type: parsed.type,
-      amountCents: parsed.amountCents,
-      categoryId: parsed.categoryId,
-      description: parsed.description,
-      date: parsed.date,
+      type: validated.type,
+      amountCents: validated.amountCents,
+      categoryId: validated.categoryId,
+      description: validated.description,
+      date: validated.date,
       source,
       createdAt: now,
       updatedAt: now,

--- a/apps/mobile/features/email-capture/services/email-pipeline.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline.ts
@@ -106,6 +106,8 @@ export async function processEmails(
     const now = new Date().toISOString();
 
     // TODO: Step 5 — deduplicate by amount + date + description (deferred)
+    // TODO: Wrap insert + enqueue + markProcessed in db.transaction() for atomicity
+    //       Requires widening AnyDb to accept ExpoSQLiteTransaction
 
     await insertTransaction(db, {
       id: txId,

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -102,27 +102,32 @@ export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActio
 
   fetchAndProcess: async (gmailClientId, outlookClientId) => {
     if (!dbRef || !userIdRef) return;
+    if (get().isFetching) return;
 
     set({ isFetching: true });
 
     try {
       const { accounts } = get();
       const stubParseFn = async () => null;
+      const senderEmails = DEFAULT_BANK_SENDERS.map((s) => s.email);
 
       for (const account of accounts) {
-        const since = account.lastFetchedAt ?? new Date(0).toISOString();
-        const senderEmails = DEFAULT_BANK_SENDERS.map((s) => s.email);
+        try {
+          const since = account.lastFetchedAt ?? new Date(0).toISOString();
 
-        const rawEmails =
-          account.provider === "gmail"
-            ? await fetchGmailEmails(gmailClientId, since, senderEmails)
-            : await fetchOutlookEmails(outlookClientId, since, senderEmails);
+          const rawEmails =
+            account.provider === "gmail"
+              ? await fetchGmailEmails(gmailClientId, since, senderEmails)
+              : await fetchOutlookEmails(outlookClientId, since, senderEmails);
 
-        if (rawEmails.length > 0) {
-          await processEmails(dbRef, userIdRef, rawEmails, DEFAULT_BANK_SENDERS, stubParseFn);
+          if (rawEmails.length > 0) {
+            await processEmails(dbRef!, userIdRef!, rawEmails, DEFAULT_BANK_SENDERS, stubParseFn);
+          }
+
+          await updateLastFetchedAt(dbRef!, account.id, new Date().toISOString());
+        } catch {
+          // Continue processing remaining accounts
         }
-
-        await updateLastFetchedAt(dbRef, account.id, new Date().toISOString());
       }
 
       const failedEmails = await getFailedEmails(dbRef);

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import type { AnyDb } from "@/shared/db/client";
 import { generateId } from "@/shared/lib/generate-id";
+import { DEFAULT_BANK_SENDERS } from "./lib/bank-senders";
 import type { EmailAccountRow, ProcessedEmailRow } from "./lib/repository";
 import {
   deleteEmailAccount,
@@ -8,10 +9,12 @@ import {
   getEmailAccounts,
   getFailedEmails,
   insertEmailAccount,
+  updateLastFetchedAt,
 } from "./lib/repository";
 import type { EmailProvider } from "./schema";
-import { connectGmail } from "./services/gmail-adapter";
-import { connectOutlook } from "./services/outlook-adapter";
+import { processEmails } from "./services/email-pipeline";
+import { connectGmail, fetchGmailEmails } from "./services/gmail-adapter";
+import { connectOutlook, fetchOutlookEmails } from "./services/outlook-adapter";
 
 let dbRef: AnyDb | null = null;
 let userIdRef: string | null = null;
@@ -32,6 +35,7 @@ type EmailCaptureActions = {
   dismissFailedEmail: (id: string) => Promise<void>;
   connectEmail: (provider: EmailProvider, clientId: string) => Promise<void>;
   disconnectEmail: (id: string) => Promise<void>;
+  fetchAndProcess: (gmailClientId: string, outlookClientId: string) => Promise<void>;
 };
 
 export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActions>((set, get) => ({
@@ -94,5 +98,37 @@ export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActio
     set((state) => ({
       accounts: state.accounts.filter((a) => a.id !== id),
     }));
+  },
+
+  fetchAndProcess: async (gmailClientId, outlookClientId) => {
+    if (!dbRef || !userIdRef) return;
+
+    set({ isFetching: true });
+
+    try {
+      const { accounts } = get();
+      const stubParseFn = async () => null;
+
+      for (const account of accounts) {
+        const since = account.lastFetchedAt ?? new Date(0).toISOString();
+        const senderEmails = DEFAULT_BANK_SENDERS.map((s) => s.email);
+
+        const rawEmails =
+          account.provider === "gmail"
+            ? await fetchGmailEmails(gmailClientId, since, senderEmails)
+            : await fetchOutlookEmails(outlookClientId, since, senderEmails);
+
+        if (rawEmails.length > 0) {
+          await processEmails(dbRef, userIdRef, rawEmails, DEFAULT_BANK_SENDERS, stubParseFn);
+        }
+
+        await updateLastFetchedAt(dbRef, account.id, new Date().toISOString());
+      }
+
+      const failedEmails = await getFailedEmails(dbRef);
+      set({ failedEmails, failedCount: failedEmails.length });
+    } finally {
+      set({ isFetching: false });
+    }
   },
 }));


### PR DESCRIPTION
- Add isFetching guard to prevent concurrent fetchAndProcess calls
- Add per-account error isolation in fetchAndProcess loop
- Use Zod validation.data instead of raw parsed input
- Hoist senderEmails outside loop
- Add TODO for deferred transaction-level deduplication

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the mobile email capture pipeline and store for safer batch processing. Prevents concurrent runs, isolates per-account failures, validates parsed data, and fixes a flaky isFetching guard test.

- **Bug Fixes**
  - Added isFetching guard in fetchAndProcess to block concurrent runs.
  - Fixed false-positive isFetching guard test by adding accounts.
  - Isolated errors per account so one failing account doesn’t stop others.

- **Refactors**
  - Switched to Zod validation.data for transaction creation.
  - Hoisted senderEmails computation outside the loop.
  - Added TODOs for transaction-level deduplication and atomic insert+enqueue+markProcessed.

<sup>Written for commit cd193f9ff73ca6260b1d6ac42d6eca63a43bffda. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

