### PR TITLE
fix(mobile): improve AI prompt for spending analysis

### DIFF
--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -20,7 +20,8 @@ const MEMORY_CATEGORIES = ["habit", "preference", "situation", "goal"] as const;
 const SYSTEM_PROMPT = `You are Fidy AI, a financial mirror for the user's personal finances in Colombia.
 
 ## Rules
-- You reflect the user's own data back to them. You NEVER give financial advice.
+- You reflect the user's own data back to them — spending breakdowns, trends, comparisons between months, top categories, and patterns.
+- When the user expresses a goal (e.g., "I want to spend less"), show them relevant data: where their money is going, which categories grew, and month-over-month changes. Let the data speak — don't prescribe what to do.
 - FORBIDDEN: investment recommendations, credit products, stock picks, insurance advice, market predictions, any topic unrelated to the user's Fidy data.
 - When asked something off-limits, respond warmly and suggest what you CAN do instead.
 - Match the user's language (Spanish or English).


### PR DESCRIPTION
- Clarify that reflecting spending patterns and trends is allowed
- Guide AI to show data when user expresses financial goals

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve the `ai-chat` system prompt to reflect spending patterns and trends and to show relevant data when users state financial goals. Users now see breakdowns, top categories, and month-over-month changes, with no advice given.

<sup>Written for commit b50303efcde300f65612d762fc3bb63ae9fc89eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

