### PR TITLE
feat(mobile): add email capture UI and lifecycle

### DIFF
--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -11,11 +11,13 @@ vi.mock("@/features/email-capture/lib/repository", () => ({
 
 vi.mock("@/features/email-capture/services/gmail-adapter", () => ({
   connectGmail: vi.fn(),
+  disconnectGmail: vi.fn().mockResolvedValue(undefined),
   fetchGmailEmails: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock("@/features/email-capture/services/outlook-adapter", () => ({
   connectOutlook: vi.fn(),
+  disconnectOutlook: vi.fn().mockResolvedValue(undefined),
   fetchOutlookEmails: vi.fn().mockResolvedValue([]),
 }));
 

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -42,6 +42,8 @@ export default function TabsLayout() {
         <Tabs.Screen name="goals" options={{ title: "Goals" }} />
         <Tabs.Screen name="menu" options={{ title: "Menu" }} />
         <Tabs.Screen name="calendar" options={{ href: null }} />
+        <Tabs.Screen name="connected-accounts" options={{ href: null }} />
+        <Tabs.Screen name="failed-emails" options={{ href: null }} />
       </Tabs>
       <AddTransactionSheet />
       <MenuPanel />

--- a/apps/mobile/app/(tabs)/connected-accounts.tsx
+++ b/apps/mobile/app/(tabs)/connected-accounts.tsx
@@ -1,0 +1,168 @@
+import { useRouter } from "expo-router";
+import { ChevronLeft, Mail } from "lucide-react-native";
+import { Pressable, ScrollView, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useEmailCaptureStore } from "@/features/email-capture/store";
+import { useThemeColor } from "@/shared/hooks/use-theme-color";
+
+export default function ConnectedAccountsScreen() {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const accounts = useEmailCaptureStore((s) => s.accounts);
+  const connectEmail = useEmailCaptureStore((s) => s.connectEmail);
+  const disconnectEmail = useEmailCaptureStore((s) => s.disconnectEmail);
+  const primaryColor = useThemeColor("primary");
+  const greenColor = useThemeColor("accentGreen");
+  const tertiaryColor = useThemeColor("tertiary");
+
+  const gmailAccount = accounts.find((a) => a.provider === "gmail");
+  const outlookAccount = accounts.find((a) => a.provider === "outlook");
+
+  return (
+    <View className="flex-1 bg-page dark:bg-page-dark">
+      <ScrollView
+        contentContainerStyle={{ paddingTop: insets.top, paddingBottom: 40 }}
+        className="flex-1 px-5"
+      >
+        <View style={{ gap: 24 }}>
+          <View className="flex-row items-center" style={{ gap: 12 }}>
+            <Pressable onPress={() => router.back()} hitSlop={12}>
+              <ChevronLeft size={24} color={primaryColor} />
+            </Pressable>
+            <Text className="font-poppins-bold text-title text-primary dark:text-primary-dark">
+              Connected Accounts
+            </Text>
+          </View>
+
+          <Text className="font-poppins-medium text-label text-secondary dark:text-secondary-dark leading-relaxed">
+            Manage your connected email accounts for automatic bank transaction capture.
+          </Text>
+
+          <AccountCard
+            provider="Gmail"
+            account={gmailAccount}
+            greenColor={greenColor}
+            tertiaryColor={tertiaryColor}
+            onConnect={() => connectEmail("gmail", "")}
+            onDisconnect={() => gmailAccount && disconnectEmail(gmailAccount.id)}
+          />
+
+          <AccountCard
+            provider="Outlook"
+            account={outlookAccount}
+            greenColor={greenColor}
+            tertiaryColor={tertiaryColor}
+            onConnect={() => connectEmail("outlook", "")}
+            onDisconnect={() => outlookAccount && disconnectEmail(outlookAccount.id)}
+          />
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+type AccountCardProps = {
+  provider: string;
+  account: { email: string; lastFetchedAt?: string | null } | undefined;
+  greenColor: string;
+  tertiaryColor: string;
+  onConnect: () => void;
+  onDisconnect: () => void;
+};
+
+function AccountCard({
+  provider,
+  account,
+  greenColor,
+  tertiaryColor,
+  onConnect,
+  onDisconnect,
+}: AccountCardProps) {
+  const iconColor = useThemeColor("primary");
+
+  if (account) {
+    return (
+      <View className="rounded-chart bg-card p-5 dark:bg-card-dark" style={{ gap: 14 }}>
+        <View className="flex-row items-center justify-between">
+          <View className="flex-row items-center" style={{ gap: 12 }}>
+            <View style={{ width: 10, height: 10, borderRadius: 5, backgroundColor: greenColor }} />
+            <Text className="font-poppins-semibold text-section text-primary dark:text-primary-dark">
+              {provider}
+            </Text>
+          </View>
+          <View className="rounded-lg bg-accent-green-light px-2.5 py-1 dark:bg-accent-green-light-dark">
+            <Text className="font-poppins-semibold text-[11px] text-accent-green dark:text-accent-green-dark">
+              Connected
+            </Text>
+          </View>
+        </View>
+
+        <Text className="font-poppins-medium text-label text-secondary dark:text-secondary-dark">
+          {account.email}
+        </Text>
+
+        <Text className="font-poppins-medium text-caption text-tertiary dark:text-tertiary-dark">
+          {account.lastFetchedAt
+            ? `Last synced: ${formatTimeAgo(account.lastFetchedAt)}`
+            : "Not synced yet"}
+        </Text>
+
+        <Pressable
+          onPress={onDisconnect}
+          className="h-10 items-center justify-center rounded-[10px]"
+          style={{ borderWidth: 1, borderColor: "#D45B5B33" }}
+        >
+          <Text className="font-poppins-medium text-label text-accent-red dark:text-accent-red-dark">
+            Disconnect
+          </Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  return (
+    <View className="rounded-chart bg-card p-5 dark:bg-card-dark" style={{ gap: 14 }}>
+      <View className="flex-row items-center justify-between">
+        <View className="flex-row items-center" style={{ gap: 12 }}>
+          <View
+            style={{ width: 10, height: 10, borderRadius: 5, backgroundColor: tertiaryColor }}
+          />
+          <Text className="font-poppins-semibold text-section text-primary dark:text-primary-dark">
+            {provider}
+          </Text>
+        </View>
+        <View className="rounded-lg bg-peach-btn px-2.5 py-1 dark:bg-peach-btn-dark">
+          <Text className="font-poppins-semibold text-[11px] text-tertiary dark:text-tertiary-dark">
+            Not connected
+          </Text>
+        </View>
+      </View>
+
+      <Text className="font-poppins-medium text-label text-secondary dark:text-secondary-dark leading-relaxed">
+        Connect your {provider} account to capture bank emails.
+      </Text>
+
+      <Pressable
+        onPress={onConnect}
+        className="h-11 flex-row items-center justify-center rounded-icon bg-peach-btn dark:bg-peach-btn-dark"
+        style={{ gap: 8 }}
+      >
+        <Mail size={18} color={iconColor} />
+        <Text className="font-poppins-semibold text-body text-primary dark:text-primary-dark">
+          Connect {provider}
+        </Text>
+      </Pressable>
+    </View>
+  );
+}
+
+function formatTimeAgo(isoString: string): string {
+  const diff = Date.now() - new Date(isoString).getTime();
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}

--- a/apps/mobile/app/(tabs)/failed-emails.tsx
+++ b/apps/mobile/app/(tabs)/failed-emails.tsx
@@ -1,0 +1,138 @@
+import { useRouter } from "expo-router";
+import { ChevronLeft, Info, Plus, TriangleAlert } from "lucide-react-native";
+import { Pressable, ScrollView, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import type { ProcessedEmailRow } from "@/features/email-capture/lib/repository";
+import { useEmailCaptureStore } from "@/features/email-capture/store";
+import { useThemeColor } from "@/shared/hooks/use-theme-color";
+
+export default function FailedEmailsScreen() {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const failedEmails = useEmailCaptureStore((s) => s.failedEmails);
+  const dismissFailedEmail = useEmailCaptureStore((s) => s.dismissFailedEmail);
+  const primaryColor = useThemeColor("primary");
+
+  return (
+    <View className="flex-1 bg-page dark:bg-page-dark">
+      <ScrollView
+        contentContainerStyle={{ paddingTop: insets.top, paddingBottom: 40 }}
+        className="flex-1 px-5"
+      >
+        <View style={{ gap: 20 }}>
+          <View className="flex-row items-center" style={{ gap: 12 }}>
+            <Pressable onPress={() => router.back()} hitSlop={12}>
+              <ChevronLeft size={24} color={primaryColor} />
+            </Pressable>
+            <Text className="font-poppins-bold text-title text-primary dark:text-primary-dark">
+              Unprocessed Emails
+            </Text>
+          </View>
+
+          <Text className="font-poppins-medium text-label text-secondary dark:text-secondary-dark leading-relaxed">
+            {"These bank emails couldn't be processed automatically. You can add them as transactions manually."}
+          </Text>
+
+          <View style={{ gap: 10 }}>
+            {failedEmails.map((email) => (
+              <FailedEmailCard
+                key={email.id}
+                email={email}
+                onDismiss={() => dismissFailedEmail(email.id)}
+              />
+            ))}
+          </View>
+
+          {failedEmails.length === 0 && (
+            <Text className="font-poppins-medium text-label text-tertiary dark:text-tertiary-dark text-center pt-8">
+              No unprocessed emails
+            </Text>
+          )}
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+function FailedEmailCard({
+  email,
+  onDismiss,
+}: {
+  email: ProcessedEmailRow;
+  onDismiss: () => void;
+}) {
+  const redColor = useThemeColor("accentRed");
+  const primaryColor = useThemeColor("primary");
+
+  const dateStr = email.receivedAt
+    ? new Date(email.receivedAt).toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      })
+    : "";
+
+  return (
+    <View className="rounded-chart bg-card p-4 dark:bg-card-dark" style={{ gap: 12 }}>
+      <View className="flex-row items-center justify-between">
+        <View className="flex-row items-center" style={{ gap: 10 }}>
+          <TriangleAlert size={18} color={redColor} />
+          <Text className="font-poppins-semibold text-body text-primary dark:text-primary-dark">
+            {email.provider === "gmail" ? "Gmail" : "Outlook"}
+          </Text>
+        </View>
+        <Text className="font-poppins-medium text-caption text-tertiary dark:text-tertiary-dark">
+          {dateStr}
+        </Text>
+      </View>
+
+      <Text
+        className="font-poppins-medium text-label text-secondary dark:text-secondary-dark"
+        numberOfLines={2}
+      >
+        {email.subject}
+      </Text>
+
+      {email.failureReason && (
+        <View
+          className="flex-row items-center rounded-lg bg-accent-red-light px-2.5 dark:bg-accent-red-light-dark"
+          style={{ gap: 6, paddingVertical: 4 }}
+        >
+          <Info size={14} color={redColor} />
+          <Text className="font-poppins-medium text-[11px] text-accent-red dark:text-accent-red-dark">
+            {formatReason(email.failureReason)}
+          </Text>
+        </View>
+      )}
+
+      <View className="flex-row" style={{ gap: 10 }}>
+        <Pressable
+          className="flex-1 h-10 flex-row items-center justify-center rounded-[10px] bg-peach-btn dark:bg-peach-btn-dark"
+          style={{ gap: 6 }}
+        >
+          <Plus size={16} color={primaryColor} />
+          <Text className="font-poppins-semibold text-label text-primary dark:text-primary-dark">
+            Add manually
+          </Text>
+        </Pressable>
+
+        <Pressable
+          onPress={onDismiss}
+          className="flex-1 h-10 items-center justify-center rounded-[10px]"
+          style={{ borderWidth: 1, borderColor: "#EBEBEB" }}
+        >
+          <Text className="font-poppins-medium text-label text-tertiary dark:text-tertiary-dark">
+            Dismiss
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+function formatReason(reason: string): string {
+  if (reason === "parse_failed") return "Could not extract transaction data";
+  if (reason === "parse_error") return "Error while processing email";
+  if (reason.startsWith("validation:")) return reason.replace("validation: ", "");
+  return reason;
+}

--- a/apps/mobile/app/(tabs)/failed-emails.tsx
+++ b/apps/mobile/app/(tabs)/failed-emails.tsx
@@ -4,6 +4,7 @@ import { Pressable, ScrollView, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type { ProcessedEmailRow } from "@/features/email-capture/lib/repository";
 import { useEmailCaptureStore } from "@/features/email-capture/store";
+import { useTransactionStore } from "@/features/transactions/store";
 import { useThemeColor } from "@/shared/hooks/use-theme-color";
 
 export default function FailedEmailsScreen() {
@@ -11,6 +12,7 @@ export default function FailedEmailsScreen() {
   const router = useRouter();
   const failedEmails = useEmailCaptureStore((s) => s.failedEmails);
   const dismissFailedEmail = useEmailCaptureStore((s) => s.dismissFailedEmail);
+  const openSheet = useTransactionStore((s) => s.openSheet);
   const primaryColor = useThemeColor("primary");
 
   return (
@@ -30,7 +32,9 @@ export default function FailedEmailsScreen() {
           </View>
 
           <Text className="font-poppins-medium text-label text-secondary dark:text-secondary-dark leading-relaxed">
-            {"These bank emails couldn't be processed automatically. You can add them as transactions manually."}
+            {
+              "These bank emails couldn't be processed automatically. You can add them as transactions manually."
+            }
           </Text>
 
           <View style={{ gap: 10 }}>
@@ -39,6 +43,7 @@ export default function FailedEmailsScreen() {
                 key={email.id}
                 email={email}
                 onDismiss={() => dismissFailedEmail(email.id)}
+                onAddManually={openSheet}
               />
             ))}
           </View>
@@ -57,9 +62,11 @@ export default function FailedEmailsScreen() {
 function FailedEmailCard({
   email,
   onDismiss,
+  onAddManually,
 }: {
   email: ProcessedEmailRow;
   onDismiss: () => void;
+  onAddManually: () => void;
 }) {
   const redColor = useThemeColor("accentRed");
   const primaryColor = useThemeColor("primary");
@@ -107,6 +114,7 @@ function FailedEmailCard({
 
       <View className="flex-row" style={{ gap: 10 }}>
         <Pressable
+          onPress={onAddManually}
           className="flex-1 h-10 flex-row items-center justify-center rounded-[10px] bg-peach-btn dark:bg-peach-btn-dark"
           style={{ gap: 6 }}
         >

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -14,6 +14,7 @@ import { StatusBar } from "expo-status-bar";
 import { useEffect } from "react";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { useAuthStore } from "@/features/auth/store";
+import { useEmailCapture } from "@/features/email-capture/hooks/useEmailCapture";
 import { useSync } from "@/features/sync/hooks/useSync";
 import { useTransactionStore } from "@/features/transactions/store";
 import type { AnyDb } from "@/shared/db/client";
@@ -36,6 +37,7 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: string }) {
   }, [migrationsReady, db, userId]);
 
   useSync(migrationsReady ? db : null, userId);
+  useEmailCapture(migrationsReady ? db : null, userId);
 
   useEffect(() => {
     if (migrationsReady || migrationsError) {

--- a/apps/mobile/features/dashboard/components/HomeScreen.tsx
+++ b/apps/mobile/features/dashboard/components/HomeScreen.tsx
@@ -1,6 +1,10 @@
+import { useRouter } from "expo-router";
 import { Bell } from "lucide-react-native";
 import { ScrollView, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { EmailConnectBanner } from "@/features/email-capture/components/EmailConnectBanner";
+import { FailedEmailsBanner } from "@/features/email-capture/components/FailedEmailsBanner";
+import { useEmailCaptureStore } from "@/features/email-capture/store";
 import { useThemeColor } from "@/shared/hooks/use-theme-color";
 import { BalanceSection } from "./BalanceSection";
 import { ChartSection } from "./ChartSection";
@@ -23,6 +27,8 @@ const TAB_BAR_CLEARANCE = 100;
 
 export const HomeScreen = () => {
   const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const connectEmail = useEmailCaptureStore((s) => s.connectEmail);
 
   return (
     <View className="flex-1 bg-page dark:bg-page-dark">
@@ -33,6 +39,13 @@ export const HomeScreen = () => {
       >
         <View className="gap-4">
           <Header />
+          <EmailConnectBanner
+            onConnect={(provider) => {
+              const clientId = provider === "gmail" ? "" : "";
+              connectEmail(provider, clientId);
+            }}
+          />
+          <FailedEmailsBanner onPress={() => router.push("/failed-emails" as never)} />
           <BalanceSection />
           <ChartSection />
           <TransactionsPreview />

--- a/apps/mobile/features/email-capture/components/EmailConnectBanner.tsx
+++ b/apps/mobile/features/email-capture/components/EmailConnectBanner.tsx
@@ -1,0 +1,62 @@
+import { Mail, X } from "lucide-react-native";
+import { Pressable, Text, View } from "react-native";
+import { useThemeColor } from "@/shared/hooks/use-theme-color";
+import { useEmailCaptureStore } from "../store";
+
+export const EmailConnectBanner = ({
+  onConnect,
+}: {
+  onConnect: (provider: "gmail" | "outlook") => void;
+}) => {
+  const accounts = useEmailCaptureStore((s) => s.accounts);
+  const bannerDismissed = useEmailCaptureStore((s) => s.bannerDismissed);
+  const dismissBanner = useEmailCaptureStore((s) => s.dismissBanner);
+  const iconColor = useThemeColor("accentRed");
+  const closeColor = useThemeColor("tertiary");
+
+  if (accounts.length > 0 || bannerDismissed) return null;
+
+  return (
+    <View className="rounded-chart bg-card p-5 dark:bg-card-dark" style={{ gap: 16 }}>
+      <View className="flex-row items-center justify-between">
+        <View className="flex-row items-center" style={{ gap: 10 }}>
+          <Mail size={22} color={iconColor} />
+          <Text className="font-poppins-semibold text-body text-primary dark:text-primary-dark">
+            Auto-capture transactions
+          </Text>
+        </View>
+        <Pressable onPress={dismissBanner} hitSlop={12}>
+          <X size={18} color={closeColor} />
+        </Pressable>
+      </View>
+
+      <Text className="font-poppins-medium text-label text-secondary dark:text-secondary-dark leading-relaxed">
+        Connect your email to automatically capture bank transactions.
+      </Text>
+
+      <View className="flex-row" style={{ gap: 10 }}>
+        <Pressable
+          onPress={() => onConnect("gmail")}
+          className="flex-1 flex-row items-center justify-center rounded-icon bg-peach-btn dark:bg-peach-btn-dark"
+          style={{ height: 44, gap: 8, borderWidth: 1, borderColor: "#EBEBEB" }}
+        >
+          <Mail size={18} color={iconColor} />
+          <Text className="font-poppins-semibold text-body text-primary dark:text-primary-dark">
+            Gmail
+          </Text>
+        </Pressable>
+
+        <Pressable
+          onPress={() => onConnect("outlook")}
+          className="flex-1 flex-row items-center justify-center rounded-icon bg-peach-btn dark:bg-peach-btn-dark"
+          style={{ height: 44, gap: 8, borderWidth: 1, borderColor: "#EBEBEB" }}
+        >
+          <Mail size={18} color="#4A90D9" />
+          <Text className="font-poppins-semibold text-body text-primary dark:text-primary-dark">
+            Outlook
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+};

--- a/apps/mobile/features/email-capture/components/FailedEmailsBanner.tsx
+++ b/apps/mobile/features/email-capture/components/FailedEmailsBanner.tsx
@@ -1,0 +1,29 @@
+import { TriangleAlert } from "lucide-react-native";
+import { Pressable, Text, View } from "react-native";
+import { useThemeColor } from "@/shared/hooks/use-theme-color";
+import { useEmailCaptureStore } from "../store";
+
+export const FailedEmailsBanner = ({ onPress }: { onPress: () => void }) => {
+  const failedCount = useEmailCaptureStore((s) => s.failedCount);
+  const iconColor = useThemeColor("accentRed");
+
+  if (failedCount === 0) return null;
+
+  return (
+    <Pressable
+      onPress={onPress}
+      className="flex-row items-center rounded-chart bg-card p-4 dark:bg-card-dark"
+      style={{ gap: 12 }}
+    >
+      <TriangleAlert size={20} color={iconColor} />
+      <View className="flex-1">
+        <Text className="font-poppins-semibold text-body text-primary dark:text-primary-dark">
+          {failedCount} unprocessed {failedCount === 1 ? "email" : "emails"}
+        </Text>
+        <Text className="font-poppins-medium text-caption text-secondary dark:text-secondary-dark">
+          Tap to review and add manually
+        </Text>
+      </View>
+    </Pressable>
+  );
+};

--- a/apps/mobile/features/email-capture/hooks/useEmailCapture.ts
+++ b/apps/mobile/features/email-capture/hooks/useEmailCapture.ts
@@ -8,14 +8,6 @@ export function useEmailCapture(db: AnyDb | null, userId: string | null) {
     if (!db || !userId) return;
 
     useEmailCaptureStore.getState().initStore(db, userId);
-    useEmailCaptureStore
-      .getState()
-      .loadAccounts()
-      .catch(() => {});
-    useEmailCaptureStore
-      .getState()
-      .loadFailedEmails()
-      .catch(() => {});
 
     const runFetch = () => {
       useEmailCaptureStore
@@ -24,7 +16,15 @@ export function useEmailCapture(db: AnyDb | null, userId: string | null) {
         .catch(() => {});
     };
 
-    runFetch();
+    useEmailCaptureStore
+      .getState()
+      .loadAccounts()
+      .then(() => runFetch())
+      .catch(() => {});
+    useEmailCaptureStore
+      .getState()
+      .loadFailedEmails()
+      .catch(() => {});
 
     const subscription = AppState.addEventListener("change", (state) => {
       if (state === "active") runFetch();

--- a/apps/mobile/features/email-capture/hooks/useEmailCapture.ts
+++ b/apps/mobile/features/email-capture/hooks/useEmailCapture.ts
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+import { AppState } from "react-native";
+import type { AnyDb } from "@/shared/db/client";
+import { useEmailCaptureStore } from "../store";
+
+export function useEmailCapture(db: AnyDb | null, userId: string | null) {
+  useEffect(() => {
+    if (!db || !userId) return;
+
+    useEmailCaptureStore.getState().initStore(db, userId);
+    useEmailCaptureStore
+      .getState()
+      .loadAccounts()
+      .catch(() => {});
+    useEmailCaptureStore
+      .getState()
+      .loadFailedEmails()
+      .catch(() => {});
+
+    const runFetch = () => {
+      useEmailCaptureStore
+        .getState()
+        .fetchAndProcess("", "")
+        .catch(() => {});
+    };
+
+    runFetch();
+
+    const subscription = AppState.addEventListener("change", (state) => {
+      if (state === "active") runFetch();
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, [db, userId]);
+}

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -13,8 +13,8 @@ import {
 } from "./lib/repository";
 import type { EmailProvider } from "./schema";
 import { processEmails } from "./services/email-pipeline";
-import { connectGmail, fetchGmailEmails } from "./services/gmail-adapter";
-import { connectOutlook, fetchOutlookEmails } from "./services/outlook-adapter";
+import { connectGmail, disconnectGmail, fetchGmailEmails } from "./services/gmail-adapter";
+import { connectOutlook, disconnectOutlook, fetchOutlookEmails } from "./services/outlook-adapter";
 
 let dbRef: AnyDb | null = null;
 let userIdRef: string | null = null;
@@ -94,6 +94,11 @@ export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActio
 
   disconnectEmail: async (id) => {
     if (!dbRef) return;
+    const account = get().accounts.find((a) => a.id === id);
+    if (account) {
+      if (account.provider === "gmail") await disconnectGmail();
+      else if (account.provider === "outlook") await disconnectOutlook();
+    }
     await deleteEmailAccount(dbRef, id);
     set((state) => ({
       accounts: state.accounts.filter((a) => a.id !== id),

--- a/apps/mobile/features/menu/components/MenuPanel.tsx
+++ b/apps/mobile/features/menu/components/MenuPanel.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "expo-router";
-import { Calendar } from "lucide-react-native";
+import { Calendar, Mail } from "lucide-react-native";
 import { useEffect } from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from "react-native-reanimated";
@@ -51,6 +51,11 @@ export function MenuPanel() {
     router.push("/(tabs)/calendar");
   };
 
+  const handleConnectedAccounts = () => {
+    closeMenu();
+    router.push("/connected-accounts" as never);
+  };
+
   return (
     <View style={StyleSheet.absoluteFill} pointerEvents={isOpen ? "auto" : "none"}>
       <Animated.View style={[styles.backdrop, backdropStyle]}>
@@ -70,6 +75,13 @@ export function MenuPanel() {
         <Pressable style={[styles.menuItem, { backgroundColor: itemBg }]} onPress={handleCalendar}>
           <Calendar size={20} color={primaryColor} />
           <Text style={[styles.menuItemText, { color: primaryColor }]}>Calendar</Text>
+        </Pressable>
+        <Pressable
+          style={[styles.menuItem, { backgroundColor: itemBg, marginTop: 8 }]}
+          onPress={handleConnectedAccounts}
+        >
+          <Mail size={20} color={primaryColor} />
+          <Text style={[styles.menuItemText, { color: primaryColor }]}>Connected Accounts</Text>
         </Pressable>
       </Animated.View>
     </View>

--- a/apps/mobile/tailwind.config.ts
+++ b/apps/mobile/tailwind.config.ts
@@ -41,6 +41,12 @@ const config: Config = {
         "login-google-border-dark": "#3A3A3C",
         "login-ms": "#F3F2EE",
         "login-ms-dark": "#2C2C2E",
+        "border-subtle": "#EBEBEB",
+        "border-subtle-dark": "#2C2C2E",
+        "accent-red-light": "#D45B5B11",
+        "accent-red-light-dark": "#E0606011",
+        "peach-btn": "#FAE3D9",
+        "peach-btn-dark": "#2A1F1A",
       },
       fontFamily: {
         "poppins-medium": ["Poppins_500Medium"],


### PR DESCRIPTION
- Add EmailConnectBanner with Gmail/Outlook buttons
- Add FailedEmailsBanner with unprocessed count
- Add connected accounts settings screen
- Add failed emails review screen
- Add useEmailCapture lifecycle hook
- Wire banners into HomeScreen and hook into _layout
- Add border-subtle, accent-red-light, peach-btn tailwind colors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds email capture to mobile so users can connect Gmail/Outlook and auto-capture bank emails, with a flow to review and fix unprocessed emails. Wired into Home and the app shell for background fetch and processing.

- **New Features**
  - EmailConnectBanner on Home with Gmail/Outlook buttons and dismiss.
  - FailedEmailsBanner on Home showing unprocessed count; tap to review.
  - Connected Accounts screen to connect/disconnect and see status/last sync; reachable from Menu.
  - Unprocessed Emails screen to review failures, add manually, or dismiss.
  - Email capture lifecycle (useEmailCapture) runs on app start/foreground; loads accounts and failed emails; triggers fetch/process; integrated in app layout.
  - Adds Tailwind tokens: border-subtle, accent-red-light, peach-btn.

- **Bug Fixes**
  - Disconnect now clears OAuth tokens; “Add manually” opens the transaction sheet.
  - await loadAccounts before first fetch to prevent fetchAndProcess from reading empty accounts.

<sup>Written for commit c86fadd9ab032a118dda47df229a12f0915f4006. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

