### PR TITLE
fix(mobile): prevent save button double-tap

### DIFF
--- a/apps/mobile/__tests__/shared/create-async-guard.test.ts
+++ b/apps/mobile/__tests__/shared/create-async-guard.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "vitest";
+import { createAsyncGuard } from "@/shared/lib/create-async-guard";
+
+describe("createAsyncGuard", () => {
+  test("tryAcquire succeeds when idle", () => {
+    const guard = createAsyncGuard();
+    expect(guard.tryAcquire()).toBe(true);
+  });
+
+  test("tryAcquire fails while already acquired", () => {
+    const guard = createAsyncGuard();
+    guard.tryAcquire();
+    expect(guard.tryAcquire()).toBe(false);
+  });
+
+  test("tryAcquire succeeds again after release", () => {
+    const guard = createAsyncGuard();
+    guard.tryAcquire();
+    guard.release();
+    expect(guard.tryAcquire()).toBe(true);
+  });
+
+  test("isBusy reflects current state", () => {
+    const guard = createAsyncGuard();
+    expect(guard.isBusy()).toBe(false);
+    guard.tryAcquire();
+    expect(guard.isBusy()).toBe(true);
+    guard.release();
+    expect(guard.isBusy()).toBe(false);
+  });
+
+  test("concurrent save simulation — only first caller proceeds", async () => {
+    const guard = createAsyncGuard();
+
+    const simulateSave = async (id: number): Promise<number | undefined> => {
+      if (!guard.tryAcquire()) return undefined;
+      try {
+        await new Promise((r) => setTimeout(r, 10));
+        return id;
+      } finally {
+        guard.release();
+      }
+    };
+
+    const results = await Promise.all([simulateSave(1), simulateSave(2), simulateSave(3)]);
+    const executed = results.filter((r) => r !== undefined);
+
+    expect(executed).toEqual([1]);
+  });
+
+  test("guard resets after async work throws", async () => {
+    const guard = createAsyncGuard();
+
+    const failingWork = async () => {
+      if (!guard.tryAcquire()) return "blocked";
+      try {
+        throw new Error("save failed");
+      } finally {
+        guard.release();
+      }
+    };
+
+    await failingWork().catch(() => {});
+    expect(guard.isBusy()).toBe(false);
+    expect(guard.tryAcquire()).toBe(true);
+  });
+});

--- a/apps/mobile/app/add-bill.tsx
+++ b/apps/mobile/app/add-bill.tsx
@@ -18,6 +18,7 @@ import { useCalendarStore } from "@/features/calendar/store";
 import type { CategoryId } from "@/features/transactions/lib/categories";
 import { CATEGORIES } from "@/features/transactions/lib/categories";
 import { centsToDisplay } from "@/features/transactions/lib/format-amount";
+import { useAsyncGuard } from "@/shared/hooks/use-async-guard";
 import { useThemeColor } from "@/shared/hooks/use-theme-color";
 
 export default function AddBillScreen() {
@@ -60,26 +61,29 @@ export default function AddBillScreen() {
     }
   }, [existingBill?.id]);
 
