### PR TITLE
feat(mobile): arch decisions + single-step add transaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ GoogleService-Info.plist
 
 # Docs (local-only)
 docs/
+TODOS.md
 
 # Superpowers brainstorm artifacts
 .superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,3 +29,29 @@ All code in the financial core (`lib/`, schemas, utils) MUST follow functional p
 - No `while`/`for` loops — use declarative alternatives or recursion
 - Separate pure functions from side effects: pure logic in `lib/`, effects in stores/hooks
 - Pure functions take all dependencies as parameters (no reaching into module state)
+
+## Architectural Decisions
+
+### Calendar-month budgets only
+Budget periods are always calendar months (1st to last day). No custom periods. Reuse `deriveSpendingByCategory(month)` directly. Extend only if user research demands it.
+
+### Non-nullable accountId with default account (Phase 3)
+When multi-account (#9) ships, `accountId` on transactions must be NOT NULL with a default account. Do NOT add a nullable accountId column early. Phase 3 migration: (1) create `accounts` table with default account, (2) `ALTER TABLE transactions ADD COLUMN account_id TEXT NOT NULL DEFAULT '{default_id}'`, (3) backfill from source → bank mapping.
+
+### Sync all new tables
+Every new DB table that stores user data must integrate with the sync queue. Use the shared `enqueueSync(db, tableName, rowId, operation)` helper from `shared/db/enqueue-sync.ts`. Add ~S effort per feature for sync integration.
+
+### On-device derivations for everything
+All budget/goal/analytics computations run on-device using local SQLite. No new Edge Functions for derivations. Edge Functions are only for: (1) weekly digest scheduler (cron), (2) AI chat context extension.
+
+### LIKE queries for search
+Use `WHERE description LIKE '%term%'` for transaction search. No FTS5 unless profiling shows degradation beyond 50ms on 2K+ rows.
+
+### SQL aggregation for analytics
+Follow existing `getBalanceAggregate()` pattern in repository. Use SQL `GROUP BY` + `SUM` at the repository level. Never load all rows into JS for aggregation.
+
+### Budget progress = pure derivation
+`deriveBudgetProgress()` must be a pure function in `derive.ts`. Takes budget + transactions as params, returns progress. Memoize in store on transaction change. Consistent with FP mandate.
+
+### Direct unit tests for pure functions
+New derivation/pure functions get direct unit tests with fixture data. File-source reading pattern (`readFileSync` test pattern) stays for navigation/layout tests only.

--- a/apps/mobile/__tests__/calendar/store.test.ts
+++ b/apps/mobile/__tests__/calendar/store.test.ts
@@ -16,8 +16,11 @@ vi.mock("@/features/calendar/lib/repository", () => ({
 // Mock the transaction repository module
 vi.mock("@/features/transactions/lib/repository", () => ({
   insertTransaction: vi.fn().mockResolvedValue(undefined),
-  enqueueSync: vi.fn().mockResolvedValue(undefined),
   softDeleteTransaction: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/shared/db/enqueue-sync", () => ({
+  enqueueSync: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { useCalendarStore } from "@/features/calendar/store";
@@ -394,7 +397,7 @@ describe("useCalendarStore", () => {
   });
 
   test("markBillPaid enqueues sync for the transaction", async () => {
-    const { enqueueSync } = await import("@/features/transactions/lib/repository");
+    const { enqueueSync } = await import("@/shared/db/enqueue-sync");
     vi.mocked(enqueueSync).mockClear();
 
     await useCalendarStore.getState().addBill("Netflix", "15.99", "monthly", "services", testDate);
@@ -460,7 +463,7 @@ describe("useCalendarStore", () => {
 
   test("unmarkBillPaid soft-deletes the linked transaction", async () => {
     const { softDeleteTransaction } = await import("@/features/transactions/lib/repository");
-    const { enqueueSync } = await import("@/features/transactions/lib/repository");
+    const { enqueueSync } = await import("@/shared/db/enqueue-sync");
     vi.mocked(softDeleteTransaction).mockClear();
     vi.mocked(enqueueSync).mockClear();
 

--- a/apps/mobile/__tests__/capture-sources/apple-pay-pipeline.test.ts
+++ b/apps/mobile/__tests__/capture-sources/apple-pay-pipeline.test.ts
@@ -13,6 +13,9 @@ const mockInsertProcessedCapture = vi.fn();
 
 vi.mock("@/features/transactions/lib/repository", () => ({
   insertTransaction: (...args: any[]) => mockInsertTransaction(...args),
+}));
+
+vi.mock("@/shared/db/enqueue-sync", () => ({
   enqueueSync: (...args: any[]) => mockEnqueueSync(...args),
 }));
 

--- a/apps/mobile/__tests__/capture-sources/notification-pipeline.test.ts
+++ b/apps/mobile/__tests__/capture-sources/notification-pipeline.test.ts
@@ -14,6 +14,9 @@ const mockStripPii = vi.fn().mockImplementation((t: string) => t);
 
 vi.mock("@/features/transactions/lib/repository", () => ({
   insertTransaction: (...args: any[]) => mockInsertTransaction(...args),
+}));
+
+vi.mock("@/shared/db/enqueue-sync", () => ({
   enqueueSync: (...args: any[]) => mockEnqueueSync(...args),
 }));
 

--- a/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
@@ -32,6 +32,9 @@ vi.mock("@/features/email-capture/lib/repository", () => ({
 
 vi.mock("@/features/transactions/lib/repository", () => ({
   insertTransaction: (...args: unknown[]) => mockInsertTransaction(...args),
+}));
+
+vi.mock("@/shared/db/enqueue-sync", () => ({
   enqueueSync: (...args: unknown[]) => mockEnqueueSync(...args),
 }));
 

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -67,7 +67,7 @@ vi.mock("@/features/email-capture/lib/bank-senders", async (importOriginal) => {
   };
 });
 
-vi.mock("@/features/transactions/lib/repository", () => ({
+vi.mock("@/shared/db/enqueue-sync", () => ({
   enqueueSync: vi.fn(),
 }));
 

--- a/apps/mobile/__tests__/error-handling/pipeline-save-error.test.ts
+++ b/apps/mobile/__tests__/error-handling/pipeline-save-error.test.ts
@@ -28,6 +28,9 @@ vi.mock("@/features/email-capture/lib/repository", () => ({
 
 vi.mock("@/features/transactions/lib/repository", () => ({
   insertTransaction: (...args: unknown[]) => mockInsertTransaction(...args),
+}));
+
+vi.mock("@/shared/db/enqueue-sync", () => ({
   enqueueSync: (...args: unknown[]) => mockEnqueueSync(...args),
 }));
 

--- a/apps/mobile/__tests__/transactions/build-transaction.test.ts
+++ b/apps/mobile/__tests__/transactions/build-transaction.test.ts
@@ -23,7 +23,7 @@ describe("buildTransaction", () => {
     if (!result.success) return;
     expect(result.transaction.id).toBe("tx-1");
     expect(result.transaction.userId).toBe("user-1");
-    expect(result.transaction.amountCents).toBe(1234);
+    expect(result.transaction.amountCents).toBe(123400);
     expect(result.transaction.categoryId).toBe("food");
     expect(result.transaction.createdAt).toBe(NOW);
     expect(result.transaction.updatedAt).toBe(NOW);

--- a/apps/mobile/__tests__/transactions/categories.test.ts
+++ b/apps/mobile/__tests__/transactions/categories.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { CATEGORIES, CATEGORY_IDS } from "../../features/transactions/lib/categories";
+import {
+  CATEGORIES,
+  CATEGORY_IDS,
+  DEFAULT_CATEGORY_IDS,
+  isValidCategoryId,
+} from "../../features/transactions/lib/categories";
 
 describe("categories", () => {
   it("exports exactly 10 categories", () => {
@@ -28,6 +33,40 @@ describe("categories", () => {
       expect(category.label).toHaveProperty("es");
       expect(category.label.en).toBeTruthy();
       expect(category.label.es).toBeTruthy();
+    }
+  });
+
+  describe("isValidCategoryId", () => {
+    it("returns true for all 10 built-in category IDs", () => {
+      for (const id of CATEGORY_IDS) {
+        expect(isValidCategoryId(id)).toBe(true);
+      }
+    });
+
+    it("returns false for unknown string", () => {
+      expect(isValidCategoryId("groceries")).toBe(false);
+    });
+
+    it("returns false for empty string", () => {
+      expect(isValidCategoryId("")).toBe(false);
+    });
+
+    it("accepts custom validIds set when provided", () => {
+      const custom = new Set(["custom-a", "custom-b"]);
+      expect(isValidCategoryId("custom-a", custom)).toBe(true);
+      expect(isValidCategoryId("custom-b", custom)).toBe(true);
+    });
+
+    it("returns false for built-in ID when custom set excludes it", () => {
+      const custom = new Set(["only-this"]);
+      expect(isValidCategoryId("food", custom)).toBe(false);
+    });
+  });
+
+  it("DEFAULT_CATEGORY_IDS matches CATEGORY_IDS", () => {
+    expect(DEFAULT_CATEGORY_IDS.size).toBe(CATEGORY_IDS.length);
+    for (const id of CATEGORY_IDS) {
+      expect(DEFAULT_CATEGORY_IDS.has(id)).toBe(true);
     }
   });
 });

--- a/apps/mobile/__tests__/transactions/category-pill.test.ts
+++ b/apps/mobile/__tests__/transactions/category-pill.test.ts
@@ -6,8 +6,8 @@ describe("CategoryPill component", () => {
     expect(mod.CategoryPill).toBeDefined();
   });
 
-  it("CategoryPill is a function component", async () => {
+  it("CategoryPill is a memoized component", async () => {
     const mod = await import("@/features/transactions/components/CategoryPill");
-    expect(typeof mod.CategoryPill).toBe("function");
+    expect(mod.CategoryPill).toHaveProperty("$$typeof");
   });
 });

--- a/apps/mobile/__tests__/transactions/format-amount.test.ts
+++ b/apps/mobile/__tests__/transactions/format-amount.test.ts
@@ -3,8 +3,10 @@ import {
   amountToCents,
   centsToDisplay,
   cleanDigitInput,
+  digitsToCents,
   formatAmount,
   formatCents,
+  formatDollars,
   formatSignedAmount,
 } from "@/features/transactions/lib/format-amount";
 
@@ -87,6 +89,38 @@ describe("formatSignedAmount", () => {
 
   it("returns positive sign for income", () => {
     expect(formatSignedAmount(6740000, "income")).toBe("+$67,400");
+  });
+});
+
+describe("formatDollars", () => {
+  it("returns $0 for empty string", () => {
+    expect(formatDollars("")).toBe("$0");
+  });
+
+  it("formats single digit", () => {
+    expect(formatDollars("5")).toBe("$5");
+  });
+
+  it("formats with commas", () => {
+    expect(formatDollars("10000")).toBe("$10,000");
+  });
+
+  it("strips leading zeros", () => {
+    expect(formatDollars("007")).toBe("$7");
+  });
+});
+
+describe("digitsToCents", () => {
+  it("converts dollar digits to cents", () => {
+    expect(digitsToCents("100")).toBe(10000);
+  });
+
+  it("returns 0 for empty string", () => {
+    expect(digitsToCents("")).toBe(0);
+  });
+
+  it("handles large amounts", () => {
+    expect(digitsToCents("10000")).toBe(1000000);
   });
 });
 

--- a/apps/mobile/__tests__/transactions/handle-numpad-press.test.ts
+++ b/apps/mobile/__tests__/transactions/handle-numpad-press.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { handleNumpadPress } from "@/features/transactions/lib/handle-numpad-press";
+
+describe("handleNumpadPress", () => {
+  it("appends a digit to empty string", () => {
+    expect(handleNumpadPress("", "5")).toBe("5");
+  });
+
+  it("appends a digit to existing digits", () => {
+    expect(handleNumpadPress("12", "3")).toBe("123");
+  });
+
+  it("appends 000 to digits", () => {
+    expect(handleNumpadPress("5", "000")).toBe("5000");
+  });
+
+  it("caps at 8 digits when appending a single digit", () => {
+    expect(handleNumpadPress("12345678", "9")).toBe("12345678");
+  });
+
+  it("caps at 8 digits when appending 000", () => {
+    expect(handleNumpadPress("123456", "000")).toBe("12345600");
+  });
+
+  it("truncates 000 if it would exceed 8 digits", () => {
+    expect(handleNumpadPress("1234567", "000")).toBe("12345670");
+  });
+
+  it("deletes last digit", () => {
+    expect(handleNumpadPress("123", "delete")).toBe("12");
+  });
+
+  it("returns empty string when deleting last digit", () => {
+    expect(handleNumpadPress("1", "delete")).toBe("");
+  });
+
+  it("returns empty string when deleting from empty", () => {
+    expect(handleNumpadPress("", "delete")).toBe("");
+  });
+
+  it("ignores non-digit non-special keys", () => {
+    expect(handleNumpadPress("123", "abc")).toBe("123");
+  });
+});

--- a/apps/mobile/__tests__/transactions/store.test.ts
+++ b/apps/mobile/__tests__/transactions/store.test.ts
@@ -9,17 +9,20 @@ vi.mock("@/features/transactions/lib/repository", () => ({
   getRecentTransactions: vi.fn().mockReturnValue([]),
   getTransactionById: vi.fn().mockReturnValue(null),
   softDeleteTransaction: vi.fn(),
+}));
+
+vi.mock("@/shared/db/enqueue-sync", () => ({
   enqueueSync: vi.fn(),
 }));
 
 import {
-  enqueueSync,
   getBalanceAggregate,
   getTransactionsPaginated,
   insertTransaction,
   softDeleteTransaction,
 } from "@/features/transactions/lib/repository";
 import { useTransactionStore } from "@/features/transactions/store";
+import { enqueueSync } from "@/shared/db/enqueue-sync";
 
 // biome-ignore lint/suspicious/noExplicitAny: mock db needs flexible typing
 const mockDb = {} as any;
@@ -101,7 +104,7 @@ describe("useTransactionStore", () => {
     const result = await store.saveTransaction();
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.transaction.amountCents).toBe(4520);
+      expect(result.transaction.amountCents).toBe(452000);
       expect(result.transaction.categoryId).toBe("food");
       expect(result.transaction.description).toBe("Groceries");
       expect(result.transaction.type).toBe("expense");
@@ -113,7 +116,7 @@ describe("useTransactionStore", () => {
     expect(insertTransaction).toHaveBeenCalledWith(
       mockDb,
       expect.objectContaining({
-        amountCents: 4520,
+        amountCents: 452000,
         categoryId: "food",
         type: "expense",
         userId: mockUserId,

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -142,7 +142,10 @@ function RootLayout() {
         <Stack screenOptions={{ headerShown: false }}>
           <Stack.Screen name="(auth)" />
           <Stack.Screen name="(tabs)" />
-          <Stack.Screen name="add-transaction" options={{ presentation: "formSheet" }} />
+          <Stack.Screen
+            name="add-transaction"
+            options={{ presentation: "formSheet", sheetAllowedDetents: [0.53] }}
+          />
           <Stack.Screen
             name="add-bill"
             options={{ presentation: "formSheet", sheetAllowedDetents: "fitToContents" }}

--- a/apps/mobile/app/add-bill.tsx
+++ b/apps/mobile/app/add-bill.tsx
@@ -16,7 +16,7 @@ import type { BillFrequency } from "@/features/calendar/schema";
 import { FREQUENCIES } from "@/features/calendar/schema";
 import { useCalendarStore } from "@/features/calendar/store";
 import type { CategoryId } from "@/features/transactions/lib/categories";
-import { CATEGORIES } from "@/features/transactions/lib/categories";
+import { CATEGORIES, isValidCategoryId } from "@/features/transactions/lib/categories";
 import { centsToDisplay } from "@/features/transactions/lib/format-amount";
 import { useAsyncGuard } from "@/shared/hooks/use-async-guard";
 import { useThemeColor } from "@/shared/hooks/use-theme-color";
@@ -37,7 +37,9 @@ export default function AddBillScreen() {
   );
   const [frequency, setFrequency] = useState<BillFrequency>(existingBill?.frequency ?? "monthly");
   const [category, setCategory] = useState<CategoryId>(
-    (existingBill?.categoryId as CategoryId) ?? "services"
+    existingBill?.categoryId && isValidCategoryId(existingBill.categoryId)
+      ? existingBill.categoryId
+      : "services"
   );
   const [startDate, setStartDate] = useState(existingBill?.startDate ?? new Date());
 
@@ -56,7 +58,9 @@ export default function AddBillScreen() {
       setName(existingBill.name);
       setAmount(centsToDisplay(existingBill.amountCents).replace("$", ""));
       setFrequency(existingBill.frequency);
-      setCategory(existingBill.categoryId as CategoryId);
+      setCategory(
+        isValidCategoryId(existingBill.categoryId) ? existingBill.categoryId : "services"
+      );
       setStartDate(existingBill.startDate);
     }
   }, [existingBill?.id]);

--- a/apps/mobile/app/add-transaction.tsx
+++ b/apps/mobile/app/add-transaction.tsx
@@ -65,7 +65,7 @@ export default function AddTransactionModal() {
   const borderSubtle = useThemeColor("borderSubtle");
 
   const amountColor = type === "expense" ? accentRed : accentGreen;
-  const displayAmount = digits.length > 0 ? formatDollars(digits) : "$0";
+  const displayAmount = digits.length > 0 ? formatDollars(digits) : "$";
   const canSave = digitsToCents(digits) > 0;
   const buttonBg = canSave ? accentGreen : "#CCCCCC";
   const dateLabel = useMemo(() => getDateLabel(date, new Date()), [date]);

--- a/apps/mobile/app/add-transaction.tsx
+++ b/apps/mobile/app/add-transaction.tsx
@@ -1,38 +1,265 @@
-import { useEffect } from "react";
-import { View } from "react-native";
-import Animated, { FadeIn, FadeOut } from "react-native-reanimated";
-import { AmountEntry } from "@/features/transactions/components/AmountEntry";
-import { TransactionDetails } from "@/features/transactions/components/TransactionDetails";
+import * as Haptics from "expo-haptics";
+import { useRouter } from "expo-router";
+import { Calendar } from "lucide-react-native";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from "react-native-reanimated";
+import { useShallow } from "zustand/react/shallow";
+import { CategoryPill } from "@/features/transactions/components/CategoryPill";
+import { TypeToggle } from "@/features/transactions/components/TypeToggle";
+import { CATEGORIES } from "@/features/transactions/lib/categories";
+import { digitsToCents, formatDollars } from "@/features/transactions/lib/format-amount";
+import { getDateLabel } from "@/features/transactions/lib/format-date";
+import { handleNumpadPress } from "@/features/transactions/lib/handle-numpad-press";
 import { useTransactionStore } from "@/features/transactions/store";
+import { FidyNumpad } from "@/shared/components/FidyNumpad";
+import { useAsyncGuard } from "@/shared/hooks/use-async-guard";
 import { useThemeColor } from "@/shared/hooks/use-theme-color";
 
 export default function AddTransactionModal() {
-  const step = useTransactionStore((s) => s.step);
-  const resetForm = useTransactionStore((s) => s.resetForm);
+  const { back } = useRouter();
+  const {
+    type,
+    digits,
+    categoryId,
+    description,
+    date,
+    setType,
+    setDigits,
+    setCategoryId,
+    setDescription,
+    saveTransaction,
+    resetForm,
+  } = useTransactionStore(
+    useShallow((s) => ({
+      type: s.type,
+      digits: s.digits,
+      categoryId: s.categoryId,
+      description: s.description,
+      date: s.date,
+      setType: s.setType,
+      setDigits: s.setDigits,
+      setCategoryId: s.setCategoryId,
+      setDescription: s.setDescription,
+      saveTransaction: s.saveTransaction,
+      resetForm: s.resetForm,
+    }))
+  );
 
   useEffect(() => {
     resetForm();
   }, [resetForm]);
+
   const cardColor = useThemeColor("card");
+  const accentRed = useThemeColor("accentRed");
+  const accentGreen = useThemeColor("accentGreen");
+  const secondary = useThemeColor("secondary");
+  const tertiary = useThemeColor("tertiary");
+  const primary = useThemeColor("primary");
+  const borderSubtle = useThemeColor("borderSubtle");
+
+  const amountColor = type === "expense" ? accentRed : accentGreen;
+  const displayAmount = digits.length > 0 ? formatDollars(digits) : "$0";
+  const canSave = digitsToCents(digits) > 0;
+  const buttonBg = canSave ? accentGreen : "#CCCCCC";
+  const dateLabel = useMemo(() => getDateLabel(date, new Date()), [date]);
+
+  // Stable ref for digits so handleKey doesn't change on every keystroke
+  const digitsRef = useRef(digits);
+  digitsRef.current = digits;
+
+  // Blinking cursor — always active since numpad is always visible
+  const cursorOpacity = useSharedValue(1);
+
+  useEffect(() => {
+    cursorOpacity.value = withRepeat(
+      withSequence(
+        withTiming(1, { duration: 0 }),
+        withTiming(1, { duration: 530 }),
+        withTiming(0, { duration: 0 }),
+        withTiming(0, { duration: 530 })
+      ),
+      -1
+    );
+  }, [cursorOpacity]);
+
+  const cursorStyle = useAnimatedStyle(() => ({
+    opacity: cursorOpacity.value,
+  }));
+
+  const { isBusy: isSaving, run: guardedSave } = useAsyncGuard();
+
+  const handleSave = () =>
+    guardedSave(async () => {
+      const result = await saveTransaction();
+      if (result.success) {
+        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+        resetForm();
+        back();
+      }
+    });
+
+  const handleKey = useCallback(
+    (key: string) => {
+      setDigits(handleNumpadPress(digitsRef.current, key));
+    },
+    [setDigits]
+  );
 
   return (
-    <View
-      style={{
-        flex: 1,
-        backgroundColor: cardColor,
+    <ScrollView
+      style={{ flex: 1, backgroundColor: cardColor }}
+      contentContainerStyle={{
+        flexGrow: 1,
+        justifyContent: "center",
         paddingHorizontal: 24,
-        paddingTop: 16,
-        paddingBottom: 32,
+        gap: 8,
+        paddingTop: 0,
       }}
+      keyboardShouldPersistTaps="handled"
+      showsVerticalScrollIndicator={false}
     >
-      <Animated.View
-        key={step}
-        entering={FadeIn.duration(200)}
-        exiting={FadeOut.duration(150)}
-        style={{ flex: 1 }}
+      {/* Sheet handle */}
+      <View style={{ alignItems: "center", marginBottom: 8 }}>
+        <View
+          style={{
+            width: 40,
+            height: 4,
+            borderRadius: 2,
+            backgroundColor: "#5E5E5E",
+          }}
+        />
+      </View>
+      {/* Type toggle + Amount */}
+      <View style={{ alignItems: "center", gap: 2 }}>
+        <TypeToggle value={type} onChange={setType} />
+        <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "center" }}>
+          <Text
+            style={{
+              fontFamily: "Poppins_700Bold",
+              fontSize: 32,
+              color: amountColor,
+            }}
+          >
+            {displayAmount}
+          </Text>
+          <Animated.View
+            style={[
+              {
+                width: 2,
+                height: 28,
+                marginLeft: 2,
+                borderRadius: 1,
+                backgroundColor: amountColor,
+              },
+              cursorStyle,
+            ]}
+          />
+        </View>
+      </View>
+
+      {/* Categories */}
+      <View style={{ gap: 4 }}>
+        <Text
+          style={{
+            fontFamily: "Poppins_500Medium",
+            fontSize: 12,
+            color: secondary,
+          }}
+        >
+          Category
+        </Text>
+        <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 6 }}>
+          {CATEGORIES.map((cat) => (
+            <CategoryPill
+              key={cat.id}
+              category={cat}
+              isSelected={categoryId === cat.id}
+              onPress={() => setCategoryId(cat.id)}
+            />
+          ))}
+        </View>
+      </View>
+
+      {/* Description + Date */}
+      <View style={{ flexDirection: "row", gap: 8 }}>
+        <TextInput
+          style={{
+            flex: 1,
+            height: 36,
+            borderRadius: 10,
+            paddingHorizontal: 12,
+            fontFamily: "Poppins_500Medium",
+            fontSize: 12,
+            color: primary,
+            borderWidth: 1,
+            borderColor: borderSubtle,
+          }}
+          placeholder="Description (optional)"
+          placeholderTextColor={tertiary}
+          value={description}
+          onChangeText={setDescription}
+          maxLength={200}
+        />
+        <View
+          style={{
+            height: 36,
+            borderRadius: 10,
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 6,
+            paddingHorizontal: 10,
+            borderWidth: 1,
+            borderColor: borderSubtle,
+          }}
+        >
+          <Calendar size={14} color={secondary} />
+          <Text
+            style={{
+              fontFamily: "Poppins_500Medium",
+              fontSize: 12,
+              color: primary,
+            }}
+          >
+            {dateLabel}
+          </Text>
+        </View>
+      </View>
+
+      {/* Save button */}
+      <Pressable
+        style={{
+          height: 44,
+          borderRadius: 12,
+          backgroundColor: buttonBg,
+          alignItems: "center",
+          justifyContent: "center",
+          opacity: isSaving ? 0.5 : 1,
+        }}
+        onPress={canSave ? handleSave : undefined}
+        disabled={!canSave || isSaving}
+        accessibilityRole="button"
+        accessibilityLabel="Save Transaction"
       >
-        {step === 1 ? <AmountEntry /> : <TransactionDetails />}
-      </Animated.View>
-    </View>
+        <Text
+          style={{
+            fontFamily: "Poppins_600SemiBold",
+            fontSize: 14,
+            color: "#FFFFFF",
+          }}
+        >
+          Save Transaction
+        </Text>
+      </Pressable>
+
+      {/* Custom numpad */}
+      <FidyNumpad onKeyPress={handleKey} />
+    </ScrollView>
   );
 }

--- a/apps/mobile/features/calendar/schema.ts
+++ b/apps/mobile/features/calendar/schema.ts
@@ -83,7 +83,7 @@ export function fromBillRow(row: {
     name: row.name,
     amountCents: row.amountCents,
     frequency: row.frequency as BillFrequency,
-    categoryId: row.categoryId as z.infer<typeof categoryIdSchema>,
+    categoryId: row.categoryId,
     startDate: new Date(row.startDate),
     isActive: row.isActive,
   };

--- a/apps/mobile/features/calendar/store.ts
+++ b/apps/mobile/features/calendar/store.ts
@@ -1,14 +1,11 @@
 import { addMonths, endOfMonth, startOfMonth, subMonths } from "date-fns";
 import { create } from "zustand";
 import { toTransactionRow } from "@/features/transactions/lib/build-transaction";
-import {
-  enqueueSync,
-  insertTransaction,
-  softDeleteTransaction,
-} from "@/features/transactions/lib/repository";
+import { insertTransaction, softDeleteTransaction } from "@/features/transactions/lib/repository";
 import type { StoredTransaction } from "@/features/transactions/schema";
 import { useTransactionStore } from "@/features/transactions/store";
 import type { AnyDb } from "@/shared/db/client";
+import { enqueueSync } from "@/shared/db/enqueue-sync";
 import { parseIsoDate, toIsoDate } from "@/shared/lib/format-date";
 import { generateId } from "@/shared/lib/generate-id";
 import { captureError } from "@/shared/lib/sentry";

--- a/apps/mobile/features/capture-sources/services/apple-pay-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/apple-pay-pipeline.ts
@@ -3,8 +3,10 @@ import {
   lookupMerchantRule,
 } from "@/features/email-capture/lib/merchant-rules";
 import { classifyMerchantApi } from "@/features/email-capture/services/parse-email-api";
-import { enqueueSync, insertTransaction } from "@/features/transactions/lib/repository";
+import { isValidCategoryId } from "@/features/transactions/lib/categories";
+import { insertTransaction } from "@/features/transactions/lib/repository";
 import type { AnyDb } from "@/shared/db/client";
+import { enqueueSync } from "@/shared/db/enqueue-sync";
 import { toIsoDate } from "@/shared/lib/format-date";
 import { generateId } from "@/shared/lib/generate-id";
 import { normalizeMerchant } from "@/shared/lib/normalize-merchant";
@@ -73,7 +75,8 @@ export async function processApplePayIntent(
     const cachedCategoryId = await lookupMerchantRule(db, userId, merchantKey);
 
     // If no cached category, classify via LLM
-    const categoryId = cachedCategoryId ?? (await classifyMerchantApi(intent.merchant));
+    const rawCategoryId = cachedCategoryId ?? (await classifyMerchantApi(intent.merchant));
+    const categoryId = isValidCategoryId(rawCategoryId) ? rawCategoryId : "other";
 
     // Save transaction
     const txId = generateId("tx");

--- a/apps/mobile/features/capture-sources/services/notification-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/notification-pipeline.ts
@@ -3,8 +3,10 @@ import {
   lookupMerchantRule,
 } from "@/features/email-capture/lib/merchant-rules";
 import { stripPii } from "@/features/email-capture/services/parse-email-api";
-import { enqueueSync, insertTransaction } from "@/features/transactions/lib/repository";
+import { isValidCategoryId } from "@/features/transactions/lib/categories";
+import { insertTransaction } from "@/features/transactions/lib/repository";
 import type { AnyDb } from "@/shared/db/client";
+import { enqueueSync } from "@/shared/db/enqueue-sync";
 import { toIsoDate } from "@/shared/lib/format-date";
 import { generateId } from "@/shared/lib/generate-id";
 import { normalizeMerchant } from "@/shared/lib/normalize-merchant";
@@ -113,7 +115,8 @@ export async function processNotification(
     // Check merchant rules cache
     const merchantKey = normalizeMerchant(parsed.merchant);
     const cachedCategoryId = await lookupMerchantRule(db, userId, merchantKey);
-    const finalCategoryId = cachedCategoryId ?? parsed.categoryId;
+    const rawCategoryId = cachedCategoryId ?? parsed.categoryId;
+    const finalCategoryId = isValidCategoryId(rawCategoryId) ? rawCategoryId : "other";
 
     // Save transaction
     const txId = generateId("tx");

--- a/apps/mobile/features/email-capture/components/NeedsReviewCard.tsx
+++ b/apps/mobile/features/email-capture/components/NeedsReviewCard.tsx
@@ -1,7 +1,11 @@
 import { format } from "date-fns";
 import { useCallback, useEffect, useState } from "react";
 import { Pressable, ScrollView, Text, View } from "react-native";
-import { CATEGORIES, type CategoryId } from "@/features/transactions/lib/categories";
+import {
+  CATEGORIES,
+  type CategoryId,
+  isValidCategoryId,
+} from "@/features/transactions/lib/categories";
 import { formatSignedAmount } from "@/features/transactions/lib/format-amount";
 import type { StoredTransaction } from "@/features/transactions/schema";
 import type { ProcessedEmailRow } from "../lib/repository";
@@ -17,7 +21,10 @@ export const NeedsReviewCard = ({
   transaction,
   onConfirm,
 }: NeedsReviewCardProps) => {
-  const suggestedCategory: CategoryId = (transaction?.categoryId as CategoryId) ?? "other";
+  const suggestedCategory: CategoryId =
+    transaction?.categoryId && isValidCategoryId(transaction.categoryId)
+      ? transaction.categoryId
+      : "other";
   const [selectedCategory, setSelectedCategory] = useState<CategoryId>(suggestedCategory);
 
   useEffect(() => {

--- a/apps/mobile/features/email-capture/services/email-pipeline.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline.ts
@@ -265,11 +265,14 @@ export async function processEmails(
 
       try {
         const merchantKey = normalizeMerchant(parsed.description);
+        const validatedCategoryId = isValidCategoryId(parsed.categoryId)
+          ? parsed.categoryId
+          : "other";
         await insertMerchantRule(
           db,
           userId,
           merchantKey,
-          parsed.categoryId,
+          validatedCategoryId,
           new Date().toISOString()
         );
       } catch (ruleErr) {
@@ -355,13 +358,14 @@ export async function processRetries(db: AnyDb, userId: string): Promise<RetryRe
       const now = new Date().toISOString();
       const source = email.provider === "gmail" ? "email_gmail" : "email_outlook";
       const status = parsed.confidence < 0.7 ? "needs_review" : "success";
+      const retryCategoryId = isValidCategoryId(parsed.categoryId) ? parsed.categoryId : "other";
 
       await insertTransaction(db, {
         id: txId,
         userId,
         type: parsed.type,
         amountCents: parsed.amountCents,
-        categoryId: parsed.categoryId,
+        categoryId: retryCategoryId,
         description: parsed.description,
         date: parsed.date,
         source,
@@ -379,7 +383,7 @@ export async function processRetries(db: AnyDb, userId: string): Promise<RetryRe
 
       if (status === "success") {
         const merchantKey = normalizeMerchant(parsed.description);
-        await insertMerchantRule(db, userId, merchantKey, parsed.categoryId, now);
+        await insertMerchantRule(db, userId, merchantKey, retryCategoryId, now);
       }
 
       await markRetrySuccess(db, email.id, status, txId, parsed.confidence);

--- a/apps/mobile/features/email-capture/services/email-pipeline.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline.ts
@@ -1,6 +1,8 @@
 import { findDuplicateTransaction } from "@/features/capture-sources/lib/dedup";
-import { enqueueSync, insertTransaction } from "@/features/transactions/lib/repository";
+import { isValidCategoryId } from "@/features/transactions/lib/categories";
+import { insertTransaction } from "@/features/transactions/lib/repository";
 import type { AnyDb } from "@/shared/db/client";
+import { enqueueSync } from "@/shared/db/enqueue-sync";
 import { generateId } from "@/shared/lib/generate-id";
 import { normalizeMerchant } from "@/shared/lib/normalize-merchant";
 import { captureError } from "@/shared/lib/sentry";
@@ -56,12 +58,14 @@ async function saveTransaction(
   const txId = generateId("tx");
   const now = new Date().toISOString();
 
+  const categoryId = isValidCategoryId(validated.categoryId) ? validated.categoryId : "other";
+
   await insertTransaction(db, {
     id: txId,
     userId,
     type: validated.type,
     amountCents: validated.amountCents,
-    categoryId: validated.categoryId,
+    categoryId,
     description: validated.description,
     date: validated.date,
     source,

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -1,8 +1,8 @@
 import { eq } from "drizzle-orm";
 import { create } from "zustand";
-import { enqueueSync } from "@/features/transactions/lib/repository";
 import { useTransactionStore } from "@/features/transactions/store";
 import type { AnyDb } from "@/shared/db/client";
+import { enqueueSync } from "@/shared/db/enqueue-sync";
 import { transactions } from "@/shared/db/schema";
 import { generateId } from "@/shared/lib/generate-id";
 import { normalizeMerchant } from "@/shared/lib/normalize-merchant";

--- a/apps/mobile/features/sync/store.ts
+++ b/apps/mobile/features/sync/store.ts
@@ -1,7 +1,8 @@
 import { create } from "zustand";
-import { enqueueSync, upsertTransaction } from "@/features/transactions/lib/repository";
+import { upsertTransaction } from "@/features/transactions/lib/repository";
 import { useTransactionStore } from "@/features/transactions/store";
 import type { AnyDb } from "@/shared/db/client";
+import { enqueueSync } from "@/shared/db/enqueue-sync";
 import { generateId } from "@/shared/lib/generate-id";
 import { captureError } from "@/shared/lib/sentry";
 import {

--- a/apps/mobile/features/transactions/components/AmountEntry.tsx
+++ b/apps/mobile/features/transactions/components/AmountEntry.tsx
@@ -1,8 +1,15 @@
-import { useRef } from "react";
+import { useCallback, useRef, useState } from "react";
 import { Pressable, Text, TextInput, View } from "react-native";
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from "react-native-reanimated";
 import { useShallow } from "zustand/react/shallow";
 import { useThemeColor } from "@/shared/hooks/use-theme-color";
-import { amountToCents, cleanDigitInput, formatAmount } from "../lib/format-amount";
+import { cleanDigitInput, digitsToCents } from "../lib/format-amount";
 import { useTransactionStore } from "../store";
 import { TypeToggle } from "./TypeToggle";
 
@@ -19,24 +26,79 @@ export const AmountEntry = () => {
   const accentRed = useThemeColor("accentRed");
   const accentGreen = useThemeColor("accentGreen");
   const inputRef = useRef<TextInput>(null);
+  const [isFocused, setIsFocused] = useState(false);
+
+  const cursorOpacity = useSharedValue(0);
+
+  const startBlink = useCallback(() => {
+    cursorOpacity.value = withRepeat(
+      withSequence(
+        withTiming(1, { duration: 0 }),
+        withTiming(1, { duration: 530 }),
+        withTiming(0, { duration: 0 }),
+        withTiming(0, { duration: 530 })
+      ),
+      -1
+    );
+  }, [cursorOpacity]);
+
+  const stopBlink = useCallback(() => {
+    cursorOpacity.value = withTiming(0, { duration: 100 });
+  }, [cursorOpacity]);
+
+  const cursorStyle = useAnimatedStyle(() => ({
+    opacity: cursorOpacity.value,
+  }));
 
   const amountColor = type === "expense" ? accentRed : accentGreen;
-  const displayAmount = formatAmount(digits);
-  const canProceed = amountToCents(digits) > 0;
+  const hasDigits = digits.length > 0;
+  const displayAmount = hasDigits
+    ? `$${digits.replace(/\B(?=(\d{3})+(?!\d))/g, ",")}`
+    : isFocused
+      ? "$"
+      : "$0";
+  const canProceed = digitsToCents(digits) > 0;
   const buttonBg = canProceed ? accentGreen : "#CCCCCC";
 
   const handleChangeText = (text: string) => {
     setDigits(cleanDigitInput(text));
   };
 
+  const handleFocus = () => {
+    setIsFocused(true);
+    startBlink();
+  };
+
+  const handleBlur = () => {
+    setIsFocused(false);
+    stopBlink();
+  };
+
   return (
-    <View className="flex-1 items-center gap-4">
+    <View className="items-center gap-4">
       <TypeToggle value={type} onChange={setType} />
 
-      <Pressable onPress={() => inputRef.current?.focus()} className="py-4">
+      <Pressable
+        onPress={() => inputRef.current?.focus()}
+        className="flex-row items-center justify-center py-4"
+      >
         <Text className="font-poppins-bold text-[40px]" style={{ color: amountColor }}>
           {displayAmount}
         </Text>
+        {isFocused && (
+          <Animated.View
+            style={[
+              {
+                width: 2,
+                height: 36,
+                marginLeft: 2,
+                borderRadius: 1,
+                backgroundColor: amountColor,
+              },
+              cursorStyle,
+            ]}
+          />
+        )}
       </Pressable>
 
       {/* Hidden input to trigger native keyboard — user taps amount to focus */}
@@ -44,13 +106,15 @@ export const AmountEntry = () => {
         ref={inputRef}
         value={digits}
         onChangeText={handleChangeText}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
         keyboardType="number-pad"
         caretHidden
         autoCorrect={false}
         style={{ position: "absolute", opacity: 0, height: 0 }}
       />
 
-      <View className="w-full mt-auto">
+      <View className="w-full">
         <Pressable
           className="h-[52px] w-full items-center justify-center rounded-xl"
           style={{ backgroundColor: buttonBg }}

--- a/apps/mobile/features/transactions/components/AmountEntry.tsx
+++ b/apps/mobile/features/transactions/components/AmountEntry.tsx
@@ -9,7 +9,7 @@ import Animated, {
 } from "react-native-reanimated";
 import { useShallow } from "zustand/react/shallow";
 import { useThemeColor } from "@/shared/hooks/use-theme-color";
-import { cleanDigitInput, digitsToCents } from "../lib/format-amount";
+import { cleanDigitInput, digitsToCents, formatDollars } from "../lib/format-amount";
 import { useTransactionStore } from "../store";
 import { TypeToggle } from "./TypeToggle";
 
@@ -52,11 +52,7 @@ export const AmountEntry = () => {
 
   const amountColor = type === "expense" ? accentRed : accentGreen;
   const hasDigits = digits.length > 0;
-  const displayAmount = hasDigits
-    ? `$${digits.replace(/\B(?=(\d{3})+(?!\d))/g, ",")}`
-    : isFocused
-      ? "$"
-      : "$0";
+  const displayAmount = hasDigits ? formatDollars(digits) : isFocused ? "$" : "$0";
   const canProceed = digitsToCents(digits) > 0;
   const buttonBg = canProceed ? accentGreen : "#CCCCCC";
 

--- a/apps/mobile/features/transactions/components/CategoryPill.tsx
+++ b/apps/mobile/features/transactions/components/CategoryPill.tsx
@@ -1,5 +1,6 @@
 import * as Haptics from "expo-haptics";
-import { Pressable, Text } from "react-native";
+import { memo } from "react";
+import { Pressable } from "react-native";
 import { useThemeColor } from "@/shared/hooks/use-theme-color";
 import type { Category } from "../lib/categories";
 
@@ -9,9 +10,8 @@ type CategoryPillProps = {
   onPress: () => void;
 };
 
-export const CategoryPill = ({ category, isSelected, onPress }: CategoryPillProps) => {
+export const CategoryPill = memo(({ category, isSelected, onPress }: CategoryPillProps) => {
   const peachLight = useThemeColor("peachLight");
-  const primary = useThemeColor("primary");
   const Icon = category.icon;
 
   const handlePress = () => {
@@ -21,7 +21,7 @@ export const CategoryPill = ({ category, isSelected, onPress }: CategoryPillProp
 
   return (
     <Pressable
-      className="flex-1 h-9 flex-row items-center justify-center gap-1.5 rounded-full px-2"
+      className="h-8 w-8 items-center justify-center rounded-full"
       style={{
         backgroundColor: isSelected ? category.color : peachLight,
       }}
@@ -31,13 +31,8 @@ export const CategoryPill = ({ category, isSelected, onPress }: CategoryPillProp
       accessibilityLabel={category.label.en}
     >
       <Icon size={16} color={isSelected ? "#FFFFFF" : category.color} />
-      <Text
-        className="font-poppins-medium text-[13px]"
-        style={{ color: isSelected ? "#FFFFFF" : primary }}
-        numberOfLines={1}
-      >
-        {category.label.en}
-      </Text>
     </Pressable>
   );
-};
+});
+
+CategoryPill.displayName = "CategoryPill";

--- a/apps/mobile/features/transactions/components/TransactionDetails.tsx
+++ b/apps/mobile/features/transactions/components/TransactionDetails.tsx
@@ -5,8 +5,8 @@ import { Pressable, Text, TextInput, View } from "react-native";
 import { useShallow } from "zustand/react/shallow";
 import { useAsyncGuard } from "@/shared/hooks/use-async-guard";
 import { useThemeColor } from "@/shared/hooks/use-theme-color";
-import { CATEGORY_ROW_KEYS, CATEGORY_ROWS } from "../lib/categories";
-import { formatAmount } from "../lib/format-amount";
+import { CATEGORIES } from "../lib/categories";
+import { formatDollars } from "../lib/format-amount";
 import { getDateLabel } from "../lib/format-date";
 import { useTransactionStore } from "../store";
 import { CategoryPill } from "./CategoryPill";
@@ -47,7 +47,7 @@ export const TransactionDetails = () => {
   const borderSubtle = useThemeColor("borderSubtle");
 
   const amountColor = type === "expense" ? accentRed : accentGreen;
-  const displayAmount = formatAmount(digits);
+  const displayAmount = formatDollars(digits);
   const dateLabel = getDateLabel(date, new Date());
 
   const { isBusy: isSaving, run: guardedSave } = useAsyncGuard();
@@ -63,7 +63,7 @@ export const TransactionDetails = () => {
     });
 
   return (
-    <View className="flex-1 gap-4">
+    <View className="gap-4">
       {/* Amount display — tap to go back */}
       <Pressable
         className="flex-row items-center justify-center gap-2"
@@ -82,18 +82,16 @@ export const TransactionDetails = () => {
         <Text className="font-poppins-medium text-[13px]" style={{ color: secondary }}>
           Category
         </Text>
-        {CATEGORY_ROWS.map((row, i) => (
-          <View key={CATEGORY_ROW_KEYS[i]} className="flex-row gap-2">
-            {row.map((cat) => (
-              <CategoryPill
-                key={cat.id}
-                category={cat}
-                isSelected={categoryId === cat.id}
-                onPress={() => setCategoryId(cat.id)}
-              />
-            ))}
-          </View>
-        ))}
+        <View className="flex-row flex-wrap gap-2">
+          {CATEGORIES.map((cat) => (
+            <CategoryPill
+              key={cat.id}
+              category={cat}
+              isSelected={categoryId === cat.id}
+              onPress={() => setCategoryId(cat.id)}
+            />
+          ))}
+        </View>
       </View>
 
       {/* Description input */}
@@ -119,8 +117,8 @@ export const TransactionDetails = () => {
         </Text>
       </View>
 
-      {/* Save button pushed to bottom */}
-      <View className="mt-auto">
+      {/* Save button */}
+      <View>
         <Pressable
           className="h-[52px] w-full items-center justify-center rounded-xl"
           style={{ backgroundColor: accentGreen, opacity: isSaving ? 0.5 : 1 }}

--- a/apps/mobile/features/transactions/lib/build-transaction.ts
+++ b/apps/mobile/features/transactions/lib/build-transaction.ts
@@ -2,7 +2,8 @@ import { parseIsoDate, toIsoDate } from "@/shared/lib/format-date";
 import type { CreateTransactionInput, StoredTransaction, TransactionType } from "../schema";
 import { createTransactionSchema } from "../schema";
 import type { CategoryId } from "./categories";
-import { amountToCents } from "./format-amount";
+import { isValidCategoryId } from "./categories";
+import { digitsToCents } from "./format-amount";
 import type { TransactionRow } from "./repository";
 
 type BuildInput = {
@@ -19,7 +20,7 @@ export function buildTransaction(
   id: string,
   now: Date
 ): { success: true; transaction: StoredTransaction } | { success: false; error: string } {
-  const amountCents = amountToCents(input.digits);
+  const amountCents = digitsToCents(input.digits);
 
   const raw: CreateTransactionInput = {
     type: input.type,
@@ -44,7 +45,7 @@ export function buildTransaction(
       userId,
       type: result.data.type,
       amountCents: result.data.amountCents,
-      categoryId: result.data.categoryId as CategoryId,
+      categoryId: result.data.categoryId,
       description: result.data.description ?? "",
       date: result.data.date,
       createdAt: now,
@@ -60,7 +61,7 @@ export function toStoredTransaction(row: TransactionRow): StoredTransaction {
     userId: row.userId,
     type: row.type as TransactionType,
     amountCents: row.amountCents,
-    categoryId: row.categoryId as CategoryId,
+    categoryId: isValidCategoryId(row.categoryId) ? row.categoryId : "other",
     description: row.description ?? "",
     date: parseIsoDate(row.date),
     createdAt: new Date(row.createdAt),

--- a/apps/mobile/features/transactions/lib/categories.ts
+++ b/apps/mobile/features/transactions/lib/categories.ts
@@ -13,17 +13,7 @@ import {
 } from "lucide-react-native";
 import { Colors } from "@/shared/constants/theme";
 
-export type CategoryId =
-  | "food"
-  | "transport"
-  | "entertainment"
-  | "health"
-  | "education"
-  | "home"
-  | "clothing"
-  | "services"
-  | "transfer"
-  | "other";
+export type CategoryId = string;
 
 export type Category = {
   readonly id: CategoryId;
@@ -80,10 +70,16 @@ export const CATEGORIES: readonly Category[] = [
   { id: "other", label: { en: "Other", es: "Otro" }, icon: Ellipsis, color: Colors.chart.other },
 ] as const;
 
-export const CATEGORY_MAP = Object.fromEntries(CATEGORIES.map((c) => [c.id, c])) as Record<
-  CategoryId,
-  Category
->;
+export const CATEGORY_MAP: Record<string, Category> = Object.fromEntries(
+  CATEGORIES.map((c) => [c.id, c])
+);
+
+export const DEFAULT_CATEGORY_IDS: ReadonlySet<string> = new Set(CATEGORIES.map((c) => c.id));
+
+export const isValidCategoryId = (
+  id: string,
+  validIds: ReadonlySet<string> = DEFAULT_CATEGORY_IDS
+): id is CategoryId => validIds.has(id);
 
 export const CATEGORY_IDS = CATEGORIES.map((c) => c.id);
 

--- a/apps/mobile/features/transactions/lib/categories.ts
+++ b/apps/mobile/features/transactions/lib/categories.ts
@@ -70,7 +70,7 @@ export const CATEGORIES: readonly Category[] = [
   { id: "other", label: { en: "Other", es: "Otro" }, icon: Ellipsis, color: Colors.chart.other },
 ] as const;
 
-export const CATEGORY_MAP: Record<string, Category> = Object.fromEntries(
+export const CATEGORY_MAP: Record<string, Category | undefined> = Object.fromEntries(
   CATEGORIES.map((c) => [c.id, c])
 );
 

--- a/apps/mobile/features/transactions/lib/format-amount.ts
+++ b/apps/mobile/features/transactions/lib/format-amount.ts
@@ -1,8 +1,10 @@
+export const MAX_AMOUNT_DIGITS = 8;
+
 /**
- * Strips non-digit characters and caps at 8 digits for amount input.
+ * Strips non-digit characters and caps at MAX_AMOUNT_DIGITS digits for amount input.
  */
 export function cleanDigitInput(text: string): string {
-  return text.replace(/[^0-9]/g, "").slice(0, 8);
+  return text.replace(/[^0-9]/g, "").slice(0, MAX_AMOUNT_DIGITS);
 }
 
 /**
@@ -28,6 +30,27 @@ export function formatAmount(digits: string): string {
 export function amountToCents(formatted: string): number {
   const cleaned = formatted.replace(/[^0-9]/g, "");
   return Number.parseInt(cleaned, 10) || 0;
+}
+
+/**
+ * Formats raw digit input as a whole-dollar display string.
+ * "10000" → "$10,000", "" → "$0"
+ */
+export function formatDollars(digits: string): string {
+  const cleaned = digits.replace(/[^0-9]/g, "");
+  if (cleaned.length === 0) return "$0";
+  const dollars = cleaned.replace(/^0+/, "") || "0";
+  const withCommas = dollars.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  return `$${withCommas}`;
+}
+
+/**
+ * Converts raw digit input (whole dollars) to cents.
+ * "10000" → 1000000, "100" → 10000
+ */
+export function digitsToCents(digits: string): number {
+  const cleaned = digits.replace(/[^0-9]/g, "");
+  return (Number.parseInt(cleaned, 10) || 0) * 100;
 }
 
 /**

--- a/apps/mobile/features/transactions/lib/handle-numpad-press.ts
+++ b/apps/mobile/features/transactions/lib/handle-numpad-press.ts
@@ -1,0 +1,17 @@
+import { MAX_AMOUNT_DIGITS } from "./format-amount";
+
+export const handleNumpadPress = (currentDigits: string, key: string): string => {
+  if (key === "delete") {
+    return currentDigits.slice(0, -1);
+  }
+
+  if (key === "000") {
+    return (currentDigits + key).slice(0, MAX_AMOUNT_DIGITS);
+  }
+
+  if (/^[0-9]$/.test(key)) {
+    return currentDigits.length < MAX_AMOUNT_DIGITS ? currentDigits + key : currentDigits;
+  }
+
+  return currentDigits;
+};

--- a/apps/mobile/features/transactions/lib/repository.ts
+++ b/apps/mobile/features/transactions/lib/repository.ts
@@ -2,8 +2,7 @@ import { and, between, desc, eq, inArray, isNull, like, or, sql, sum } from "dri
 import type { AnyDb } from "@/shared/db/client";
 import { syncMeta, syncQueue, transactions } from "@/shared/db/schema";
 
-export type SyncOperation = "insert" | "update" | "delete";
-export type SyncTableName = "transactions";
+export type { SyncOperation, SyncQueueEntry, SyncTableName } from "@/shared/db/enqueue-sync";
 
 export type TransactionRow = typeof transactions.$inferInsert;
 
@@ -142,17 +141,7 @@ export function upsertTransaction(db: AnyDb, row: TransactionRow) {
     .run();
 }
 
-export type SyncQueueEntry = {
-  id: string;
-  tableName: SyncTableName;
-  rowId: string;
-  operation: SyncOperation;
-  createdAt: string;
-};
-
-export function enqueueSync(db: AnyDb, entry: SyncQueueEntry) {
-  db.insert(syncQueue).values(entry).run();
-}
+export { enqueueSync } from "@/shared/db/enqueue-sync";
 
 export function getQueuedSyncEntries(db: AnyDb) {
   return db.select().from(syncQueue).all();

--- a/apps/mobile/features/transactions/schema.ts
+++ b/apps/mobile/features/transactions/schema.ts
@@ -1,11 +1,12 @@
 import { z } from "zod";
-import { CATEGORIES, type CategoryId } from "./lib/categories";
+import { type CategoryId, isValidCategoryId } from "./lib/categories";
 
 export const transactionTypeSchema = z.enum(["expense", "income"]);
 export type TransactionType = z.infer<typeof transactionTypeSchema>;
 
-const categoryIds = CATEGORIES.map((c) => c.id) as [CategoryId, ...CategoryId[]];
-export const categoryIdSchema = z.enum(categoryIds);
+export const categoryIdSchema = z.string().refine(isValidCategoryId, {
+  message: "Invalid category ID",
+});
 
 export const createTransactionSchema = z.object({
   type: transactionTypeSchema,

--- a/apps/mobile/features/transactions/store.ts
+++ b/apps/mobile/features/transactions/store.ts
@@ -1,11 +1,11 @@
 import { create } from "zustand";
 import type { AnyDb } from "@/shared/db/client";
+import { enqueueSync } from "@/shared/db/enqueue-sync";
 import { toIsoDate } from "@/shared/lib/format-date";
 import { generateId } from "@/shared/lib/generate-id";
 import { buildTransaction, toStoredTransaction, toTransactionRow } from "./lib/build-transaction";
 import type { CategoryId } from "./lib/categories";
 import {
-  enqueueSync,
   getBalanceAggregate,
   getDailySpendingAggregate,
   getSpendingByCategoryAggregate,

--- a/apps/mobile/shared/components/FidyNumpad.tsx
+++ b/apps/mobile/shared/components/FidyNumpad.tsx
@@ -1,0 +1,90 @@
+import * as Haptics from "expo-haptics";
+import { Delete } from "lucide-react-native";
+import { memo } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { useThemeColor } from "@/shared/hooks/use-theme-color";
+
+type FidyNumpadProps = {
+  onKeyPress: (key: string) => void;
+};
+
+const ROWS = [
+  ["1", "2", "3"],
+  ["4", "5", "6"],
+  ["7", "8", "9"],
+  ["000", "0", "delete"],
+] as const;
+
+export const FidyNumpad = memo(({ onKeyPress }: FidyNumpadProps) => {
+  const keyBg = useThemeColor("numpadKey");
+  const specialKeyBg = useThemeColor("numpadSpecialKey");
+  const keyText = useThemeColor("primary");
+  const specialText = useThemeColor("peach");
+
+  const handlePress = (key: string) => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    onKeyPress(key);
+  };
+
+  return (
+    <View style={styles.container}>
+      {ROWS.map((row) => (
+        <View key={row.join("-")} style={styles.row}>
+          {row.map((key) => {
+            const isSpecial = key === "000" || key === "delete";
+            return (
+              <Pressable
+                key={key}
+                style={[styles.key, { backgroundColor: isSpecial ? specialKeyBg : keyBg }]}
+                onPress={() => handlePress(key)}
+                accessibilityRole="button"
+                accessibilityLabel={key === "delete" ? "Delete" : key}
+              >
+                {key === "delete" ? (
+                  <Delete size={24} color={specialText} />
+                ) : (
+                  <Text
+                    style={[
+                      styles.keyLabel,
+                      {
+                        color: isSpecial ? specialText : keyText,
+                        fontSize: key === "000" ? 18 : 22,
+                      },
+                    ]}
+                  >
+                    {key}
+                  </Text>
+                )}
+              </Pressable>
+            );
+          })}
+        </View>
+      ))}
+    </View>
+  );
+});
+
+FidyNumpad.displayName = "FidyNumpad";
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 6,
+    paddingTop: 8,
+    paddingBottom: 0,
+  },
+  row: {
+    flexDirection: "row",
+    gap: 6,
+    height: 42,
+  },
+  key: {
+    flex: 1,
+    borderRadius: 14,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  keyLabel: {
+    fontFamily: "Poppins_600SemiBold",
+    fontWeight: "600",
+  },
+});

--- a/apps/mobile/shared/constants/theme.ts
+++ b/apps/mobile/shared/constants/theme.ts
@@ -11,6 +11,9 @@ export const Colors = {
     accentGreenLight: "#D4EDBA",
     chartBg: "#F5E1C8",
     borderSubtle: "#EBEBEB",
+    peach: "#6D6D6D",
+    numpadKey: "#fdf3ee",
+    numpadSpecialKey: "#fae3d9",
     nav: "#1A1A1A",
   },
   dark: {
@@ -25,6 +28,9 @@ export const Colors = {
     accentGreenLight: "#1A2E12",
     chartBg: "#2A1F1A",
     borderSubtle: "#2C2C2E",
+    peach: "#E8A090",
+    numpadKey: "#2A1F1A",
+    numpadSpecialKey: "#3A2820",
     nav: "#1C1C1E",
   },
   chart: {

--- a/apps/mobile/shared/db/enqueue-sync.ts
+++ b/apps/mobile/shared/db/enqueue-sync.ts
@@ -1,0 +1,17 @@
+import type { AnyDb } from "@/shared/db/client";
+import { syncQueue } from "@/shared/db/schema";
+
+export type SyncOperation = "insert" | "update" | "delete";
+export type SyncTableName = "transactions";
+
+export type SyncQueueEntry = {
+  id: string;
+  tableName: SyncTableName;
+  rowId: string;
+  operation: SyncOperation;
+  createdAt: string;
+};
+
+export function enqueueSync(db: AnyDb, entry: SyncQueueEntry) {
+  db.insert(syncQueue).values(entry).run();
+}


### PR DESCRIPTION
- Extract enqueueSync to shared/db/enqueue-sync.ts
- Loosen CategoryId to string with runtime validation
- Add isValidCategoryId with TDD at pipeline boundaries
- Switch amount input to whole-dollar paradigm (digitsToCents)
- Replace two-step flow with single-step add-transaction sheet
- Build FidyNumpad custom numpad (reusable, brand-themed)
- Memo-wrap CategoryPill and FidyNumpad for render perf
- Codify 8 architectural decisions in CLAUDE.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the two-step add-transaction flow with a single-step sheet and a custom numpad for faster whole-dollar entry. Also extracted the sync queue helper to `@/shared/db/enqueue-sync` and hardened category validation and display across pipelines.

- **New Features**
  - Single-step add-transaction sheet with type toggle, amount display with blinking cursor and "$" placeholder, category grid, optional description, and date label; haptics on save; sheet detent set to 53%.
  - Whole-dollar input: `formatDollars`, `digitsToCents`, and `FidyNumpad` (includes 000 and delete) with `handleNumpadPress` and tests.
  - Memoized `CategoryPill` and `FidyNumpad` to reduce re-renders.

- **Refactors**
  - Moved `enqueueSync` to `@/shared/db/enqueue-sync`; updated stores, pipelines, and tests.
  - Loosened `CategoryId` to `string` with `isValidCategoryId` enforced across pipelines and before merchant-rule caching; fallback to `"other"` when invalid; typed `CATEGORY_MAP` values as `Category | undefined`.
  - Added 8 architectural decisions to `CLAUDE.md`.

<sup>Written for commit e06f6ec1813b7f42180f4b9c6bfdb92912a313b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

