### PR TITLE
chore(mobile): add Android package name to app.json

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -22,6 +22,7 @@
       }
     },
     "android": {
+      "package": "com.obarbozaa.fidy",
       "adaptiveIcon": {
         "backgroundColor": "#E6F4FE",
         "foregroundImage": "./assets/images/android-icon-foreground.png",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set the Android package name to `com.obarbozaa.fidy` in app.json. This gives the app a consistent identifier for builds, signing, and Play Store submission.

<sup>Written for commit dcdbfb8ebf143103fa32c8b8a5756e643f64984c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

