### PR TITLE
fix(mobile): streaming fetch and cents display in AI chat

### DIFF
--- a/apps/mobile/__tests__/ai-chat/build-context.test.ts
+++ b/apps/mobile/__tests__/ai-chat/build-context.test.ts
@@ -46,7 +46,7 @@ describe("buildChatContext", () => {
 
     const result = buildChatContext(txs, memories, "2026-03");
 
-    expect(result.summary.balance).toBe(435000);
+    expect(result.summary.balanceCents).toBe(435000);
     expect(result.summary.currentMonthSpending).toEqual([
       { categoryId: "food", totalCents: 30000 },
       { categoryId: "transport", totalCents: 15000 },
@@ -61,7 +61,7 @@ describe("buildChatContext", () => {
   it("handles empty transactions", () => {
     const result = buildChatContext([], [], "2026-03");
 
-    expect(result.summary.balance).toBe(0);
+    expect(result.summary.balanceCents).toBe(0);
     expect(result.summary.currentMonthSpending).toEqual([]);
     expect(result.summary.previousMonthSpending).toEqual([]);
     expect(result.transactions).toEqual([]);

--- a/apps/mobile/features/ai-chat/components/ChatInput.tsx
+++ b/apps/mobile/features/ai-chat/components/ChatInput.tsx
@@ -39,7 +39,7 @@ export function ChatInput({ onSend, disabled = false }: ChatInputProps) {
 
   return (
     <View
-      className="flex-row items-end gap-2 bg-card dark:bg-card-dark"
+      className="flex-row items-center gap-2 bg-card dark:bg-card-dark"
       style={{
         paddingTop: 8,
         paddingBottom: keyboardVisible ? 8 : TAB_BAR_CLEARANCE,

--- a/apps/mobile/features/ai-chat/lib/build-context.ts
+++ b/apps/mobile/features/ai-chat/lib/build-context.ts
@@ -14,7 +14,7 @@ type TransactionContext = {
 type ChatContext = {
   readonly transactions: readonly TransactionContext[];
   readonly summary: {
-    readonly balance: number;
+    readonly balanceCents: number;
     readonly currentMonthSpending: readonly {
       readonly categoryId: string;
       readonly totalCents: number;
@@ -55,7 +55,7 @@ export function buildChatContext(
       date: toIsoDate(tx.date),
     })),
     summary: {
-      balance: deriveBalance(transactions),
+      balanceCents: deriveBalance(transactions),
       currentMonthSpending: deriveSpendingByCategory(relevantTransactions, currentMonth),
       previousMonthSpending: deriveSpendingByCategory(relevantTransactions, prevMonth),
     },

--- a/apps/mobile/features/ai-chat/services/ai-chat-api.ts
+++ b/apps/mobile/features/ai-chat/services/ai-chat-api.ts
@@ -1,3 +1,4 @@
+import { fetch } from "expo/fetch";
 import { getSupabase } from "@/shared/lib/supabase";
 import type { ExtractedMemory } from "../schema";
 

--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -24,7 +24,8 @@ const SYSTEM_PROMPT = `You are Fidy AI, a financial mirror for the user's person
 - FORBIDDEN: investment recommendations, credit products, stock picks, insurance advice, market predictions, any topic unrelated to the user's Fidy data.
 - When asked something off-limits, respond warmly and suggest what you CAN do instead.
 - Match the user's language (Spanish or English).
-- All amounts are in Colombian Pesos (COP). Format with thousands separators: $50.000 COP.
+- All monetary values in the context (balanceCents, totalCents, amountCents) are in CENTS. Divide by 100 to get COP before displaying.
+- Format amounts in Colombian Pesos with dot separators: $50.000 COP.
 - Be concise and factual.
 
 ## Transaction Mutations


### PR DESCRIPTION
- Use expo/fetch for ReadableStream support in RN
- Rename balance to balanceCents in chat context
- Instruct LLM to divide cents by 100 for display
- Fix input text jiggle with items-center alignment

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables streaming chat on mobile using `expo/fetch` and standardizes money display by using cents across the chat context and system prompt. Also smooths the chat input alignment.

- **New Features**
  - Supabase Edge Function `ai-chat` streams responses (SSE) and is deployed in CI.

- **Bug Fixes**
  - Use `expo/fetch` to support streaming in React Native.
  - Standardize on cents: rename `summary.balance` to `summary.balanceCents`; update the `ai-chat` prompt to divide by 100 and format COP with dot separators; update tests.
  - Align input content with `items-center` to stop the jiggle.

<sup>Written for commit 035a6b3e4a42229acee425532274815404ab32df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

