### PR TITLE
feat(mobile): sync conflict resolution system

### DIFF
--- a/apps/mobile/__tests__/sync/conflict-detection.test.ts
+++ b/apps/mobile/__tests__/sync/conflict-detection.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+const makeRow = (overrides = {}) => ({
+  id: "tx-1",
+  userId: "user-1",
+  type: "expense",
+  amountCents: 1000,
+  categoryId: "food",
+  description: "Coffee",
+  date: "2026-03-10",
+  createdAt: "2026-03-10T10:00:00.000Z",
+  updatedAt: "2026-03-10T10:00:00.000Z",
+  deletedAt: null,
+  source: "manual",
+  ...overrides,
+});
+
+describe("hasDataConflict", () => {
+  it("returns false when all fields match", async () => {
+    const { hasDataConflict } = await import("@/features/sync/lib/conflict-detection");
+    expect(hasDataConflict(makeRow(), makeRow())).toBe(false);
+  });
+
+  it("returns false when only updatedAt differs", async () => {
+    const { hasDataConflict } = await import("@/features/sync/lib/conflict-detection");
+    expect(hasDataConflict(makeRow(), makeRow({ updatedAt: "2026-03-10T12:00:00.000Z" }))).toBe(
+      false
+    );
+  });
+
+  it("returns false when only source differs", async () => {
+    const { hasDataConflict } = await import("@/features/sync/lib/conflict-detection");
+    expect(hasDataConflict(makeRow({ source: "manual" }), makeRow({ source: "email" }))).toBe(
+      false
+    );
+  });
+
+  it("returns true when amountCents differs", async () => {
+    const { hasDataConflict } = await import("@/features/sync/lib/conflict-detection");
+    expect(hasDataConflict(makeRow(), makeRow({ amountCents: 2000 }))).toBe(true);
+  });
+
+  it("returns true when categoryId differs", async () => {
+    const { hasDataConflict } = await import("@/features/sync/lib/conflict-detection");
+    expect(hasDataConflict(makeRow(), makeRow({ categoryId: "transport" }))).toBe(true);
+  });
+
+  it("returns true when description differs", async () => {
+    const { hasDataConflict } = await import("@/features/sync/lib/conflict-detection");
+    expect(hasDataConflict(makeRow(), makeRow({ description: "Lunch" }))).toBe(true);
+  });
+
+  it("returns true when date differs", async () => {
+    const { hasDataConflict } = await import("@/features/sync/lib/conflict-detection");
+    expect(hasDataConflict(makeRow(), makeRow({ date: "2026-03-11" }))).toBe(true);
+  });
+
+  it("returns true when type differs", async () => {
+    const { hasDataConflict } = await import("@/features/sync/lib/conflict-detection");
+    expect(hasDataConflict(makeRow(), makeRow({ type: "income" }))).toBe(true);
+  });
+
+  it("returns true when deletedAt differs", async () => {
+    const { hasDataConflict } = await import("@/features/sync/lib/conflict-detection");
+    expect(hasDataConflict(makeRow(), makeRow({ deletedAt: "2026-03-10T15:00:00.000Z" }))).toBe(
+      true
+    );
+  });
+
+  it("returns false when both descriptions are null", async () => {
+    const { hasDataConflict } = await import("@/features/sync/lib/conflict-detection");
+    expect(hasDataConflict(makeRow({ description: null }), makeRow({ description: null }))).toBe(
+      false
+    );
+  });
+});

