### PR TITLE
feat(landing): wire up waitlist email collection

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,6 @@
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Supabase anon keys are public by design (role: anon, embedded in clients)"
+paths = ["apps/landing/waitlist.js"]

--- a/apps/landing/en/index.html
+++ b/apps/landing/en/index.html
@@ -33,8 +33,11 @@
       <section class="hero">
         <h1>Finally, total control of your money</h1>
         <p>Know exactly where your money goes. Without tracking a thing.</p>
-        <form class="waitlist-form">
-          <input type="email" placeholder="Your email address">
+        <form class="waitlist-form" data-locale="en"
+              data-msg-success="You're on the list! We'll let you know when Fidy is ready."
+              data-msg-duplicate="You're already on the list! We'll be in touch soon."
+              data-msg-error="Something went wrong, please try again.">
+          <input type="email" placeholder="Your email address" required>
           <button type="submit">Join the waitlist</button>
         </form>
       </section>
@@ -87,5 +90,6 @@
       <p>&copy; 2026 Fidy &middot; obarbozaa@gmail.com</p>
     </footer>
   </div>
+<script src="../waitlist.js"></script>
 </body>
 </html>

--- a/apps/landing/es/index.html
+++ b/apps/landing/es/index.html
@@ -33,8 +33,11 @@
       <section class="hero">
         <h1>Por fin, control total de tu dinero</h1>
         <p>Sabes exactamente en que gastas tu dinero. Sin anotar nada.</p>
-        <form class="waitlist-form">
-          <input type="email" placeholder="Tu correo electronico">
+        <form class="waitlist-form" data-locale="es"
+              data-msg-success="&iexcl;Ya est&aacute;s en la lista! Te avisaremos cuando Fidy est&eacute; listo."
+              data-msg-duplicate="&iexcl;Ya est&aacute;s en la lista! Pronto nos pondremos en contacto."
+              data-msg-error="Algo sali&oacute; mal, por favor intenta de nuevo.">
+          <input type="email" placeholder="Tu correo electronico" required>
           <button type="submit">Unirme a la lista</button>
         </form>
       </section>
@@ -87,5 +90,6 @@
       <p>&copy; 2026 Fidy &middot; obarbozaa@gmail.com</p>
     </footer>
   </div>
+<script src="../waitlist.js"></script>
 </body>
 </html>

--- a/apps/landing/styles.css
+++ b/apps/landing/styles.css
@@ -168,6 +168,18 @@ a {
   background: var(--color-accent-green-dark);
 }
 
