### PR TITLE
feat(edge): add rate limiting and body size validation

### DIFF
--- a/apps/mobile/supabase/migrations/0003_rate_limits.sql
+++ b/apps/mobile/supabase/migrations/0003_rate_limits.sql
@@ -25,6 +25,7 @@ create or replace function public.check_rate_limit(
 returns table (current_count integer, allowed boolean)
 language sql
 security definer
+set search_path = public
 as $$
   insert into public.rate_limits (user_id, function_name, window_key, request_count)
   values (p_user_id, p_function_name, p_window_key, 1)
@@ -34,6 +35,9 @@ as $$
     public.rate_limits.request_count as current_count,
     (public.rate_limits.request_count <= p_max_count) as allowed;
 $$;
+
+-- Only service role (Edge Functions) may call this function
+revoke execute on function public.check_rate_limit from public, anon, authenticated;
 
 -- TODO: enable cleanup before launch — rows grow ~1M/day with active users
 -- Hourly cleanup (uncomment if pg_cron is enabled)

--- a/apps/mobile/supabase/migrations/0003_rate_limits.sql
+++ b/apps/mobile/supabase/migrations/0003_rate_limits.sql
@@ -1,0 +1,43 @@
+-- Rate limit counter table
+create table public.rate_limits (
+  user_id        uuid    not null,
+  function_name  text    not null,
+  window_key     text    not null,
+  request_count  integer not null default 1,
+  constraint rate_limits_pkey primary key (user_id, function_name, window_key),
+  constraint rate_limits_count_positive check (request_count > 0)
+);
+
+-- RLS enabled, no policies = inaccessible to anon/authenticated
+-- Service role (used by Edge Functions) bypasses RLS
+alter table public.rate_limits enable row level security;
+
+-- Index for cleanup queries
+create index idx_rate_limits_window_key on public.rate_limits (window_key);
+
+-- Atomic check-and-increment function
+create or replace function public.check_rate_limit(
+  p_user_id       uuid,
+  p_function_name text,
+  p_window_key    text,
+  p_max_count     integer
+)
+returns table (current_count integer, allowed boolean)
+language sql
+security definer
+as $$
+  insert into public.rate_limits (user_id, function_name, window_key, request_count)
+  values (p_user_id, p_function_name, p_window_key, 1)
+  on conflict on constraint rate_limits_pkey
+  do update set request_count = public.rate_limits.request_count + 1
+  returning
+    public.rate_limits.request_count as current_count,
+    (public.rate_limits.request_count <= p_max_count) as allowed;
+$$;
+
+-- TODO: enable cleanup before launch — rows grow ~1M/day with active users
+-- Hourly cleanup (uncomment if pg_cron is enabled)
+-- select cron.schedule('cleanup-rate-limits', '0 * * * *',
+--   $$delete from public.rate_limits
+--     where window_key < to_char(now() - interval '1 hour', 'YYYY-MM-DD"T"HH24:MI')$$
+-- );

--- a/apps/mobile/supabase/migrations/0003_rate_limits.sql
+++ b/apps/mobile/supabase/migrations/0003_rate_limits.sql
@@ -39,9 +39,5 @@ $$;
 -- Only service role (Edge Functions) may call this function
 revoke execute on function public.check_rate_limit from public, anon, authenticated;
 
--- TODO: enable cleanup before launch — rows grow ~1M/day with active users
--- Hourly cleanup (uncomment if pg_cron is enabled)
--- select cron.schedule('cleanup-rate-limits', '0 * * * *',
---   $$delete from public.rate_limits
---     where window_key < to_char(now() - interval '1 hour', 'YYYY-MM-DD"T"HH24:MI')$$
--- );
+-- Stale row cleanup is handled by probabilistic self-cleanup in the RPC
+-- (see 0005_rate_limit_self_cleanup.sql)

--- a/apps/mobile/supabase/migrations/0004_rate_limit_security.sql
+++ b/apps/mobile/supabase/migrations/0004_rate_limit_security.sql
@@ -1,0 +1,24 @@
+-- Fix SECURITY DEFINER function: pin search_path and revoke public access
+
+create or replace function public.check_rate_limit(
+  p_user_id       uuid,
+  p_function_name text,
+  p_window_key    text,
+  p_max_count     integer
+)
+returns table (current_count integer, allowed boolean)
+language sql
+security definer
+set search_path = public
+as $$
+  insert into public.rate_limits (user_id, function_name, window_key, request_count)
+  values (p_user_id, p_function_name, p_window_key, 1)
+  on conflict on constraint rate_limits_pkey
+  do update set request_count = public.rate_limits.request_count + 1
+  returning
+    public.rate_limits.request_count as current_count,
+    (public.rate_limits.request_count <= p_max_count) as allowed;
+$$;
+
+-- Only service role (Edge Functions) may call this function
+revoke execute on function public.check_rate_limit from public, anon, authenticated;

--- a/apps/mobile/supabase/migrations/0005_rate_limit_self_cleanup.sql
+++ b/apps/mobile/supabase/migrations/0005_rate_limit_self_cleanup.sql
@@ -1,0 +1,34 @@
+-- Replace SQL function with plpgsql to add probabilistic self-cleanup.
+-- On ~1% of calls, deletes stale rows older than 2 hours before the upsert.
+
+create or replace function public.check_rate_limit(
+  p_user_id       uuid,
+  p_function_name text,
+  p_window_key    text,
+  p_max_count     integer
+)
+returns table (current_count integer, allowed boolean)
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  -- Probabilistic cleanup: ~1% of calls purge stale windows
+  if random() < 0.01 then
+    delete from public.rate_limits
+    where window_key < to_char(now() - interval '2 hours', 'YYYY-MM-DD"T"HH24:MI');
+  end if;
+
+  return query
+    insert into public.rate_limits (user_id, function_name, window_key, request_count)
+    values (p_user_id, p_function_name, p_window_key, 1)
+    on conflict on constraint rate_limits_pkey
+    do update set request_count = public.rate_limits.request_count + 1
+    returning
+      public.rate_limits.request_count as current_count,
+      (public.rate_limits.request_count <= p_max_count) as allowed;
+end;
+$$;
+
+-- Re-apply privilege restriction (CREATE OR REPLACE resets grants)
+revoke execute on function public.check_rate_limit from public, anon, authenticated;

--- a/supabase/functions/_shared/body-size.ts
+++ b/supabase/functions/_shared/body-size.ts
@@ -1,0 +1,30 @@
+type BodyResult = { ok: true; text: string } | { ok: false };
+
+export async function readBodyWithLimit(req: Request, maxBytes = 10240): Promise<BodyResult> {
+  const contentLength = req.headers.get("Content-Length");
+  if (contentLength && parseInt(contentLength, 10) > maxBytes) {
+    return { ok: false };
+  }
+
+  const reader = req.body?.getReader();
+  if (!reader) {
+    return { ok: true, text: "" };
+  }
+
+  const decoder = new TextDecoder();
+  const parts: string[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      reader.cancel();
+      return { ok: false };
+    }
+    parts.push(decoder.decode(value, { stream: true }));
+  }
+  parts.push(decoder.decode());
+
+  return { ok: true, text: parts.join("") };
+}