-  const handleSave = async () => {
-    const trimmedName = name.trim();
-    if (!trimmedName) return;
+  const { isBusy: isSaving, run: guardedSave } = useAsyncGuard();
 
-    if (isEdit && existingBill) {
-      const cents = Math.round(parseFloat(amount.replace(/,/g, "")) * 100);
-      if (Number.isNaN(cents) || cents <= 0) return;
-      await updateBillAction(existingBill.id, {
-        name: trimmedName,
-        amountCents: cents,
-        frequency,
-        categoryId: category,
-        startDate,
-      });
-      router.back();
-    } else {
-      const success = await addBill(trimmedName, amount, frequency, category, startDate);
-      if (success) router.back();
-    }
-  };
+  const handleSave = () =>
+    guardedSave(async () => {
+      const trimmedName = name.trim();
+      if (!trimmedName) return;
+
+      if (isEdit && existingBill) {
+        const cents = Math.round(parseFloat(amount.replace(/,/g, "")) * 100);
+        if (Number.isNaN(cents) || cents <= 0) return;
+        await updateBillAction(existingBill.id, {
+          name: trimmedName,
+          amountCents: cents,
+          frequency,
+          categoryId: category,
+          startDate,
+        });
+        router.back();
+      } else {
+        const success = await addBill(trimmedName, amount, frequency, category, startDate);
+        if (success) router.back();
+      }
+    });
 
   const handleFrequencyPress = (value: BillFrequency) => {
     Keyboard.dismiss();
@@ -204,8 +208,9 @@ export default function AddBillScreen() {
         </View>
 
         <Pressable
-          style={[styles.saveButton, { backgroundColor: accentGreen }]}
+          style={[styles.saveButton, { backgroundColor: accentGreen, opacity: isSaving ? 0.5 : 1 }]}
           onPress={handleSave}
+          disabled={isSaving}
         >
           <Text style={styles.saveButtonText}>{isEdit ? "Save Changes" : "Add"}</Text>
         </Pressable>

--- a/apps/mobile/features/transactions/components/TransactionDetails.tsx
+++ b/apps/mobile/features/transactions/components/TransactionDetails.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "expo-router";
 import { Calendar, ChevronLeft } from "lucide-react-native";
 import { Pressable, Text, TextInput, View } from "react-native";
 import { useShallow } from "zustand/react/shallow";
+import { useAsyncGuard } from "@/shared/hooks/use-async-guard";
 import { useThemeColor } from "@/shared/hooks/use-theme-color";
 import { CATEGORY_ROW_KEYS, CATEGORY_ROWS } from "../lib/categories";
 import { formatAmount } from "../lib/format-amount";
@@ -49,14 +50,17 @@ export const TransactionDetails = () => {
   const displayAmount = formatAmount(digits);
   const dateLabel = getDateLabel(date, new Date());
 
-  const handleSave = async () => {
-    const result = await saveTransaction();
-    if (result.success) {
-      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-      resetForm();
-      back();
-    }
-  };
+  const { isBusy: isSaving, run: guardedSave } = useAsyncGuard();
+
+  const handleSave = () =>
+    guardedSave(async () => {
+      const result = await saveTransaction();
+      if (result.success) {
+        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+        resetForm();
+        back();
+      }
+    });
 
   return (
     <View className="flex-1 gap-4">
@@ -119,8 +123,9 @@ export const TransactionDetails = () => {
       <View className="mt-auto">
         <Pressable
           className="h-[52px] w-full items-center justify-center rounded-xl"
-          style={{ backgroundColor: accentGreen }}
+          style={{ backgroundColor: accentGreen, opacity: isSaving ? 0.5 : 1 }}
           onPress={handleSave}
+          disabled={isSaving}
           accessibilityRole="button"
           accessibilityLabel="Save Transaction"
         >

--- a/apps/mobile/shared/hooks/use-async-guard.ts
+++ b/apps/mobile/shared/hooks/use-async-guard.ts
@@ -1,0 +1,31 @@
+import { useCallback, useRef, useState } from "react";
+import { createAsyncGuard } from "@/shared/lib/create-async-guard";
+
+/**
+ * React hook wrapping createAsyncGuard with reactive state for UI feedback.
+ * Prevents concurrent execution of an async callback and exposes `isBusy`
+ * for disabling buttons / dimming UI during the operation.
+ */
+export function useAsyncGuard() {
+  const guardRef = useRef<ReturnType<typeof createAsyncGuard> | null>(null);
+  if (!guardRef.current) guardRef.current = createAsyncGuard();
+  const guard = guardRef.current;
+
+  const [isBusy, setIsBusy] = useState(false);
+
+  const run = useCallback(
+    async (fn: () => Promise<void>) => {
+      if (!guard.tryAcquire()) return;
+      setIsBusy(true);
+      try {
+        await fn();
+      } finally {
+        guard.release();
+        setIsBusy(false);
+      }
+    },
+    [guard]
+  );
+
+  return { isBusy, run } as const;
+}

--- a/apps/mobile/shared/lib/create-async-guard.ts
+++ b/apps/mobile/shared/lib/create-async-guard.ts
@@ -1,0 +1,18 @@
+/**
+ * Creates a synchronous mutex guard for preventing concurrent async operations.
+ * Use with useRef in React components to protect save buttons from double-tap.
+ */
+export function createAsyncGuard() {
+  let busy = false;
+  return {
+    tryAcquire: (): boolean => {
+      if (busy) return false;
+      busy = true;
+      return true;
+    },
+    release: (): void => {
+      busy = false;
+    },
+    isBusy: (): boolean => busy,
+  };
+}


### PR DESCRIPTION
- Add createAsyncGuard mutex utility with tests
- Add useAsyncGuard hook for React integration
- Guard save buttons in TransactionDetails and add-bill
- Disable and dim button while save is in progress

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents double-tapping Save on mobile by guarding async saves and disabling/dimming the button while a save is running. Adds a small mutex utility and React hook, integrated into `TransactionDetails` and `add-bill`.

- **Bug Fixes**
  - Added `createAsyncGuard` mutex with unit tests to block concurrent async work.
  - Added `useAsyncGuard` hook exposing `run` and `isBusy` for React.
  - Wrapped save handlers in `TransactionDetails` and `add-bill`; buttons are disabled and dimmed during save.

<sup>Written for commit 633d401c0591ca5cb82411fa9c0ee59175b79191. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

