### PR TITLE
fix(mobile): allow AI to give data-driven suggestions

### DIFF
--- a/apps/mobile/__tests__/ai-chat/build-context.test.ts
+++ b/apps/mobile/__tests__/ai-chat/build-context.test.ts
@@ -30,7 +30,7 @@ const makeMemory = (overrides: Partial<UserMemory>): UserMemory => ({
 });
 
 describe("buildChatContext", () => {
-  it("returns correctly shaped context with transactions and memories", () => {
+  it("converts cents to COP in summary", () => {
     const txs = [
       makeTx({ type: "income", amountCents: 500000, date: new Date(2026, 2, 1) }),
       makeTx({ id: "tx_2", amountCents: 30000, categoryId: "food", date: new Date(2026, 2, 2) }),
@@ -46,24 +46,80 @@ describe("buildChatContext", () => {
 
     const result = buildChatContext(txs, memories, "2026-03");
 
-    expect(result.summary.balanceCents).toBe(435000);
+    expect(result.summary.balance).toBe(4350);
     expect(result.summary.currentMonthSpending).toEqual([
-      { categoryId: "food", totalCents: 30000 },
-      { categoryId: "transport", totalCents: 15000 },
+      { categoryId: "food", total: 300 },
+      { categoryId: "transport", total: 150 },
     ]);
-    expect(result.summary.previousMonthSpending).toEqual([
-      { categoryId: "food", totalCents: 20000 },
-    ]);
+    expect(result.summary.previousMonthSpending).toEqual([{ categoryId: "food", total: 200 }]);
     expect(result.memories).toEqual([{ fact: "Gets paid on the 15th", category: "habit" }]);
     expect(result.transactions).toHaveLength(4);
+  });
+
+  it("converts transaction amounts to COP", () => {
+    const txs = [
+      makeTx({
+        type: "expense",
+        amountCents: 5000,
+        categoryId: "food",
+        description: "Lunch",
+        date: new Date(2026, 2, 1),
+      }),
+    ];
+    const result = buildChatContext(txs, [], "2026-03");
+
+    expect(result.transactions[0]).toEqual({
+      type: "expense",
+      amount: 50,
+      categoryId: "food",
+      description: "Lunch",
+      date: "2026-03-01",
+    });
+  });
+
+  it("computes month-over-month deltas", () => {
+    const txs = [
+      makeTx({ amountCents: 30000, categoryId: "food", date: new Date(2026, 2, 2) }),
+      makeTx({
+        id: "tx_2",
+        amountCents: 15000,
+        categoryId: "transport",
+        date: new Date(2026, 2, 3),
+      }),
+      makeTx({ id: "tx_3", amountCents: 20000, categoryId: "food", date: new Date(2026, 1, 15) }),
+      makeTx({
+        id: "tx_4",
+        amountCents: 10000,
+        categoryId: "health",
+        date: new Date(2026, 1, 10),
+      }),
+    ];
+
+    const result = buildChatContext(txs, [], "2026-03");
+    const deltas = result.summary.monthOverMonthDeltas;
+
+    const foodDelta = deltas.find((d) => d.categoryId === "food");
+    expect(foodDelta).toEqual({ categoryId: "food", current: 300, previous: 200, delta: 100 });
+
+    const transportDelta = deltas.find((d) => d.categoryId === "transport");
+    expect(transportDelta).toEqual({
+      categoryId: "transport",
+      current: 150,
+      previous: 0,
+      delta: 150,
+    });
+
+    const healthDelta = deltas.find((d) => d.categoryId === "health");
+    expect(healthDelta).toEqual({ categoryId: "health", current: 0, previous: 100, delta: -100 });
   });
 
   it("handles empty transactions", () => {
     const result = buildChatContext([], [], "2026-03");
 
-    expect(result.summary.balanceCents).toBe(0);
+    expect(result.summary.balance).toBe(0);
     expect(result.summary.currentMonthSpending).toEqual([]);
     expect(result.summary.previousMonthSpending).toEqual([]);
+    expect(result.summary.monthOverMonthDeltas).toEqual([]);
     expect(result.transactions).toEqual([]);
     expect(result.memories).toEqual([]);
   });
@@ -85,26 +141,5 @@ describe("buildChatContext", () => {
     const result = buildChatContext(txs, [], "2026-03");
 
     expect(result.transactions).toHaveLength(2);
-  });
-
-  it("maps transactions to context shape", () => {
-    const txs = [
-      makeTx({
-        type: "expense",
-        amountCents: 5000,
-        categoryId: "food",
-        description: "Lunch",
-        date: new Date(2026, 2, 1),
-      }),
-    ];
-    const result = buildChatContext(txs, [], "2026-03");
-
-    expect(result.transactions[0]).toEqual({
-      type: "expense",
-      amountCents: 5000,
-      categoryId: "food",
-      description: "Lunch",
-      date: "2026-03-01",
-    });
   });
 });

--- a/apps/mobile/features/ai-chat/lib/build-context.ts
+++ b/apps/mobile/features/ai-chat/lib/build-context.ts
@@ -5,33 +5,68 @@ import type { UserMemory } from "../schema";
 
 type TransactionContext = {
   readonly type: string;
-  readonly amountCents: number;
+  readonly amount: number;
   readonly categoryId: string;
   readonly description: string;
   readonly date: string;
 };
 
+type CategorySpending = {
+  readonly categoryId: string;
+  readonly total: number;
+};
+
+type CategoryDelta = {
+  readonly categoryId: string;
+  readonly current: number;
+  readonly previous: number;
+  readonly delta: number;
+};
+
 type ChatContext = {
   readonly transactions: readonly TransactionContext[];
   readonly summary: {
-    readonly balanceCents: number;
-    readonly currentMonthSpending: readonly {
-      readonly categoryId: string;
-      readonly totalCents: number;
-    }[];
-    readonly previousMonthSpending: readonly {
-      readonly categoryId: string;
-      readonly totalCents: number;
-    }[];
+    readonly balance: number;
+    readonly currentMonthSpending: readonly CategorySpending[];
+    readonly previousMonthSpending: readonly CategorySpending[];
+    readonly monthOverMonthDeltas: readonly CategoryDelta[];
   };
   readonly memories: readonly { readonly fact: string; readonly category: string }[];
 };
+
+const CENTS_PER_COP = 100;
+
+function centsToCop(cents: number): number {
+  return cents / CENTS_PER_COP;
+}
 
 function previousMonth(month: string): string {
   const [year, m] = month.split("-").map(Number);
   const prevMonth = m === 1 ? 12 : m - 1;
   const prevYear = m === 1 ? year - 1 : year;
   return `${prevYear}-${String(prevMonth).padStart(2, "0")}`;
+}
+
+function computeDeltas(
+  current: readonly { readonly categoryId: string; readonly totalCents: number }[],
+  previous: readonly { readonly categoryId: string; readonly totalCents: number }[]
+): readonly CategoryDelta[] {
+  const prevMap = new Map(previous.map((p) => [p.categoryId, p.totalCents]));
+  const allCategories = new Set([
+    ...current.map((c) => c.categoryId),
+    ...previous.map((p) => p.categoryId),
+  ]);
+
+  return Array.from(allCategories).map((categoryId) => {
+    const currentCents = current.find((c) => c.categoryId === categoryId)?.totalCents ?? 0;
+    const previousCents = prevMap.get(categoryId) ?? 0;
+    return {
+      categoryId,
+      current: centsToCop(currentCents),
+      previous: centsToCop(previousCents),
+      delta: centsToCop(currentCents - previousCents),
+    };
+  });
 }
 
 export function buildChatContext(
@@ -46,18 +81,28 @@ export function buildChatContext(
     return isoDate.startsWith(currentMonth) || isoDate.startsWith(prevMonth);
   });
 
+  const currentSpendingCents = deriveSpendingByCategory(relevantTransactions, currentMonth);
+  const previousSpendingCents = deriveSpendingByCategory(relevantTransactions, prevMonth);
+
   return {
     transactions: relevantTransactions.map((tx) => ({
       type: tx.type,
-      amountCents: tx.amountCents,
+      amount: centsToCop(tx.amountCents),
       categoryId: tx.categoryId,
       description: tx.description,
       date: toIsoDate(tx.date),
     })),
     summary: {
-      balanceCents: deriveBalance(transactions),
-      currentMonthSpending: deriveSpendingByCategory(relevantTransactions, currentMonth),
-      previousMonthSpending: deriveSpendingByCategory(relevantTransactions, prevMonth),
+      balance: centsToCop(deriveBalance(transactions)),
+      currentMonthSpending: currentSpendingCents.map((c) => ({
+        categoryId: c.categoryId,
+        total: centsToCop(c.totalCents),
+      })),
+      previousMonthSpending: previousSpendingCents.map((c) => ({
+        categoryId: c.categoryId,
+        total: centsToCop(c.totalCents),
+      })),
+      monthOverMonthDeltas: computeDeltas(currentSpendingCents, previousSpendingCents),
     },
     memories: memories.map((m) => ({ fact: m.fact, category: m.category })),
   };

--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -30,10 +30,12 @@ const SYSTEM_PROMPT = `You are Fidy AI, a financial mirror for the user's person
 - Be concise and factual.
 
 ## Transaction Mutations
+IMPORTANT: Action block amounts use CENTS (COP × 100). If the user says $50.000 COP, the amountCents value is 5000000. This is different from the context values which are already in COP.
+
 When the user asks to add, edit, or delete a transaction, include EXACTLY ONE action block in your response:
-- Add: [ACTION]{"type":"add","data":{"type":"expense|income","amountCents":<int>,"categoryId":"<id>","description":"<text>","date":"YYYY-MM-DD"}}[/ACTION]
+- Add: [ACTION]{"type":"add","data":{"type":"expense|income","amountCents":<int COP×100>,"categoryId":"<id>","description":"<text>","date":"YYYY-MM-DD"}}[/ACTION]
 - Edit: [ACTION]{"type":"edit","transactionId":"<id>","data":{...partial fields...}}[/ACTION]
-- Delete: [ACTION]{"type":"delete","transactionId":"<id>","description":"<text>","amountCents":<int>,"date":"YYYY-MM-DD"}[/ACTION]
+- Delete: [ACTION]{"type":"delete","transactionId":"<id>","description":"<text>","amountCents":<int COP×100>,"date":"YYYY-MM-DD"}[/ACTION]
 
 Valid categoryIds: ${CATEGORY_IDS.join(", ")}
 

--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -21,8 +21,8 @@ const SYSTEM_PROMPT = `You are Fidy AI, a financial mirror for the user's person
 
 ## Rules
 - You reflect the user's own data back to them — spending breakdowns, trends, comparisons between months, top categories, and patterns.
-- When the user expresses a goal (e.g., "I want to spend less"), show them relevant data: where their money is going, which categories grew, and month-over-month changes. Let the data speak — don't prescribe what to do.
-- FORBIDDEN: investment recommendations, credit products, stock picks, insurance advice, market predictions, any topic unrelated to the user's Fidy data.
+- When the user expresses a goal (e.g., "I want to spend less"), analyze their data AND give light, actionable suggestions grounded in their spending. Examples: "Tu gasto en comida creció 15% — revisar restaurantes vs mercado podría ayudar", "Transporte subió $14.000 este mes — ¿cambiaste de ruta o medio?". Keep suggestions practical and based on what the data shows.
+- FORBIDDEN: investment recommendations, credit products, stock picks, insurance advice, market predictions, recommending specific financial services or apps, any topic unrelated to the user's Fidy data.
 - When asked something off-limits, respond warmly and suggest what you CAN do instead.
 - Match the user's language (Spanish or English).
 - All monetary values in the context (balanceCents, totalCents, amountCents) are in CENTS. Divide by 100 to get COP before displaying.

--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -25,8 +25,8 @@ const SYSTEM_PROMPT = `You are Fidy AI, a financial mirror for the user's person
 - FORBIDDEN: investment recommendations, credit products, stock picks, insurance advice, market predictions, recommending specific financial services or apps, any topic unrelated to the user's Fidy data.
 - When asked something off-limits, respond warmly and suggest what you CAN do instead.
 - Match the user's language (Spanish or English).
-- All monetary values in the context (balanceCents, totalCents, amountCents) are in CENTS. Divide by 100 to get COP before displaying.
-- Format amounts in Colombian Pesos with dot separators: $50.000 COP.
+- All monetary values in the context (balance, total, amount, delta) are already in Colombian Pesos (COP). Do NOT multiply or divide them.
+- Format amounts with dot as thousands separator: $50.000 COP. The context also includes monthOverMonthDeltas with current, previous, and delta per category — use these directly.
 - Be concise and factual.
 
 ## Transaction Mutations


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable light, data-driven suggestions when users state a goal, grounded in their spending data, and forbid recommending specific financial services or apps. Pre-compute COP values and per-category month-over-month deltas in `buildChatContext` (transactions, balance, totals, and deltas now in COP), update the system prompt to use these values and clarify that mutation action amounts use cents (COP×100), and update tests.

<sup>Written for commit 1a7d71ca3e9b1bed2dfb3e70a34d7e3ef5c02105. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