--- a/apps/mobile/__tests__/sync/conflict-repository.test.ts
+++ b/apps/mobile/__tests__/sync/conflict-repository.test.ts
@@ -1,0 +1,90 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: mock db needs flexible typing
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockRun = vi.fn();
+const mockAll = vi.fn().mockReturnValue([]);
+const mockSelect = vi.fn().mockReturnThis();
+const mockFrom = vi.fn().mockReturnThis();
+const mockWhere = vi.fn().mockReturnThis();
+const mockOrderBy = vi.fn().mockReturnThis();
+const mockInsert = vi.fn().mockReturnThis();
+const mockValues = vi.fn().mockReturnThis();
+const mockUpdate = vi.fn().mockReturnThis();
+const mockSet = vi.fn().mockReturnThis();
+const mockUpdateWhere = vi.fn().mockReturnThis();
+
+const mockDb = {
+  insert: mockInsert,
+  select: mockSelect,
+  update: mockUpdate,
+} as any;
+
+describe("conflict repository", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mockInsert.mockReturnValue({ values: mockValues });
+    mockValues.mockReturnValue({ run: mockRun });
+    mockSelect.mockReturnValue({ from: mockFrom });
+    mockFrom.mockReturnValue({ where: mockWhere });
+    mockWhere.mockReturnValue({ orderBy: mockOrderBy });
+    mockOrderBy.mockReturnValue({ all: mockAll });
+    mockUpdate.mockReturnValue({ set: mockSet });
+    mockSet.mockReturnValue({ where: mockUpdateWhere });
+    mockUpdateWhere.mockReturnValue({ run: mockRun });
+  });
+
+  it("insertConflict calls db.insert with correct values", async () => {
+    const { insertConflict } = await import("@/features/sync/lib/conflict-repository");
+    const row = {
+      id: "conflict-1",
+      transactionId: "tx-1",
+      localData: '{"amountCents":1000}',
+      serverData: '{"amountCents":2000}',
+      detectedAt: "2026-03-15T10:00:00.000Z",
+    };
+
+    insertConflict(mockDb, row);
+
+    expect(mockInsert).toHaveBeenCalled();
+    expect(mockValues).toHaveBeenCalledWith(row);
+    expect(mockRun).toHaveBeenCalled();
+  });
+
+  it("getUnresolvedConflicts queries for null resolvedAt", async () => {
+    const mockConflicts = [
+      {
+        id: "conflict-1",
+        transactionId: "tx-1",
+        localData: "{}",
+        serverData: "{}",
+        detectedAt: "2026-03-15T10:00:00.000Z",
+        resolvedAt: null,
+        resolution: null,
+      },
+    ];
+    mockAll.mockReturnValueOnce(mockConflicts);
+
+    const { getUnresolvedConflicts } = await import("@/features/sync/lib/conflict-repository");
+    const result = getUnresolvedConflicts(mockDb);
+
+    expect(mockSelect).toHaveBeenCalled();
+    expect(mockFrom).toHaveBeenCalled();
+    expect(mockWhere).toHaveBeenCalled();
+    expect(mockOrderBy).toHaveBeenCalled();
+    expect(result).toEqual(mockConflicts);
+  });
+
+  it("resolveConflict updates with resolvedAt and resolution", async () => {
+    const { resolveConflict } = await import("@/features/sync/lib/conflict-repository");
+
+    resolveConflict(mockDb, "conflict-1", "local", "2026-03-15T12:00:00.000Z");
+
+    expect(mockUpdate).toHaveBeenCalled();
+    expect(mockSet).toHaveBeenCalledWith({
+      resolvedAt: "2026-03-15T12:00:00.000Z",
+      resolution: "local",
+    });
+    expect(mockRun).toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/__tests__/sync/syncEngine.test.ts
+++ b/apps/mobile/__tests__/sync/syncEngine.test.ts
@@ -9,6 +9,11 @@ const mockGetSyncMeta = vi.fn().mockResolvedValue(null);
 const mockSetSyncMeta = vi.fn();
 const mockUpsertTransaction = vi.fn();
 
+const mockInsertConflict = vi.fn();
+vi.mock("@/features/sync/lib/conflict-repository", () => ({
+  insertConflict: (...args: any[]) => mockInsertConflict(...args),
+}));
+
 vi.mock("@/features/transactions/lib/repository", () => ({
   getQueuedSyncEntries: (...args: any[]) => mockGetQueuedSyncEntries(...args),
   clearSyncEntries: (...args: any[]) => mockClearSyncEntries(...args),
@@ -307,6 +312,115 @@ describe("syncEngine", () => {
 
       expect(mockGetSyncMeta).toHaveBeenCalled();
       expect(mockGetQueuedSyncEntries).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("conflict logging", () => {
+    it("logs conflict when server overwrites local with different data", async () => {
+      mockGetSyncMeta.mockResolvedValueOnce(null);
+      const serverRows = [
+        {
+          id: "tx-1",
+          user_id: "user-1",
+          type: "expense",
+          amount_cents: 2000,
+          category_id: "food",
+          description: "Updated by server",
+          date: "2026-03-04",
+          created_at: "2026-03-04T10:00:00.000Z",
+          updated_at: "2026-03-04T14:00:00.000Z",
+          deleted_at: null,
+        },
+      ];
+      const mockSupabase = createMockSupabase({ data: serverRows, error: null });
+      mockGetTransactionById.mockResolvedValueOnce({
+        id: "tx-1",
+        userId: "user-1",
+        type: "expense",
+        amountCents: 1000,
+        categoryId: "food",
+        description: "Local version",
+        date: "2026-03-04",
+        createdAt: "2026-03-04T10:00:00.000Z",
+        updatedAt: "2026-03-04T10:00:00.000Z",
+        deletedAt: null,
+        source: "manual",
+      });
+
+      const { syncPull } = await import("@/features/sync/services/syncEngine");
+      await syncPull(mockDb, mockSupabase, "user-1");
+
+      expect(mockInsertConflict).toHaveBeenCalledWith(
+        mockDb,
+        expect.objectContaining({
+          transactionId: "tx-1",
+        })
+      );
+      expect(mockUpsertTransaction).toHaveBeenCalled();
+    });
+
+    it("does not log conflict when data matches (only timestamp differs)", async () => {
+      mockGetSyncMeta.mockResolvedValueOnce(null);
+      const serverRows = [
+        {
+          id: "tx-1",
+          user_id: "user-1",
+          type: "expense",
+          amount_cents: 1000,
+          category_id: "food",
+          description: "Same data",
+          date: "2026-03-04",
+          created_at: "2026-03-04T10:00:00.000Z",
+          updated_at: "2026-03-04T14:00:00.000Z",
+          deleted_at: null,
+        },
+      ];
+      const mockSupabase = createMockSupabase({ data: serverRows, error: null });
+      mockGetTransactionById.mockResolvedValueOnce({
+        id: "tx-1",
+        userId: "user-1",
+        type: "expense",
+        amountCents: 1000,
+        categoryId: "food",
+        description: "Same data",
+        date: "2026-03-04",
+        createdAt: "2026-03-04T10:00:00.000Z",
+        updatedAt: "2026-03-04T10:00:00.000Z",
+        deletedAt: null,
+        source: "manual",
+      });
+
+      const { syncPull } = await import("@/features/sync/services/syncEngine");
+      await syncPull(mockDb, mockSupabase, "user-1");
+
+      expect(mockInsertConflict).not.toHaveBeenCalled();
+      expect(mockUpsertTransaction).toHaveBeenCalled();
+    });
+
+    it("does not log conflict for new server-only transactions", async () => {
+      mockGetSyncMeta.mockResolvedValueOnce(null);
+      const serverRows = [
+        {
+          id: "tx-new",
+          user_id: "user-1",
+          type: "expense",
+          amount_cents: 5000,
+          category_id: "transport",
+          description: "New from server",
+          date: "2026-03-04",
+          created_at: "2026-03-04T10:00:00.000Z",
+          updated_at: "2026-03-04T10:00:00.000Z",
+          deleted_at: null,
+        },
+      ];
+      const mockSupabase = createMockSupabase({ data: serverRows, error: null });
+      mockGetTransactionById.mockResolvedValueOnce(null);
+
+      const { syncPull } = await import("@/features/sync/services/syncEngine");
+      await syncPull(mockDb, mockSupabase, "user-1");
+
+      expect(mockInsertConflict).not.toHaveBeenCalled();
+      expect(mockUpsertTransaction).toHaveBeenCalled();
     });
   });
 });

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -24,6 +24,7 @@ import { useCaptureSourcesStore } from "@/features/capture-sources/store";
 import { useEmailCapture } from "@/features/email-capture/hooks/useEmailCapture";
 import { useEmailCaptureStore } from "@/features/email-capture/store";
 import { useSync } from "@/features/sync/hooks/useSync";
+import { useSyncConflictStore } from "@/features/sync/store";
 import { useTransactionStore } from "@/features/transactions/store";
 import { ErrorFallback } from "@/shared/components/ErrorFallback";
 import type { AnyDb } from "@/shared/db/client";
@@ -49,6 +50,7 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: string }) {
       useCaptureSourcesStore.getState().initStore(db, userId);
       useChatStore.getState().initStore(db, userId);
       useCalendarStore.getState().initStore(db, userId);
+      useSyncConflictStore.getState().initStore(db);
       Promise.all([
         useCalendarStore.getState().loadBills(),
         useCalendarStore.getState().loadPaymentsForMonth(),
@@ -66,6 +68,7 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: string }) {
         .getState()
         .loadInitialPage()
         .catch(handleRecoverableError("Failed to load transactions"));
+      useSyncConflictStore.getState().loadConflicts();
       registerBackgroundTask().catch(captureError);
     }
   }, [migrationsReady, db, userId]);

--- a/apps/mobile/app/sync-conflicts.tsx
+++ b/apps/mobile/app/sync-conflicts.tsx
@@ -1,0 +1,3 @@
+import ConflictResolutionScreen from "@/features/sync/components/ConflictResolutionScreen";
+
+export default ConflictResolutionScreen;

--- a/apps/mobile/drizzle/0011_clear_black_tarantula.sql
+++ b/apps/mobile/drizzle/0011_clear_black_tarantula.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `sync_conflicts` (
+	`id` text PRIMARY KEY NOT NULL,
+	`transaction_id` text NOT NULL,
+	`local_data` text NOT NULL,
+	`server_data` text NOT NULL,
+	`detected_at` text NOT NULL,
+	`resolved_at` text,
+	`resolution` text
+);
+--> statement-breakpoint
+CREATE INDEX `idx_sync_conflicts_resolved` ON `sync_conflicts` (`resolved_at`);

--- a/apps/mobile/drizzle/meta/0011_snapshot.json
+++ b/apps/mobile/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,1013 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e92b9efc-4df1-402b-85ae-d6be93793555",
+  "prevId": "267a64d2-71c2-4449-8f16-ec35ed038b7d",
+  "tables": {
+    "bill_payments": {
+      "name": "bill_payments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bill_id": {
+          "name": "bill_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_bill_payments_bill": {
+          "name": "idx_bill_payments_bill",
+          "columns": ["bill_id"],
+          "isUnique": false
+        },
+        "uq_bill_payment_occurrence": {
+          "name": "uq_bill_payment_occurrence",
+          "columns": ["bill_id", "due_date"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bills": {
+      "name": "bills",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_bills_user": {
+          "name": "idx_bills_user",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "idx_bills_user_active": {
+          "name": "idx_bills_user_active",
+          "columns": ["user_id", "is_active"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_messages": {
+      "name": "chat_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action_status": {
+          "name": "action_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_chat_messages_session_created": {
+          "name": "idx_chat_messages_session_created",
+          "columns": ["session_id", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_sessions": {
+      "name": "chat_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_chat_sessions_user_created": {
+          "name": "idx_chat_sessions_user_created",
+          "columns": ["user_id", "created_at"],
+          "isUnique": false
+        },
+        "idx_chat_sessions_expires": {
+          "name": "idx_chat_sessions_expires",
+          "columns": ["expires_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "detected_sms_events": {
+      "name": "detected_sms_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sender_label": {
+          "name": "sender_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dismissed": {
+          "name": "dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "linked_transaction_id": {
+          "name": "linked_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_sms_events_user_dismissed": {
+          "name": "idx_sms_events_user_dismissed",
+          "columns": ["user_id", "dismissed"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "email_accounts": {
+      "name": "email_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_email_accounts_user": {
+          "name": "idx_email_accounts_user",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "merchant_rules": {
+      "name": "merchant_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_merchant_rule_v2": {
+          "name": "uq_merchant_rule_v2",
+          "columns": ["user_id", "keyword"],
+          "isUnique": true
+        },
+        "idx_merchant_lookup_v2": {
+          "name": "idx_merchant_lookup_v2",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_sources": {
+      "name": "notification_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_notification_source": {
+          "name": "uq_notification_source",
+          "columns": ["user_id", "package_name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "processed_captures": {
+      "name": "processed_captures",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fingerprint_hash": {
+          "name": "fingerprint_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_text": {
+          "name": "raw_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_capture_fingerprint": {
+          "name": "uq_capture_fingerprint",
+          "columns": ["fingerprint_hash"],
+          "isUnique": true
+        },
+        "idx_capture_source": {
+          "name": "idx_capture_source",
+          "columns": ["source"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "processed_emails": {
+      "name": "processed_emails",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_body_preview": {
+          "name": "raw_body_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_processed_external_id": {
+          "name": "uq_processed_external_id",
+          "columns": ["external_id"],
+          "isUnique": true
+        },
+        "idx_processed_status": {
+          "name": "idx_processed_status",
+          "columns": ["status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_conflicts": {
+      "name": "sync_conflicts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_data": {
+          "name": "local_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_data": {
+          "name": "server_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_sync_conflicts_resolved": {
+          "name": "idx_sync_conflicts_resolved",
+          "columns": ["resolved_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_meta": {
+      "name": "sync_meta",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_queue": {
+      "name": "sync_queue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transactions": {
+      "name": "transactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "idx_transactions_user_date": {
+          "name": "idx_transactions_user_date",
+          "columns": ["user_id", "date"],
+          "isUnique": false
+        },
+        "idx_transactions_user_category": {
+          "name": "idx_transactions_user_category",
+          "columns": ["user_id", "category_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_memories": {
+      "name": "user_memories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fact": {
+          "name": "fact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_user_memories_user": {
+          "name": "idx_user_memories_user",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/mobile/drizzle/meta/_journal.json
+++ b/apps/mobile/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1773376839742,
       "tag": "0010_wakeful_tony_stark",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1773556897757,
+      "tag": "0011_clear_black_tarantula",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/mobile/drizzle/migrations.js
+++ b/apps/mobile/drizzle/migrations.js
@@ -10,6 +10,7 @@ import m0007 from "./0007_neat_wolfpack.sql";
 import m0008 from "./0008_eminent_the_hunter.sql";
 import m0009 from "./0009_fine_groot.sql";
 import m0010 from "./0010_wakeful_tony_stark.sql";
+import m0011 from "./0011_clear_black_tarantula.sql";
 import journal from "./meta/_journal.json";
 
 export default {
@@ -26,5 +27,6 @@ export default {
     m0008,
     m0009,
     m0010,
+    m0011,
   },
 };

--- a/apps/mobile/features/dashboard/components/HomeScreen.tsx
+++ b/apps/mobile/features/dashboard/components/HomeScreen.tsx
@@ -15,6 +15,7 @@ import { EmailConnectBanner } from "@/features/email-capture/components/EmailCon
 import { FailedEmailsBanner } from "@/features/email-capture/components/FailedEmailsBanner";
 import { getGmailClientId, getOutlookClientId } from "@/features/email-capture/schema";
 import { useEmailCaptureStore } from "@/features/email-capture/store";
+import { SyncConflictBanner } from "@/features/sync/components/SyncConflictBanner";
 import { CATEGORY_MAP } from "@/features/transactions/lib/categories";
 import { formatSignedAmount } from "@/features/transactions/lib/format-amount";
 import { makeDateLabel } from "@/features/transactions/lib/group-by-date";
@@ -93,6 +94,7 @@ const ListHeader = memo(function ListHeader({
       />
       <FailedEmailsBanner onPress={() => push("/failed-emails" as never)} />
       <NeedsReviewBanner onPress={() => push("/needs-review" as never)} />
+      <SyncConflictBanner onPress={() => push("/sync-conflicts" as never)} />
       {Platform.OS === "ios" && (
         <DetectedTransactionsBanner onPress={() => push("/connected-accounts" as never)} />
       )}

--- a/apps/mobile/features/sync/components/ConflictCard.tsx
+++ b/apps/mobile/features/sync/components/ConflictCard.tsx
@@ -15,21 +15,35 @@ type DiffRowProps = {
   readonly label: string;
   readonly localValue: string;
   readonly serverValue: string;
+  readonly accentRed: string;
+  readonly accentGreen: string;
 };
 
-const DiffRow = memo(function DiffRow({ label, localValue, serverValue }: DiffRowProps) {
+const DiffRow = memo(function DiffRow({
+  label,
+  localValue,
+  serverValue,
+  accentRed,
+  accentGreen,
+}: DiffRowProps) {
   return (
     <View className="flex-row items-center py-1.5" style={{ gap: 8 }}>
       <Text className="w-20 font-poppins-medium text-caption text-secondary dark:text-secondary-dark">
         {label}
       </Text>
-      <View className="flex-1 rounded-md bg-red-50 px-2 py-1 dark:bg-red-950">
-        <Text className="font-poppins-medium text-caption text-accent-red dark:text-accent-red-dark">
+      <View
+        className="flex-1 rounded-lg px-2 py-1.5"
+        style={{ backgroundColor: `${accentRed}18` }}
+      >
+        <Text className="font-poppins-medium text-caption" style={{ color: accentRed }}>
           {localValue}
         </Text>
       </View>
-      <View className="flex-1 rounded-md bg-green-50 px-2 py-1 dark:bg-green-950">
-        <Text className="font-poppins-medium text-caption text-accent-green dark:text-accent-green-dark">
+      <View
+        className="flex-1 rounded-lg px-2 py-1.5"
+        style={{ backgroundColor: `${accentGreen}18` }}
+      >
+        <Text className="font-poppins-medium text-caption" style={{ color: accentGreen }}>
           {serverValue}
         </Text>
       </View>
@@ -49,9 +63,10 @@ export const ConflictCard = memo(function ConflictCard({
 }: ConflictCardProps) {
   const accentGreen = useThemeColor("accentGreen");
   const accentRed = useThemeColor("accentRed");
+  const peachBg = useThemeColor("peachLight");
   const { localData, serverData } = conflict;
 
-  const diffs: DiffRowProps[] = [];
+  const diffs: Omit<DiffRowProps, "accentRed" | "accentGreen">[] = [];
 
   if (localData.amountCents !== serverData.amountCents) {
     diffs.push({
@@ -107,44 +122,40 @@ export const ConflictCard = memo(function ConflictCard({
   }
 
   return (
-    <View className="rounded-xl bg-chart-bg p-4 dark:bg-chart-bg-dark">
-      <Text className="mb-1 font-poppins-semibold text-body text-primary dark:text-primary-dark">
+    <View className="rounded-xl p-4" style={{ backgroundColor: peachBg }}>
+      <Text className="mb-2 font-poppins-semibold text-body text-primary dark:text-primary-dark">
         {localData.description || serverData.description || "Transaction"}
       </Text>
 
-      <View className="mb-2 flex-row" style={{ gap: 8 }}>
-        <View className="flex-1">
-          <Text className="font-poppins-medium text-caption text-secondary dark:text-secondary-dark">
-            Your version
-          </Text>
-        </View>
-        <View className="flex-1">
-          <Text className="font-poppins-medium text-caption text-secondary dark:text-secondary-dark">
-            Synced version
-          </Text>
-        </View>
+      <View className="mb-1 flex-row" style={{ gap: 8, paddingLeft: 80 + 8 }}>
+        <Text className="flex-1 font-poppins-medium text-caption text-tertiary dark:text-tertiary-dark">
+          Your version
+        </Text>
+        <Text className="flex-1 font-poppins-medium text-caption text-tertiary dark:text-tertiary-dark">
+          Synced version
+        </Text>
       </View>
 
       {diffs.map((diff) => (
-        <DiffRow key={diff.label} {...diff} />
+        <DiffRow key={diff.label} {...diff} accentRed={accentRed} accentGreen={accentGreen} />
       ))}
 
-      <View className="mt-3 flex-row" style={{ gap: 8 }}>
+      <View className="mt-4 flex-row" style={{ gap: 8 }}>
         <Pressable
           onPress={onKeepLocal}
-          className="flex-1 items-center rounded-lg py-2"
+          className="flex-1 items-center rounded-xl py-3"
           style={{ backgroundColor: `${accentRed}20` }}
         >
-          <Text className="font-poppins-semibold text-caption" style={{ color: accentRed }}>
+          <Text className="font-poppins-semibold text-body" style={{ color: accentRed }}>
             Keep mine
           </Text>
         </Pressable>
         <Pressable
           onPress={onAcceptServer}
-          className="flex-1 items-center rounded-lg py-2"
+          className="flex-1 items-center rounded-xl py-3"
           style={{ backgroundColor: `${accentGreen}20` }}
         >
-          <Text className="font-poppins-semibold text-caption" style={{ color: accentGreen }}>
+          <Text className="font-poppins-semibold text-body" style={{ color: accentGreen }}>
             Accept synced
           </Text>
         </Pressable>

--- a/apps/mobile/features/sync/components/ConflictCard.tsx
+++ b/apps/mobile/features/sync/components/ConflictCard.tsx
@@ -96,11 +96,13 @@ export const ConflictCard = memo(function ConflictCard({
     });
   }
 
-  if (localData.deletedAt !== serverData.deletedAt) {
+  const localDeleted = localData.deletedAt != null;
+  const serverDeleted = serverData.deletedAt != null;
+  if (localDeleted !== serverDeleted) {
     diffs.push({
       label: "Status",
-      localValue: localData.deletedAt ? "Deleted" : "Active",
-      serverValue: serverData.deletedAt ? "Deleted" : "Active",
+      localValue: localDeleted ? "Deleted" : "Active",
+      serverValue: serverDeleted ? "Deleted" : "Active",
     });
   }
 

--- a/apps/mobile/features/sync/components/ConflictCard.tsx
+++ b/apps/mobile/features/sync/components/ConflictCard.tsx
@@ -31,10 +31,7 @@ const DiffRow = memo(function DiffRow({
       <Text className="w-20 font-poppins-medium text-caption text-secondary dark:text-secondary-dark">
         {label}
       </Text>
-      <View
-        className="flex-1 rounded-lg px-2 py-1.5"
-        style={{ backgroundColor: `${accentRed}18` }}
-      >
+      <View className="flex-1 rounded-lg px-2 py-1.5" style={{ backgroundColor: `${accentRed}18` }}>
         <Text className="font-poppins-medium text-caption" style={{ color: accentRed }}>
           {localValue}
         </Text>

--- a/apps/mobile/features/sync/components/ConflictCard.tsx
+++ b/apps/mobile/features/sync/components/ConflictCard.tsx
@@ -96,6 +96,14 @@ export const ConflictCard = memo(function ConflictCard({
     });
   }
 
+  if (localData.deletedAt !== serverData.deletedAt) {
+    diffs.push({
+      label: "Status",
+      localValue: localData.deletedAt ? "Deleted" : "Active",
+      serverValue: serverData.deletedAt ? "Deleted" : "Active",
+    });
+  }
+
   return (
     <View className="rounded-xl bg-chart-bg p-4 dark:bg-chart-bg-dark">
       <Text className="mb-1 font-poppins-semibold text-body text-primary dark:text-primary-dark">

--- a/apps/mobile/features/sync/components/ConflictCard.tsx
+++ b/apps/mobile/features/sync/components/ConflictCard.tsx
@@ -1,0 +1,144 @@
+import { memo } from "react";
+import { Pressable, Text, View } from "react-native";
+import { CATEGORY_MAP } from "@/features/transactions/lib/categories";
+import { formatSignedAmount } from "@/features/transactions/lib/format-amount";
+import { useThemeColor } from "@/shared/hooks/use-theme-color";
+import type { SyncConflict } from "../store";
+
+type ConflictCardProps = {
+  readonly conflict: SyncConflict;
+  readonly onKeepLocal: () => void;
+  readonly onAcceptServer: () => void;
+};
+
+type DiffRowProps = {
+  readonly label: string;
+  readonly localValue: string;
+  readonly serverValue: string;
+};
+
+const DiffRow = memo(function DiffRow({ label, localValue, serverValue }: DiffRowProps) {
+  return (
+    <View className="flex-row items-center py-1.5" style={{ gap: 8 }}>
+      <Text className="w-20 font-poppins-medium text-caption text-secondary dark:text-secondary-dark">
+        {label}
+      </Text>
+      <View className="flex-1 rounded-md bg-red-50 px-2 py-1 dark:bg-red-950">
+        <Text className="font-poppins-medium text-caption text-accent-red dark:text-accent-red-dark">
+          {localValue}
+        </Text>
+      </View>
+      <View className="flex-1 rounded-md bg-green-50 px-2 py-1 dark:bg-green-950">
+        <Text className="font-poppins-medium text-caption text-accent-green dark:text-accent-green-dark">
+          {serverValue}
+        </Text>
+      </View>
+    </View>
+  );
+});
+
+function getCategoryLabel(categoryId: string): string {
+  const cat = CATEGORY_MAP[categoryId as keyof typeof CATEGORY_MAP];
+  return cat?.label.en ?? categoryId;
+}
+
+export const ConflictCard = memo(function ConflictCard({
+  conflict,
+  onKeepLocal,
+  onAcceptServer,
+}: ConflictCardProps) {
+  const accentGreen = useThemeColor("accentGreen");
+  const accentRed = useThemeColor("accentRed");
+  const { localData, serverData } = conflict;
+
+  const diffs: DiffRowProps[] = [];
+
+  if (localData.amountCents !== serverData.amountCents) {
+    diffs.push({
+      label: "Amount",
+      localValue: formatSignedAmount(localData.amountCents, localData.type as "expense" | "income"),
+      serverValue: formatSignedAmount(
+        serverData.amountCents,
+        serverData.type as "expense" | "income"
+      ),
+    });
+  }
+
+  if (localData.categoryId !== serverData.categoryId) {
+    diffs.push({
+      label: "Category",
+      localValue: getCategoryLabel(localData.categoryId),
+      serverValue: getCategoryLabel(serverData.categoryId),
+    });
+  }
+
+  if (localData.description !== serverData.description) {
+    diffs.push({
+      label: "Description",
+      localValue: localData.description ?? "(none)",
+      serverValue: serverData.description ?? "(none)",
+    });
+  }
+
+  if (localData.date !== serverData.date) {
+    diffs.push({
+      label: "Date",
+      localValue: localData.date,
+      serverValue: serverData.date,
+    });
+  }
+
+  if (localData.type !== serverData.type) {
+    diffs.push({
+      label: "Type",
+      localValue: localData.type,
+      serverValue: serverData.type,
+    });
+  }
+
+  return (
+    <View className="rounded-xl bg-chart-bg p-4 dark:bg-chart-bg-dark">
+      <Text className="mb-1 font-poppins-semibold text-body text-primary dark:text-primary-dark">
+        {localData.description || serverData.description || "Transaction"}
+      </Text>
+
+      <View className="mb-2 flex-row" style={{ gap: 8 }}>
+        <View className="flex-1">
+          <Text className="font-poppins-medium text-caption text-secondary dark:text-secondary-dark">
+            Your version
+          </Text>
+        </View>
+        <View className="flex-1">
+          <Text className="font-poppins-medium text-caption text-secondary dark:text-secondary-dark">
+            Synced version
+          </Text>
+        </View>
+      </View>
+
+      {diffs.map((diff) => (
+        <DiffRow key={diff.label} {...diff} />
+      ))}
+
+      <View className="mt-3 flex-row" style={{ gap: 8 }}>
+        <Pressable
+          onPress={onKeepLocal}
+          className="flex-1 items-center rounded-lg py-2"
+          style={{ backgroundColor: `${accentRed}20` }}
+        >
+          <Text className="font-poppins-semibold text-caption" style={{ color: accentRed }}>
+            Keep mine
+          </Text>
+        </Pressable>
+        <Pressable
+          onPress={onAcceptServer}
+          className="flex-1 items-center rounded-lg py-2"
+          style={{ backgroundColor: `${accentGreen}20` }}
+        >
+          <Text className="font-poppins-semibold text-caption" style={{ color: accentGreen }}>
+            Accept synced
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+});

--- a/apps/mobile/features/sync/components/ConflictResolutionScreen.tsx
+++ b/apps/mobile/features/sync/components/ConflictResolutionScreen.tsx
@@ -1,0 +1,49 @@
+import { useRouter } from "expo-router";
+import { useCallback } from "react";
+import { FlatList, Text, View } from "react-native";
+import { ScreenLayout } from "@/shared/components/ScreenLayout";
+import type { SyncConflict } from "../store";
+import { useSyncConflictStore } from "../store";
+import { ConflictCard } from "./ConflictCard";
+
+export default function ConflictResolutionScreen() {
+  const router = useRouter();
+  const conflicts = useSyncConflictStore((s) => s.conflicts);
+  const resolveConflict = useSyncConflictStore((s) => s.resolveConflict);
+
+  const renderItem = useCallback(
+    ({ item }: { item: SyncConflict }) => (
+      <ConflictCard
+        conflict={item}
+        onKeepLocal={() => resolveConflict(item.id, "local")}
+        onAcceptServer={() => resolveConflict(item.id, "server")}
+      />
+    ),
+    [resolveConflict]
+  );
+
+  const keyExtractor = useCallback((item: SyncConflict) => item.id, []);
+
+  return (
+    <ScreenLayout title="Sync Conflicts" variant="sub" onBack={() => router.back()}>
+      {conflicts.length === 0 ? (
+        <View className="flex-1 items-center justify-center px-10">
+          <Text className="font-poppins-semibold text-base text-primary dark:text-primary-dark">
+            All resolved!
+          </Text>
+          <Text className="mt-1 text-center font-poppins-medium text-caption text-secondary dark:text-secondary-dark">
+            No sync conflicts right now.
+          </Text>
+        </View>
+      ) : (
+        <FlatList
+          data={conflicts}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 24 }}
+          ItemSeparatorComponent={() => <View style={{ height: 16 }} />}
+        />
+      )}
+    </ScreenLayout>
+  );
+}

--- a/apps/mobile/features/sync/components/SyncConflictBanner.tsx
+++ b/apps/mobile/features/sync/components/SyncConflictBanner.tsx
@@ -1,5 +1,6 @@
 import { ChevronRight, GitMerge } from "lucide-react-native";
 import { Pressable, Text, View } from "react-native";
+import { useThemeColor } from "@/shared/hooks/use-theme-color";
 import { useSyncConflictStore } from "../store";
 
 type SyncConflictBannerProps = {
@@ -8,6 +9,9 @@ type SyncConflictBannerProps = {
 
 export const SyncConflictBanner = ({ onPress }: SyncConflictBannerProps) => {
   const count = useSyncConflictStore((s) => s.conflictCount);
+  const peachBg = useThemeColor("peachLight");
+  const accentRed = useThemeColor("accentRed");
+  const secondaryColor = useThemeColor("secondary");
 
   if (count === 0) return null;
 
@@ -15,20 +19,20 @@ export const SyncConflictBanner = ({ onPress }: SyncConflictBannerProps) => {
     <Pressable
       onPress={onPress}
       className="flex-row items-center justify-between rounded-xl p-3"
-      style={{ backgroundColor: "#FFF3E0", gap: 12 }}
+      style={{ backgroundColor: peachBg, gap: 12 }}
     >
       <View className="flex-1 flex-row items-center" style={{ gap: 10 }}>
-        <GitMerge size={18} color="#E65100" />
+        <GitMerge size={18} color={accentRed} />
         <View>
           <Text className="font-poppins-semibold text-body text-primary dark:text-primary-dark">
             {count} sync {count === 1 ? "conflict needs" : "conflicts need"} review
           </Text>
-          <Text className="font-poppins-medium text-caption" style={{ color: "#6D6D6D" }}>
+          <Text className="font-poppins-medium text-caption" style={{ color: secondaryColor }}>
             Changes from another device
           </Text>
         </View>
       </View>
-      <ChevronRight size={16} color="#6D6D6D" />
+      <ChevronRight size={16} color={secondaryColor} />
     </Pressable>
   );
 };

--- a/apps/mobile/features/sync/components/SyncConflictBanner.tsx
+++ b/apps/mobile/features/sync/components/SyncConflictBanner.tsx
@@ -1,0 +1,34 @@
+import { ChevronRight, GitMerge } from "lucide-react-native";
+import { Pressable, Text, View } from "react-native";
+import { useSyncConflictStore } from "../store";
+
+type SyncConflictBannerProps = {
+  readonly onPress: () => void;
+};
+
+export const SyncConflictBanner = ({ onPress }: SyncConflictBannerProps) => {
+  const count = useSyncConflictStore((s) => s.conflictCount);
+
+  if (count === 0) return null;
+
+  return (
+    <Pressable
+      onPress={onPress}
+      className="flex-row items-center justify-between rounded-xl p-3"
+      style={{ backgroundColor: "#FFF3E0", gap: 12 }}
+    >
+      <View className="flex-1 flex-row items-center" style={{ gap: 10 }}>
+        <GitMerge size={18} color="#E65100" />
+        <View>
+          <Text className="font-poppins-semibold text-body text-primary dark:text-primary-dark">
+            {count} sync {count === 1 ? "conflict needs" : "conflicts need"} review
+          </Text>
+          <Text className="font-poppins-medium text-caption" style={{ color: "#6D6D6D" }}>
+            Changes from another device
+          </Text>
+        </View>
+      </View>
+      <ChevronRight size={16} color="#6D6D6D" />
+    </Pressable>
+  );
+};

--- a/apps/mobile/features/sync/hooks/useSync.ts
+++ b/apps/mobile/features/sync/hooks/useSync.ts
@@ -5,6 +5,7 @@ import type { AnyDb } from "@/shared/db/client";
 import { getSupabase } from "@/shared/db/supabase";
 import { isOnline, onConnectivityChange } from "../services/networkMonitor";
 import { fullSync } from "../services/syncEngine";
+import { useSyncConflictStore } from "../store";
 
 export function useSync(db: AnyDb | null, userId: string | null) {
   const isSyncing = useRef(false);
@@ -22,6 +23,7 @@ export function useSync(db: AnyDb | null, userId: string | null) {
       try {
         await fullSync(db, supabase, userId);
         await useTransactionStore.getState().refresh();
+        useSyncConflictStore.getState().loadConflicts();
       } catch (error) {
         console.warn("[sync] background sync failed:", error);
       } finally {

--- a/apps/mobile/features/sync/lib/conflict-detection.ts
+++ b/apps/mobile/features/sync/lib/conflict-detection.ts
@@ -1,0 +1,19 @@
+type TransactionRow = {
+  readonly amountCents: number;
+  readonly categoryId: string;
+  readonly description: string | null;
+  readonly date: string;
+  readonly type: string;
+  readonly deletedAt: string | null;
+};
+
+export function hasDataConflict(local: TransactionRow, server: TransactionRow): boolean {
+  return (
+    local.amountCents !== server.amountCents ||
+    local.categoryId !== server.categoryId ||
+    local.description !== server.description ||
+    local.date !== server.date ||
+    local.type !== server.type ||
+    local.deletedAt !== server.deletedAt
+  );
+}

--- a/apps/mobile/features/sync/lib/conflict-repository.ts
+++ b/apps/mobile/features/sync/lib/conflict-repository.ts
@@ -1,0 +1,22 @@
+import { desc, eq, isNull } from "drizzle-orm";
+import type { AnyDb } from "@/shared/db/client";
+import { syncConflicts } from "@/shared/db/schema";
+
+export type ConflictRow = typeof syncConflicts.$inferInsert;
+
+export function insertConflict(db: AnyDb, row: ConflictRow) {
+  db.insert(syncConflicts).values(row).run();
+}
+
+export function getUnresolvedConflicts(db: AnyDb) {
+  return db
+    .select()
+    .from(syncConflicts)
+    .where(isNull(syncConflicts.resolvedAt))
+    .orderBy(desc(syncConflicts.detectedAt))
+    .all();
+}
+
+export function resolveConflict(db: AnyDb, id: string, resolution: string, resolvedAt: string) {
+  db.update(syncConflicts).set({ resolvedAt, resolution }).where(eq(syncConflicts.id, id)).run();
+}

--- a/apps/mobile/features/sync/services/syncEngine.ts
+++ b/apps/mobile/features/sync/services/syncEngine.ts
@@ -9,7 +9,10 @@ import {
   upsertTransaction,
 } from "@/features/transactions/lib/repository";
 import type { AnyDb } from "@/shared/db/client";
+import { generateId } from "@/shared/lib/generate-id";
 import { captureError } from "@/shared/lib/sentry";
+import { hasDataConflict } from "../lib/conflict-detection";
+import { insertConflict } from "../lib/conflict-repository";
 
 const LAST_SYNC_AT = "last_sync_at";
 
@@ -124,9 +127,19 @@ export async function syncPull(
   for (const serverRow of rows) {
     try {
       const localRow = await getTransactionById(db, serverRow.id);
+      const mappedServerRow = fromSupabaseRow(serverRow);
 
       if (shouldUpdateLocal(serverRow.updated_at, localRow?.updatedAt)) {
-        await upsertTransaction(db, fromSupabaseRow(serverRow));
+        if (localRow && hasDataConflict(localRow, mappedServerRow)) {
+          insertConflict(db, {
+            id: generateId("conflict"),
+            transactionId: serverRow.id,
+            localData: JSON.stringify(localRow),
+            serverData: JSON.stringify(mappedServerRow),
+            detectedAt: new Date().toISOString(),
+          });
+        }
+        await upsertTransaction(db, mappedServerRow);
       }
     } catch (error) {
       captureError(error);

--- a/apps/mobile/features/sync/services/syncEngine.ts
+++ b/apps/mobile/features/sync/services/syncEngine.ts
@@ -132,15 +132,20 @@ export async function syncPull(
       if (shouldUpdateLocal(serverRow.updated_at, localRow?.updatedAt)) {
         const isConflict = localRow != null && hasDataConflict(localRow, mappedServerRow);
         await upsertTransaction(db, mappedServerRow);
-        // Log conflict only after successful upsert to avoid duplicates on retry
+        // Log conflict after successful upsert to avoid duplicates on retry.
+        // Own try/catch so a conflict-logging failure doesn't affect the sync flow.
         if (isConflict) {
-          insertConflict(db, {
-            id: generateId("conflict"),
-            transactionId: serverRow.id,
-            localData: JSON.stringify(localRow),
-            serverData: JSON.stringify(mappedServerRow),
-            detectedAt: new Date().toISOString(),
-          });
+          try {
+            insertConflict(db, {
+              id: generateId("conflict"),
+              transactionId: serverRow.id,
+              localData: JSON.stringify(localRow),
+              serverData: JSON.stringify(mappedServerRow),
+              detectedAt: new Date().toISOString(),
+            });
+          } catch (conflictErr) {
+            captureError(conflictErr);
+          }
         }
       }
     } catch (error) {

--- a/apps/mobile/features/sync/services/syncEngine.ts
+++ b/apps/mobile/features/sync/services/syncEngine.ts
@@ -130,7 +130,10 @@ export async function syncPull(
       const mappedServerRow = fromSupabaseRow(serverRow);
 
       if (shouldUpdateLocal(serverRow.updated_at, localRow?.updatedAt)) {
-        if (localRow && hasDataConflict(localRow, mappedServerRow)) {
+        const isConflict = localRow != null && hasDataConflict(localRow, mappedServerRow);
+        await upsertTransaction(db, mappedServerRow);
+        // Log conflict only after successful upsert to avoid duplicates on retry
+        if (isConflict) {
           insertConflict(db, {
             id: generateId("conflict"),
             transactionId: serverRow.id,
@@ -139,7 +142,6 @@ export async function syncPull(
             detectedAt: new Date().toISOString(),
           });
         }
-        await upsertTransaction(db, mappedServerRow);
       }
     } catch (error) {
       captureError(error);

--- a/apps/mobile/features/sync/store.ts
+++ b/apps/mobile/features/sync/store.ts
@@ -3,6 +3,7 @@ import { enqueueSync, upsertTransaction } from "@/features/transactions/lib/repo
 import { useTransactionStore } from "@/features/transactions/store";
 import type { AnyDb } from "@/shared/db/client";
 import { generateId } from "@/shared/lib/generate-id";
+import { captureError } from "@/shared/lib/sentry";
 import {
   getUnresolvedConflicts,
   resolveConflict as resolveConflictDb,
@@ -63,8 +64,8 @@ export const useSyncConflictStore = create<SyncConflictState & SyncConflictActio
         detectedAt: row.detectedAt,
       }));
       set({ conflicts, conflictCount: conflicts.length });
-    } catch {
-      // DB read failed — keep existing state
+    } catch (err) {
+      captureError(err);
     }
   },
 

--- a/apps/mobile/features/sync/store.ts
+++ b/apps/mobile/features/sync/store.ts
@@ -77,7 +77,7 @@ export const useSyncConflictStore = create<SyncConflictState & SyncConflictActio
     const now = new Date().toISOString();
 
     if (resolution === "local") {
-      upsertTransaction(dbRef, conflict.localData);
+      upsertTransaction(dbRef, { ...conflict.localData, updatedAt: now });
       enqueueSync(dbRef, {
         id: generateId("sq"),
         tableName: "transactions",

--- a/apps/mobile/features/sync/store.ts
+++ b/apps/mobile/features/sync/store.ts
@@ -1,0 +1,93 @@
+import { create } from "zustand";
+import { enqueueSync, upsertTransaction } from "@/features/transactions/lib/repository";
+import { useTransactionStore } from "@/features/transactions/store";
+import type { AnyDb } from "@/shared/db/client";
+import { generateId } from "@/shared/lib/generate-id";
+import {
+  getUnresolvedConflicts,
+  resolveConflict as resolveConflictDb,
+} from "./lib/conflict-repository";
+
+let dbRef: AnyDb | null = null;
+
+type TransactionSnapshot = {
+  readonly id: string;
+  readonly userId: string;
+  readonly type: string;
+  readonly amountCents: number;
+  readonly categoryId: string;
+  readonly description: string | null;
+  readonly date: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly deletedAt: string | null;
+  readonly source: string;
+};
+
+export type SyncConflict = {
+  readonly id: string;
+  readonly transactionId: string;
+  readonly localData: TransactionSnapshot;
+  readonly serverData: TransactionSnapshot;
+  readonly detectedAt: string;
+};
+
+type SyncConflictState = {
+  conflicts: SyncConflict[];
+  conflictCount: number;
+};
+
+type SyncConflictActions = {
+  initStore: (db: AnyDb) => void;
+  loadConflicts: () => void;
+  resolveConflict: (id: string, resolution: "local" | "server") => Promise<void>;
+};
+
+export const useSyncConflictStore = create<SyncConflictState & SyncConflictActions>((set, get) => ({
+  conflicts: [],
+  conflictCount: 0,
+
+  initStore: (db) => {
+    dbRef = db;
+  },
+
+  loadConflicts: () => {
+    if (!dbRef) return;
+    try {
+      const rows = getUnresolvedConflicts(dbRef);
+      const conflicts = rows.map((row) => ({
+        id: row.id,
+        transactionId: row.transactionId,
+        localData: JSON.parse(row.localData) as TransactionSnapshot,
+        serverData: JSON.parse(row.serverData) as TransactionSnapshot,
+        detectedAt: row.detectedAt,
+      }));
+      set({ conflicts, conflictCount: conflicts.length });
+    } catch {
+      // DB read failed — keep existing state
+    }
+  },
+
+  resolveConflict: async (id, resolution) => {
+    if (!dbRef) return;
+    const conflict = get().conflicts.find((c) => c.id === id);
+    if (!conflict) return;
+
+    const now = new Date().toISOString();
+
+    if (resolution === "local") {
+      upsertTransaction(dbRef, conflict.localData);
+      enqueueSync(dbRef, {
+        id: generateId("sq"),
+        tableName: "transactions",
+        rowId: conflict.transactionId,
+        operation: "update",
+        createdAt: now,
+      });
+    }
+
+    resolveConflictDb(dbRef, id, resolution, now);
+    get().loadConflicts();
+    await useTransactionStore.getState().refresh();
+  },
+}));

--- a/apps/mobile/shared/db/schema.ts
+++ b/apps/mobile/shared/db/schema.ts
@@ -104,6 +104,20 @@ export const syncMeta = sqliteTable("sync_meta", {
   value: text("value").notNull(),
 });
 
+export const syncConflicts = sqliteTable(
+  "sync_conflicts",
+  {
+    id: text("id").primaryKey(),
+    transactionId: text("transaction_id").notNull(),
+    localData: text("local_data").notNull(),
+    serverData: text("server_data").notNull(),
+    detectedAt: text("detected_at").notNull(),
+    resolvedAt: text("resolved_at"),
+    resolution: text("resolution"),
+  },
+  (table) => [index("idx_sync_conflicts_resolved").on(table.resolvedAt)]
+);
+
 export const merchantRules = sqliteTable(
   "merchant_rules",
   {


### PR DESCRIPTION
- Add syncConflicts table + migration
- Detect conflicts in syncPull before LWW overwrite
- Log both local and server snapshots
- Add conflict store with resolve actions
- Add banner + resolution screen with side-by-side diff
- Wire into home screen and sync hook

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds conflict detection and resolution to mobile sync so users can review and resolve changes before server overwrites. Conflicts are logged after a successful upsert and the logging is isolated in its own try/catch to avoid breaking sync.

- **New Features**
  - Added `sync_conflicts` table and index; stores local and server snapshots.
  - Detects conflicts in `syncPull`; compares data fields and deleted/active state (boolean), applies server updates, then logs the conflict in a separate try/catch.
  - UI: Home banner and `sync-conflicts` screen with side‑by‑side diffs (including deleted/active status), themed with `peachLight` + `accentRed`/`accentGreen` for light/dark contrast; actions to keep local or accept server.
  - Store: `useSyncConflictStore` to load and resolve conflicts; auto‑inits in layout and reloads after sync; when keeping local, upserts with a fresh `updatedAt` and enqueues sync; errors reported to Sentry.
  - Tests cover detection, repository operations, and conflict logging.

- **Migration**
  - Run mobile drizzle migration 0011 to create `sync_conflicts` and `idx_sync_conflicts_resolved`. No breaking changes.

<sup>Written for commit 842594971862f7304618b1340c7f71822ec7c336. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

