### PR TITLE
feat(mobile): add email capture pipeline and UI

### DIFF
--- a/.claude/skills/committing-changes/SKILL.md
+++ b/.claude/skills/committing-changes/SKILL.md
@@ -3,7 +3,7 @@ name: committing-changes
 description: Run all CI checks locally and commit if everything passes. Use this before every commit.
 ---
 
-Before committing any changes, you MUST run every CI job locally in this order. If any step fails, stop, fix the issue, and start over from step 1.
+Before committing any changes, you MUST run every step in this order. If any step fails, stop, fix the issue, and start over from step 1.
 
 ## Step 0 — Pull Rebase
 
@@ -13,14 +13,22 @@ git pull --rebase --autostash origin main
 
 Ensure your branch is up to date with the main branch before running checks or committing.
 
-## Step 1 — Lint
+## Step 1 — Code Review
+
+Invoke the `/requesting-code-review` skill to review the current changes against the plan/requirements. Fix any Critical or Important issues found before proceeding. Minor issues can be noted and skipped.
+
+## Step 2 — Simplify
+
+Invoke the `/simplify` skill on all changed files. This reviews for code reuse, quality, and efficiency. Fix any issues it finds. If either step 1 or step 2 produced code changes, you must continue to step 3 to validate them.
+
+## Step 3 — Lint
 
 ```bash
 bunx biome check .
 bun run --cwd apps/mobile lint
 ```
 
-## Step 2 — Type Check
+## Step 4 — Type Check
 
 ```bash
 bun run --cwd packages/types typecheck
@@ -29,13 +37,13 @@ bun run --cwd packages/utils typecheck
 bun run --cwd apps/mobile typecheck
 ```
 
-## Step 3 — Tests
+## Step 5 — Tests
 
 ```bash
 cd apps/mobile && npx vitest run
 ```
 
-## Step 4 — Commit
+## Step 6 — Commit
 
 Only proceed here if all steps above passed with no errors.
 
@@ -57,7 +65,7 @@ type(scope): message
 
 **Never include** `Co-Authored-By` lines.
 
-## Step 5 — Push & PR
+## Step 7 — Push & PR
 
 Push to the feature branch after committing. Main is protected — direct pushes are not allowed.
 