--- a/supabase/functions/_shared/rate-limit.ts
+++ b/supabase/functions/_shared/rate-limit.ts
@@ -31,8 +31,8 @@ export async function checkRateLimit(
       return { allowed: true, count: 0 };
     }
 
-    const row = data?.[0] ?? data;
-    if (!row) {
+    const row = Array.isArray(data) ? data[0] : data;
+    if (!row || typeof row.allowed !== "boolean") {
       console.error("Rate limit RPC returned no data, failing open");
       return { allowed: true, count: 0 };
     }

--- a/supabase/functions/_shared/rate-limit.ts
+++ b/supabase/functions/_shared/rate-limit.ts
@@ -1,0 +1,50 @@
+// biome-ignore-all lint/style/useNamingConvention: Supabase RPC parameter names
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+const serviceClient = createClient(
+  Deno.env.get("SUPABASE_URL") ?? "",
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+);
+
+type RateLimitResult =
+  | { allowed: true; count: number }
+  | { allowed: false; count: number; retryAfterSeconds: number };
+
+export async function checkRateLimit(
+  userId: string,
+  functionName: string,
+  maxPerMinute: number
+): Promise<RateLimitResult> {
+  const now = new Date();
+  const windowKey = now.toISOString().slice(0, 16); // YYYY-MM-DDTHH:MM
+
+  try {
+    const { data, error } = await serviceClient.rpc("check_rate_limit", {
+      p_user_id: userId,
+      p_function_name: functionName,
+      p_window_key: windowKey,
+      p_max_count: maxPerMinute,
+    });
+
+    if (error) {
+      console.error("Rate limit RPC error, failing open:", error.message);
+      return { allowed: true, count: 0 };
+    }
+
+    const row = data?.[0] ?? data;
+    if (!row) {
+      console.error("Rate limit RPC returned no data, failing open");
+      return { allowed: true, count: 0 };
+    }
+
+    if (row.allowed) {
+      return { allowed: true, count: row.current_count };
+    }
+
+    const retryAfterSeconds = 60 - now.getSeconds();
+    return { allowed: false, count: row.current_count, retryAfterSeconds };
+  } catch (err) {
+    console.error("Rate limit check failed, failing open:", err);
+    return { allowed: true, count: 0 };
+  }
+}

--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -1,6 +1,8 @@
 // biome-ignore-all lint/style/useNamingConvention: OpenAI SDK and API field names
 import OpenAI from "https://deno.land/x/openai@v4.24.0/mod.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
+import { readBodyWithLimit } from "../_shared/body-size.ts";
+import { checkRateLimit } from "../_shared/rate-limit.ts";
 
 const CATEGORY_IDS = [
   "food",
@@ -83,10 +85,14 @@ const supabase = createClient(
   Deno.env.get("SUPABASE_ANON_KEY") ?? ""
 );
 
-function jsonResponse(body: unknown, status = 200): Response {
+function jsonResponse(
+  body: unknown,
+  status = 200,
+  extraHeaders?: Record<string, string>
+): Response {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...extraHeaders },
   });
 }
 
