### PR TITLE
feat(mobile): add bank_senders Supabase table and feature exports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Both scanners need full git history
+          fetch-depth: 0
+      - name: Fetch base ref
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}
       - name: Gitleaks — pattern-based secret scan
         uses: gitleaks/gitleaks-action@v2
         env:

--- a/apps/mobile/__tests__/email-capture/bank-senders.test.ts
+++ b/apps/mobile/__tests__/email-capture/bank-senders.test.ts
@@ -1,5 +1,30 @@
-import { describe, expect, it } from "vitest";
-import { DEFAULT_BANK_SENDERS, isBankSender } from "@/features/email-capture/lib/bank-senders";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_BANK_SENDERS,
+  fetchBankSenders,
+  isBankSender,
+  resetBankSendersCache,
+} from "@/features/email-capture/lib/bank-senders";
+
+vi.mock("@/shared/lib/supabase", () => ({
+  getSupabase: vi.fn(),
+}));
+
+import { getSupabase } from "@/shared/lib/supabase";
+
+const mockFrom = vi.fn();
+const mockSelect = vi.fn();
+
+beforeEach(() => {
+  resetBankSendersCache();
+  mockSelect.mockReset();
+  mockFrom.mockReset().mockReturnValue({ select: mockSelect });
+  vi.mocked(getSupabase).mockReturnValue({ from: mockFrom } as never);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("bank senders", () => {
   it("has default verified bank senders", () => {
@@ -19,5 +44,63 @@ describe("bank senders", () => {
 
   it("isBankSender is case-insensitive", () => {
     expect(isBankSender("BBVA@BBVANET.COM.CO", DEFAULT_BANK_SENDERS)).toBe(true);
+  });
+});
+
+describe("fetchBankSenders", () => {
+  it("returns remote senders on success", async () => {
+    const remote = [{ bank: "RemoteBank", email: "remote@bank.com" }];
+    mockSelect.mockResolvedValue({ data: remote, error: null });
+
+    const result = await fetchBankSenders();
+
+    expect(result).toEqual([{ bank: "RemoteBank", email: "remote@bank.com" }]);
+  });
+
+  it("caches remote senders for subsequent calls", async () => {
+    const remote = [{ bank: "Cached", email: "cached@bank.com" }];
+    mockSelect.mockResolvedValue({ data: remote, error: null });
+
+    await fetchBankSenders();
+
+    mockSelect.mockResolvedValue({ data: null, error: { message: "offline" } });
+    const result = await fetchBankSenders();
+
+    expect(result).toEqual([{ bank: "Cached", email: "cached@bank.com" }]);
+  });
+
+  it("falls back to defaults on Supabase error with no cache", async () => {
+    mockSelect.mockResolvedValue({ data: null, error: { message: "fail" } });
+
+    const result = await fetchBankSenders();
+
+    expect(result).toBe(DEFAULT_BANK_SENDERS);
+  });
+
+  it("falls back to defaults on empty response with no cache", async () => {
+    mockSelect.mockResolvedValue({ data: [], error: null });
+
+    const result = await fetchBankSenders();
+
+    expect(result).toBe(DEFAULT_BANK_SENDERS);
+  });
+
+  it("falls back to defaults on network exception with no cache", async () => {
+    mockSelect.mockRejectedValue(new Error("network error"));
+
+    const result = await fetchBankSenders();
+
+    expect(result).toBe(DEFAULT_BANK_SENDERS);
+  });
+
+  it("falls back to cache on network exception when cache exists", async () => {
+    const remote = [{ bank: "First", email: "first@bank.com" }];
+    mockSelect.mockResolvedValue({ data: remote, error: null });
+    await fetchBankSenders();
+
+    mockSelect.mockRejectedValue(new Error("network error"));
+    const result = await fetchBankSenders();
+
+    expect(result).toEqual([{ bank: "First", email: "first@bank.com" }]);
   });
 });

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -27,6 +27,14 @@ vi.mock("@/features/email-capture/services/email-pipeline", () => ({
     .mockResolvedValue({ filtered: 0, skippedDuplicate: 0, saved: 0, failed: 0 }),
 }));
 
+vi.mock("@/features/email-capture/lib/bank-senders", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/email-capture/lib/bank-senders")>();
+  return {
+    ...actual,
+    fetchBankSenders: vi.fn().mockResolvedValue(actual.DEFAULT_BANK_SENDERS),
+  };
+});
+
 vi.mock("@/shared/lib/generate-id", () => ({
   generateId: vi.fn(() => "ea-generated"),
 }));

--- a/apps/mobile/features/email-capture/index.ts
+++ b/apps/mobile/features/email-capture/index.ts
@@ -1,0 +1,6 @@
+export { EmailConnectBanner } from "./components/EmailConnectBanner";
+export { FailedEmailsBanner } from "./components/FailedEmailsBanner";
+export { useEmailCapture } from "./hooks/useEmailCapture";
+export type { BankSender } from "./lib/bank-senders";
+export type { EmailProvider } from "./schema";
+export { useEmailCaptureStore } from "./store";

--- a/apps/mobile/features/email-capture/lib/bank-senders.ts
+++ b/apps/mobile/features/email-capture/lib/bank-senders.ts
@@ -1,3 +1,5 @@
+import { getSupabase } from "@/shared/lib/supabase";
+
 export type BankSender = {
   readonly bank: string;
   readonly email: string;
@@ -8,6 +10,27 @@ export const DEFAULT_BANK_SENDERS: readonly BankSender[] = [
   { bank: "BBVA", email: "BBVA@bbvanet.com.co" },
   { bank: "Rappi", email: "noreply@rappicard.co" },
 ] as const;
+
+let cachedSenders: readonly BankSender[] | null = null;
+
+export async function fetchBankSenders(): Promise<readonly BankSender[]> {
+  try {
+    const { data, error } = await getSupabase().from("bank_senders").select("bank, email");
+
+    if (error || !data || data.length === 0) {
+      return cachedSenders ?? DEFAULT_BANK_SENDERS;
+    }
+
+    cachedSenders = data.map((row) => ({ bank: row.bank, email: row.email }));
+    return cachedSenders;
+  } catch {
+    return cachedSenders ?? DEFAULT_BANK_SENDERS;
+  }
+}
+
+export function resetBankSendersCache() {
+  cachedSenders = null;
+}
 
 export function isBankSender(from: string, senders: readonly BankSender[]): boolean {
   const normalized = from.toLowerCase();

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import type { AnyDb } from "@/shared/db/client";
 import { generateId } from "@/shared/lib/generate-id";
-import { DEFAULT_BANK_SENDERS } from "./lib/bank-senders";
+import { fetchBankSenders } from "./lib/bank-senders";
 import type { EmailAccountRow, ProcessedEmailRow } from "./lib/repository";
 import {
   deleteEmailAccount,
@@ -114,7 +114,8 @@ export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActio
     try {
       const { accounts } = get();
       const stubParseFn = async () => null;
-      const senderEmails = DEFAULT_BANK_SENDERS.map((s) => s.email);
+      const senders = await fetchBankSenders();
+      const senderEmails = senders.map((s) => s.email);
 
       for (const account of accounts) {
         try {
@@ -126,7 +127,7 @@ export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActio
               : await fetchOutlookEmails(outlookClientId, since, senderEmails);
 
           if (rawEmails.length > 0) {
-            await processEmails(dbRef!, userIdRef!, rawEmails, DEFAULT_BANK_SENDERS, stubParseFn);
+            await processEmails(dbRef!, userIdRef!, rawEmails, senders, stubParseFn);
           }
 
           await updateLastFetchedAt(dbRef!, account.id, new Date().toISOString());

--- a/apps/mobile/supabase/migrations/0002_bank_senders.sql
+++ b/apps/mobile/supabase/migrations/0002_bank_senders.sql
@@ -1,0 +1,19 @@
+create table public.bank_senders (
+  id uuid primary key default gen_random_uuid(),
+  bank text not null,
+  email text not null unique,
+  created_at timestamptz not null default now()
+);
+
+-- All authenticated users can read bank senders
+alter table public.bank_senders enable row level security;
+
+create policy "Authenticated users can read bank senders"
+  on public.bank_senders for select
+  using (auth.role() = 'authenticated');
+
+-- Seed with default senders
+insert into public.bank_senders (bank, email) values
+  ('Davibank', 'davibankinforma@davibank.com'),
+  ('BBVA', 'BBVA@bbvanet.com.co'),
+  ('Rappi', 'noreply@rappicard.co');


### PR DESCRIPTION
- Add bank_senders migration with RLS and seed data
- Add fetchBankSenders with Supabase fetch, cache, offline fallback
- Wire fetchBankSenders into store fetchAndProcess
- Add feature index with public exports
- Add 6 tests for fetchBankSenders

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Supabase-backed source of verified bank sender emails with caching and offline fallback, wired into email capture processing. Also fixes CI secret scanning by fetching the base ref for Gitleaks.

- **New Features**
  - Adds bank_senders table with RLS and seed data; run migration 0002.
  - Introduces fetchBankSenders with in-memory cache and fallback to cache or defaults; store now uses fetched senders in fetchAndProcess.
  - Adds public exports in features/email-capture/index for components, hooks, types, and store.

- **Bug Fixes**
  - CI: fetch base ref before running Gitleaks to resolve commit range.

<sup>Written for commit 6df82365f279ddcfdfdfd4150b587bb5435f8246. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

