### PR TITLE
feat(mobile): secure SQLCipher key via SecureStore

### DIFF
--- a/apps/mobile/__tests__/db/client.test.ts
+++ b/apps/mobile/__tests__/db/client.test.ts
@@ -8,7 +8,23 @@ vi.mock("drizzle-orm/expo-sqlite", () => ({
   drizzle: vi.fn((sqliteDb: unknown) => ({ _: "drizzle-instance", sqliteDb })),
 }));
 
+vi.mock("expo-secure-store", () => ({
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  deleteItemAsync: vi.fn(),
+}));
+
+vi.mock("expo-crypto", () => ({
+  getRandomBytes: vi.fn(() => new Uint8Array(32)),
+}));
+
+vi.mock("@/shared/lib/sentry", () => ({
+  captureError: vi.fn(),
+}));
+
 import { openDatabaseSync } from "expo-sqlite";
+import { getItem, setItem, deleteItemAsync } from "expo-secure-store";
+import { getRandomBytes } from "expo-crypto";
 import { getDb, resetDb } from "@/shared/db/client";
 
 describe("getDb", () => {
@@ -34,7 +50,25 @@ describe("getDb", () => {
     expect(openDatabaseSync).toHaveBeenCalledWith("fidy-user-123.db");
   });
 
-  it("sets SQLCipher encryption key derived from userId", () => {
+  it("generates and stores a random encryption key on first call", () => {
+    getDb("user-123");
+    expect(getRandomBytes).toHaveBeenCalledWith(32);
+    expect(setItem).toHaveBeenCalledWith(
+      "fidy-db-key-user-123",
+      expect.stringMatching(/^[0-9a-f]{64}$/),
+    );
+  });
+
+  it("reuses stored key from SecureStore on subsequent init", () => {
+    const storedKey = "ab".repeat(32);
+    vi.mocked(getItem).mockReturnValueOnce(storedKey);
+
+    getDb("user-123");
+    expect(getRandomBytes).not.toHaveBeenCalled();
+    expect(setItem).not.toHaveBeenCalled();
+  });
+
+  it("uses raw hex PRAGMA key syntax", () => {
     const mockExecSync = vi.fn();
     vi.mocked(openDatabaseSync).mockReturnValueOnce({
       execSync: mockExecSync,
@@ -42,7 +76,24 @@ describe("getDb", () => {
     } as unknown as ReturnType<typeof openDatabaseSync>);
 
     getDb("user-123");
-    expect(mockExecSync).toHaveBeenCalledWith(expect.stringContaining("PRAGMA key"));
+    expect(mockExecSync).toHaveBeenCalledWith(
+      expect.stringMatching(/^PRAGMA key = "x'[0-9a-f]{64}'"$/),
+    );
+  });
+
+  it("uses separate SecureStore keys per userId", () => {
+    getDb("user-123");
+    resetDb();
+    vi.clearAllMocks();
+    getDb("user-456");
+
+    expect(getItem).toHaveBeenCalledWith("fidy-db-key-user-456");
+  });
+
+  it("resetDb does not delete encryption key", () => {
+    getDb("user-123");
+    resetDb();
+    expect(deleteItemAsync).not.toHaveBeenCalled();
   });
 
   it("resets and closes the connection on resetDb", () => {

--- a/apps/mobile/__tests__/db/client.test.ts
+++ b/apps/mobile/__tests__/db/client.test.ts
@@ -22,9 +22,9 @@ vi.mock("@/shared/lib/sentry", () => ({
   captureError: vi.fn(),
 }));
 
-import { openDatabaseSync } from "expo-sqlite";
-import { getItem, setItem, deleteItemAsync } from "expo-secure-store";
 import { getRandomBytes } from "expo-crypto";
+import { deleteItemAsync, getItem, setItem } from "expo-secure-store";
+import { openDatabaseSync } from "expo-sqlite";
 import { getDb, resetDb } from "@/shared/db/client";
 
 describe("getDb", () => {
@@ -55,7 +55,7 @@ describe("getDb", () => {
     expect(getRandomBytes).toHaveBeenCalledWith(32);
     expect(setItem).toHaveBeenCalledWith(
       "fidy-db-key-user-123",
-      expect.stringMatching(/^[0-9a-f]{64}$/),
+      expect.stringMatching(/^[0-9a-f]{64}$/)
     );
   });
 
@@ -77,7 +77,7 @@ describe("getDb", () => {
 
     getDb("user-123");
     expect(mockExecSync).toHaveBeenCalledWith(
-      expect.stringMatching(/^PRAGMA key = "x'[0-9a-f]{64}'"$/),
+      expect.stringMatching(/^PRAGMA key = "x'[0-9a-f]{64}'"$/)
     );
   });
 

--- a/apps/mobile/__tests__/error-handling/db-client-error.test.ts
+++ b/apps/mobile/__tests__/error-handling/db-client-error.test.ts
@@ -14,6 +14,15 @@ vi.mock("drizzle-orm/expo-sqlite", () => ({
   drizzle: vi.fn((sqliteDb: unknown) => ({ _: "drizzle-instance", sqliteDb })),
 }));
 
+vi.mock("expo-secure-store", () => ({
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+}));
+
+vi.mock("expo-crypto", () => ({
+  getRandomBytes: vi.fn(() => new Uint8Array(32)),
+}));
+
 import { openDatabaseSync } from "expo-sqlite";
 import { getDb, resetDb } from "@/shared/db/client";
 

--- a/apps/mobile/__tests__/setup.ts
+++ b/apps/mobile/__tests__/setup.ts
@@ -158,6 +158,13 @@ vi.mock("expo-secure-store", () => ({
   getItemAsync: vi.fn(),
   setItemAsync: vi.fn(),
   deleteItemAsync: vi.fn(),
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+}));
+
+// Mock expo-crypto
+vi.mock("expo-crypto", () => ({
+  getRandomBytes: vi.fn(() => new Uint8Array(32)),
 }));
 
 // Mock @react-native-community/netinfo

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -42,7 +42,7 @@
     "expo-android-notification-listener-service": "^1.1.0",
     "expo-background-task": "~1.0.10",
     "expo-constants": "~18.0.13",
-    "expo-crypto": "^55.0.9",
+    "expo-crypto": "~15.0.8",
     "expo-font": "~14.0.11",
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -42,6 +42,7 @@
     "expo-android-notification-listener-service": "^1.1.0",
     "expo-background-task": "~1.0.10",
     "expo-constants": "~18.0.13",
+    "expo-crypto": "^55.0.9",
     "expo-font": "~14.0.11",
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",

--- a/apps/mobile/shared/db/client.ts
+++ b/apps/mobile/shared/db/client.ts
@@ -1,7 +1,7 @@
-import * as Crypto from "expo-crypto";
-import * as SecureStore from "expo-secure-store";
 import type { ExpoSQLiteDatabase } from "drizzle-orm/expo-sqlite";
 import { drizzle } from "drizzle-orm/expo-sqlite";
+import * as Crypto from "expo-crypto";
+import * as SecureStore from "expo-secure-store";
 import { openDatabaseSync } from "expo-sqlite";
 import { captureError } from "@/shared/lib/sentry";
 
@@ -16,9 +16,7 @@ function getOrCreateEncryptionKey(userId: string): string {
   if (existing && HEX_KEY_PATTERN.test(existing)) return existing;
 
   const randomBytes = Crypto.getRandomBytes(32);
-  const hexKey = Array.from(randomBytes, (b) =>
-    b.toString(16).padStart(2, "0"),
-  ).join("");
+  const hexKey = Array.from(randomBytes, (b) => b.toString(16).padStart(2, "0")).join("");
   SecureStore.setItem(storeKey, hexKey);
   return hexKey;
 }

--- a/apps/mobile/shared/db/client.ts
+++ b/apps/mobile/shared/db/client.ts
@@ -1,3 +1,5 @@
+import * as Crypto from "expo-crypto";
+import * as SecureStore from "expo-secure-store";
 import type { ExpoSQLiteDatabase } from "drizzle-orm/expo-sqlite";
 import { drizzle } from "drizzle-orm/expo-sqlite";
 import { openDatabaseSync } from "expo-sqlite";
@@ -5,6 +7,21 @@ import { captureError } from "@/shared/lib/sentry";
 
 // biome-ignore lint/suspicious/noExplicitAny: drizzle generic varies by caller
 export type AnyDb = ExpoSQLiteDatabase<any>;
+
+const HEX_KEY_PATTERN = /^[0-9a-f]{64}$/;
+
+function getOrCreateEncryptionKey(userId: string): string {
+  const storeKey = `fidy-db-key-${userId}`;
+  const existing = SecureStore.getItem(storeKey);
+  if (existing && HEX_KEY_PATTERN.test(existing)) return existing;
+
+  const randomBytes = Crypto.getRandomBytes(32);
+  const hexKey = Array.from(randomBytes, (b) =>
+    b.toString(16).padStart(2, "0"),
+  ).join("");
+  SecureStore.setItem(storeKey, hexKey);
+  return hexKey;
+}
 
 let db: ReturnType<typeof drizzle> | null = null;
 let sqliteRef: ReturnType<typeof openDatabaseSync> | null = null;
@@ -17,9 +34,9 @@ export function getDb(userId: string) {
   if (!db) {
     try {
       const dbName = `fidy-${userId}.db`;
-      const dbKey = `fidy-key-${userId}`;
+      const encryptionKey = getOrCreateEncryptionKey(userId);
       sqliteRef = openDatabaseSync(dbName);
-      sqliteRef.execSync(`PRAGMA key = '${dbKey}'`);
+      sqliteRef.execSync(`PRAGMA key = "x'${encryptionKey}'"`);
       db = drizzle(sqliteRef);
       currentUserId = userId;
     } catch (error) {

--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,7 @@
         "expo-android-notification-listener-service": "^1.1.0",
         "expo-background-task": "~1.0.10",
         "expo-constants": "~18.0.13",
+        "expo-crypto": "^55.0.9",
         "expo-font": "~14.0.11",
         "expo-haptics": "~15.0.8",
         "expo-image": "~3.0.11",
@@ -1348,6 +1349,8 @@
     "expo-background-task": ["expo-background-task@1.0.10", "", { "dependencies": { "expo-task-manager": "~14.0.9" }, "peerDependencies": { "expo": "*" } }, "sha512-EbPnuf52Ps/RJiaSFwqKGT6TkvMChv7bI0wF42eADbH3J2EMm5y5Qvj0oFmF1CBOwc3mUhqj63o7Pl6OLkGPZQ=="],
 
     "expo-constants": ["expo-constants@18.0.13", "", { "dependencies": { "@expo/config": "~12.0.13", "@expo/env": "~2.0.8" }, "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ=="],
+
+    "expo-crypto": ["expo-crypto@55.0.9", "", { "peerDependencies": { "expo": "*" } }, "sha512-hYiZYRPMXGQXSgKjp/m84l/6Uq8mTeMts1C7bFZXN5M5TUOiRhrLeqMSYZFXrAlkFpXeO46V+Ts1CFauMBLuCw=="],
 
     "expo-eas-client": ["expo-eas-client@55.0.2", "", {}, "sha512-fjOgSXaZFBK2Xmzn/uw0DTF3BsYv97JEa4PYXXqVCEvNJPwJB1cV1eX6Xyq6iKGIhMPH9k62sOc+oUdt094WCw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -41,7 +41,7 @@
         "expo-android-notification-listener-service": "^1.1.0",
         "expo-background-task": "~1.0.10",
         "expo-constants": "~18.0.13",
-        "expo-crypto": "^55.0.9",
+        "expo-crypto": "~15.0.8",
         "expo-font": "~14.0.11",
         "expo-haptics": "~15.0.8",
         "expo-image": "~3.0.11",
@@ -1350,7 +1350,7 @@
 
     "expo-constants": ["expo-constants@18.0.13", "", { "dependencies": { "@expo/config": "~12.0.13", "@expo/env": "~2.0.8" }, "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ=="],
 
-    "expo-crypto": ["expo-crypto@55.0.9", "", { "peerDependencies": { "expo": "*" } }, "sha512-hYiZYRPMXGQXSgKjp/m84l/6Uq8mTeMts1C7bFZXN5M5TUOiRhrLeqMSYZFXrAlkFpXeO46V+Ts1CFauMBLuCw=="],
+    "expo-crypto": ["expo-crypto@15.0.8", "", { "dependencies": { "base64-js": "^1.3.0" }, "peerDependencies": { "expo": "*" } }, "sha512-aF7A914TB66WIlTJvl5J6/itejfY78O7dq3ibvFltL9vnTALJ/7LYHvLT4fwmx9yUNS6ekLBtDGWivFWnj2Fcw=="],
 
     "expo-eas-client": ["expo-eas-client@55.0.2", "", {}, "sha512-fjOgSXaZFBK2Xmzn/uw0DTF3BsYv97JEa4PYXXqVCEvNJPwJB1cV1eX6Xyq6iKGIhMPH9k62sOc+oUdt094WCw=="],
 


### PR DESCRIPTION
- Generate random 256-bit key stored in iOS Keychain / Android Keystore
- Replace deterministic userId-derived PRAGMA key with hex format
- Validate hex format on keys read from SecureStore

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encrypts the mobile SQLite database with a random 256‑bit SQLCipher key stored in the OS keystore via `expo-secure-store`. Replaces the userId‑derived key with a per‑user hex key and sets it using raw SQLCipher PRAGMA syntax.

- **New Features**
  - Generate a 32‑byte key with `expo-crypto` and persist it in `expo-secure-store` per user.
  - Validate stored keys (64‑char hex); regenerate if invalid.
  - Set the key as raw hex: PRAGMA key = "x'<hex>'".
  - Keep the key across sessions; `resetDb` closes the DB but does not delete the key.
  - Tests updated to mock `expo-secure-store`/`expo-crypto` and cover key creation, reuse, per‑user isolation, and PRAGMA syntax.

- **Bug Fixes**
  - Pin `expo-crypto` to `~15.0.8` for Expo SDK 54 compatibility.
  - Remove debug logs from key creation.
  - Fix import order to satisfy biome CI.

<sup>Written for commit 8f51737fbd932c2a815d0c751c008baafc966720. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

