### PR TITLE
feat(mobile): AI chat with streaming and memory

### DIFF
--- a/.github/workflows/deploy-edge-functions.yml
+++ b/.github/workflows/deploy-edge-functions.yml
@@ -22,3 +22,8 @@ jobs:
         run: supabase functions deploy parse-email --no-verify-jwt --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+
+      - name: Deploy ai-chat
+        run: supabase functions deploy ai-chat --no-verify-jwt --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/apps/mobile/__tests__/ai-chat/build-context.test.ts
+++ b/apps/mobile/__tests__/ai-chat/build-context.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { buildChatContext } from "../../features/ai-chat/lib/build-context";
+import type { UserMemory } from "../../features/ai-chat/schema";
+import type { StoredTransaction } from "../../features/transactions/schema";
+
+const NOW = new Date(2026, 2, 5, 12, 0, 0);
+
+const makeTx = (overrides: Partial<StoredTransaction>): StoredTransaction => ({
+  id: "tx_1",
+  userId: "u1",
+  type: "expense",
+  amountCents: 1000,
+  categoryId: "food",
+  description: "test",
+  date: new Date(2026, 2, 1),
+  createdAt: NOW,
+  updatedAt: NOW,
+  deletedAt: null,
+  ...overrides,
+});
+
+const makeMemory = (overrides: Partial<UserMemory>): UserMemory => ({
+  id: "mem_1",
+  userId: "u1",
+  fact: "Gets paid on the 15th",
+  category: "habit",
+  createdAt: NOW.toISOString(),
+  updatedAt: NOW.toISOString(),
+  ...overrides,
+});
+
+describe("buildChatContext", () => {
+  it("returns correctly shaped context with transactions and memories", () => {
+    const txs = [
+      makeTx({ type: "income", amountCents: 500000, date: new Date(2026, 2, 1) }),
+      makeTx({ id: "tx_2", amountCents: 30000, categoryId: "food", date: new Date(2026, 2, 2) }),
+      makeTx({
+        id: "tx_3",
+        amountCents: 15000,
+        categoryId: "transport",
+        date: new Date(2026, 2, 3),
+      }),
+      makeTx({ id: "tx_4", amountCents: 20000, categoryId: "food", date: new Date(2026, 1, 15) }),
+    ];
+    const memories = [makeMemory({})];
+
+    const result = buildChatContext(txs, memories, "2026-03");
+
+    expect(result.summary.balance).toBe(435000);
+    expect(result.summary.currentMonthSpending).toEqual([
+      { categoryId: "food", totalCents: 30000 },
+      { categoryId: "transport", totalCents: 15000 },
+    ]);
+    expect(result.summary.previousMonthSpending).toEqual([
+      { categoryId: "food", totalCents: 20000 },
+    ]);
+    expect(result.memories).toEqual([{ fact: "Gets paid on the 15th", category: "habit" }]);
+    expect(result.transactions).toHaveLength(4);
+  });
+
+  it("handles empty transactions", () => {
+    const result = buildChatContext([], [], "2026-03");
+
+    expect(result.summary.balance).toBe(0);
+    expect(result.summary.currentMonthSpending).toEqual([]);
+    expect(result.summary.previousMonthSpending).toEqual([]);
+    expect(result.transactions).toEqual([]);
+    expect(result.memories).toEqual([]);
+  });
+
+  it("handles empty memories with transactions", () => {
+    const txs = [makeTx({ amountCents: 5000 })];
+    const result = buildChatContext(txs, [], "2026-03");
+
+    expect(result.memories).toEqual([]);
+    expect(result.transactions).toHaveLength(1);
+  });
+
+  it("filters transactions to current and previous month", () => {
+    const txs = [
+      makeTx({ date: new Date(2026, 2, 1) }), // March - current
+      makeTx({ id: "tx_2", date: new Date(2026, 1, 15) }), // Feb - previous
+      makeTx({ id: "tx_3", date: new Date(2026, 0, 10) }), // Jan - excluded
+    ];
+    const result = buildChatContext(txs, [], "2026-03");
+
+    expect(result.transactions).toHaveLength(2);
+  });
+
+  it("maps transactions to context shape", () => {
+    const txs = [
+      makeTx({
+        type: "expense",
+        amountCents: 5000,
+        categoryId: "food",
+        description: "Lunch",
+        date: new Date(2026, 2, 1),
+      }),
+    ];
+    const result = buildChatContext(txs, [], "2026-03");
+
+    expect(result.transactions[0]).toEqual({
+      type: "expense",
+      amountCents: 5000,
+      categoryId: "food",
+      description: "Lunch",
+      date: "2026-03-01",
+    });
+  });
+});

--- a/apps/mobile/__tests__/ai-chat/memories.test.ts
+++ b/apps/mobile/__tests__/ai-chat/memories.test.ts
@@ -63,4 +63,19 @@ describe("deduplicateMemories", () => {
   it("handles both empty", () => {
     expect(deduplicateMemories([], [])).toEqual([]);
   });
+
+  it("deduplicates within newFacts batch", () => {
+    const newFacts: readonly ExtractedMemory[] = [
+      { fact: "Works from home", category: "situation" },
+      { fact: "works from home", category: "situation" },
+      { fact: "Has a dog", category: "preference" },
+    ];
+
+    const result = deduplicateMemories([], newFacts);
+
+    expect(result).toEqual([
+      { fact: "Works from home", category: "situation" },
+      { fact: "Has a dog", category: "preference" },
+    ]);
+  });
 });

--- a/apps/mobile/__tests__/ai-chat/memories.test.ts
+++ b/apps/mobile/__tests__/ai-chat/memories.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { deduplicateMemories } from "../../features/ai-chat/lib/memories";
+import type { ExtractedMemory, UserMemory } from "../../features/ai-chat/schema";
+
+const NOW = new Date(2026, 2, 5).toISOString();
+
+const makeMemory = (fact: string): UserMemory => ({
+  id: "mem_1",
+  userId: "u1",
+  fact,
+  category: "habit",
+  createdAt: NOW,
+  updatedAt: NOW,
+});
+
+describe("deduplicateMemories", () => {
+  it("filters out facts that already exist (case-insensitive)", () => {
+    const existing: readonly UserMemory[] = [
+      makeMemory("Gets paid on the 15th"),
+      makeMemory("Prefers to eat out"),
+    ];
+    const newFacts: readonly ExtractedMemory[] = [
+      { fact: "gets paid on the 15th", category: "habit" },
+      { fact: "Has a car loan", category: "situation" },
+    ];
+
+    const result = deduplicateMemories(existing, newFacts);
+
+    expect(result).toEqual([{ fact: "Has a car loan", category: "situation" }]);
+  });
+
+  it("keeps genuinely new facts", () => {
+    const existing: readonly UserMemory[] = [makeMemory("Gets paid on the 15th")];
+    const newFacts: readonly ExtractedMemory[] = [
+      { fact: "Works from home", category: "situation" },
+      { fact: "Trying to save for vacation", category: "goal" },
+    ];
+
+    const result = deduplicateMemories(existing, newFacts);
+
+    expect(result).toEqual([
+      { fact: "Works from home", category: "situation" },
+      { fact: "Trying to save for vacation", category: "goal" },
+    ]);
+  });
+
+  it("handles empty existing memories", () => {
+    const newFacts: readonly ExtractedMemory[] = [{ fact: "New fact", category: "preference" }];
+
+    const result = deduplicateMemories([], newFacts);
+
+    expect(result).toEqual([{ fact: "New fact", category: "preference" }]);
+  });
+
+  it("handles empty new facts", () => {
+    const existing: readonly UserMemory[] = [makeMemory("Existing fact")];
+
+    const result = deduplicateMemories(existing, []);
+
+    expect(result).toEqual([]);
+  });
+
+  it("handles both empty", () => {
+    expect(deduplicateMemories([], [])).toEqual([]);
+  });
+});

--- a/apps/mobile/__tests__/ai-chat/parse-action.test.ts
+++ b/apps/mobile/__tests__/ai-chat/parse-action.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { parseActionFromResponse } from "../../features/ai-chat/lib/parse-action";
+
+describe("parseActionFromResponse", () => {
+  it("extracts add action from mixed text", () => {
+    const text =
+      'Sure, I\'ll add that for you. [ACTION]{"type":"add","data":{"type":"expense","amountCents":5000000,"categoryId":"food","description":"Almuerzo","date":"2026-03-05"}}[/ACTION]';
+
+    const result = parseActionFromResponse(text);
+
+    expect(result).toEqual({
+      type: "add",
+      data: {
+        type: "expense",
+        amountCents: 5000000,
+        categoryId: "food",
+        description: "Almuerzo",
+        date: "2026-03-05",
+      },
+    });
+  });
+
+  it("extracts delete action", () => {
+    const text =
+      'I\'ll delete that transaction. [ACTION]{"type":"delete","transactionId":"tx-123","description":"Uber","amountCents":1500000,"date":"2026-03-01"}[/ACTION] Done!';
+
+    const result = parseActionFromResponse(text);
+
+    expect(result).toEqual({
+      type: "delete",
+      transactionId: "tx-123",
+      description: "Uber",
+      amountCents: 1500000,
+      date: "2026-03-01",
+    });
+  });
+
+  it("extracts edit action", () => {
+    const text =
+      '[ACTION]{"type":"edit","transactionId":"tx-456","data":{"amountCents":2000000}}[/ACTION]';
+
+    const result = parseActionFromResponse(text);
+
+    expect(result).toEqual({
+      type: "edit",
+      transactionId: "tx-456",
+      data: { amountCents: 2000000 },
+    });
+  });
+
+  it("returns null when no action block present", () => {
+    const text = "Your total spending this month is $150,000 COP.";
+    expect(parseActionFromResponse(text)).toBeNull();
+  });
+
+  it("returns null for malformed JSON", () => {
+    const text = "[ACTION]{not valid json}[/ACTION]";
+    expect(parseActionFromResponse(text)).toBeNull();
+  });
+
+  it("returns null for invalid action shape", () => {
+    const text = '[ACTION]{"type":"unknown","foo":"bar"}[/ACTION]';
+    expect(parseActionFromResponse(text)).toBeNull();
+  });
+
+  it("extracts text content without action block", () => {
+    const text =
+      'Here is the result. [ACTION]{"type":"add","data":{"type":"expense","amountCents":1000,"categoryId":"food","description":"test","date":"2026-03-01"}}[/ACTION] All done.';
+
+    const result = parseActionFromResponse(text);
+    expect(result).not.toBeNull();
+  });
+});