@@ -73,7 +81,7 @@ BODY=$(git log -1 --format=%b)
 gh pr create --title "$TITLE" --body "$BODY"
 ```
 
-## Step 6 — Merge (only when the user explicitly asks)
+## Step 8 — Merge (only when the user explicitly asks)
 
 **NEVER merge on your own.** Only run this step when the user tells you to merge.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Both scanners need full git history
+          fetch-depth: 0
+      - name: Fetch base ref
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}
       - name: Gitleaks — pattern-based secret scan
         uses: gitleaks/gitleaks-action@v2
         env:

--- a/apps/mobile/__tests__/email-capture/bank-senders.test.ts
+++ b/apps/mobile/__tests__/email-capture/bank-senders.test.ts
@@ -1,5 +1,30 @@
-import { describe, expect, it } from "vitest";
-import { DEFAULT_BANK_SENDERS, isBankSender } from "@/features/email-capture/lib/bank-senders";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_BANK_SENDERS,
+  fetchBankSenders,
+  isBankSender,
+  resetBankSendersCache,
+} from "@/features/email-capture/lib/bank-senders";
+
+vi.mock("@/shared/lib/supabase", () => ({
+  getSupabase: vi.fn(),
+}));
+
+import { getSupabase } from "@/shared/lib/supabase";
+
+const mockFrom = vi.fn();
+const mockSelect = vi.fn();
+
+beforeEach(() => {
+  resetBankSendersCache();
+  mockSelect.mockReset();
+  mockFrom.mockReset().mockReturnValue({ select: mockSelect });
+  vi.mocked(getSupabase).mockReturnValue({ from: mockFrom } as never);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("bank senders", () => {
   it("has default verified bank senders", () => {
@@ -19,5 +44,63 @@ describe("bank senders", () => {
 
   it("isBankSender is case-insensitive", () => {
     expect(isBankSender("BBVA@BBVANET.COM.CO", DEFAULT_BANK_SENDERS)).toBe(true);
+  });
+});
+
+describe("fetchBankSenders", () => {
+  it("returns remote senders on success", async () => {
+    const remote = [{ bank: "RemoteBank", email: "remote@bank.com" }];
+    mockSelect.mockResolvedValue({ data: remote, error: null });
+
+    const result = await fetchBankSenders();
+
+    expect(result).toEqual([{ bank: "RemoteBank", email: "remote@bank.com" }]);
+  });
+
+  it("caches remote senders for subsequent calls", async () => {
+    const remote = [{ bank: "Cached", email: "cached@bank.com" }];
+    mockSelect.mockResolvedValue({ data: remote, error: null });
+
+    await fetchBankSenders();
+
+    mockSelect.mockResolvedValue({ data: null, error: { message: "offline" } });
+    const result = await fetchBankSenders();
+
+    expect(result).toEqual([{ bank: "Cached", email: "cached@bank.com" }]);
+  });
+
+  it("falls back to defaults on Supabase error with no cache", async () => {
+    mockSelect.mockResolvedValue({ data: null, error: { message: "fail" } });
+
+    const result = await fetchBankSenders();
+
+    expect(result).toBe(DEFAULT_BANK_SENDERS);
+  });
+
+  it("falls back to defaults on empty response with no cache", async () => {
+    mockSelect.mockResolvedValue({ data: [], error: null });
+
+    const result = await fetchBankSenders();
+
+    expect(result).toBe(DEFAULT_BANK_SENDERS);
+  });
+
+  it("falls back to defaults on network exception with no cache", async () => {
+    mockSelect.mockRejectedValue(new Error("network error"));
+
+    const result = await fetchBankSenders();
+
+    expect(result).toBe(DEFAULT_BANK_SENDERS);
+  });
+
+  it("falls back to cache on network exception when cache exists", async () => {
+    const remote = [{ bank: "First", email: "first@bank.com" }];
+    mockSelect.mockResolvedValue({ data: remote, error: null });
+    await fetchBankSenders();
+
+    mockSelect.mockRejectedValue(new Error("network error"));
+    const result = await fetchBankSenders();
+
+    expect(result).toEqual([{ bank: "First", email: "first@bank.com" }]);
   });
 });

--- a/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
@@ -3,13 +3,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { BankSender } from "@/features/email-capture/lib/bank-senders";
 import type { RawEmail } from "@/features/email-capture/schema";
 
-const mockGetProcessedEmailByExternalId = vi.fn();
+const mockGetProcessedExternalIds = vi.fn().mockResolvedValue(new Set<string>());
 const mockInsertProcessedEmail = vi.fn();
 const mockInsertTransaction = vi.fn();
 const mockEnqueueSync = vi.fn();
 
 vi.mock("@/features/email-capture/lib/repository", () => ({
-  getProcessedEmailByExternalId: (...args: unknown[]) => mockGetProcessedEmailByExternalId(...args),
+  getProcessedExternalIds: (...args: unknown[]) => mockGetProcessedExternalIds(...args),
   insertProcessedEmail: (...args: unknown[]) => mockInsertProcessedEmail(...args),
 }));
 
@@ -55,7 +55,7 @@ describe("email processing pipeline", () => {
       idCounter++;
       return `${prefix}-${idCounter}`;
     });
-    mockGetProcessedEmailByExternalId.mockResolvedValue(null);
+    mockGetProcessedExternalIds.mockResolvedValue(new Set<string>());
     mockInsertProcessedEmail.mockResolvedValue(undefined);
     mockInsertTransaction.mockResolvedValue(undefined);
     mockEnqueueSync.mockResolvedValue(undefined);
@@ -73,11 +73,7 @@ describe("email processing pipeline", () => {
   });
 
   it("skips already processed emails", async () => {
-    mockGetProcessedEmailByExternalId.mockResolvedValueOnce({
-      id: "pe-1",
-      externalId: "ext-1",
-      status: "success",
-    });
+    mockGetProcessedExternalIds.mockResolvedValueOnce(new Set(["ext-1"]));
 
     const emails = [makeRawEmail()];
     const parseFn = vi.fn();

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -27,6 +27,14 @@ vi.mock("@/features/email-capture/services/email-pipeline", () => ({
     .mockResolvedValue({ filtered: 0, skippedDuplicate: 0, saved: 0, failed: 0 }),
 }));
 
+vi.mock("@/features/email-capture/lib/bank-senders", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/email-capture/lib/bank-senders")>();
+  return {
+    ...actual,
+    fetchBankSenders: vi.fn().mockResolvedValue(actual.DEFAULT_BANK_SENDERS),
+  };
+});
+
 vi.mock("@/shared/lib/generate-id", () => ({
   generateId: vi.fn(() => "ea-generated"),
 }));

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -66,7 +66,6 @@ describe("useEmailCaptureStore", () => {
     useEmailCaptureStore.setState({
       accounts: [],
       failedEmails: [],
-      failedCount: 0,
       isFetching: false,
       bannerDismissed: false,
     });
@@ -76,7 +75,6 @@ describe("useEmailCaptureStore", () => {
     const state = useEmailCaptureStore.getState();
     expect(state.accounts).toEqual([]);
     expect(state.failedEmails).toEqual([]);
-    expect(state.failedCount).toBe(0);
     expect(state.isFetching).toBe(false);
     expect(state.bannerDismissed).toBe(false);
   });
@@ -121,7 +119,7 @@ describe("useEmailCaptureStore", () => {
 
     expect(getFailedEmails).toHaveBeenCalledWith(mockDb);
     expect(useEmailCaptureStore.getState().failedEmails).toEqual(mockFailed);
-    expect(useEmailCaptureStore.getState().failedCount).toBe(1);
+    expect(useEmailCaptureStore.getState().failedEmails).toHaveLength(1);
   });
 
   it("dismissBanner sets bannerDismissed to true", () => {
@@ -145,14 +143,12 @@ describe("useEmailCaptureStore", () => {
           createdAt: "2026-03-05T10:00:00Z",
         },
       ],
-      failedCount: 1,
     });
 
     await useEmailCaptureStore.getState().dismissFailedEmail("pe-1");
 
     expect(dismissProcessedEmail).toHaveBeenCalledWith(mockDb, "pe-1");
     expect(useEmailCaptureStore.getState().failedEmails).toHaveLength(0);
-    expect(useEmailCaptureStore.getState().failedCount).toBe(0);
   });
 
   it("connectEmail calls Gmail adapter and saves account", async () => {

--- a/apps/mobile/app/(tabs)/connected-accounts.tsx
+++ b/apps/mobile/app/(tabs)/connected-accounts.tsx
@@ -1,3 +1,4 @@
+import { formatDistanceToNow } from "date-fns";
 import { useRouter } from "expo-router";
 import { ChevronLeft, Mail } from "lucide-react-native";
 import { Pressable, ScrollView, Text, View } from "react-native";
@@ -103,7 +104,7 @@ function AccountCard({
 
         <Text className="font-poppins-medium text-caption text-tertiary dark:text-tertiary-dark">
           {account.lastFetchedAt
-            ? `Last synced: ${formatTimeAgo(account.lastFetchedAt)}`
+            ? `Last synced: ${formatDistanceToNow(new Date(account.lastFetchedAt), { addSuffix: true })}`
             : "Not synced yet"}
         </Text>
 
@@ -154,15 +155,4 @@ function AccountCard({
       </Pressable>
     </View>
   );
-}
-
-function formatTimeAgo(isoString: string): string {
-  const diff = Date.now() - new Date(isoString).getTime();
-  const minutes = Math.floor(diff / 60000);
-  if (minutes < 1) return "just now";
-  if (minutes < 60) return `${minutes} min ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
 }