+.waitlist-form button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.waitlist-success {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--color-accent-green-dark);
+  padding: 12px 0;
+}
+
 /* ── Features ── */
 .features {
   display: grid;

--- a/apps/landing/waitlist.js
+++ b/apps/landing/waitlist.js
@@ -1,0 +1,43 @@
+(() => {
+  var SupabaseUrl = "https://rwnewsjvphqqzhdunwll.supabase.co";
+  var AnonKey =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJ3bmV3c2p2cGhxcXpoZHVud2xsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzIzODA5MzIsImV4cCI6MjA4Nzk1NjkzMn0.wmPXL_GUjz_lO7ft4hLZQNwHtJSSgBMhGXALZubn9zE";
+
+  var form = document.querySelector(".waitlist-form");
+  var locale = form.getAttribute("data-locale");
+  var msgSuccess = form.getAttribute("data-msg-success");
+  var msgDuplicate = form.getAttribute("data-msg-duplicate");
+  var msgError = form.getAttribute("data-msg-error");
+
+  form.addEventListener("submit", (e) => {
+    e.preventDefault();
+    var email = form.querySelector('input[type="email"]').value.trim();
+    var btn = form.querySelector('button[type="submit"]');
+    btn.disabled = true;
+
+    fetch(`${SupabaseUrl}/rest/v1/waitlist_emails`, {
+      method: "POST",
+      headers: {
+        apikey: AnonKey,
+        Authorization: `Bearer ${AnonKey}`,
+        "Content-Type": "application/json",
+        Prefer: "return=minimal",
+      },
+      body: JSON.stringify({ email: email, locale: locale }),
+    })
+      .then((res) => {
+        if (res.status === 201) {
+          form.innerHTML = `<p class="waitlist-success">${msgSuccess}</p>`;
+        } else if (res.status === 409) {
+          form.innerHTML = `<p class="waitlist-success">${msgDuplicate}</p>`;
+        } else {
+          btn.disabled = false;
+          alert(msgError);
+        }
+      })
+      .catch(() => {
+        btn.disabled = false;
+        alert(msgError);
+      });
+  });
+})();

--- a/apps/mobile/supabase/migrations/0006_waitlist_emails.sql
+++ b/apps/mobile/supabase/migrations/0006_waitlist_emails.sql
@@ -1,22 +1,19 @@
 CREATE TABLE public.waitlist_emails (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  email TEXT NOT NULL UNIQUE,
+  email TEXT NOT NULL,
   locale TEXT NOT NULL CHECK (locale IN ('en', 'es')),
   created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
+-- Case-insensitive uniqueness so User@Example.com = user@example.com
+CREATE UNIQUE INDEX waitlist_emails_email_unique ON public.waitlist_emails (lower(email));
+
 ALTER TABLE public.waitlist_emails ENABLE ROW LEVEL SECURITY;
 
 -- Anon can only INSERT (landing page has no auth)
+-- Reading is done via Supabase dashboard (service_role bypasses RLS)
 CREATE POLICY "anon_insert_only"
   ON public.waitlist_emails
   FOR INSERT
   TO anon
   WITH CHECK (true);
-
--- Authenticated users (you) can read all emails
-CREATE POLICY "authenticated_read"
-  ON public.waitlist_emails
-  FOR SELECT
-  TO authenticated
-  USING (true);

--- a/apps/mobile/supabase/migrations/0006_waitlist_emails.sql
+++ b/apps/mobile/supabase/migrations/0006_waitlist_emails.sql
@@ -1,0 +1,22 @@
+CREATE TABLE public.waitlist_emails (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email TEXT NOT NULL UNIQUE,
+  locale TEXT NOT NULL CHECK (locale IN ('en', 'es')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.waitlist_emails ENABLE ROW LEVEL SECURITY;
+
+-- Anon can only INSERT (landing page has no auth)
+CREATE POLICY "anon_insert_only"
+  ON public.waitlist_emails
+  FOR INSERT
+  TO anon
+  WITH CHECK (true);
+
+-- Authenticated users (you) can read all emails
+CREATE POLICY "authenticated_read"
+  ON public.waitlist_emails
+  FOR SELECT
+  TO authenticated
+  USING (true);


### PR DESCRIPTION
- Supabase migration for waitlist_emails table with RLS
- Shared waitlist.js with data-attribute-driven i18n
- Inline success/duplicate/error handling on form submit
- Added required attribute + disabled/success CSS states

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Connects the landing pages to Supabase to collect waitlist emails with localized success/duplicate messages. Hardens the migration with a case-insensitive unique email index and anon insert-only RLS (no SELECT policy).

- **New Features**
  - Create `waitlist_emails` table with RLS (anon insert-only).
  - Add `waitlist.js` to POST email + locale via Supabase REST with inline success/duplicate/error.
  - Require email, disable submit during request, add success styles, and wire `en`/`es` with data-attribute i18n.
  - Add `.gitleaks.toml` to allowlist public Supabase `anon` key to avoid CI false positives.

- **Migration**
  - Run `apps/mobile/supabase/migrations/0006_waitlist_emails.sql`.
  - Add case-insensitive unique index on `lower(email)`.
  - Remove authenticated SELECT policy; reads via service role only.

<sup>Written for commit a6ee770e7baa709dd56c1811f9a08095ee577405. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