--- a/apps/mobile/__tests__/ai-chat/sessions.test.ts
+++ b/apps/mobile/__tests__/ai-chat/sessions.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { deriveConversationTitle, findExpiredSessions } from "../../features/ai-chat/lib/sessions";
+import type { ChatSession } from "../../features/ai-chat/schema";
+
+const makeSession = (overrides: Partial<ChatSession>): ChatSession => ({
+  id: "sess_1",
+  userId: "u1",
+  title: "Test session",
+  createdAt: "2026-02-01T00:00:00.000Z",
+  expiresAt: "2026-03-03T00:00:00.000Z",
+  deletedAt: null,
+  ...overrides,
+});
+
+describe("deriveConversationTitle", () => {
+  it("truncates long messages to 50 characters with ellipsis", () => {
+    const longMessage =
+      "How much did I spend on food and transportation this month compared to last month?";
+    const title = deriveConversationTitle(longMessage);
+
+    expect(title.length).toBeLessThanOrEqual(53); // 50 + "..."
+    expect(title).toMatch(/\.\.\.$/);
+  });
+
+  it("keeps short messages as-is", () => {
+    const shortMessage = "Food spending?";
+    expect(deriveConversationTitle(shortMessage)).toBe("Food spending?");
+  });
+
+  it("handles exactly 50 characters", () => {
+    const msg = "A".repeat(50);
+    expect(deriveConversationTitle(msg)).toBe(msg);
+  });
+});
+
+describe("findExpiredSessions", () => {
+  it("returns only sessions past their expiresAt", () => {
+    const now = "2026-03-10T00:00:00.000Z";
+    const sessions = [
+      makeSession({ id: "s1", expiresAt: "2026-03-05T00:00:00.000Z" }), // expired
+      makeSession({ id: "s2", expiresAt: "2026-03-15T00:00:00.000Z" }), // not expired
+      makeSession({ id: "s3", expiresAt: "2026-03-09T23:59:59.999Z" }), // expired
+    ];
+
+    const result = findExpiredSessions(sessions, now);
+
+    expect(result.map((s) => s.id)).toEqual(["s1", "s3"]);
+  });
+
+  it("excludes already-deleted sessions", () => {
+    const now = "2026-03-10T00:00:00.000Z";
+    const sessions = [
+      makeSession({
+        id: "s1",
+        expiresAt: "2026-03-05T00:00:00.000Z",
+        deletedAt: "2026-03-06T00:00:00.000Z",
+      }),
+      makeSession({ id: "s2", expiresAt: "2026-03-05T00:00:00.000Z" }),
+    ];
+
+    const result = findExpiredSessions(sessions, now);
+
+    expect(result.map((s) => s.id)).toEqual(["s2"]);
+  });
+
+  it("returns empty array when nothing expired", () => {
+    const now = "2026-03-01T00:00:00.000Z";
+    const sessions = [makeSession({ expiresAt: "2026-03-15T00:00:00.000Z" })];
+
+    expect(findExpiredSessions(sessions, now)).toEqual([]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(findExpiredSessions([], "2026-03-10T00:00:00.000Z")).toEqual([]);
+  });
+});

--- a/apps/mobile/__tests__/coming-soon/ai-tab.test.ts
+++ b/apps/mobile/__tests__/coming-soon/ai-tab.test.ts
@@ -5,23 +5,26 @@ import { describe, expect, test } from "vitest";
 describe("AI tab", () => {
   const source = readFileSync(resolve(__dirname, "../../app/(tabs)/ai.tsx"), "utf-8");
 
-  test("imports ComingSoonScreen", () => {
-    expect(source).toContain("ComingSoonScreen");
+  test("imports ConversationList component", () => {
+    expect(source).toContain("ConversationList");
   });
 
-  test("imports Sparkles icon from lucide", () => {
-    expect(source).toContain("Sparkles");
+  test("imports ChatScreen component", () => {
+    expect(source).toContain("ChatScreen");
   });
 
-  test("passes AI Advisor as headerTitle", () => {
-    expect(source).toContain('headerTitle="AI Advisor"');
+  test("imports MemoryManager component", () => {
+    expect(source).toContain("MemoryManager");
   });
 
-  test("passes teaser headline", () => {
-    expect(source).toContain('headline="Your AI Advisor is on its way"');
+  test("manages view state for navigation", () => {
+    expect(source).toContain("AiView");
+    expect(source).toContain('"list"');
+    expect(source).toContain('"chat"');
+    expect(source).toContain('"memories"');
   });
 
-  test("passes feature description", () => {
-    expect(source).toContain("Smart insights about your spending");
+  test("extracts memories when leaving chat", () => {
+    expect(source).toContain("extractAndSaveMemories");
   });
 });

--- a/apps/mobile/app/(tabs)/ai.tsx
+++ b/apps/mobile/app/(tabs)/ai.tsx
@@ -1,13 +1,54 @@
-import { Sparkles } from "lucide-react-native";
-import { ComingSoonScreen } from "@/shared/components/ComingSoonScreen";
+import { useCallback, useState } from "react";
+import { ChatScreen } from "@/features/ai-chat/components/ChatScreen";
+import { ConversationList } from "@/features/ai-chat/components/ConversationList";
+import { MemoryManager } from "@/features/ai-chat/components/MemoryManager";
+import { useChatStore } from "@/features/ai-chat/store";
+
+type AiView = "list" | "chat" | "memories";
 
 export default function AiTab() {
-  return (
-    <ComingSoonScreen
-      Icon={Sparkles}
-      headerTitle="AI Advisor"
-      headline="Your AI Advisor is on its way"
-      description="Smart insights about your spending, budgets, and savings — powered by AI"
-    />
+  const [view, setView] = useState<AiView>("list");
+  const selectSession = useChatStore((s) => s.selectSession);
+  const extractAndSaveMemories = useChatStore((s) => s.extractAndSaveMemories);
+
+  const handleSelectSession = useCallback(
+    async (id: string) => {
+      await selectSession(id);
+      setView("chat");
+    },
+    [selectSession]
   );
+
+  const handleNewChat = useCallback(() => {
+    useChatStore.setState({ currentSessionId: null, messages: [] });
+    setView("chat");
+  }, []);
+
+  const handleBackFromChat = useCallback(() => {
+    extractAndSaveMemories();
+    setView("list");
+  }, [extractAndSaveMemories]);
+
+  const handleOpenMemories = useCallback(() => {
+    setView("memories");
+  }, []);
+
+  const handleBackFromMemories = useCallback(() => {
+    setView("list");
+  }, []);
+
+  switch (view) {
+    case "chat":
+      return <ChatScreen onBack={handleBackFromChat} />;
+    case "memories":
+      return <MemoryManager onBack={handleBackFromMemories} />;
+    default:
+      return (
+        <ConversationList
+          onSelectSession={handleSelectSession}
+          onNewChat={handleNewChat}
+          onOpenMemories={handleOpenMemories}
+        />
+      );
+  }
 }

--- a/apps/mobile/app/(tabs)/ai.tsx
+++ b/apps/mobile/app/(tabs)/ai.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from "react";
 import { ChatScreen } from "@/features/ai-chat/components/ChatScreen";
 import { ConversationList } from "@/features/ai-chat/components/ConversationList";
 import { MemoryManager } from "@/features/ai-chat/components/MemoryManager";
+import { cancelActiveStream } from "@/features/ai-chat/hooks/use-streaming-chat";
 import { useChatStore } from "@/features/ai-chat/store";
 
 type AiView = "list" | "chat" | "memories";
@@ -25,7 +26,8 @@ export default function AiTab() {
   }, []);
 
   const handleBackFromChat = useCallback(() => {
-    extractAndSaveMemories();
+    cancelActiveStream();
+    extractAndSaveMemories().catch(() => {});
     setView("list");
   }, [extractAndSaveMemories]);
 

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -13,6 +13,7 @@ import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
 import { useEffect } from "react";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { useChatStore } from "@/features/ai-chat/store";
 import { useAuthStore } from "@/features/auth/store";
 import { registerBackgroundTask } from "@/features/background-fetch/register";
 import { useApplePayCapture } from "@/features/capture-sources/hooks/useApplePayCapture";
@@ -37,6 +38,12 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: string }) {
       useTransactionStore.getState().initStore(db, userId);
       useEmailCaptureStore.getState().initStore(db, userId);
       useCaptureSourcesStore.getState().initStore(db, userId);
+      useChatStore.getState().initStore(db, userId);
+      useChatStore
+        .getState()
+        .loadSessions()
+        .then(() => useChatStore.getState().cleanupExpiredSessions())
+        .catch(() => {});
       useCaptureSourcesStore
         .getState()
         .hydrate()

--- a/apps/mobile/drizzle/0007_neat_wolfpack.sql
+++ b/apps/mobile/drizzle/0007_neat_wolfpack.sql
@@ -1,0 +1,32 @@
+CREATE TABLE `chat_messages` (
+	`id` text PRIMARY KEY NOT NULL,
+	`session_id` text NOT NULL,
+	`role` text NOT NULL,
+	`content` text NOT NULL,
+	`action` text,
+	`action_status` text,
+	`created_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_chat_messages_session_created` ON `chat_messages` (`session_id`,`created_at`);--> statement-breakpoint
+CREATE TABLE `chat_sessions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`title` text NOT NULL,
+	`created_at` text NOT NULL,
+	`expires_at` text NOT NULL,
+	`deleted_at` text
+);
+--> statement-breakpoint
+CREATE INDEX `idx_chat_sessions_user_created` ON `chat_sessions` (`user_id`,`created_at`);--> statement-breakpoint
+CREATE INDEX `idx_chat_sessions_expires` ON `chat_sessions` (`expires_at`);--> statement-breakpoint
+CREATE TABLE `user_memories` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`fact` text NOT NULL,
+	`category` text NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_user_memories_user` ON `user_memories` (`user_id`);

--- a/apps/mobile/drizzle/meta/0007_snapshot.json
+++ b/apps/mobile/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,800 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "2041b295-3abb-472b-9c55-7bdc0549f1f2",
+  "prevId": "8cb00543-9f0f-4c72-ab18-b4061ad10457",
+  "tables": {
+    "chat_messages": {
+      "name": "chat_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action_status": {
+          "name": "action_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_chat_messages_session_created": {
+          "name": "idx_chat_messages_session_created",
+          "columns": ["session_id", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_sessions": {
+      "name": "chat_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_chat_sessions_user_created": {
+          "name": "idx_chat_sessions_user_created",
+          "columns": ["user_id", "created_at"],
+          "isUnique": false
+        },
+        "idx_chat_sessions_expires": {
+          "name": "idx_chat_sessions_expires",
+          "columns": ["expires_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "detected_sms_events": {
+      "name": "detected_sms_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sender_label": {
+          "name": "sender_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dismissed": {
+          "name": "dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "linked_transaction_id": {
+          "name": "linked_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_sms_events_user_dismissed": {
+          "name": "idx_sms_events_user_dismissed",
+          "columns": ["user_id", "dismissed"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "email_accounts": {
+      "name": "email_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_email_accounts_user": {
+          "name": "idx_email_accounts_user",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "merchant_rules": {
+      "name": "merchant_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sender_email": {
+          "name": "sender_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_merchant_rule": {
+          "name": "uq_merchant_rule",
+          "columns": ["user_id", "sender_email", "keyword"],
+          "isUnique": true
+        },
+        "idx_merchant_lookup": {
+          "name": "idx_merchant_lookup",
+          "columns": ["user_id", "sender_email"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_sources": {
+      "name": "notification_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_notification_source": {
+          "name": "uq_notification_source",
+          "columns": ["user_id", "package_name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "processed_captures": {
+      "name": "processed_captures",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fingerprint_hash": {
+          "name": "fingerprint_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_text": {
+          "name": "raw_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_capture_fingerprint": {
+          "name": "uq_capture_fingerprint",
+          "columns": ["fingerprint_hash"],
+          "isUnique": true
+        },
+        "idx_capture_source": {
+          "name": "idx_capture_source",
+          "columns": ["source"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "processed_emails": {
+      "name": "processed_emails",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_body_preview": {
+          "name": "raw_body_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_processed_external_id": {
+          "name": "uq_processed_external_id",
+          "columns": ["external_id"],
+          "isUnique": true
+        },
+        "idx_processed_status": {
+          "name": "idx_processed_status",
+          "columns": ["status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_meta": {
+      "name": "sync_meta",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_queue": {
+      "name": "sync_queue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transactions": {
+      "name": "transactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "idx_transactions_user_date": {
+          "name": "idx_transactions_user_date",
+          "columns": ["user_id", "date"],
+          "isUnique": false
+        },
+        "idx_transactions_user_category": {
+          "name": "idx_transactions_user_category",
+          "columns": ["user_id", "category_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_memories": {
+      "name": "user_memories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fact": {
+          "name": "fact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_user_memories_user": {
+          "name": "idx_user_memories_user",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/mobile/drizzle/meta/_journal.json
+++ b/apps/mobile/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1772940334156,
       "tag": "0006_daily_stone_men",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1772987260095,
+      "tag": "0007_neat_wolfpack",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/mobile/drizzle/migrations.js
+++ b/apps/mobile/drizzle/migrations.js
@@ -5,6 +5,8 @@ import m0002 from "./0002_blue_maria_hill.sql";
 import m0003 from "./0003_brave_the_professor.sql";
 import m0004 from "./0004_wooden_toro.sql";
 import m0005 from "./0005_shallow_komodo.sql";
+import m0006 from "./0006_daily_stone_men.sql";
+import m0007 from "./0007_neat_wolfpack.sql";
 import journal from "./meta/_journal.json";
 
 export default {
@@ -16,5 +18,7 @@ export default {
     m0003,
     m0004,
     m0005,
+    m0006,
+    m0007,
   },
 };

--- a/apps/mobile/features/ai-chat/components/ActionCard.tsx
+++ b/apps/mobile/features/ai-chat/components/ActionCard.tsx
@@ -1,0 +1,78 @@
+import { Trash2 } from "lucide-react-native";
+import { Pressable, Text, View } from "react-native";
+import { formatCents } from "@/features/transactions/lib/format-amount";
+import { useThemeColor } from "@/shared/hooks/use-theme-color";
+import type { ChatAction } from "../schema";
+
+type ActionCardProps = {
+  readonly action: ChatAction;
+  readonly onConfirm: () => void;
+  readonly onDismiss: () => void;
+};
+
+export function ActionCard({ action, onConfirm, onDismiss }: ActionCardProps) {
+  const accentRed = useThemeColor("accentRed");
+  const borderSubtle = useThemeColor("borderSubtle");
+
+  if (action.type !== "delete") return null;
+
+  return (
+    <View
+      className="bg-card dark:bg-card-dark"
+      style={{
+        borderRadius: 16,
+        padding: 16,
+        gap: 12,
+        borderWidth: 1,
+        borderColor: borderSubtle,
+      }}
+    >
+      <View style={{ flexDirection: "row", alignItems: "center", gap: 12 }}>
+        <Trash2 size={20} color={accentRed} />
+        <View style={{ flex: 1, gap: 2 }}>
+          <Text className="font-poppins-semibold text-body text-primary dark:text-primary-dark">
+            Delete transaction
+          </Text>
+          <Text className="font-poppins-medium text-label text-secondary dark:text-secondary-dark">
+            {formatCents(action.amountCents)} — {action.description}
+          </Text>
+          <Text className="font-poppins-medium text-caption text-tertiary dark:text-tertiary-dark">
+            {action.date}
+          </Text>
+        </View>
+      </View>
+      <View style={{ flexDirection: "row", gap: 8 }}>
+        <Pressable
+          onPress={onDismiss}
+          className="bg-page dark:bg-page-dark"
+          style={{
+            flex: 1,
+            height: 36,
+            borderRadius: 12,
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <Text className="font-poppins-semibold text-label text-secondary dark:text-secondary-dark">
+            Cancel
+          </Text>
+        </Pressable>
+        <Pressable
+          onPress={onConfirm}
+          style={{
+            flex: 1,
+            height: 36,
+            borderRadius: 12,
+            backgroundColor: accentRed,
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <Text className="font-poppins-semibold text-label" style={{ color: "#FFFFFF" }}>
+            Delete
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/features/ai-chat/components/ChatHeader.tsx
+++ b/apps/mobile/features/ai-chat/components/ChatHeader.tsx
@@ -1,0 +1,39 @@
+import { ChevronLeft } from "lucide-react-native";
+import { Pressable, Text, View } from "react-native";
+import { useThemeColor } from "@/shared/hooks/use-theme-color";
+
+type ChatHeaderProps = {
+  readonly title: string;
+  readonly onBack: () => void;
+  readonly topInset: number;
+};
+
+export function ChatHeader({ title, onBack, topInset }: ChatHeaderProps) {
+  const primary = useThemeColor("primary");
+  const borderSubtle = useThemeColor("borderSubtle");
+
+  return (
+    <View
+      style={{
+        paddingTop: topInset + 12,
+        paddingBottom: 12,
+        paddingHorizontal: 20,
+        borderBottomWidth: 1,
+        borderBottomColor: borderSubtle,
+      }}
+    >
+      <View style={{ flexDirection: "row", alignItems: "center", gap: 12 }}>
+        <Pressable onPress={onBack} hitSlop={12}>
+          <ChevronLeft size={24} color={primary} />
+        </Pressable>
+        <Text
+          className="font-poppins-bold text-primary dark:text-primary-dark"
+          style={{ fontSize: 18 }}
+          numberOfLines={1}
+        >
+          {title}
+        </Text>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/features/ai-chat/components/ChatInput.tsx
+++ b/apps/mobile/features/ai-chat/components/ChatInput.tsx
@@ -1,0 +1,85 @@
+import { SendHorizonal } from "lucide-react-native";
+import { useCallback, useEffect, useState } from "react";
+import { Keyboard, Platform, Pressable, TextInput, View } from "react-native";
+import { useThemeColor } from "@/shared/hooks/use-theme-color";
+
+const TAB_BAR_CLEARANCE = 100;
+
+type ChatInputProps = {
+  readonly onSend: (text: string) => void;
+  readonly disabled?: boolean;
+};
+
+export function ChatInput({ onSend, disabled = false }: ChatInputProps) {
+  const [text, setText] = useState("");
+  const [keyboardVisible, setKeyboardVisible] = useState(false);
+  const borderSubtle = useThemeColor("borderSubtle");
+  const tertiary = useThemeColor("tertiary");
+  const accentGreen = useThemeColor("accentGreen");
+
+  useEffect(() => {
+    const showEvent = Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow";
+    const hideEvent = Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide";
+    const showSub = Keyboard.addListener(showEvent, () => setKeyboardVisible(true));
+    const hideSub = Keyboard.addListener(hideEvent, () => setKeyboardVisible(false));
+    return () => {
+      showSub.remove();
+      hideSub.remove();
+    };
+  }, []);
+
+  const handleSend = useCallback(() => {
+    const trimmed = text.trim();
+    if (!trimmed || disabled) return;
+    onSend(trimmed);
+    setText("");
+  }, [text, disabled, onSend]);
+
+  const canSend = !disabled && text.trim().length > 0;
+
+  return (
+    <View
+      className="flex-row items-end gap-2 bg-card dark:bg-card-dark"
+      style={{
+        paddingTop: 8,
+        paddingBottom: keyboardVisible ? 8 : TAB_BAR_CLEARANCE,
+        paddingHorizontal: 16,
+        borderTopWidth: 1,
+        borderTopColor: borderSubtle,
+      }}
+    >
+      <View
+        className="flex-1 flex-row items-center bg-page dark:bg-page-dark"
+        style={{ borderRadius: 20, paddingVertical: 10, paddingHorizontal: 16 }}
+      >
+        <TextInput
+          className="flex-1 text-primary dark:text-primary-dark"
+          style={{ fontFamily: "poppins-medium", fontSize: 14, maxHeight: 100, padding: 0 }}
+          placeholder="Ask about your finances..."
+          placeholderTextColor={tertiary}
+          value={text}
+          onChangeText={setText}
+          multiline
+          editable={!disabled}
+          onSubmitEditing={handleSend}
+          blurOnSubmit={false}
+        />
+      </View>
+      <Pressable
+        onPress={handleSend}
+        disabled={!canSend}
+        style={{
+          width: 40,
+          height: 40,
+          borderRadius: 20,
+          backgroundColor: canSend ? accentGreen : tertiary,
+          opacity: canSend ? 1 : 0.4,
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <SendHorizonal size={18} color="#fff" />
+      </Pressable>
+    </View>
+  );
+}

--- a/apps/mobile/features/ai-chat/components/ChatScreen.tsx
+++ b/apps/mobile/features/ai-chat/components/ChatScreen.tsx
@@ -50,7 +50,12 @@ export function ChatScreen({ onBack }: ChatScreenProps) {
     async (messageId: string) => {
       const msg = messages.find((m) => m.id === messageId);
       if (msg?.action?.type === "delete") {
-        await useTransactionStore.getState().removeTransaction(msg.action.transactionId);
+        try {
+          await useTransactionStore.getState().removeTransaction(msg.action.transactionId);
+        } catch {
+          updateActionStatus(messageId, "dismissed");
+          return;
+        }
       }
       updateActionStatus(messageId, "confirmed");
     },

--- a/apps/mobile/features/ai-chat/components/ChatScreen.tsx
+++ b/apps/mobile/features/ai-chat/components/ChatScreen.tsx
@@ -1,0 +1,145 @@
+import { FlashList } from "@shopify/flash-list";
+import { memo, useCallback, useRef } from "react";
+import { Keyboard, KeyboardAvoidingView, Platform, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTransactionStore } from "@/features/transactions/store";
+import { useStreamingChat } from "../hooks/use-streaming-chat";
+import type { ChatMessage } from "../schema";
+import { useChatStore } from "../store";
+import { ChatHeader } from "./ChatHeader";
+import { ChatInput } from "./ChatInput";
+import { MessageBubble } from "./MessageBubble";
+import { StarterSuggestions } from "./StarterSuggestions";
+import { StreamingBubble } from "./StreamingBubble";
+
+type ChatScreenProps = {
+  readonly onBack: () => void;
+};
+
+const keyExtractor = (item: ChatMessage) => item.id;
+
+const MemoizedMessageBubble = memo(function MemoizedBubble({
+  message,
+  onConfirm,
+  onDismiss,
+}: {
+  readonly message: ChatMessage;
+  readonly onConfirm: (id: string) => void;
+  readonly onDismiss: (id: string) => void;
+}) {
+  return (
+    <MessageBubble message={message} onConfirmAction={onConfirm} onDismissAction={onDismiss} />
+  );
+});
+
+export function ChatScreen({ onBack }: ChatScreenProps) {
+  const insets = useSafeAreaInsets();
+  const listRef = useRef<FlashList<ChatMessage>>(null);
+
+  const messages = useChatStore((s) => s.messages);
+  const sessions = useChatStore((s) => s.sessions);
+  const currentSessionId = useChatStore((s) => s.currentSessionId);
+  const updateActionStatus = useChatStore((s) => s.updateActionStatus);
+
+  const { sendMessage, isStreaming, streamingContent } = useStreamingChat();
+
+  const currentSession = sessions.find((s) => s.id === currentSessionId);
+  const title = currentSession?.title ?? "Fidy AI";
+
+  const handleConfirmAction = useCallback(
+    async (messageId: string) => {
+      const msg = messages.find((m) => m.id === messageId);
+      if (msg?.action?.type === "delete") {
+        await useTransactionStore.getState().removeTransaction(msg.action.transactionId);
+      }
+      updateActionStatus(messageId, "confirmed");
+    },
+    [messages, updateActionStatus]
+  );
+
+  const handleDismissAction = useCallback(
+    (messageId: string) => {
+      updateActionStatus(messageId, "dismissed");
+    },
+    [updateActionStatus]
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { item: ChatMessage }) => (
+      <MemoizedMessageBubble
+        message={item}
+        onConfirm={handleConfirmAction}
+        onDismiss={handleDismissAction}
+      />
+    ),
+    [handleConfirmAction, handleDismissAction]
+  );
+
+  const handleSend = useCallback(
+    (text: string) => {
+      sendMessage(text);
+      setTimeout(() => {
+        listRef.current?.scrollToEnd({ animated: true });
+      }, 100);
+    },
+    [sendMessage]
+  );
+
+  const handleSuggestionSelect = useCallback(
+    (text: string) => {
+      handleSend(text);
+    },
+    [handleSend]
+  );
+
+  const isEmpty = messages.length === 0 && !isStreaming;
+
+  return (
+    <View className="flex-1 bg-page dark:bg-page-dark">
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        keyboardVerticalOffset={0}
+      >
+        <ChatHeader title={title} onBack={onBack} topInset={insets.top} />
+
+        {isEmpty ? (
+          <View
+            style={{ flex: 1 }}
+            onStartShouldSetResponder={() => {
+              Keyboard.dismiss();
+              return false;
+            }}
+          >
+            <StarterSuggestions onSelect={handleSuggestionSelect} />
+          </View>
+        ) : (
+          <FlashList
+            ref={listRef}
+            data={messages}
+            renderItem={renderItem}
+            keyExtractor={keyExtractor}
+            estimatedItemSize={80}
+            keyboardDismissMode="on-drag"
+            keyboardShouldPersistTaps="handled"
+            contentContainerStyle={{
+              paddingHorizontal: 16,
+              paddingTop: 12,
+              paddingBottom: 12,
+            }}
+            contentInsetAdjustmentBehavior="automatic"
+            showsVerticalScrollIndicator={false}
+            onContentSizeChange={() => {
+              listRef.current?.scrollToEnd({ animated: false });
+            }}
+            ListFooterComponent={
+              isStreaming ? <StreamingBubble content={streamingContent} /> : null
+            }
+          />
+        )}
+
+        <ChatInput onSend={handleSend} disabled={isStreaming} />
+      </KeyboardAvoidingView>
+    </View>
+  );
+}

--- a/apps/mobile/features/ai-chat/components/ConversationList.tsx
+++ b/apps/mobile/features/ai-chat/components/ConversationList.tsx
@@ -1,0 +1,169 @@
+import { FlashList } from "@shopify/flash-list";
+import { format } from "date-fns";
+import { MessageSquare, Plus, Trash2 } from "lucide-react-native";
+import { memo, useCallback, useEffect } from "react";
+import { Platform, Pressable, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useThemeColor } from "@/shared/hooks/use-theme-color";
+import type { ChatSession } from "../schema";
+import { useChatStore } from "../store";
+
+type ConversationListProps = {
+  readonly onSelectSession: (id: string) => void;
+  readonly onNewChat: () => void;
+  readonly onOpenMemories: () => void;
+};
+
+const ItemSeparator = () => <View style={{ height: 10 }} />;
+
+const SessionCard = memo(function SessionCardInner({
+  session,
+  onSelect,
+  onDelete,
+}: {
+  readonly session: ChatSession;
+  readonly onSelect: () => void;
+  readonly onDelete: () => void;
+}) {
+  const tertiary = useThemeColor("tertiary");
+  const accentRed = useThemeColor("accentRed");
+
+  const dateStr = format(new Date(session.createdAt), "MMM d, yyyy");
+
+  return (
+    <Pressable
+      onPress={onSelect}
+      className="bg-card dark:bg-card-dark"
+      style={{
+        borderRadius: 16,
+        paddingVertical: 14,
+        paddingHorizontal: 16,
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 12,
+      }}
+    >
+      <MessageSquare size={20} color={tertiary} />
+      <View style={{ flex: 1, gap: 2 }}>
+        <Text
+          className="font-poppins-semibold text-body text-primary dark:text-primary-dark"
+          numberOfLines={1}
+        >
+          {session.title}
+        </Text>
+        <Text className="font-poppins-medium text-caption text-tertiary dark:text-tertiary-dark">
+          {dateStr}
+        </Text>
+      </View>
+      <Pressable onPress={() => onDelete()} hitSlop={12} style={{ padding: 4 }}>
+        <Trash2 size={18} color={accentRed} />
+      </Pressable>
+    </Pressable>
+  );
+});
+
+export function ConversationList({
+  onSelectSession,
+  onNewChat,
+  onOpenMemories,
+}: ConversationListProps) {
+  const insets = useSafeAreaInsets();
+  const sessions = useChatStore((s) => s.sessions);
+  const loadSessions = useChatStore((s) => s.loadSessions);
+  const deleteSession = useChatStore((s) => s.deleteSession);
+
+  const accentGreen = useThemeColor("accentGreen");
+
+  useEffect(() => {
+    loadSessions();
+  }, [loadSessions]);
+
+  const handleDelete = useCallback(
+    (id: string) => {
+      deleteSession(id);
+    },
+    [deleteSession]
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { item: ChatSession }) => (
+      <SessionCard
+        session={item}
+        onSelect={() => onSelectSession(item.id)}
+        onDelete={() => handleDelete(item.id)}
+      />
+    ),
+    [onSelectSession, handleDelete]
+  );
+
+  return (
+    <View className="flex-1 bg-page dark:bg-page-dark">
+      <FlashList
+        data={sessions}
+        renderItem={renderItem}
+        keyExtractor={(item) => item.id}
+        estimatedItemSize={72}
+        contentInsetAdjustmentBehavior="automatic"
+        contentContainerStyle={{
+          paddingTop: Platform.OS === "android" ? insets.top : 0,
+          paddingBottom: 100,
+          paddingHorizontal: 20,
+        }}
+        ItemSeparatorComponent={ItemSeparator}
+        ListHeaderComponent={
+          <View style={{ paddingBottom: 16 }}>
+            <View
+              style={{
+                flexDirection: "row",
+                alignItems: "center",
+                justifyContent: "space-between",
+              }}
+            >
+              <Text className="font-poppins-bold text-logo text-primary dark:text-primary-dark">
+                AI Chat
+              </Text>
+              <View style={{ flexDirection: "row", alignItems: "center", gap: 12 }}>
+                <Pressable
+                  onPress={onOpenMemories}
+                  className="bg-peach-light dark:bg-peach-light-dark"
+                  style={{
+                    borderRadius: 16,
+                    paddingVertical: 6,
+                    paddingHorizontal: 14,
+                  }}
+                >
+                  <Text className="font-poppins-semibold text-label" style={{ color: accentGreen }}>
+                    Memories
+                  </Text>
+                </Pressable>
+                <Pressable
+                  onPress={onNewChat}
+                  style={{
+                    width: 32,
+                    height: 32,
+                    borderRadius: 16,
+                    backgroundColor: accentGreen,
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  <Plus size={18} color="#FFFFFF" />
+                </Pressable>
+              </View>
+            </View>
+          </View>
+        }
+        ListEmptyComponent={
+          <View style={{ alignItems: "center", paddingTop: 60, gap: 8 }}>
+            <Text className="font-poppins-medium text-body text-tertiary dark:text-tertiary-dark text-center">
+              No conversations yet
+            </Text>
+            <Text className="font-poppins-medium text-label text-tertiary dark:text-tertiary-dark text-center">
+              Tap + to start a new chat
+            </Text>
+          </View>
+        }
+      />
+    </View>
+  );
+}

--- a/apps/mobile/features/ai-chat/components/MemoryManager.tsx
+++ b/apps/mobile/features/ai-chat/components/MemoryManager.tsx
@@ -1,0 +1,138 @@
+import { FlashList } from "@shopify/flash-list";
+import { ChevronLeft, Trash2 } from "lucide-react-native";
+import { memo, useCallback, useEffect } from "react";
+import { Platform, Pressable, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useThemeColor } from "@/shared/hooks/use-theme-color";
+import type { UserMemory } from "../schema";
+import { useChatStore } from "../store";
+
+type MemoryManagerProps = {
+  readonly onBack: () => void;
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  habit: "Habit",
+  preference: "Preference",
+  situation: "Situation",
+  goal: "Goal",
+};
+
+const ItemSeparator = () => <View style={{ height: 8 }} />;
+
+const MemoryCard = memo(function MemoryCardInner({
+  memory,
+  onDelete,
+}: {
+  readonly memory: UserMemory;
+  readonly onDelete: () => void;
+}) {
+  const accentRed = useThemeColor("accentRed");
+
+  return (
+    <View
+      className="bg-card dark:bg-card-dark"
+      style={{
+        borderRadius: 16,
+        padding: 16,
+        flexDirection: "row",
+        alignItems: "flex-start",
+        gap: 12,
+      }}
+    >
+      <View style={{ flex: 1, gap: 4 }}>
+        <Text className="font-poppins-medium text-body text-primary dark:text-primary-dark">
+          {memory.fact}
+        </Text>
+        <View
+          className="bg-peach-light dark:bg-peach-light-dark"
+          style={{
+            alignSelf: "flex-start",
+            borderRadius: 8,
+            paddingVertical: 2,
+            paddingHorizontal: 8,
+          }}
+        >
+          <Text
+            className="font-poppins-medium text-tertiary dark:text-tertiary-dark"
+            style={{ fontSize: 11 }}
+          >
+            {CATEGORY_LABELS[memory.category] ?? memory.category}
+          </Text>
+        </View>
+      </View>
+      <Pressable onPress={onDelete} hitSlop={12} style={{ padding: 4 }}>
+        <Trash2 size={18} color={accentRed} />
+      </Pressable>
+    </View>
+  );
+});
+
+export function MemoryManager({ onBack }: MemoryManagerProps) {
+  const insets = useSafeAreaInsets();
+  const memories = useChatStore((s) => s.memories);
+  const loadMemories = useChatStore((s) => s.loadMemories);
+  const deleteMemory = useChatStore((s) => s.deleteMemory);
+  const primary = useThemeColor("primary");
+
+  useEffect(() => {
+    loadMemories();
+  }, [loadMemories]);
+
+  const handleDelete = useCallback(
+    (id: string) => {
+      deleteMemory(id);
+    },
+    [deleteMemory]
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { item: UserMemory }) => (
+      <MemoryCard memory={item} onDelete={() => handleDelete(item.id)} />
+    ),
+    [handleDelete]
+  );
+
+  return (
+    <View className="flex-1 bg-page dark:bg-page-dark">
+      <FlashList
+        data={memories}
+        renderItem={renderItem}
+        keyExtractor={(item) => item.id}
+        estimatedItemSize={80}
+        contentInsetAdjustmentBehavior="automatic"
+        contentContainerStyle={{
+          paddingTop: Platform.OS === "android" ? insets.top : 0,
+          paddingBottom: 100,
+          paddingHorizontal: 20,
+        }}
+        ItemSeparatorComponent={ItemSeparator}
+        ListHeaderComponent={
+          <View style={{ gap: 20, paddingBottom: 16 }}>
+            <View style={{ flexDirection: "row", alignItems: "center", gap: 12 }}>
+              <Pressable onPress={onBack} hitSlop={12}>
+                <ChevronLeft size={24} color={primary} />
+              </Pressable>
+              <Text className="font-poppins-bold text-title text-primary dark:text-primary-dark">
+                Memories
+              </Text>
+            </View>
+            <Text className="font-poppins-medium text-label text-tertiary dark:text-tertiary-dark leading-relaxed">
+              Things Fidy AI remembers about you. Delete any memory you'd like it to forget.
+            </Text>
+          </View>
+        }
+        ListEmptyComponent={
+          <View style={{ alignItems: "center", paddingTop: 60, gap: 8 }}>
+            <Text className="font-poppins-medium text-body text-tertiary dark:text-tertiary-dark text-center">
+              No memories yet
+            </Text>
+            <Text className="font-poppins-medium text-label text-tertiary dark:text-tertiary-dark text-center">
+              Fidy AI will learn about you as you chat
+            </Text>
+          </View>
+        }
+      />
+    </View>
+  );
+}

--- a/apps/mobile/features/ai-chat/components/MessageBubble.tsx
+++ b/apps/mobile/features/ai-chat/components/MessageBubble.tsx
@@ -72,24 +72,22 @@ function MessageBubbleInner({ message, onConfirmAction, onDismissAction }: Messa
         </View>
       )}
 
-      {message.action &&
-        message.actionStatus === "confirmed" &&
-        message.action.type !== "delete" && (
-          <View
-            style={{
-              flexDirection: "row",
-              alignItems: "center",
-              gap: 6,
-              paddingLeft: 36,
-              marginTop: 4,
-            }}
-          >
-            <CircleCheck size={14} color={accentGreen} />
-            <Text className="font-poppins-semibold text-caption" style={{ color: accentGreen }}>
-              Added
-            </Text>
-          </View>
-        )}
+      {message.action && message.actionStatus === "confirmed" && message.action.type === "add" && (
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 6,
+            paddingLeft: 36,
+            marginTop: 4,
+          }}
+        >
+          <CircleCheck size={14} color={accentGreen} />
+          <Text className="font-poppins-semibold text-caption" style={{ color: accentGreen }}>
+            Added
+          </Text>
+        </View>
+      )}
 
       {message.action && message.actionStatus === "pending" && message.action.type === "delete" && (
         <View style={{ paddingLeft: 36, marginTop: 8 }}>

--- a/apps/mobile/features/ai-chat/components/MessageBubble.tsx
+++ b/apps/mobile/features/ai-chat/components/MessageBubble.tsx
@@ -1,0 +1,134 @@
+import { CircleCheck, Sparkles } from "lucide-react-native";
+import { memo } from "react";
+import { Text, View } from "react-native";
+import { useThemeColor } from "@/shared/hooks/use-theme-color";
+import { ACTION_BLOCK_REGEX } from "../lib/parse-action";
+import type { ChatMessage } from "../schema";
+import { ActionCard } from "./ActionCard";
+
+type MessageBubbleProps = {
+  readonly message: ChatMessage;
+  readonly onConfirmAction?: (messageId: string) => void;
+  readonly onDismissAction?: (messageId: string) => void;
+};
+
+function MessageBubbleInner({ message, onConfirmAction, onDismissAction }: MessageBubbleProps) {
+  const accentGreen = useThemeColor("accentGreen");
+  const accentRed = useThemeColor("accentRed");
+
+  const isUser = message.role === "user";
+
+  const contentWithoutAction = message.content.replace(ACTION_BLOCK_REGEX, "").trim();
+
+  return (
+    <View style={{ marginBottom: 4 }}>
+      {isUser ? (
+        <View style={{ alignItems: "flex-end" }}>
+          <View
+            style={{
+              maxWidth: "85%",
+              backgroundColor: accentGreen,
+              borderRadius: 16,
+              borderBottomRightRadius: 4,
+              paddingVertical: 10,
+              paddingHorizontal: 14,
+            }}
+          >
+            <Text className="font-poppins-medium text-body" style={{ color: "#FFFFFF" }}>
+              {contentWithoutAction}
+            </Text>
+          </View>
+        </View>
+      ) : (
+        <View style={{ flexDirection: "row", alignItems: "flex-start", gap: 8 }}>
+          <View
+            className="bg-nav dark:bg-nav-dark"
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: 14,
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <Sparkles size={16} color={accentGreen} />
+          </View>
+          <View style={{ flex: 1 }}>
+            <View
+              className="bg-nav dark:bg-nav-dark"
+              style={{
+                maxWidth: "90%",
+                borderRadius: 16,
+                borderBottomLeftRadius: 4,
+                paddingVertical: 10,
+                paddingHorizontal: 14,
+              }}
+            >
+              <Text className="font-poppins-medium text-body text-primary dark:text-primary-dark">
+                {contentWithoutAction}
+              </Text>
+            </View>
+          </View>
+        </View>
+      )}
+
+      {message.action &&
+        message.actionStatus === "confirmed" &&
+        message.action.type !== "delete" && (
+          <View
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              gap: 6,
+              paddingLeft: 36,
+              marginTop: 4,
+            }}
+          >
+            <CircleCheck size={14} color={accentGreen} />
+            <Text className="font-poppins-semibold text-caption" style={{ color: accentGreen }}>
+              Added
+            </Text>
+          </View>
+        )}
+
+      {message.action && message.actionStatus === "pending" && message.action.type === "delete" && (
+        <View style={{ paddingLeft: 36, marginTop: 8 }}>
+          <ActionCard
+            action={message.action}
+            onConfirm={() => onConfirmAction?.(message.id)}
+            onDismiss={() => onDismissAction?.(message.id)}
+          />
+        </View>
+      )}
+
+      {message.action &&
+        message.actionStatus === "confirmed" &&
+        message.action.type === "delete" && (
+          <View
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              gap: 6,
+              paddingLeft: 36,
+              marginTop: 4,
+            }}
+          >
+            <CircleCheck size={14} color={accentRed} />
+            <Text className="font-poppins-semibold text-caption" style={{ color: accentRed }}>
+              Deleted
+            </Text>
+          </View>
+        )}
+
+      {message.action && message.actionStatus === "dismissed" && (
+        <View style={{ paddingLeft: 36, marginTop: 4 }}>
+          <Text className="font-poppins-medium text-caption text-tertiary dark:text-tertiary-dark">
+            Dismissed
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+export const MessageBubble = memo(MessageBubbleInner);

--- a/apps/mobile/features/ai-chat/components/StarterSuggestions.tsx
+++ b/apps/mobile/features/ai-chat/components/StarterSuggestions.tsx
@@ -1,0 +1,75 @@
+import { Sparkles } from "lucide-react-native";
+import { Pressable, Text, View } from "react-native";
+import { useThemeColor } from "@/shared/hooks/use-theme-color";
+
+const SUGGESTIONS = [
+  "How much did I spend this month?",
+  "What's my biggest expense?",
+  "Compare my spending to last month",
+  "Add a food expense for today",
+] as const;
+
+type StarterSuggestionsProps = {
+  readonly onSelect: (text: string) => void;
+};
+
+export function StarterSuggestions({ onSelect }: StarterSuggestionsProps) {
+  const accentGreenLight = useThemeColor("accentGreenLight");
+  const accentGreen = useThemeColor("accentGreen");
+  const borderSubtle = useThemeColor("borderSubtle");
+
+  return (
+    <View
+      style={{
+        flex: 1,
+        alignItems: "center",
+        justifyContent: "center",
+        paddingHorizontal: 32,
+        gap: 24,
+      }}
+    >
+      <View style={{ alignItems: "center", gap: 8 }}>
+        <View
+          style={{
+            width: 56,
+            height: 56,
+            borderRadius: 28,
+            backgroundColor: accentGreenLight,
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <Sparkles size={24} color={accentGreen} />
+        </View>
+        <Text className="font-poppins-bold text-title text-primary dark:text-primary-dark">
+          Fidy AI
+        </Text>
+        <Text className="font-poppins-medium text-body text-tertiary dark:text-tertiary-dark text-center">
+          Ask me anything about your finances
+        </Text>
+      </View>
+      <View style={{ width: "100%", gap: 10 }}>
+        {SUGGESTIONS.map((suggestion) => (
+          <Pressable
+            key={suggestion}
+            onPress={() => onSelect(suggestion)}
+            className="bg-peach-light dark:bg-peach-light-dark"
+            style={{
+              borderRadius: 24,
+              borderWidth: 1,
+              borderColor: borderSubtle,
+              paddingVertical: 12,
+              paddingHorizontal: 20,
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <Text className="font-poppins-medium text-label text-primary dark:text-primary-dark">
+              {suggestion}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/features/ai-chat/components/StreamingBubble.tsx
+++ b/apps/mobile/features/ai-chat/components/StreamingBubble.tsx
@@ -1,0 +1,47 @@
+import { Sparkles } from "lucide-react-native";
+import { memo } from "react";
+import { Text, View } from "react-native";
+import { useThemeColor } from "@/shared/hooks/use-theme-color";
+
+type StreamingBubbleProps = {
+  readonly content: string;
+};
+
+function StreamingBubbleInner({ content }: StreamingBubbleProps) {
+  const accentGreen = useThemeColor("accentGreen");
+
+  return (
+    <View style={{ flexDirection: "row", alignItems: "flex-start", gap: 8, marginBottom: 4 }}>
+      <View
+        className="bg-nav dark:bg-nav-dark"
+        style={{
+          width: 28,
+          height: 28,
+          borderRadius: 14,
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <Sparkles size={16} color={accentGreen} />
+      </View>
+      <View style={{ flex: 1 }}>
+        <View
+          className="bg-nav dark:bg-nav-dark"
+          style={{
+            maxWidth: "90%",
+            borderRadius: 16,
+            borderBottomLeftRadius: 4,
+            paddingVertical: 10,
+            paddingHorizontal: 14,
+          }}
+        >
+          <Text className="font-poppins-medium text-body text-primary dark:text-primary-dark">
+            {content || "..."}
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+export const StreamingBubble = memo(StreamingBubbleInner);

--- a/apps/mobile/features/ai-chat/hooks/use-streaming-chat.ts
+++ b/apps/mobile/features/ai-chat/hooks/use-streaming-chat.ts
@@ -1,0 +1,131 @@
+import { useCallback, useRef } from "react";
+import { useTransactionStore } from "@/features/transactions/store";
+import { parseIsoDate, toIsoDate } from "@/shared/lib/format-date";
+import { buildChatContext } from "../lib/build-context";
+import { parseActionFromResponse } from "../lib/parse-action";
+import type { ChatAction } from "../schema";
+import { streamChat } from "../services/ai-chat-api";
+import { useChatStore } from "../store";
+
+export function useStreamingChat() {
+  const abortRef = useRef<AbortController | null>(null);
+
+  const {
+    messages,
+    currentSessionId,
+    memories,
+    isStreaming,
+    streamingContent,
+    createSession,
+    addUserMessage,
+    addAssistantMessage,
+    setStreaming,
+    setStreamingContent,
+  } = useChatStore();
+
+  const executeAction = useCallback(async (action: ChatAction) => {
+    switch (action.type) {
+      case "add": {
+        const store = useTransactionStore.getState();
+        store.setType(action.data.type);
+        store.setDigits(String(action.data.amountCents));
+        store.setCategoryId(action.data.categoryId);
+        store.setDescription(action.data.description);
+        store.setDate(parseIsoDate(action.data.date));
+        await store.saveTransaction();
+        store.resetForm();
+        break;
+      }
+      case "edit": {
+        // Edit not yet fully wired
+        break;
+      }
+    }
+  }, []);
+
+  const sendMessage = useCallback(
+    async (text: string) => {
+      if (isStreaming || !text.trim()) return;
+
+      let sessionId = currentSessionId;
+      if (!sessionId) {
+        sessionId = await createSession(text);
+      }
+
+      await addUserMessage(text);
+
+      const currentMonth = toIsoDate(new Date()).slice(0, 7);
+      const context = buildChatContext(
+        useTransactionStore.getState().transactions,
+        memories,
+        currentMonth
+      );
+
+      const allMessages = [
+        ...messages.map((m) => ({ role: m.role as "user" | "assistant", content: m.content })),
+        { role: "user" as const, content: text },
+      ];
+
+      setStreaming(true);
+      setStreamingContent("");
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      let accumulated = "";
+
+      await streamChat(
+        allMessages,
+        context,
+        {
+          onChunk: (chunk) => {
+            accumulated += chunk;
+            setStreamingContent(accumulated);
+          },
+          onDone: async () => {
+            const action = parseActionFromResponse(accumulated);
+            await addAssistantMessage(accumulated, action);
+
+            // Auto-execute add/edit actions immediately (no confirmation needed)
+            if (action && action.type !== "delete") {
+              await executeAction(action);
+            }
+
+            setStreaming(false);
+            setStreamingContent("");
+            abortRef.current = null;
+          },
+          onError: async (error) => {
+            const errorMessage =
+              accumulated || `I'm sorry, something went wrong. Please try again. (${error})`;
+            await addAssistantMessage(errorMessage);
+            setStreaming(false);
+            setStreamingContent("");
+            abortRef.current = null;
+          },
+        },
+        controller.signal
+      );
+    },
+    [
+      isStreaming,
+      currentSessionId,
+      messages,
+      memories,
+      createSession,
+      addUserMessage,
+      addAssistantMessage,
+      executeAction,
+      setStreaming,
+      setStreamingContent,
+    ]
+  );
+
+  const cancelStream = useCallback(() => {
+    abortRef.current?.abort();
+    setStreaming(false);
+    setStreamingContent("");
+  }, [setStreaming, setStreamingContent]);
+
+  return { sendMessage, cancelStream, isStreaming, streamingContent };
+}

--- a/apps/mobile/features/ai-chat/hooks/use-streaming-chat.ts
+++ b/apps/mobile/features/ai-chat/hooks/use-streaming-chat.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { useCallback } from "react";
 import { useTransactionStore } from "@/features/transactions/store";
 import { parseIsoDate, toIsoDate } from "@/shared/lib/format-date";
 import { buildChatContext } from "../lib/build-context";
@@ -7,21 +7,22 @@ import type { ChatAction } from "../schema";
 import { streamChat } from "../services/ai-chat-api";
 import { useChatStore } from "../store";
 
-export function useStreamingChat() {
-  const abortRef = useRef<AbortController | null>(null);
+let activeController: AbortController | null = null;
 
-  const {
-    messages,
-    currentSessionId,
-    memories,
-    isStreaming,
-    streamingContent,
-    createSession,
-    addUserMessage,
-    addAssistantMessage,
-    setStreaming,
-    setStreamingContent,
-  } = useChatStore();
+function resetStreamState(): void {
+  useChatStore.getState().setStreaming(false);
+  useChatStore.getState().setStreamingContent("");
+  activeController = null;
+}
+
+export function cancelActiveStream(): void {
+  activeController?.abort();
+  resetStreamState();
+}
+
+export function useStreamingChat() {
+  const isStreaming = useChatStore((s) => s.isStreaming);
+  const streamingContent = useChatStore((s) => s.streamingContent);
 
   const executeAction = useCallback(async (action: ChatAction) => {
     switch (action.type) {
@@ -32,8 +33,11 @@ export function useStreamingChat() {
         store.setCategoryId(action.data.categoryId);
         store.setDescription(action.data.description);
         store.setDate(parseIsoDate(action.data.date));
-        await store.saveTransaction();
-        store.resetForm();
+        try {
+          await store.saveTransaction();
+        } finally {
+          store.resetForm();
+        }
         break;
       }
       case "edit": {
@@ -47,85 +51,78 @@ export function useStreamingChat() {
     async (text: string) => {
       if (isStreaming || !text.trim()) return;
 
-      let sessionId = currentSessionId;
+      const store = useChatStore.getState();
+
+      let sessionId = store.currentSessionId;
       if (!sessionId) {
-        sessionId = await createSession(text);
+        sessionId = await store.createSession(text);
       }
 
-      await addUserMessage(text);
+      await store.addUserMessage(text);
 
       const currentMonth = toIsoDate(new Date()).slice(0, 7);
       const context = buildChatContext(
         useTransactionStore.getState().transactions,
-        memories,
+        store.memories,
         currentMonth
       );
 
       const allMessages = [
-        ...messages.map((m) => ({ role: m.role as "user" | "assistant", content: m.content })),
+        ...store.messages.map((m) => ({
+          role: m.role as "user" | "assistant",
+          content: m.content,
+        })),
         { role: "user" as const, content: text },
       ];
 
-      setStreaming(true);
-      setStreamingContent("");
+      store.setStreaming(true);
+      store.setStreamingContent("");
 
       const controller = new AbortController();
-      abortRef.current = controller;
+      activeController = controller;
 
       let accumulated = "";
 
-      await streamChat(
-        allMessages,
-        context,
-        {
-          onChunk: (chunk) => {
-            accumulated += chunk;
-            setStreamingContent(accumulated);
-          },
-          onDone: async () => {
-            const action = parseActionFromResponse(accumulated);
-            await addAssistantMessage(accumulated, action);
+      try {
+        await streamChat(
+          allMessages,
+          context,
+          {
+            onChunk: (chunk) => {
+              accumulated += chunk;
+              useChatStore.getState().setStreamingContent(accumulated);
+            },
+            onDone: async () => {
+              const action = parseActionFromResponse(accumulated);
+              await useChatStore.getState().addAssistantMessage(accumulated, action);
 
-            // Auto-execute add/edit actions immediately (no confirmation needed)
-            if (action && action.type !== "delete") {
-              await executeAction(action);
-            }
+              if (action && action.type === "add") {
+                await executeAction(action);
+              }
 
-            setStreaming(false);
-            setStreamingContent("");
-            abortRef.current = null;
+              resetStreamState();
+            },
+            onError: async (error) => {
+              const errorMessage =
+                accumulated || `I'm sorry, something went wrong. Please try again. (${error})`;
+              await useChatStore.getState().addAssistantMessage(errorMessage);
+              resetStreamState();
+            },
           },
-          onError: async (error) => {
-            const errorMessage =
-              accumulated || `I'm sorry, something went wrong. Please try again. (${error})`;
-            await addAssistantMessage(errorMessage);
-            setStreaming(false);
-            setStreamingContent("");
-            abortRef.current = null;
-          },
-        },
-        controller.signal
-      );
+          controller.signal
+        );
+      } catch (err) {
+        if (!controller.signal.aborted) {
+          const errorMessage =
+            accumulated ||
+            `I'm sorry, something went wrong. Please try again. (${err instanceof Error ? err.message : "Unknown error"})`;
+          await useChatStore.getState().addAssistantMessage(errorMessage);
+        }
+        resetStreamState();
+      }
     },
-    [
-      isStreaming,
-      currentSessionId,
-      messages,
-      memories,
-      createSession,
-      addUserMessage,
-      addAssistantMessage,
-      executeAction,
-      setStreaming,
-      setStreamingContent,
-    ]
+    [isStreaming, executeAction]
   );
 
-  const cancelStream = useCallback(() => {
-    abortRef.current?.abort();
-    setStreaming(false);
-    setStreamingContent("");
-  }, [setStreaming, setStreamingContent]);
-
-  return { sendMessage, cancelStream, isStreaming, streamingContent };
+  return { sendMessage, cancelStream: cancelActiveStream, isStreaming, streamingContent };
 }

--- a/apps/mobile/features/ai-chat/lib/build-context.ts
+++ b/apps/mobile/features/ai-chat/lib/build-context.ts
@@ -56,8 +56,8 @@ export function buildChatContext(
     })),
     summary: {
       balance: deriveBalance(transactions),
-      currentMonthSpending: deriveSpendingByCategory(transactions, currentMonth),
-      previousMonthSpending: deriveSpendingByCategory(transactions, prevMonth),
+      currentMonthSpending: deriveSpendingByCategory(relevantTransactions, currentMonth),
+      previousMonthSpending: deriveSpendingByCategory(relevantTransactions, prevMonth),
     },
     memories: memories.map((m) => ({ fact: m.fact, category: m.category })),
   };

--- a/apps/mobile/features/ai-chat/lib/build-context.ts
+++ b/apps/mobile/features/ai-chat/lib/build-context.ts
@@ -1,0 +1,64 @@
+import { deriveBalance, deriveSpendingByCategory } from "@/features/transactions/lib/derive";
+import type { StoredTransaction } from "@/features/transactions/schema";
+import { toIsoDate } from "@/shared/lib/format-date";
+import type { UserMemory } from "../schema";
+
+type TransactionContext = {
+  readonly type: string;
+  readonly amountCents: number;
+  readonly categoryId: string;
+  readonly description: string;
+  readonly date: string;
+};
+
+type ChatContext = {
+  readonly transactions: readonly TransactionContext[];
+  readonly summary: {
+    readonly balance: number;
+    readonly currentMonthSpending: readonly {
+      readonly categoryId: string;
+      readonly totalCents: number;
+    }[];
+    readonly previousMonthSpending: readonly {
+      readonly categoryId: string;
+      readonly totalCents: number;
+    }[];
+  };
+  readonly memories: readonly { readonly fact: string; readonly category: string }[];
+};
+
+function previousMonth(month: string): string {
+  const [year, m] = month.split("-").map(Number);
+  const prevMonth = m === 1 ? 12 : m - 1;
+  const prevYear = m === 1 ? year - 1 : year;
+  return `${prevYear}-${String(prevMonth).padStart(2, "0")}`;
+}
+
+export function buildChatContext(
+  transactions: readonly StoredTransaction[],
+  memories: readonly UserMemory[],
+  currentMonth: string
+): ChatContext {
+  const prevMonth = previousMonth(currentMonth);
+
+  const relevantTransactions = transactions.filter((tx) => {
+    const isoDate = toIsoDate(tx.date);
+    return isoDate.startsWith(currentMonth) || isoDate.startsWith(prevMonth);
+  });
+
+  return {
+    transactions: relevantTransactions.map((tx) => ({
+      type: tx.type,
+      amountCents: tx.amountCents,
+      categoryId: tx.categoryId,
+      description: tx.description,
+      date: toIsoDate(tx.date),
+    })),
+    summary: {
+      balance: deriveBalance(transactions),
+      currentMonthSpending: deriveSpendingByCategory(transactions, currentMonth),
+      previousMonthSpending: deriveSpendingByCategory(transactions, prevMonth),
+    },
+    memories: memories.map((m) => ({ fact: m.fact, category: m.category })),
+  };
+}

--- a/apps/mobile/features/ai-chat/lib/memories.ts
+++ b/apps/mobile/features/ai-chat/lib/memories.ts
@@ -5,5 +5,11 @@ export function deduplicateMemories(
   newFacts: readonly ExtractedMemory[]
 ): readonly ExtractedMemory[] {
   const existingLower = new Set(existing.map((m) => m.fact.toLowerCase()));
-  return newFacts.filter((f) => !existingLower.has(f.fact.toLowerCase()));
+  const seen = new Set<string>();
+  return newFacts.filter((f) => {
+    const lower = f.fact.toLowerCase();
+    if (existingLower.has(lower) || seen.has(lower)) return false;
+    seen.add(lower);
+    return true;
+  });
 }

--- a/apps/mobile/features/ai-chat/lib/memories.ts
+++ b/apps/mobile/features/ai-chat/lib/memories.ts
@@ -1,0 +1,9 @@
+import type { ExtractedMemory, UserMemory } from "../schema";
+
+export function deduplicateMemories(
+  existing: readonly UserMemory[],
+  newFacts: readonly ExtractedMemory[]
+): readonly ExtractedMemory[] {
+  const existingLower = new Set(existing.map((m) => m.fact.toLowerCase()));
+  return newFacts.filter((f) => !existingLower.has(f.fact.toLowerCase()));
+}

--- a/apps/mobile/features/ai-chat/lib/parse-action.ts
+++ b/apps/mobile/features/ai-chat/lib/parse-action.ts
@@ -1,0 +1,18 @@
+import { type ChatAction, chatActionSchema } from "../schema";
+
+const ACTION_REGEX = /\[ACTION\]([\s\S]*?)\[\/ACTION\]/;
+
+export const ACTION_BLOCK_REGEX = /\[ACTION\][\s\S]*?\[\/ACTION\]/g;
+
+export function parseActionFromResponse(text: string): ChatAction | null {
+  const match = ACTION_REGEX.exec(text);
+  if (!match) return null;
+
+  try {
+    const parsed = JSON.parse(match[1]);
+    const result = chatActionSchema.safeParse(parsed);
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/mobile/features/ai-chat/lib/sessions.ts
+++ b/apps/mobile/features/ai-chat/lib/sessions.ts
@@ -1,0 +1,15 @@
+import type { ChatSession } from "../schema";
+
+const MAX_TITLE_LENGTH = 50;
+
+export function deriveConversationTitle(firstMessage: string): string {
+  if (firstMessage.length <= MAX_TITLE_LENGTH) return firstMessage;
+  return `${firstMessage.slice(0, MAX_TITLE_LENGTH)}...`;
+}
+
+export function findExpiredSessions(
+  sessions: readonly ChatSession[],
+  now: string
+): readonly ChatSession[] {
+  return sessions.filter((s) => s.deletedAt === null && s.expiresAt < now);
+}

--- a/apps/mobile/features/ai-chat/schema.ts
+++ b/apps/mobile/features/ai-chat/schema.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+import { categoryIdSchema, transactionTypeSchema } from "../transactions/schema";
+
+export const memoryCategory = z.enum(["habit", "preference", "situation", "goal"]);
+export type MemoryCategory = z.infer<typeof memoryCategory>;
+
+export const chatRoleSchema = z.enum(["user", "assistant"]);
+export type ChatRole = z.infer<typeof chatRoleSchema>;
+
+export const actionStatusSchema = z.enum(["pending", "confirmed", "dismissed"]);
+export type ActionStatus = z.infer<typeof actionStatusSchema>;
+
+export const addActionSchema = z.object({
+  type: z.literal("add"),
+  data: z.object({
+    type: transactionTypeSchema,
+    amountCents: z.number().int().positive(),
+    categoryId: categoryIdSchema,
+    description: z.string(),
+    date: z.string(),
+  }),
+});
+
+export const editActionSchema = z.object({
+  type: z.literal("edit"),
+  transactionId: z.string(),
+  data: z.object({
+    amountCents: z.number().int().positive().optional(),
+    categoryId: categoryIdSchema.optional(),
+    description: z.string().optional(),
+    date: z.string().optional(),
+  }),
+});
+
+export const deleteActionSchema = z.object({
+  type: z.literal("delete"),
+  transactionId: z.string(),
+  description: z.string(),
+  amountCents: z.number().int().positive(),
+  date: z.string(),
+});
+
+export const chatActionSchema = z.discriminatedUnion("type", [
+  addActionSchema,
+  editActionSchema,
+  deleteActionSchema,
+]);
+export type ChatAction = z.infer<typeof chatActionSchema>;
+
+export type ChatSession = {
+  readonly id: string;
+  readonly userId: string;
+  readonly title: string;
+  readonly createdAt: string;
+  readonly expiresAt: string;
+  readonly deletedAt: string | null;
+};
+
+export type ChatMessage = {
+  readonly id: string;
+  readonly sessionId: string;
+  readonly role: ChatRole;
+  readonly content: string;
+  readonly action: ChatAction | null;
+  readonly actionStatus: ActionStatus | null;
+  readonly createdAt: string;
+};
+
+export type UserMemory = {
+  readonly id: string;
+  readonly userId: string;
+  readonly fact: string;
+  readonly category: MemoryCategory;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+};
+
+export const extractedMemorySchema = z.object({
+  fact: z.string(),
+  category: memoryCategory,
+});
+export type ExtractedMemory = z.infer<typeof extractedMemorySchema>;

--- a/apps/mobile/features/ai-chat/schema.ts
+++ b/apps/mobile/features/ai-chat/schema.ts
@@ -17,7 +17,7 @@ export const addActionSchema = z.object({
     amountCents: z.number().int().positive(),
     categoryId: categoryIdSchema,
     description: z.string(),
-    date: z.string(),
+    date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   }),
 });
 
@@ -28,7 +28,10 @@ export const editActionSchema = z.object({
     amountCents: z.number().int().positive().optional(),
     categoryId: categoryIdSchema.optional(),
     description: z.string().optional(),
-    date: z.string().optional(),
+    date: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/)
+      .optional(),
   }),
 });
 
@@ -37,7 +40,7 @@ export const deleteActionSchema = z.object({
   transactionId: z.string(),
   description: z.string(),
   amountCents: z.number().int().positive(),
-  date: z.string(),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
 });
 
 export const chatActionSchema = z.discriminatedUnion("type", [

--- a/apps/mobile/features/ai-chat/services/ai-chat-api.ts
+++ b/apps/mobile/features/ai-chat/services/ai-chat-api.ts
@@ -1,0 +1,113 @@
+import { getSupabase } from "@/shared/lib/supabase";
+import type { ExtractedMemory } from "../schema";
+
+type ChatMessage = { readonly role: "user" | "assistant"; readonly content: string };
+type ChatContext = {
+  readonly transactions: readonly unknown[];
+  readonly summary: unknown;
+  readonly memories: readonly { readonly fact: string; readonly category: string }[];
+};
+
+type StreamCallbacks = {
+  readonly onChunk: (text: string) => void;
+  readonly onDone: () => void;
+  readonly onError: (error: string) => void;
+};
+
+async function getAuthHeaders(): Promise<Record<string, string>> {
+  const { data } = await getSupabase().auth.getSession();
+  const token = data.session?.access_token ?? "";
+  return {
+    // biome-ignore lint/style/useNamingConvention: HTTP header name
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+  };
+}
+
+function getBaseUrl(): string {
+  return process.env.EXPO_PUBLIC_SUPABASE_URL ?? "";
+}
+
+export async function streamChat(
+  messages: readonly ChatMessage[],
+  context: ChatContext,
+  callbacks: StreamCallbacks,
+  signal?: AbortSignal
+): Promise<void> {
+  const headers = await getAuthHeaders();
+  const url = `${getBaseUrl()}/functions/v1/ai-chat`;
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ messages, context }),
+    signal,
+  });
+
+  if (!response.ok) {
+    callbacks.onError(`HTTP ${response.status}`);
+    return;
+  }
+
+  const reader = response.body?.getReader();
+  if (!reader) {
+    callbacks.onError("No response body");
+    return;
+  }
+
+  const decoder = new TextDecoder();
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      const text = decoder.decode(value, { stream: true });
+      const lines = text.split("\n");
+
+      for (const line of lines) {
+        if (!line.startsWith("data: ")) continue;
+        const payload = line.slice(6).trim();
+
+        if (payload === "[DONE]") {
+          callbacks.onDone();
+          return;
+        }
+
+        try {
+          const parsed = JSON.parse(payload);
+          if (parsed.error) {
+            callbacks.onError(parsed.error);
+            return;
+          }
+          if (parsed.content) {
+            callbacks.onChunk(parsed.content);
+          }
+        } catch {
+          // Skip malformed SSE lines
+        }
+      }
+    }
+    callbacks.onDone();
+  } catch (err) {
+    if (signal?.aborted) return;
+    callbacks.onError(err instanceof Error ? err.message : "Stream error");
+  }
+}
+
+export async function extractMemories(
+  messages: readonly ChatMessage[]
+): Promise<readonly ExtractedMemory[]> {
+  try {
+    const { data, error } = await getSupabase().functions.invoke("ai-chat", {
+      body: { mode: "extract_memories", messages },
+    });
+
+    if (error || !data?.success || !Array.isArray(data.data)) {
+      return [];
+    }
+    return data.data;
+  } catch {
+    return [];
+  }
+}

--- a/apps/mobile/features/ai-chat/services/ai-chat-api.ts
+++ b/apps/mobile/features/ai-chat/services/ai-chat-api.ts
@@ -37,12 +37,19 @@ export async function streamChat(
   const headers = await getAuthHeaders();
   const url = `${getBaseUrl()}/functions/v1/ai-chat`;
 
-  const response = await fetch(url, {
-    method: "POST",
-    headers,
-    body: JSON.stringify({ messages, context }),
-    signal,
-  });
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ messages, context }),
+      signal,
+    });
+  } catch (err) {
+    if (signal?.aborted) return;
+    callbacks.onError(err instanceof Error ? err.message : "Network error");
+    return;
+  }
 
   if (!response.ok) {
     callbacks.onError(`HTTP ${response.status}`);
@@ -56,14 +63,16 @@ export async function streamChat(
   }
 
   const decoder = new TextDecoder();
+  let buffer = "";
 
   try {
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
 
-      const text = decoder.decode(value, { stream: true });
-      const lines = text.split("\n");
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
 
       for (const line of lines) {
         if (!line.startsWith("data: ")) continue;

--- a/apps/mobile/features/ai-chat/store.ts
+++ b/apps/mobile/features/ai-chat/store.ts
@@ -1,0 +1,317 @@
+import { and, asc, desc, eq, isNull } from "drizzle-orm";
+import { create } from "zustand";
+import type { AnyDb } from "@/shared/db/client";
+import { chatMessages, chatSessions, userMemories } from "@/shared/db/schema";
+import { generateId } from "@/shared/lib/generate-id";
+import { deduplicateMemories } from "./lib/memories";
+import { deriveConversationTitle, findExpiredSessions } from "./lib/sessions";
+import type {
+  ActionStatus,
+  ChatAction,
+  ChatMessage,
+  ChatSession,
+  ExtractedMemory,
+  UserMemory,
+} from "./schema";
+import { extractMemories } from "./services/ai-chat-api";
+
+let dbRef: AnyDb | null = null;
+let userIdRef: string | null = null;
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+type ChatState = {
+  sessions: ChatSession[];
+  currentSessionId: string | null;
+  messages: ChatMessage[];
+  memories: UserMemory[];
+  isStreaming: boolean;
+  streamingContent: string;
+};
+
+type ChatActions = {
+  initStore: (db: AnyDb, userId: string) => void;
+  loadSessions: () => Promise<void>;
+  createSession: (firstMessage: string) => Promise<string>;
+  deleteSession: (id: string) => Promise<void>;
+  selectSession: (id: string) => Promise<void>;
+  addUserMessage: (content: string) => Promise<ChatMessage>;
+  addAssistantMessage: (content: string, action?: ChatAction | null) => Promise<ChatMessage>;
+  updateActionStatus: (messageId: string, status: ActionStatus) => Promise<void>;
+  setStreaming: (isStreaming: boolean) => void;
+  setStreamingContent: (content: string) => void;
+  loadMemories: () => Promise<void>;
+  deleteMemory: (id: string) => Promise<void>;
+  extractAndSaveMemories: () => Promise<void>;
+  cleanupExpiredSessions: () => Promise<readonly ChatSession[]>;
+};
+
+export const useChatStore = create<ChatState & ChatActions>((set, get) => ({
+  sessions: [],
+  currentSessionId: null,
+  messages: [],
+  memories: [],
+  isStreaming: false,
+  streamingContent: "",
+
+  initStore: (db, userId) => {
+    dbRef = db;
+    userIdRef = userId;
+  },
+
+  loadSessions: async () => {
+    if (!dbRef || !userIdRef) return;
+    const rows = await dbRef
+      .select()
+      .from(chatSessions)
+      .where(and(eq(chatSessions.userId, userIdRef), isNull(chatSessions.deletedAt)))
+      .orderBy(desc(chatSessions.createdAt));
+
+    set({
+      sessions: rows.map((r) => ({
+        id: r.id,
+        userId: r.userId,
+        title: r.title,
+        createdAt: r.createdAt,
+        expiresAt: r.expiresAt,
+        deletedAt: r.deletedAt,
+      })),
+    });
+  },
+
+  createSession: async (firstMessage) => {
+    if (!dbRef || !userIdRef) throw new Error("Store not initialized");
+    const id = generateId("cs");
+    const now = new Date();
+    const session: ChatSession = {
+      id,
+      userId: userIdRef,
+      title: deriveConversationTitle(firstMessage),
+      createdAt: now.toISOString(),
+      expiresAt: new Date(now.getTime() + THIRTY_DAYS_MS).toISOString(),
+      deletedAt: null,
+    };
+
+    await dbRef.insert(chatSessions).values({
+      id: session.id,
+      userId: session.userId,
+      title: session.title,
+      createdAt: session.createdAt,
+      expiresAt: session.expiresAt,
+      deletedAt: null,
+    });
+
+    set((state) => ({
+      sessions: [session, ...state.sessions],
+      currentSessionId: id,
+      messages: [],
+    }));
+    return id;
+  },
+
+  deleteSession: async (id) => {
+    if (!dbRef) return;
+    const now = new Date().toISOString();
+    await dbRef.update(chatSessions).set({ deletedAt: now }).where(eq(chatSessions.id, id));
+
+    set((state) => ({
+      sessions: state.sessions.filter((s) => s.id !== id),
+      currentSessionId: state.currentSessionId === id ? null : state.currentSessionId,
+      messages: state.currentSessionId === id ? [] : state.messages,
+    }));
+  },
+
+  selectSession: async (id) => {
+    if (!dbRef) return;
+    const rows = await dbRef
+      .select()
+      .from(chatMessages)
+      .where(eq(chatMessages.sessionId, id))
+      .orderBy(asc(chatMessages.createdAt));
+
+    set({
+      currentSessionId: id,
+      messages: rows.map((r) => ({
+        id: r.id,
+        sessionId: r.sessionId,
+        role: r.role as "user" | "assistant",
+        content: r.content,
+        action: r.action ? JSON.parse(r.action) : null,
+        actionStatus: r.actionStatus as ActionStatus | null,
+        createdAt: r.createdAt,
+      })),
+    });
+  },
+
+  addUserMessage: async (content) => {
+    if (!dbRef) throw new Error("Store not initialized");
+    const { currentSessionId } = get();
+    if (!currentSessionId) throw new Error("No active session");
+
+    const msg: ChatMessage = {
+      id: generateId("cm"),
+      sessionId: currentSessionId,
+      role: "user",
+      content,
+      action: null,
+      actionStatus: null,
+      createdAt: new Date().toISOString(),
+    };
+
+    await dbRef.insert(chatMessages).values({
+      id: msg.id,
+      sessionId: msg.sessionId,
+      role: msg.role,
+      content: msg.content,
+      action: null,
+      actionStatus: null,
+      createdAt: msg.createdAt,
+    });
+
+    set((state) => ({ messages: [...state.messages, msg] }));
+    return msg;
+  },
+
+  addAssistantMessage: async (content, action = null) => {
+    if (!dbRef) throw new Error("Store not initialized");
+    const { currentSessionId } = get();
+    if (!currentSessionId) throw new Error("No active session");
+
+    const actionStatus: ActionStatus | null = action
+      ? action.type === "delete"
+        ? "pending"
+        : "confirmed"
+      : null;
+
+    const msg: ChatMessage = {
+      id: generateId("cm"),
+      sessionId: currentSessionId,
+      role: "assistant",
+      content,
+      action,
+      actionStatus,
+      createdAt: new Date().toISOString(),
+    };
+
+    await dbRef.insert(chatMessages).values({
+      id: msg.id,
+      sessionId: msg.sessionId,
+      role: msg.role,
+      content: msg.content,
+      action: action ? JSON.stringify(action) : null,
+      actionStatus: msg.actionStatus,
+      createdAt: msg.createdAt,
+    });
+
+    set((state) => ({ messages: [...state.messages, msg] }));
+    return msg;
+  },
+
+  updateActionStatus: async (messageId, status) => {
+    if (!dbRef) return;
+    await dbRef
+      .update(chatMessages)
+      .set({ actionStatus: status })
+      .where(eq(chatMessages.id, messageId));
+
+    set((state) => ({
+      messages: state.messages.map((m) =>
+        m.id === messageId ? { ...m, actionStatus: status } : m
+      ),
+    }));
+  },
+
+  setStreaming: (isStreaming) => set({ isStreaming }),
+  setStreamingContent: (streamingContent) => set({ streamingContent }),
+
+  loadMemories: async () => {
+    if (!dbRef || !userIdRef) return;
+    const rows = await dbRef.select().from(userMemories).where(eq(userMemories.userId, userIdRef));
+
+    set({
+      memories: rows.map((r) => ({
+        id: r.id,
+        userId: r.userId,
+        fact: r.fact,
+        category: r.category as UserMemory["category"],
+        createdAt: r.createdAt,
+        updatedAt: r.updatedAt,
+      })),
+    });
+  },
+
+  deleteMemory: async (id) => {
+    if (!dbRef) return;
+    await dbRef.delete(userMemories).where(eq(userMemories.id, id));
+    set((state) => ({
+      memories: state.memories.filter((m) => m.id !== id),
+    }));
+  },
+
+  extractAndSaveMemories: async () => {
+    if (!dbRef || !userIdRef) return;
+    const db = dbRef;
+    const userId = userIdRef;
+    const { messages, memories } = get();
+    if (messages.length < 2) return;
+
+    const conversationMessages = messages.map((m) => ({
+      role: m.role as "user" | "assistant",
+      content: m.content,
+    }));
+
+    const extracted: readonly ExtractedMemory[] = await extractMemories(conversationMessages);
+    if (extracted.length === 0) return;
+
+    const newFacts = deduplicateMemories(memories, extracted);
+    if (newFacts.length === 0) return;
+
+    const now = new Date().toISOString();
+    const newMemories: UserMemory[] = newFacts.map((f) => ({
+      id: generateId("um"),
+      userId,
+      fact: f.fact,
+      category: f.category,
+      createdAt: now,
+      updatedAt: now,
+    }));
+
+    await db.insert(userMemories).values(
+      newMemories.map((m) => ({
+        id: m.id,
+        userId: m.userId,
+        fact: m.fact,
+        category: m.category,
+        createdAt: m.createdAt,
+        updatedAt: m.updatedAt,
+      }))
+    );
+
+    set((state) => ({
+      memories: [...state.memories, ...newMemories],
+    }));
+  },
+
+  cleanupExpiredSessions: async () => {
+    if (!dbRef) return [];
+    const db = dbRef;
+    const { sessions } = get();
+    const now = new Date().toISOString();
+    const expired = findExpiredSessions(sessions, now);
+
+    await Promise.all(
+      expired.map((s) =>
+        db.update(chatSessions).set({ deletedAt: now }).where(eq(chatSessions.id, s.id))
+      )
+    );
+
+    if (expired.length > 0) {
+      const expiredIds = new Set(expired.map((s) => s.id));
+      set((state) => ({
+        sessions: state.sessions.filter((s) => !expiredIds.has(s.id)),
+      }));
+    }
+
+    return expired;
+  },
+}));

--- a/apps/mobile/features/ai-chat/store.ts
+++ b/apps/mobile/features/ai-chat/store.ts
@@ -181,7 +181,9 @@ export const useChatStore = create<ChatState & ChatActions>((set, get) => ({
     const actionStatus: ActionStatus | null = action
       ? action.type === "add"
         ? "confirmed"
-        : "pending"
+        : action.type === "delete"
+          ? "pending"
+          : null
       : null;
 
     const msg: ChatMessage = {

--- a/apps/mobile/features/ai-chat/store.ts
+++ b/apps/mobile/features/ai-chat/store.ts
@@ -57,6 +57,7 @@ export const useChatStore = create<ChatState & ChatActions>((set, get) => ({
   initStore: (db, userId) => {
     dbRef = db;
     userIdRef = userId;
+    set({ sessions: [], currentSessionId: null, messages: [], memories: [] });
   },
 
   loadSessions: async () => {
@@ -178,9 +179,9 @@ export const useChatStore = create<ChatState & ChatActions>((set, get) => ({
     if (!currentSessionId) throw new Error("No active session");
 
     const actionStatus: ActionStatus | null = action
-      ? action.type === "delete"
-        ? "pending"
-        : "confirmed"
+      ? action.type === "add"
+        ? "confirmed"
+        : "pending"
       : null;
 
     const msg: ChatMessage = {
@@ -307,9 +308,15 @@ export const useChatStore = create<ChatState & ChatActions>((set, get) => ({
 
     if (expired.length > 0) {
       const expiredIds = new Set(expired.map((s) => s.id));
-      set((state) => ({
-        sessions: state.sessions.filter((s) => !expiredIds.has(s.id)),
-      }));
+      set((state) => {
+        const isActiveExpired = state.currentSessionId
+          ? expiredIds.has(state.currentSessionId)
+          : false;
+        return {
+          sessions: state.sessions.filter((s) => !expiredIds.has(s.id)),
+          ...(isActiveExpired ? { currentSessionId: null, messages: [] } : {}),
+        };
+      });
     }
 
     return expired;

--- a/apps/mobile/shared/db/schema.ts
+++ b/apps/mobile/shared/db/schema.ts
@@ -129,3 +129,46 @@ export const detectedSmsEvents = sqliteTable(
   },
   (table) => [index("idx_sms_events_user_dismissed").on(table.userId, table.dismissed)]
 );
+
+export const chatSessions = sqliteTable(
+  "chat_sessions",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id").notNull(),
+    title: text("title").notNull(),
+    createdAt: text("created_at").notNull(),
+    expiresAt: text("expires_at").notNull(),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [
+    index("idx_chat_sessions_user_created").on(table.userId, table.createdAt),
+    index("idx_chat_sessions_expires").on(table.expiresAt),
+  ]
+);
+
+export const chatMessages = sqliteTable(
+  "chat_messages",
+  {
+    id: text("id").primaryKey(),
+    sessionId: text("session_id").notNull(),
+    role: text("role").notNull(),
+    content: text("content").notNull(),
+    action: text("action"),
+    actionStatus: text("action_status"),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [index("idx_chat_messages_session_created").on(table.sessionId, table.createdAt)]
+);
+
+export const userMemories = sqliteTable(
+  "user_memories",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id").notNull(),
+    fact: text("fact").notNull(),
+    category: text("category").notNull(),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [index("idx_user_memories_user").on(table.userId)]
+);

--- a/apps/mobile/vitest.config.ts
+++ b/apps/mobile/vitest.config.ts
@@ -30,6 +30,8 @@ export default defineConfig({
         "features/**/data/**",
         "features/transactions/schema.ts",
         "features/transactions/store.ts",
+        "features/ai-chat/schema.ts",
+        "features/ai-chat/lib/**",
         "features/calendar/schema.ts",
         "features/calendar/store.ts",
         "features/menu/store.ts",

--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -31,7 +31,7 @@ const SYSTEM_PROMPT = `You are Fidy AI, a financial mirror for the user's person
 When the user asks to add, edit, or delete a transaction, include EXACTLY ONE action block in your response:
 - Add: [ACTION]{"type":"add","data":{"type":"expense|income","amountCents":<int>,"categoryId":"<id>","description":"<text>","date":"YYYY-MM-DD"}}[/ACTION]
 - Edit: [ACTION]{"type":"edit","transactionId":"<id>","data":{...partial fields...}}[/ACTION]
-- Delete: [ACTION]{"type":"delete","transactionId":"<id>","description":"<text>","amountCents":<int>,"date":"YYYY-MM-DD"}}[/ACTION]
+- Delete: [ACTION]{"type":"delete","transactionId":"<id>","description":"<text>","amountCents":<int>,"date":"YYYY-MM-DD"}[/ACTION]
 
 Valid categoryIds: ${CATEGORY_IDS.join(", ")}
 
@@ -146,7 +146,12 @@ Deno.serve(async (req) => {
 
     // Chat mode — streaming
     const { messages, context } = body;
-    if (!Array.isArray(messages) || !context) {
+    if (
+      !Array.isArray(messages) ||
+      !context ||
+      typeof context !== "object" ||
+      !Array.isArray(context.memories)
+    ) {
       return jsonResponse({ success: false, error: "invalid_request" }, 400);
     }
 
@@ -171,8 +176,10 @@ Deno.serve(async (req) => {
           controller.enqueue(encoder.encode("data: [DONE]\n\n"));
           controller.close();
         } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          controller.enqueue(encoder.encode(`data: ${JSON.stringify({ error: message })}\n\n`));
+          console.error("stream error:", err instanceof Error ? err.message : String(err));
+          controller.enqueue(
+            encoder.encode(`data: ${JSON.stringify({ error: "stream_error" })}\n\n`)
+          );
           controller.close();
         }
       },

--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -1,0 +1,193 @@
+// biome-ignore-all lint/style/useNamingConvention: OpenAI SDK and API field names
+import OpenAI from "https://deno.land/x/openai@v4.24.0/mod.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+const CATEGORY_IDS = [
+  "food",
+  "transport",
+  "entertainment",
+  "health",
+  "education",
+  "home",
+  "clothing",
+  "services",
+  "transfer",
+  "other",
+] as const;
+
+const MEMORY_CATEGORIES = ["habit", "preference", "situation", "goal"] as const;
+
+const SYSTEM_PROMPT = `You are Fidy AI, a financial mirror for the user's personal finances in Colombia.
+
+## Rules
+- You reflect the user's own data back to them. You NEVER give financial advice.
+- FORBIDDEN: investment recommendations, credit products, stock picks, insurance advice, market predictions, any topic unrelated to the user's Fidy data.
+- When asked something off-limits, respond warmly and suggest what you CAN do instead.
+- Match the user's language (Spanish or English).
+- All amounts are in Colombian Pesos (COP). Format with thousands separators: $50.000 COP.
+- Be concise and factual.
+
+## Transaction Mutations
+When the user asks to add, edit, or delete a transaction, include EXACTLY ONE action block in your response:
+- Add: [ACTION]{"type":"add","data":{"type":"expense|income","amountCents":<int>,"categoryId":"<id>","description":"<text>","date":"YYYY-MM-DD"}}[/ACTION]
+- Edit: [ACTION]{"type":"edit","transactionId":"<id>","data":{...partial fields...}}[/ACTION]
+- Delete: [ACTION]{"type":"delete","transactionId":"<id>","description":"<text>","amountCents":<int>,"date":"YYYY-MM-DD"}}[/ACTION]
+
+Valid categoryIds: ${CATEGORY_IDS.join(", ")}
+
+Always confirm what you're about to do BEFORE the action block. The app will show a confirmation card.`;
+
+const EXTRACT_MEMORIES_PROMPT = `Extract factual information about the user from this conversation.
+Return a JSON array of objects with "fact" and "category" fields.
+Categories: ${MEMORY_CATEGORIES.join(", ")}
+- habit: recurring behaviors (e.g., "Eats out every Friday")
+- preference: likes/dislikes (e.g., "Prefers cash over card")
+- situation: life circumstances (e.g., "Has a car loan")
+- goal: financial goals (e.g., "Saving for a vacation")
+
+Only extract CLEAR facts stated or strongly implied by the user. If no facts found, return an empty array.
+Return ONLY valid JSON, no markdown.`;
+
+const EXTRACT_MEMORIES_SCHEMA = {
+  name: "extracted_memories",
+  strict: true,
+  schema: {
+    type: "object",
+    properties: {
+      memories: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            fact: { type: "string" },
+            category: { type: "string", enum: [...MEMORY_CATEGORIES] },
+          },
+          required: ["fact", "category"],
+          additionalProperties: false,
+        },
+      },
+    },
+    required: ["memories"],
+    additionalProperties: false,
+  },
+};
+
+const MODEL = "gpt-5-nano-2025-08-07";
+const openai = new OpenAI({ apiKey: Deno.env.get("OPENAI_API_KEY") });
+const supabase = createClient(Deno.env.get("SUPABASE_URL")!, Deno.env.get("SUPABASE_ANON_KEY")!);
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function buildSystemPrompt(context: {
+  transactions: unknown[];
+  summary: unknown;
+  memories: { fact: string; category: string }[];
+}): string {
+  const parts = [SYSTEM_PROMPT];
+
+  if (context.memories.length > 0) {
+    const memoryLines = context.memories.map((m) => `- [${m.category}] ${m.fact}`).join("\n");
+    parts.push(`\n## What you know about this user\n${memoryLines}`);
+  }
+
+  parts.push(`\n## Current financial context\n${JSON.stringify(context.summary)}`);
+
+  if (context.transactions.length > 0) {
+    parts.push(`\n## Recent transactions\n${JSON.stringify(context.transactions)}`);
+  }
+
+  return parts.join("\n");
+}
+
+Deno.serve(async (req) => {
+  try {
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) {
+      return jsonResponse({ success: false, error: "missing_auth" }, 401);
+    }
+    const token = authHeader.replace("Bearer ", "");
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser(token);
+    if (authError || !user) {
+      return jsonResponse({ success: false, error: "invalid_auth" }, 401);
+    }
+
+    const body = await req.json();
+    const { mode } = body;
+
+    // Memory extraction mode — non-streaming
+    if (mode === "extract_memories") {
+      const { messages } = body;
+      if (!Array.isArray(messages) || messages.length === 0) {
+        return jsonResponse({ success: false, error: "invalid_request" }, 400);
+      }
+
+      const completion = await openai.chat.completions.create({
+        model: MODEL,
+        messages: [{ role: "system", content: EXTRACT_MEMORIES_PROMPT }, ...messages],
+        response_format: { type: "json_schema", json_schema: EXTRACT_MEMORIES_SCHEMA },
+      });
+
+      const text = completion.choices[0]?.message?.content;
+      if (!text) {
+        return jsonResponse({ success: false, error: "empty_llm_response" }, 502);
+      }
+
+      const data = JSON.parse(text);
+      return jsonResponse({ success: true, data: data.memories });
+    }
+
+    // Chat mode — streaming
+    const { messages, context } = body;
+    if (!Array.isArray(messages) || !context) {
+      return jsonResponse({ success: false, error: "invalid_request" }, 400);
+    }
+
+    const systemPrompt = buildSystemPrompt(context);
+
+    const stream = await openai.chat.completions.create({
+      model: MODEL,
+      messages: [{ role: "system", content: systemPrompt }, ...messages],
+      stream: true,
+    });
+
+    const encoder = new TextEncoder();
+    const readable = new ReadableStream({
+      async start(controller) {
+        try {
+          for await (const chunk of stream) {
+            const content = chunk.choices[0]?.delta?.content;
+            if (content) {
+              controller.enqueue(encoder.encode(`data: ${JSON.stringify({ content })}\n\n`));
+            }
+          }
+          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+          controller.close();
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify({ error: message })}\n\n`));
+          controller.close();
+        }
+      },
+    });
+
+    return new Response(readable, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("ai-chat error:", message);
+    return jsonResponse({ success: false, error: "internal_error" }, 500);
+  }
+});


### PR DESCRIPTION
- Add chat sessions, messages, and user memories DB tables
- Edge Function with SSE streaming and memory extraction
- Zustand store, streaming hook, and chat context builder
- Conversation list, chat screen, and memory manager UI
- Inline action cards for transaction mutations
- 30-day session auto-cleanup on app startup
- CI/CD workflow deploys ai-chat Edge Function

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a mobile AI chat with streaming replies and personal memory. Also hardens streaming, validation, and state handling for a more reliable experience.

- **New Features**
  - Supabase Edge Function `ai-chat` with SSE streaming and a memory-extraction mode; CI workflow deploys it.
  - Local DB tables for chat sessions, messages, and user memories; sessions auto-expire after 30 days.
  - Chat UI: conversation list, chat screen with streaming, starter suggestions, and inline action cards (confirm delete; add/edit auto-applied).
  - State and logic: `zustand` store, streaming hook, and context builder combining transactions and memories.

- **Bug Fixes**
  - Streaming reliability: buffer partial SSE lines, wrap `fetch`/`streamChat` in try/catch, cancel active stream on back navigation, and sanitize streamed error messages.
  - Validation, action, and edge-function fixes: enforce ISO date format for actions, validate context shape before LLM call, fix delete action template JSON, and skip action status for edit actions.
  - Store lifecycle: reset chat state on user switch in `initStore`.
  - Memory handling: deduplicate extracted memories within each batch.

<sup>Written for commit 6a06f6d73bfa98220ba50182c5b40dd96670b144. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

