### PR TITLE
fix(ci): add --no-verify-jwt for ES256 token compat

### DIFF
--- a/.github/workflows/deploy-edge-functions.yml
+++ b/.github/workflows/deploy-edge-functions.yml
@@ -19,6 +19,6 @@ jobs:
           version: 2.75.0
 
       - name: Deploy parse-email
-        run: supabase functions deploy parse-email --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+        run: supabase functions deploy parse-email --no-verify-jwt --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes CI deploy for the `parse-email` edge function by adding `--no-verify-jwt` to the `supabase` deploy command. This bypasses JWT verification to support ES256 tokens and prevents deployment failures in GitHub Actions.

<sup>Written for commit 18270c6a584d0188db259fe36748a8d8a456d08a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