@@ -165,8 +171,52 @@ Deno.serve(async (req) => {
     }
 
     userId = user.id;
-    const body = await req.json();
-    mode = body.mode ?? "chat";
+
+    // Rate limit: 10 requests per minute per user
+    const rateResult = await checkRateLimit(userId, "ai-chat", 10);
+    if (!rateResult.allowed) {
+      structuredLog({
+        request_id: requestId,
+        user_id: userId,
+        mode: "",
+        success: false,
+        latency_ms: Date.now() - startTime,
+        error_type: "rate_limited",
+      });
+      return jsonResponse({ success: false, error: "rate_limited" }, 429, {
+        "Retry-After": String(rateResult.retryAfterSeconds),
+      });
+    }
+
+    // Body size limit: 10KB
+    const bodyResult = await readBodyWithLimit(req);
+    if (!bodyResult.ok) {
+      structuredLog({
+        request_id: requestId,
+        user_id: userId,
+        mode: "",
+        success: false,
+        latency_ms: Date.now() - startTime,
+        error_type: "body_too_large",
+      });
+      return jsonResponse({ success: false, error: "body_too_large" }, 413);
+    }
+
+    let body: Record<string, unknown>;
+    try {
+      body = JSON.parse(bodyResult.text);
+    } catch {
+      structuredLog({
+        request_id: requestId,
+        user_id: userId,
+        mode: "",
+        success: false,
+        latency_ms: Date.now() - startTime,
+        error_type: "invalid_json",
+      });
+      return jsonResponse({ success: false, error: "invalid_json" }, 400);
+    }
+    mode = (body.mode as string) ?? "chat";
 
     // Memory extraction mode — non-streaming
     if (mode === "extract_memories") {

--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -188,8 +188,8 @@ Deno.serve(async (req) => {
       });
     }
 
-    // Body size limit: 10KB
-    const bodyResult = await readBodyWithLimit(req);
+    // Body size limit: 100KB (chat payloads include conversation + financial context)
+    const bodyResult = await readBodyWithLimit(req, 102400);
     if (!bodyResult.ok) {
       structuredLog({
         request_id: requestId,

--- a/supabase/functions/parse-email/index.ts
+++ b/supabase/functions/parse-email/index.ts
@@ -1,6 +1,8 @@
 // biome-ignore-all lint/style/useNamingConvention: OpenAI SDK and API field names
 import OpenAI from "https://deno.land/x/openai@v4.24.0/mod.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
+import { readBodyWithLimit } from "../_shared/body-size.ts";
+import { checkRateLimit } from "../_shared/rate-limit.ts";
 
 // Keep in sync with apps/mobile/features/transactions/lib/categories.ts
 const CATEGORY_IDS = [
@@ -94,10 +96,14 @@ const supabase = createClient(
   Deno.env.get("SUPABASE_ANON_KEY") ?? ""
 );
 
-function jsonResponse(body: unknown, status = 200): Response {
+function jsonResponse(
+  body: unknown,
+  status = 200,
+  extraHeaders?: Record<string, string>
+): Response {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...extraHeaders },
   });
 }
 
@@ -155,9 +161,40 @@ Deno.serve(async (req) => {
     }
 
     userId = user.id;
+
+    // Rate limit: 20 requests per minute per user
+    const rateResult = await checkRateLimit(userId, "parse-email", 20);
+    if (!rateResult.allowed) {
+      structuredLog({
+        request_id: requestId,
+        user_id: userId,
+        mode: "",
+        success: false,
+        latency_ms: Date.now() - startTime,
+        error_type: "rate_limited",
+      });
+      return jsonResponse({ success: false, error: "rate_limited" }, 429, {
+        "Retry-After": String(rateResult.retryAfterSeconds),
+      });
+    }
+
+    // Body size limit: 10KB
+    const bodyResult = await readBodyWithLimit(req);
+    if (!bodyResult.ok) {
+      structuredLog({
+        request_id: requestId,
+        user_id: userId,
+        mode: "",
+        success: false,
+        latency_ms: Date.now() - startTime,
+        error_type: "body_too_large",
+      });
+      return jsonResponse({ success: false, error: "body_too_large" }, 413);
+    }
+
     let payload: Record<string, unknown>;
     try {
-      payload = await req.json();
+      payload = JSON.parse(bodyResult.text);
     } catch {
       structuredLog({
         request_id: requestId,


### PR DESCRIPTION
- Per-user fixed-window rate limits (20/min parse-email, 10/min ai-chat)
- 10KB request body size cap with streaming reads
- Atomic check-and-increment via PostgreSQL RPC
- Fails open on DB errors for availability
- 429 + Retry-After and 413 responses

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-user rate limiting and request body size validation to Edge functions `ai-chat` and `parse-email`. Uses a secure PostgreSQL RPC with self-cleanup and returns proper 429/413 responses; `ai-chat` body limit raised to 100KB.

- **New Features**
  - Fixed-window limits: 10/min (`ai-chat`), 20/min (`parse-email`).
  - Atomic RPC `check_rate_limit` on `public.rate_limits` with ~1% self-cleanup; pinned `search_path`; `EXECUTE` revoked for `public`/`anon`/`authenticated`; fails open on DB/empty results.
  - Streaming body reader with limits: 100KB (`ai-chat`), 10KB (`parse-email`).
  - 429 with `Retry-After` and 413 responses.

- **Migration**
  - Run `apps/mobile/supabase/migrations/0003_rate_limits.sql`, `0004_rate_limit_security.sql`, `0005_rate_limit_self_cleanup.sql`.
  - Ensure Edge Functions set `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` for `@supabase/supabase-js`.

<sup>Written for commit b2c554d9edbdd6580089fe4ca46e17d53389b774. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