--- a/apps/mobile/app/(tabs)/failed-emails.tsx
+++ b/apps/mobile/app/(tabs)/failed-emails.tsx
@@ -1,3 +1,4 @@
+import { format } from "date-fns";
 import { useRouter } from "expo-router";
 import { ChevronLeft, Info, Plus, TriangleAlert } from "lucide-react-native";
 import { Pressable, ScrollView, Text, View } from "react-native";
@@ -70,14 +71,9 @@ function FailedEmailCard({
 }) {
   const redColor = useThemeColor("accentRed");
   const primaryColor = useThemeColor("primary");
+  const borderColor = useThemeColor("borderSubtle");
 
-  const dateStr = email.receivedAt
-    ? new Date(email.receivedAt).toLocaleDateString("en-US", {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-      })
-    : "";
+  const dateStr = email.receivedAt ? format(new Date(email.receivedAt), "MMM d, yyyy") : "";
 
   return (
     <View className="rounded-chart bg-card p-4 dark:bg-card-dark" style={{ gap: 12 }}>
@@ -127,7 +123,7 @@ function FailedEmailCard({
         <Pressable
           onPress={onDismiss}
           className="flex-1 h-10 items-center justify-center rounded-[10px]"
-          style={{ borderWidth: 1, borderColor: "#EBEBEB" }}
+          style={{ borderWidth: 1, borderColor }}
         >
           <Text className="font-poppins-medium text-label text-tertiary dark:text-tertiary-dark">
             Dismiss

--- a/apps/mobile/features/email-capture/components/EmailConnectBanner.tsx
+++ b/apps/mobile/features/email-capture/components/EmailConnectBanner.tsx
@@ -13,6 +13,7 @@ export const EmailConnectBanner = ({
   const dismissBanner = useEmailCaptureStore((s) => s.dismissBanner);
   const iconColor = useThemeColor("accentRed");
   const closeColor = useThemeColor("tertiary");
+  const borderColor = useThemeColor("borderSubtle");
 
   if (accounts.length > 0 || bannerDismissed) return null;
 
@@ -38,7 +39,7 @@ export const EmailConnectBanner = ({
         <Pressable
           onPress={() => onConnect("gmail")}
           className="flex-1 flex-row items-center justify-center rounded-icon bg-peach-btn dark:bg-peach-btn-dark"
-          style={{ height: 44, gap: 8, borderWidth: 1, borderColor: "#EBEBEB" }}
+          style={{ height: 44, gap: 8, borderWidth: 1, borderColor }}
         >
           <Mail size={18} color={iconColor} />
           <Text className="font-poppins-semibold text-body text-primary dark:text-primary-dark">
@@ -49,7 +50,7 @@ export const EmailConnectBanner = ({
         <Pressable
           onPress={() => onConnect("outlook")}
           className="flex-1 flex-row items-center justify-center rounded-icon bg-peach-btn dark:bg-peach-btn-dark"
-          style={{ height: 44, gap: 8, borderWidth: 1, borderColor: "#EBEBEB" }}
+          style={{ height: 44, gap: 8, borderWidth: 1, borderColor }}
         >
           <Mail size={18} color="#4A90D9" />
           <Text className="font-poppins-semibold text-body text-primary dark:text-primary-dark">

--- a/apps/mobile/features/email-capture/components/FailedEmailsBanner.tsx
+++ b/apps/mobile/features/email-capture/components/FailedEmailsBanner.tsx
@@ -4,7 +4,7 @@ import { useThemeColor } from "@/shared/hooks/use-theme-color";
 import { useEmailCaptureStore } from "../store";
 
 export const FailedEmailsBanner = ({ onPress }: { onPress: () => void }) => {
-  const failedCount = useEmailCaptureStore((s) => s.failedCount);
+  const failedCount = useEmailCaptureStore((s) => s.failedEmails.length);
   const iconColor = useThemeColor("accentRed");
 
   if (failedCount === 0) return null;

--- a/apps/mobile/features/email-capture/hooks/useEmailCapture.ts
+++ b/apps/mobile/features/email-capture/hooks/useEmailCapture.ts
@@ -21,10 +21,6 @@ export function useEmailCapture(db: AnyDb | null, userId: string | null) {
       .loadAccounts()
       .then(() => runFetch())
       .catch(() => {});
-    useEmailCaptureStore
-      .getState()
-      .loadFailedEmails()
-      .catch(() => {});
 
     const subscription = AppState.addEventListener("change", (state) => {
       if (state === "active") runFetch();

--- a/apps/mobile/features/email-capture/index.ts
+++ b/apps/mobile/features/email-capture/index.ts
@@ -1,0 +1,6 @@
+export { EmailConnectBanner } from "./components/EmailConnectBanner";
+export { FailedEmailsBanner } from "./components/FailedEmailsBanner";
+export { useEmailCapture } from "./hooks/useEmailCapture";
+export type { BankSender } from "./lib/bank-senders";
+export type { EmailProvider } from "./schema";
+export { useEmailCaptureStore } from "./store";

--- a/apps/mobile/features/email-capture/lib/bank-senders.ts
+++ b/apps/mobile/features/email-capture/lib/bank-senders.ts
@@ -1,3 +1,5 @@
+import { getSupabase } from "@/shared/lib/supabase";
+
 export type BankSender = {
   readonly bank: string;
   readonly email: string;
@@ -8,6 +10,27 @@ export const DEFAULT_BANK_SENDERS: readonly BankSender[] = [
   { bank: "BBVA", email: "BBVA@bbvanet.com.co" },
   { bank: "Rappi", email: "noreply@rappicard.co" },
 ] as const;
+
+let cachedSenders: readonly BankSender[] | null = null;
+
+export async function fetchBankSenders(): Promise<readonly BankSender[]> {
+  try {
+    const { data, error } = await getSupabase().from("bank_senders").select("bank, email");
+
+    if (error || !data || data.length === 0) {
+      return cachedSenders ?? DEFAULT_BANK_SENDERS;
+    }
+
+    cachedSenders = data.map((row) => ({ bank: row.bank, email: row.email }));
+    return cachedSenders;
+  } catch {
+    return cachedSenders ?? DEFAULT_BANK_SENDERS;
+  }
+}
+
+export function resetBankSendersCache() {
+  cachedSenders = null;
+}
 
 export function isBankSender(from: string, senders: readonly BankSender[]): boolean {
   const normalized = from.toLowerCase();

--- a/apps/mobile/features/email-capture/lib/bank-senders.ts
+++ b/apps/mobile/features/email-capture/lib/bank-senders.ts
@@ -11,9 +11,15 @@ export const DEFAULT_BANK_SENDERS: readonly BankSender[] = [
   { bank: "Rappi", email: "noreply@rappicard.co" },
 ] as const;
 
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 let cachedSenders: readonly BankSender[] | null = null;
+let cachedAt = 0;
 
 export async function fetchBankSenders(): Promise<readonly BankSender[]> {
+  if (cachedSenders && Date.now() - cachedAt < CACHE_TTL_MS) {
+    return cachedSenders;
+  }
+
   try {
     const { data, error } = await getSupabase().from("bank_senders").select("bank, email");
 
@@ -22,6 +28,7 @@ export async function fetchBankSenders(): Promise<readonly BankSender[]> {
     }
 
     cachedSenders = data.map((row) => ({ bank: row.bank, email: row.email }));
+    cachedAt = Date.now();
     return cachedSenders;
   } catch {
     return cachedSenders ?? DEFAULT_BANK_SENDERS;
@@ -30,6 +37,7 @@ export async function fetchBankSenders(): Promise<readonly BankSender[]> {
 
 export function resetBankSendersCache() {
   cachedSenders = null;
+  cachedAt = 0;
 }
 
 export function isBankSender(from: string, senders: readonly BankSender[]): boolean {

--- a/apps/mobile/features/email-capture/lib/repository.ts
+++ b/apps/mobile/features/email-capture/lib/repository.ts
@@ -1,4 +1,4 @@
-import { desc, eq } from "drizzle-orm";
+import { desc, eq, inArray } from "drizzle-orm";
 import type { AnyDb } from "@/shared/db/client";
 import { emailAccounts, processedEmails } from "@/shared/db/schema";
 
@@ -36,6 +36,15 @@ export async function getProcessedEmailByExternalId(db: AnyDb, externalId: strin
     .from(processedEmails)
     .where(eq(processedEmails.externalId, externalId));
   return rows[0] ?? null;
+}
+
+export async function getProcessedExternalIds(db: AnyDb, externalIds: string[]) {
+  if (externalIds.length === 0) return new Set<string>();
+  const rows = await db
+    .select({ externalId: processedEmails.externalId })
+    .from(processedEmails)
+    .where(inArray(processedEmails.externalId, externalIds));
+  return new Set(rows.map((r) => r.externalId));
 }
 
 export async function getFailedEmails(db: AnyDb) {

--- a/apps/mobile/features/email-capture/schema.ts
+++ b/apps/mobile/features/email-capture/schema.ts
@@ -18,3 +18,7 @@ export type RawEmail = z.infer<typeof rawEmailSchema>;
 
 export const transactionSourceSchema = z.enum(["manual", "email_gmail", "email_outlook"]);
 export type TransactionSource = z.infer<typeof transactionSourceSchema>;
+
+export const EMAIL_REDIRECT_URI = "fidy://email/callback";
+
+export type ConnectResult = { success: true; email: string } | { success: false; error: string };

--- a/apps/mobile/features/email-capture/services/email-pipeline.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline.ts
@@ -4,7 +4,7 @@ import type { AnyDb } from "@/shared/db/client";
 import { generateId } from "@/shared/lib/generate-id";
 import type { BankSender } from "../lib/bank-senders";
 import { isBankSender } from "../lib/bank-senders";
-import { getProcessedEmailByExternalId, insertProcessedEmail } from "../lib/repository";
+import { getProcessedExternalIds, insertProcessedEmail } from "../lib/repository";
 import type { RawEmail } from "../schema";
 
 export type ParsedTransaction = {
@@ -44,14 +44,16 @@ export async function processEmails(
     failed: 0,
   };
 
+  const allExternalIds = rawEmails.map((e) => e.externalId);
+  const processedIds = await getProcessedExternalIds(db, allExternalIds);
+
   for (const email of rawEmails) {
     if (!isBankSender(email.from, senders)) {
       result.filtered++;
       continue;
     }
 
-    const existing = await getProcessedEmailByExternalId(db, email.externalId);
-    if (existing) {
+    if (processedIds.has(email.externalId)) {
       result.skippedDuplicate++;
       continue;
     }

--- a/apps/mobile/features/email-capture/services/gmail-adapter.ts
+++ b/apps/mobile/features/email-capture/services/gmail-adapter.ts
@@ -1,14 +1,12 @@
 import * as SecureStore from "expo-secure-store";
-import type { RawEmail } from "../schema";
+import type { ConnectResult, RawEmail } from "../schema";
+import { EMAIL_REDIRECT_URI } from "../schema";
 
 const TOKEN_KEY = "email-gmail-token";
 const REFRESH_TOKEN_KEY = "email-gmail-refresh-token";
-const REDIRECT_URI = "fidy://email/callback";
 const AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 const TOKEN_URL = "https://oauth2.googleapis.com/token";
 const SCOPE = "https://www.googleapis.com/auth/gmail.readonly";
-
-type ConnectResult = { success: true; email: string } | { success: false; error: string };
 
 export async function isGmailConnected(): Promise<boolean> {
   const token = await SecureStore.getItemAsync(TOKEN_KEY);
@@ -53,14 +51,14 @@ export async function connectGmail(clientId: string): Promise<ConnectResult> {
 
   const params = new URLSearchParams({
     client_id: clientId,
-    redirect_uri: REDIRECT_URI,
+    redirect_uri: EMAIL_REDIRECT_URI,
     response_type: "code",
     scope: SCOPE,
     access_type: "offline",
     prompt: "consent",
   });
 
-  const result = await openAuthSessionAsync(`${AUTH_URL}?${params}`, REDIRECT_URI);
+  const result = await openAuthSessionAsync(`${AUTH_URL}?${params}`, EMAIL_REDIRECT_URI);
 
   if (result.type !== "success" || !result.url) {
     return { success: false, error: "cancelled" };
@@ -77,7 +75,7 @@ export async function connectGmail(clientId: string): Promise<ConnectResult> {
     body: new URLSearchParams({
       code,
       client_id: clientId,
-      redirect_uri: REDIRECT_URI,
+      redirect_uri: EMAIL_REDIRECT_URI,
       grant_type: "authorization_code",
     }).toString(),
   });
@@ -133,19 +131,25 @@ export async function fetchGmailEmails(
 
   if (messageIds.length === 0) return [];
 
+  const Concurrency = 5;
   const emails: RawEmail[] = [];
 
-  for (const id of messageIds) {
-    const msgResponse = await fetch(
-      `https://gmail.googleapis.com/gmail/v1/users/me/messages/${id}?format=full`,
-      { headers: { Authorization: `Bearer ${token}` } }
+  for (let i = 0; i < messageIds.length; i += Concurrency) {
+    const batch = messageIds.slice(i, i + Concurrency);
+    const results = await Promise.allSettled(
+      batch.map(async (id) => {
+        const msgResponse = await fetch(
+          `https://gmail.googleapis.com/gmail/v1/users/me/messages/${id}?format=full`,
+          { headers: { Authorization: `Bearer ${token}` } }
+        );
+        if (!msgResponse.ok) return null;
+        const msg = await msgResponse.json();
+        return parseGmailMessage(id, msg);
+      })
     );
-
-    if (!msgResponse.ok) continue;
-
-    const msg = await msgResponse.json();
-    const parsed = parseGmailMessage(id, msg);
-    if (parsed) emails.push(parsed);
+    for (const r of results) {
+      if (r.status === "fulfilled" && r.value) emails.push(r.value);
+    }
   }
 
   return emails;

--- a/apps/mobile/features/email-capture/services/outlook-adapter.ts
+++ b/apps/mobile/features/email-capture/services/outlook-adapter.ts
@@ -1,14 +1,12 @@
 import * as SecureStore from "expo-secure-store";
-import type { RawEmail } from "../schema";
+import type { ConnectResult, RawEmail } from "../schema";
+import { EMAIL_REDIRECT_URI } from "../schema";
 
 const TOKEN_KEY = "email-outlook-token";
 const REFRESH_TOKEN_KEY = "email-outlook-refresh-token";
-const REDIRECT_URI = "fidy://email/callback";
 const AUTH_URL = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize";
 const TOKEN_URL = "https://login.microsoftonline.com/common/oauth2/v2.0/token";
 const SCOPE = "Mail.Read";
-
-type ConnectResult = { success: true; email: string } | { success: false; error: string };
 
 export async function isOutlookConnected(): Promise<boolean> {
   const token = await SecureStore.getItemAsync(TOKEN_KEY);
@@ -54,13 +52,13 @@ export async function connectOutlook(clientId: string): Promise<ConnectResult> {
 
   const params = new URLSearchParams({
     client_id: clientId,
-    redirect_uri: REDIRECT_URI,
+    redirect_uri: EMAIL_REDIRECT_URI,
     response_type: "code",
     scope: `${SCOPE} User.Read`,
     prompt: "consent",
   });
 
-  const result = await openAuthSessionAsync(`${AUTH_URL}?${params}`, REDIRECT_URI);
+  const result = await openAuthSessionAsync(`${AUTH_URL}?${params}`, EMAIL_REDIRECT_URI);
 
   if (result.type !== "success" || !result.url) {
     return { success: false, error: "cancelled" };
@@ -77,7 +75,7 @@ export async function connectOutlook(clientId: string): Promise<ConnectResult> {
     body: new URLSearchParams({
       code,
       client_id: clientId,
-      redirect_uri: REDIRECT_URI,
+      redirect_uri: EMAIL_REDIRECT_URI,
       grant_type: "authorization_code",
       scope: `${SCOPE} User.Read`,
     }).toString(),

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import type { AnyDb } from "@/shared/db/client";
 import { generateId } from "@/shared/lib/generate-id";
-import { DEFAULT_BANK_SENDERS } from "./lib/bank-senders";
+import { fetchBankSenders } from "./lib/bank-senders";
 import type { EmailAccountRow, ProcessedEmailRow } from "./lib/repository";
 import {
   deleteEmailAccount,
@@ -114,7 +114,8 @@ export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActio
     try {
       const { accounts } = get();
       const stubParseFn = async () => null;
-      const senderEmails = DEFAULT_BANK_SENDERS.map((s) => s.email);
+      const senders = await fetchBankSenders();
+      const senderEmails = senders.map((s) => s.email);
 
       for (const account of accounts) {
         try {
@@ -126,7 +127,7 @@ export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActio
               : await fetchOutlookEmails(outlookClientId, since, senderEmails);
 
           if (rawEmails.length > 0) {
-            await processEmails(dbRef!, userIdRef!, rawEmails, DEFAULT_BANK_SENDERS, stubParseFn);
+            await processEmails(dbRef!, userIdRef!, rawEmails, senders, stubParseFn);
           }
 
           await updateLastFetchedAt(dbRef!, account.id, new Date().toISOString());

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -22,7 +22,6 @@ let userIdRef: string | null = null;
 type EmailCaptureState = {
   accounts: EmailAccountRow[];
   failedEmails: ProcessedEmailRow[];
-  failedCount: number;
   isFetching: boolean;
   bannerDismissed: boolean;
 };
@@ -41,7 +40,6 @@ type EmailCaptureActions = {
 export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActions>((set, get) => ({
   accounts: [],
   failedEmails: [],
-  failedCount: 0,
   isFetching: false,
   bannerDismissed: false,
 
@@ -59,7 +57,7 @@ export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActio
   loadFailedEmails: async () => {
     if (!dbRef) return;
     const failedEmails = await getFailedEmails(dbRef);
-    set({ failedEmails, failedCount: failedEmails.length });
+    set({ failedEmails });
   },
 
   dismissBanner: () => set({ bannerDismissed: true }),
@@ -68,7 +66,7 @@ export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActio
     if (!dbRef) return;
     await dismissProcessedEmail(dbRef, id);
     const updated = get().failedEmails.filter((e) => e.id !== id);
-    set({ failedEmails: updated, failedCount: updated.length });
+    set({ failedEmails: updated });
   },
 
   connectEmail: async (provider, clientId) => {
@@ -137,7 +135,7 @@ export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActio
       }
 
       const failedEmails = await getFailedEmails(dbRef);
-      set({ failedEmails, failedCount: failedEmails.length });
+      set({ failedEmails });
     } finally {
       set({ isFetching: false });
     }

--- a/apps/mobile/supabase/migrations/0002_bank_senders.sql
+++ b/apps/mobile/supabase/migrations/0002_bank_senders.sql
@@ -1,0 +1,19 @@
+create table public.bank_senders (
+  id uuid primary key default gen_random_uuid(),
+  bank text not null,
+  email text not null unique,
+  created_at timestamptz not null default now()
+);
+
+-- All authenticated users can read bank senders
+alter table public.bank_senders enable row level security;
+
+create policy "Authenticated users can read bank senders"
+  on public.bank_senders for select
+  using (auth.role() = 'authenticated');
+
+-- Seed with default senders
+insert into public.bank_senders (bank, email) values
+  ('Davibank', 'davibankinforma@davibank.com'),
+  ('BBVA', 'BBVA@bbvanet.com.co'),
+  ('Rappi', 'noreply@rappicard.co');


### PR DESCRIPTION
- Add email capture store, schema, repository, and pipeline
- Add Gmail and Outlook OAuth adapters
- Add email capture UI components and screens
- Add bank_senders Supabase migration with RLS
- Add fetchBankSenders with cache and offline fallback
- Add feature index with public exports
- Fix gitleaks base ref resolution in CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds email capture pipeline and UI in the mobile app. Fetches verified bank sender emails from Supabase with a 1-hour cache and offline fallback, and speeds up processing with batched duplicate checks and concurrent Gmail message fetching.

- **New Features**
  - Added bank_senders table with RLS and seed data.
  - Added fetchBankSenders with 1-hour cache TTL and offline fallback; reset cache helper.
  - Updated store to use remote senders for filtering/processing; exported UI components, hooks, types, and store from the feature index.

- **Migration**
  - Run Supabase migration 0002_bank_senders.sql.
  - Requires an authenticated Supabase session to read bank_senders (RLS).

<sup>Written for commit 683eeb003e56eb1b239bac0127f3ce15967e1b70. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

