### PR TITLE
feat(mobile): expired session cleanup with banner

### DIFF
--- a/apps/mobile/__tests__/ai-chat/sessions.test.ts
+++ b/apps/mobile/__tests__/ai-chat/sessions.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { deriveConversationTitle, findExpiredSessions } from "../../features/ai-chat/lib/sessions";
+import {
+  deriveConversationTitle,
+  findExpiredSessions,
+  formatCleanupMessage,
+} from "../../features/ai-chat/lib/sessions";
 import type { ChatSession } from "../../features/ai-chat/schema";
 
 const makeSession = (overrides: Partial<ChatSession>): ChatSession => ({
@@ -72,5 +76,19 @@ describe("findExpiredSessions", () => {
 
   it("returns empty array for empty input", () => {
     expect(findExpiredSessions([], "2026-03-10T00:00:00.000Z")).toEqual([]);
+  });
+});
+
+describe("formatCleanupMessage", () => {
+  it("returns singular message for 1 session", () => {
+    expect(formatCleanupMessage(1)).toBe("1 expired conversation was removed");
+  });
+
+  it("returns plural message for multiple sessions", () => {
+    expect(formatCleanupMessage(3)).toBe("3 expired conversations were removed");
+  });
+
+  it("returns null for 0 sessions", () => {
+    expect(formatCleanupMessage(0)).toBeNull();
   });
 });

--- a/apps/mobile/features/ai-chat/components/ConversationList.tsx
+++ b/apps/mobile/features/ai-chat/components/ConversationList.tsx
@@ -1,13 +1,13 @@
 import { FlashList } from "@shopify/flash-list";
 import { format } from "date-fns";
-import { MessageSquare, Plus, Trash2 } from "lucide-react-native";
+import { MessageSquare, Plus, Trash2, X } from "lucide-react-native";
 import { memo, useCallback, useEffect } from "react";
 import { Platform, Pressable, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useThemeColor } from "@/shared/hooks/use-theme-color";
+import { useSessionCleanup } from "../hooks/use-session-cleanup";
 import type { ChatSession } from "../schema";
 import { useChatStore } from "../store";
-import { ExpiredSessionsBanner } from "./ExpiredSessionsBanner";
 
 type ConversationListProps = {
   readonly onSelectSession: (id: string) => void;
@@ -74,6 +74,8 @@ export function ConversationList({
   const deleteSession = useChatStore((s) => s.deleteSession);
 
   const accentGreen = useThemeColor("accentGreen");
+  const tertiary = useThemeColor("tertiary");
+  const { message: cleanupMessage, dismiss: dismissCleanup } = useSessionCleanup();
 
   useEffect(() => {
     loadSessions();
@@ -112,7 +114,7 @@ export function ConversationList({
         }}
         ItemSeparatorComponent={ItemSeparator}
         ListHeaderComponent={
-          <View style={{ paddingBottom: 16, gap: 12 }}>
+          <View style={{ paddingBottom: 16 }}>
             <View
               style={{
                 flexDirection: "row",
@@ -152,7 +154,30 @@ export function ConversationList({
                 </Pressable>
               </View>
             </View>
-            <ExpiredSessionsBanner />
+            {cleanupMessage != null && (
+              <View
+                className="bg-card dark:bg-card-dark"
+                style={{
+                  marginTop: 12,
+                  borderRadius: 12,
+                  paddingVertical: 10,
+                  paddingHorizontal: 14,
+                  flexDirection: "row",
+                  alignItems: "center",
+                  gap: 10,
+                }}
+              >
+                <Text
+                  className="font-poppins-medium text-label text-tertiary dark:text-tertiary-dark"
+                  style={{ flex: 1 }}
+                >
+                  {cleanupMessage}
+                </Text>
+                <Pressable onPress={dismissCleanup} hitSlop={12} style={{ padding: 2 }}>
+                  <X size={16} color={tertiary} />
+                </Pressable>
+              </View>
+            )}
           </View>
         }
         ListEmptyComponent={

--- a/apps/mobile/features/ai-chat/components/ConversationList.tsx
+++ b/apps/mobile/features/ai-chat/components/ConversationList.tsx
@@ -7,6 +7,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useThemeColor } from "@/shared/hooks/use-theme-color";
 import type { ChatSession } from "../schema";
 import { useChatStore } from "../store";
+import { ExpiredSessionsBanner } from "./ExpiredSessionsBanner";
 
 type ConversationListProps = {
   readonly onSelectSession: (id: string) => void;
@@ -111,7 +112,7 @@ export function ConversationList({
         }}
         ItemSeparatorComponent={ItemSeparator}
         ListHeaderComponent={
-          <View style={{ paddingBottom: 16 }}>
+          <View style={{ paddingBottom: 16, gap: 12 }}>
             <View
               style={{
                 flexDirection: "row",
@@ -151,6 +152,7 @@ export function ConversationList({
                 </Pressable>
               </View>
             </View>
+            <ExpiredSessionsBanner />
           </View>
         }
         ListEmptyComponent={

--- a/apps/mobile/features/ai-chat/components/ExpiredSessionsBanner.tsx
+++ b/apps/mobile/features/ai-chat/components/ExpiredSessionsBanner.tsx
@@ -1,0 +1,25 @@
+import { Clock, X } from "lucide-react-native";
+import { Pressable, Text, View } from "react-native";
+import { useChatStore } from "../store";
+
+export function ExpiredSessionsBanner() {
+  const count = useChatStore((s) => s.expiredSessionCount);
+  const dismiss = useChatStore((s) => s.dismissExpiredBanner);
+
+  if (count === 0) return null;
+
+  return (
+    <View
+      className="flex-row items-center rounded-xl"
+      style={{ backgroundColor: "#FFF3E0", padding: 12, gap: 10 }}
+    >
+      <Clock size={18} color="#E65100" />
+      <Text className="font-poppins-medium text-body flex-1" style={{ color: "#4E342E" }}>
+        {count} {count === 1 ? "conversation" : "conversations"} expired and removed
+      </Text>
+      <Pressable onPress={dismiss} hitSlop={12} style={{ padding: 4 }}>
+        <X size={16} color="#6D6D6D" />
+      </Pressable>
+    </View>
+  );
+}

--- a/apps/mobile/features/ai-chat/hooks/use-session-cleanup.ts
+++ b/apps/mobile/features/ai-chat/hooks/use-session-cleanup.ts
@@ -1,0 +1,18 @@
+import { useCallback, useEffect, useState } from "react";
+import { formatCleanupMessage } from "../lib/sessions";
+import { useChatStore } from "../store";
+
+export function useSessionCleanup() {
+  const [message, setMessage] = useState<string | null>(null);
+  const cleanupExpiredSessions = useChatStore((s) => s.cleanupExpiredSessions);
+
+  useEffect(() => {
+    cleanupExpiredSessions().then((expired) => {
+      setMessage(formatCleanupMessage(expired.length));
+    });
+  }, [cleanupExpiredSessions]);
+
+  const dismiss = useCallback(() => setMessage(null), []);
+
+  return { message, dismiss };
+}

--- a/apps/mobile/features/ai-chat/lib/sessions.ts
+++ b/apps/mobile/features/ai-chat/lib/sessions.ts
@@ -13,3 +13,10 @@ export function findExpiredSessions(
 ): readonly ChatSession[] {
   return sessions.filter((s) => s.deletedAt === null && s.expiresAt < now);
 }
+
+export function formatCleanupMessage(count: number): string | null {
+  if (count === 0) return null;
+  return count === 1
+    ? "1 expired conversation was removed"
+    : `${count} expired conversations were removed`;
+}

--- a/apps/mobile/features/ai-chat/store.ts
+++ b/apps/mobile/features/ai-chat/store.ts
@@ -27,6 +27,7 @@ type ChatState = {
   memories: UserMemory[];
   isStreaming: boolean;
   streamingContent: string;
+  expiredSessionCount: number;
 };
 
 type ChatActions = {
@@ -44,6 +45,7 @@ type ChatActions = {
   deleteMemory: (id: string) => Promise<void>;
   extractAndSaveMemories: () => Promise<void>;
   cleanupExpiredSessions: () => Promise<readonly ChatSession[]>;
+  dismissExpiredBanner: () => void;
 };
 
 export const useChatStore = create<ChatState & ChatActions>((set, get) => ({
@@ -53,11 +55,18 @@ export const useChatStore = create<ChatState & ChatActions>((set, get) => ({
   memories: [],
   isStreaming: false,
   streamingContent: "",
+  expiredSessionCount: 0,
 
   initStore: (db, userId) => {
     dbRef = db;
     userIdRef = userId;
-    set({ sessions: [], currentSessionId: null, messages: [], memories: [] });
+    set({
+      sessions: [],
+      currentSessionId: null,
+      messages: [],
+      memories: [],
+      expiredSessionCount: 0,
+    });
   },
 
   loadSessions: async () => {
@@ -316,6 +325,7 @@ export const useChatStore = create<ChatState & ChatActions>((set, get) => ({
           : false;
         return {
           sessions: state.sessions.filter((s) => !expiredIds.has(s.id)),
+          expiredSessionCount: expired.length,
           ...(isActiveExpired ? { currentSessionId: null, messages: [] } : {}),
         };
       });
@@ -323,4 +333,6 @@ export const useChatStore = create<ChatState & ChatActions>((set, get) => ({
 
     return expired;
   },
+
+  dismissExpiredBanner: () => set({ expiredSessionCount: 0 }),
 }));


### PR DESCRIPTION
- Add formatCleanupMessage pure function
- Add useSessionCleanup hook to run cleanup on mount
- Show dismissible banner in ConversationList

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically cleans up expired conversations on app open and shows a dismissible banner indicating how many were removed. Reduces inbox clutter and lets users know when sessions expire.

- **New Features**
  - Run cleanup on `ConversationList` mount via `useSessionCleanup`; removes expired sessions and clears the active session if it expired.
  - Show a small, dismissible banner with the removed count; tap X to hide.
  - Track `expiredSessionCount` in the chat store; reset on init and `dismissExpiredBanner`.
  - Add `formatCleanupMessage` helper and unit tests.
  - Introduce `ExpiredSessionsBanner` component for reuse.

<sup>Written for commit c1ce63db03fd04bc8b98f42963be088975dfe742. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

