### PR TITLE
test(sync): add integration and schema contract tests

### DIFF
--- a/apps/mobile/__tests__/email-capture/schema-compat.test.ts
+++ b/apps/mobile/__tests__/email-capture/schema-compat.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Static schema compatibility test.
+ *
+ * Reads the Edge Function source as text and compares the JSON Schema
+ * (FULL_PARSE_SCHEMA) and CATEGORY_IDS against the client Zod schema,
+ * catching schema drift without any network calls.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { llmOutputSchema } from "@/features/email-capture/services/llm-parser";
+import { CATEGORY_IDS } from "@/features/transactions/lib/categories";
+
+const edgeFnSource = readFileSync(
+  resolve(__dirname, "../../../../supabase/functions/parse-email/index.ts"),
+  "utf-8"
+);
+
+// ---------------------------------------------------------------------------
+// Regex extractors (pure functions)
+// ---------------------------------------------------------------------------
+
+/** Extract property keys from FULL_PARSE_SCHEMA.schema.properties */
+function extractPropertyKeys(source: string): string[] {
+  const propsMatch = source.match(
+    /FULL_PARSE_SCHEMA\s*=\s*\{[\s\S]*?properties:\s*\{([\s\S]*?)\},\s*\n\s*required:/
+  );
+  if (!propsMatch) return [];
+  const propsBlock = propsMatch[1];
+  // Match only top-level property keys: `keyName: { type:` pattern
+  const keyMatches = propsBlock.matchAll(/(\w+)\s*:\s*\{/g);
+  return [...keyMatches].map((m) => m[1]);
+}
+
+/** Extract required field names from FULL_PARSE_SCHEMA */
+function extractRequired(source: string): string[] {
+  const reqMatch = source.match(/FULL_PARSE_SCHEMA[\s\S]*?required:\s*\[([\s\S]*?)\]/);
+  if (!reqMatch) return [];
+  return [...reqMatch[1].matchAll(/"(\w+)"/g)].map((m) => m[1]);
+}
+
+/** Extract CATEGORY_IDS array values from the Edge Function source */
+function extractCategoryIds(source: string): string[] {
+  const catMatch = source.match(/const CATEGORY_IDS\s*=\s*\[([\s\S]*?)\]\s*as const/);
+  if (!catMatch) return [];
+  return [...catMatch[1].matchAll(/"(\w+)"/g)].map((m) => m[1]);
+}
+
+/** Extract type enum values from FULL_PARSE_SCHEMA */
+function extractTypeEnum(source: string): string[] {
+  const typeMatch = source.match(
+    /FULL_PARSE_SCHEMA[\s\S]*?type:\s*\{\s*type:\s*"string",\s*enum:\s*\[([\s\S]*?)\]/
+  );
+  if (!typeMatch) return [];
+  return [...typeMatch[1].matchAll(/"(\w+)"/g)].map((m) => m[1]);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Edge Function ↔ client schema compatibility", () => {
+  it("regex extractors find non-empty results (sanity check)", () => {
+    expect(extractPropertyKeys(edgeFnSource).length).toBeGreaterThan(0);
+    expect(extractRequired(edgeFnSource).length).toBeGreaterThan(0);
+    expect(extractCategoryIds(edgeFnSource).length).toBeGreaterThan(0);
+    expect(extractTypeEnum(edgeFnSource).length).toBeGreaterThan(0);
+  });
+
+  it("FULL_PARSE_SCHEMA property keys match llmOutputSchema shape", () => {
+    const edgeKeys = extractPropertyKeys(edgeFnSource).sort();
+    const clientKeys = Object.keys(llmOutputSchema.shape).sort();
+
+    expect(edgeKeys).toEqual(clientKeys);
+  });
+
+  it("required fields match", () => {
+    const edgeRequired = extractRequired(edgeFnSource).sort();
+    const clientKeys = Object.keys(llmOutputSchema.shape).sort();
+
+    // Every required field in the edge function should exist in the client schema
+    expect(edgeRequired).toEqual(clientKeys);
+  });
+
+  it("CATEGORY_IDS match between Edge Function and client", () => {
+    const edgeCategoryIds = extractCategoryIds(edgeFnSource);
+    expect(edgeCategoryIds).toEqual(CATEGORY_IDS);
+  });
+
+  it("type enum values match", () => {
+    const edgeTypeEnums = extractTypeEnum(edgeFnSource).sort();
+    const clientTypeEnums = (llmOutputSchema.shape.type.options as string[]).slice().sort();
+
+    expect(edgeTypeEnums).toEqual(clientTypeEnums);
+  });
+});

--- a/apps/mobile/__tests__/sync/sync-pull-integration.test.ts
+++ b/apps/mobile/__tests__/sync/sync-pull-integration.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Integration test for syncPull using a real SQLite database.
+ *
+ * Unlike the unit tests that mock every repository call, this test verifies:
+ * - Column mapping (fromSupabaseRow / toSupabaseRow) works against real schema
+ * - LWW conflict detection + logging with actual DB rows
+ * - Cursor advancement (syncMeta) with real upserts
+ * - The full flow: pull server rows → compare → upsert → log conflict
+ */
+// biome-ignore-all lint/suspicious/noExplicitAny: integration test needs flexible typing
+// biome-ignore-all lint/style/useNamingConvention: snake_case matches Supabase Postgres column names
+// biome-ignore-all lint/style/noNonNullAssertion: assertions guard nullability before access
+
+import { resolve } from "node:path";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/shared/lib/sentry", () => ({
+  captureError: vi.fn(),
+}));
+
+import { getUnresolvedConflicts } from "@/features/sync/lib/conflict-repository";
+import { syncPull } from "@/features/sync/services/syncEngine";
+import {
+  getSyncMeta,
+  getTransactionById,
+  insertTransaction,
+} from "@/features/transactions/lib/repository";
+
+let sqlite: InstanceType<typeof Database>;
+let db: ReturnType<typeof drizzle>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  sqlite = new Database(":memory:");
+  db = drizzle(sqlite);
+  migrate(db, { migrationsFolder: resolve(__dirname, "../../drizzle") });
+});
+
+afterEach(() => {
+  sqlite.close();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const USER_ID = "user-integration-1";
+
+/** Build a snake_case server row (what Supabase returns). */
+function serverRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "tx-1",
+    user_id: USER_ID,
+    type: "expense",
+    amount_cents: 2000,
+    category_id: "food",
+    description: "Server merchant",
+    date: "2026-03-10",
+    created_at: "2026-03-10T10:00:00.000Z",
+    updated_at: "2026-03-10T14:00:00.000Z",
+    deleted_at: null,
+    ...overrides,
+  };
+}
+
+/** Insert a camelCase local transaction directly via the repository. */
+function insertLocalTx(overrides: Record<string, unknown> = {}) {
+  const row = {
+    id: "tx-1",
+    userId: USER_ID,
+    type: "expense",
+    amountCents: 1000,
+    categoryId: "food",
+    description: "Local merchant",
+    date: "2026-03-10",
+    createdAt: "2026-03-10T08:00:00.000Z",
+    updatedAt: "2026-03-10T10:00:00.000Z",
+    deletedAt: null,
+    source: "manual",
+    ...overrides,
+  };
+  insertTransaction(db as any, row);
+  return row;
+}
+
+/**
+ * Build a chainable mock that mirrors the Supabase PostgREST query shape
+ * used by syncPull: .from().select().eq().gte?().order().limit()
+ */
+function mockSupabase(rows: Record<string, unknown>[]) {
+  const result = { data: rows, error: null };
+  const chain = {
+    from: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    gte: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(result),
+  };
+  return chain as any;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("syncPull integration (real SQLite)", () => {
+  it("server newer → upserts and logs conflict", async () => {
+    insertLocalTx({ amountCents: 1000, updatedAt: "2026-03-10T10:00:00.000Z" });
+
+    const supabase = mockSupabase([
+      serverRow({ amount_cents: 2000, updated_at: "2026-03-10T14:00:00.000Z" }),
+    ]);
+
+    const ok = await syncPull(db as any, supabase, USER_ID);
+    expect(ok).toBe(true);
+
+    // Local row should now have the server's amount
+    const tx = getTransactionById(db as any, "tx-1");
+    expect(tx).not.toBeNull();
+    expect(tx!.amountCents).toBe(2000);
+
+    // A conflict should be logged
+    const conflicts = getUnresolvedConflicts(db as any);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].transactionId).toBe("tx-1");
+
+    const localData = JSON.parse(conflicts[0].localData);
+    const serverData = JSON.parse(conflicts[0].serverData);
+    expect(localData.amountCents).toBe(1000);
+    expect(serverData.amountCents).toBe(2000);
+  });
+
+  it("local newer → preserved, no conflict", async () => {
+    insertLocalTx({ amountCents: 1000, updatedAt: "2026-03-10T14:00:00.000Z" });
+
+    const supabase = mockSupabase([
+      serverRow({ amount_cents: 2000, updated_at: "2026-03-10T10:00:00.000Z" }),
+    ]);
+
+    const ok = await syncPull(db as any, supabase, USER_ID);
+    expect(ok).toBe(true);
+
+    // Local data should be unchanged
+    const tx = getTransactionById(db as any, "tx-1");
+    expect(tx!.amountCents).toBe(1000);
+    expect(tx!.description).toBe("Local merchant");
+
+    // No conflicts
+    const conflicts = getUnresolvedConflicts(db as any);
+    expect(conflicts).toHaveLength(0);
+  });
+
+  it("new server-only row → inserted, no conflict", async () => {
+    const supabase = mockSupabase([serverRow({ id: "tx-new", description: "Cloud-only" })]);
+
+    const ok = await syncPull(db as any, supabase, USER_ID);
+    expect(ok).toBe(true);
+
+    const tx = getTransactionById(db as any, "tx-new");
+    expect(tx).not.toBeNull();
+    expect(tx!.description).toBe("Cloud-only");
+    expect(tx!.amountCents).toBe(2000);
+
+    const conflicts = getUnresolvedConflicts(db as any);
+    expect(conflicts).toHaveLength(0);
+  });
+
+  it("same data, newer timestamp → upserts without conflict", async () => {
+    insertLocalTx({
+      amountCents: 2000,
+      categoryId: "food",
+      description: "Server merchant",
+      date: "2026-03-10",
+      type: "expense",
+      deletedAt: null,
+      updatedAt: "2026-03-10T10:00:00.000Z",
+    });
+
+    const supabase = mockSupabase([
+      serverRow({
+        amount_cents: 2000,
+        category_id: "food",
+        description: "Server merchant",
+        date: "2026-03-10",
+        type: "expense",
+        deleted_at: null,
+        updated_at: "2026-03-10T14:00:00.000Z",
+      }),
+    ]);
+
+    const ok = await syncPull(db as any, supabase, USER_ID);
+    expect(ok).toBe(true);
+
+    // Timestamp should be updated
+    const tx = getTransactionById(db as any, "tx-1");
+    expect(tx!.updatedAt).toBe("2026-03-10T14:00:00.000Z");
+
+    // No conflict since data is identical
+    const conflicts = getUnresolvedConflicts(db as any);
+    expect(conflicts).toHaveLength(0);
+  });
+
+  it("cursor advancement → syncMeta updated to max updated_at", async () => {
+    const supabase = mockSupabase([
+      serverRow({ id: "tx-a", updated_at: "2026-03-10T12:00:00.000Z" }),
+      serverRow({ id: "tx-b", updated_at: "2026-03-10T16:00:00.000Z" }),
+    ]);
+
+    const ok = await syncPull(db as any, supabase, USER_ID);
+    expect(ok).toBe(true);
+
+    const cursor = getSyncMeta(db as any, "last_sync_at");
+    expect(cursor).toBe("2026-03-10T16:00:00.000Z");
+  });
+});


### PR DESCRIPTION
- syncPull integration test with real SQLite (LWW, conflicts, cursor)
- Edge Function schema compatibility test (property keys, required, enums)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add real SQLite integration tests for syncPull to verify column mapping, LWW conflict handling/logging, and cursor updates in a full pull → compare → upsert flow. Add a static schema contract test that reads the Edge Function parser source and checks parity with the client schema (property keys, required fields, type enums, and `CATEGORY_IDS`) to catch drift early.

<sup>Written for commit d39be8e4bee1227830ef5c304fd82b00e7fe9f5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

