### PR TITLE
feat(mobile): strip Colombian PII from emails before LLM parsing

### DIFF
--- a/apps/mobile/__tests__/email-capture/parse-email-api.test.ts
+++ b/apps/mobile/__tests__/email-capture/parse-email-api.test.ts
@@ -24,10 +24,43 @@ describe("stripPii", () => {
     expect(stripPii("Tel: +573001234567")).toBe("Tel: [PHONE]");
   });
 
-  it("preserves plain digit sequences (account numbers, amounts)", () => {
-    expect(stripPii("Cuenta 1234567890")).toBe("Cuenta 1234567890");
+  it("removes Colombian ID numbers (CC, TI, CE, Cédula)", () => {
+    expect(stripPii("CC 1037654321")).toBe("[ID]");
+    expect(stripPii("C.C. 1037654321")).toBe("[ID]");
+    expect(stripPii("TI 12345678")).toBe("[ID]");
+    expect(stripPii("T.I. 12345678")).toBe("[ID]");
+    expect(stripPii("C.E. 654321")).toBe("[ID]");
+    expect(stripPii("Cedula 1037654321")).toBe("[ID]");
+    expect(stripPii("cédula: 1037654321")).toBe("[ID]");
+  });
+
+  it("removes NIT (business tax ID)", () => {
+    expect(stripPii("NIT 900.123.456-7")).toBe("[ID]");
+    expect(stripPii("NIT: 900123456")).toBe("[ID]");
+    expect(stripPii("NIT 9001234567")).toBe("[ID]");
+  });
+
+  it("removes bank account numbers", () => {
+    expect(stripPii("Cuenta 1234567890")).toBe("[ACCOUNT]");
+    expect(stripPii("Cta. Ahorros 1234567890")).toBe("[ACCOUNT]");
+    expect(stripPii("No. Cuenta 0987654321")).toBe("[ACCOUNT]");
+  });
+
+  it("removes Colombian local phone numbers", () => {
+    expect(stripPii("Tel: (601) 123 4567")).toBe("Tel: [PHONE]");
+    expect(stripPii("Llame al 604 1234567")).toBe("Llame al [PHONE]");
+  });
+
+  it("strips cedula before phone pattern can match (CC starting with 601)", () => {
+    expect(stripPii("CC 6011234567")).toBe("[ID]");
+  });
+
+  it("strips cedula but preserves amount in same text", () => {
+    expect(stripPii("CC 1037654321 compra por $50,000")).toBe("[ID] compra por $50,000");
+  });
+
+  it("preserves bare digit sequences (amounts without prefix)", () => {
     expect(stripPii("Monto: 3001234567")).toBe("Monto: 3001234567");
-    expect(stripPii("CC 1037654321")).toBe("CC 1037654321");
   });
 
   it("removes masked card numbers", () => {

--- a/apps/mobile/__tests__/email-capture/parse-email-api.test.ts
+++ b/apps/mobile/__tests__/email-capture/parse-email-api.test.ts
@@ -32,6 +32,7 @@ describe("stripPii", () => {
     expect(stripPii("C.E. 654321")).toBe("[ID]");
     expect(stripPii("Cedula 1037654321")).toBe("[ID]");
     expect(stripPii("cédula: 1037654321")).toBe("[ID]");
+    expect(stripPii("cc 1037654321")).toBe("[ID]");
   });
 
   it("removes NIT (business tax ID)", () => {

--- a/apps/mobile/features/email-capture/services/parse-email-api.ts
+++ b/apps/mobile/features/email-capture/services/parse-email-api.ts
@@ -3,14 +3,27 @@ import { getSupabase } from "@/shared/db/supabase";
 import { type LlmParsedTransaction, llmOutputSchema } from "./llm-parser";
 
 export function stripPii(text: string): string {
-  return text
-    .replace(/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g, "[EMAIL]")
-    .replace(/\+\d[\d\s-]{8,14}\d/g, "[PHONE]")
-    .replace(/\b\d{4}[\s-]\d{4}[\s-]\d{4}[\s-]\d{4}\b/g, "[CARD]")
-    .replace(/\b\d{15,16}\b/g, "[CARD]")
-    .replace(/\d{4}[\s-]*[*Xx]{2,}[\s-]*[*Xx]{2,}[\s-]*\d{4}/g, "[CARD]")
-    .replace(/[*Xx]{2,4}[\s.-]*[*Xx]{2,4}[\s.-]*[*Xx]{2,4}[\s.-]*\d{4}/g, "[CARD]")
-    .replace(/\*{1,4}\d{4}/g, "[CARD]");
+  return (
+    text
+      .replace(/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g, "[EMAIL]")
+      .replace(/\+\d[\d\s-]{8,14}\d/g, "[PHONE]")
+      // ID patterns must run before local phone — cedulas starting with 601-608 would otherwise match phones
+      .replace(
+        /\b(?:C\.?\s?C\.?|T\.?\s?I\.?|C\.?\s?E\.?|[Cc][eé]dula)\s*:?\s*#?\s*\d{6,11}\b/g,
+        "[ID]"
+      )
+      .replace(/\bNIT\s*:?\s*\d{3}\.?\d{3}\.?\d{3,4}-?\d?\b/gi, "[ID]")
+      .replace(
+        /(?:(?:No\.?\s*)?Cuenta|Cta\.?)\s*(?:(?:de\s+)?(?:Ahorros|Corriente)\s*)?(?:No\.?\s*)?#?\s{0,3}\d{8,20}/gi,
+        "[ACCOUNT]"
+      )
+      .replace(/(?<!\d)\(?60[1-8]\)?[\s-]?\d{3}[\s-]?\d{4}\b/g, "[PHONE]")
+      .replace(/\b\d{4}[\s-]\d{4}[\s-]\d{4}[\s-]\d{4}\b/g, "[CARD]")
+      .replace(/\b\d{15,16}\b/g, "[CARD]")
+      .replace(/\d{4}[\s-]*[*Xx]{2,}[\s-]*[*Xx]{2,}[\s-]*\d{4}/g, "[CARD]")
+      .replace(/[*Xx]{2,4}[\s.-]*[*Xx]{2,4}[\s.-]*[*Xx]{2,4}[\s.-]*\d{4}/g, "[CARD]")
+      .replace(/\*{1,4}\d{4}/g, "[CARD]")
+  );
 }
 
 export async function classifyMerchantApi(merchant: string): Promise<string> {

--- a/apps/mobile/features/email-capture/services/parse-email-api.ts
+++ b/apps/mobile/features/email-capture/services/parse-email-api.ts
@@ -9,7 +9,7 @@ export function stripPii(text: string): string {
       .replace(/\+\d[\d\s-]{8,14}\d/g, "[PHONE]")
       // ID patterns must run before local phone — cedulas starting with 601-608 would otherwise match phones
       .replace(
-        /\b(?:C\.?\s?C\.?|T\.?\s?I\.?|C\.?\s?E\.?|[Cc][eé]dula)\s*:?\s*#?\s*\d{6,11}\b/g,
+        /\b(?:C\.?\s?C\.?|T\.?\s?I\.?|C\.?\s?E\.?|[Cc][eé]dula)\s*:?\s*#?\s*\d{6,11}\b/gi,
         "[ID]"
       )
       .replace(/\bNIT\s*:?\s*\d{3}\.?\d{3}\.?\d{3,4}-?\d?\b/gi, "[ID]")


### PR DESCRIPTION
- Add CC/TI/CE/Cédula and NIT regex patterns → [ID]
- Add bank account number patterns (Cuenta/Cta) → [ACCOUNT]
- Add Colombian local phone patterns (601-608) → [PHONE]
- Update and expand stripPii test coverage

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip Colombian PII from captured emails before LLM parsing to reduce exposure and improve parse accuracy. Adds case-insensitive regexes for national IDs and NIT, plus patterns for bank accounts and local landlines, with expanded tests.

- **New Features**
  - Replace CC/TI/CE/Cédula and NIT numbers with [ID] (case-insensitive).
  - Replace bank account numbers (Cuenta/Cta, incl. Ahorros/Corriente) with [ACCOUNT].
  - Replace Colombian local landlines 60[1-8] with [PHONE]; run ID rules first to avoid false phone matches.
  - Preserve non-PII digit sequences (e.g., amounts).

<sup>Written for commit 626ed2574d443743cdd11a412e51c3dfcc4ad857. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

