### PR TITLE
fix(mobile): wire Gmail OAuth and fix migrations

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -8,7 +8,7 @@ import {
 } from "@expo-google-fonts/poppins";
 import { useMigrations } from "drizzle-orm/expo-sqlite/migrator";
 import { useFonts } from "expo-font";
-import { Redirect, Stack } from "expo-router";
+import { Stack, useRouter, useSegments } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
 import { useEffect } from "react";
@@ -52,6 +52,8 @@ export default function RootLayout() {
   const session = useAuthStore((s) => s.session);
   const isAuthLoading = useAuthStore((s) => s.isLoading);
   const userId = session?.user?.id ?? null;
+  const router = useRouter();
+  const segments = useSegments();
 
   const [fontsLoaded, fontsError] = useFonts({
     Poppins_500Medium,
@@ -72,6 +74,18 @@ export default function RootLayout() {
     }
   }, [fontsLoaded, fontsError, isAuthLoading, userId]);
 
+  useEffect(() => {
+    if (isAuthLoading || (!fontsLoaded && !fontsError)) return;
+
+    const inAuthGroup = segments[0] === "(auth)";
+
+    if (userId && inAuthGroup) {
+      router.replace("/(tabs)");
+    } else if (!userId && !inAuthGroup) {
+      router.replace("/(auth)");
+    }
+  }, [userId, segments, isAuthLoading, fontsLoaded, fontsError, router]);
+
   if (!fontsLoaded && !fontsError) {
     return null;
   }
@@ -88,14 +102,7 @@ export default function RootLayout() {
         <Stack.Screen name="(auth)" />
         <Stack.Screen name="(tabs)" />
       </Stack>
-      {db && userId ? (
-        <>
-          <AuthenticatedShell db={db} userId={userId} />
-          <Redirect href="/(tabs)" />
-        </>
-      ) : (
-        <Redirect href="/(auth)" />
-      )}
+      {db && userId && <AuthenticatedShell db={db} userId={userId} />}
       <StatusBar style="auto" />
     </GestureHandlerRootView>
   );


### PR DESCRIPTION
- Add missing migration imports (0002-0004) in migrations.js
- Switch Gmail OAuth to iOS client with reversed-client-ID scheme
- Have adapters own their client IDs from env vars internally
- Remove EMAIL_REDIRECT_URI from schema, move to outlook adapter
- Rename "Connected Accounts" to "Connected Mails" in UI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires up Gmail OAuth on iOS and switches auth routing to a segment-aware effect that preserves deep links and avoids unwanted redirects. Also fixes missing migrations so the app boots correctly.

- **New Features**
  - iOS Gmail OAuth using the reversed client ID scheme.
  - Segment-aware auth gating via useRouter/useSegments; only redirects when in the wrong route group and keeps deep link targets.

- **Refactors**
  - Replaced layout <Redirect> with useEffect-driven routing.
  - OAuth adapters read client IDs from env; moved EMAIL_REDIRECT_URI into the Outlook adapter.
  - Renamed “Connected Accounts” to “Connected Mails” in the UI.

<sup>Written for commit 696a10e7e910f0e9a2b69d4940629494ffc0bac6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

