### PR TITLE
ci(supabase): auto-apply migrations on merge

### DIFF
--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -1,0 +1,29 @@
+name: Deploy Migrations
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/mobile/supabase/migrations/**"
+
+jobs:
+  migrate:
+    name: Apply Migrations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 2.75.0
+
+      - name: Link project
+        run: supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+
+      - name: Apply migrations
+        run: supabase db push
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}


### PR DESCRIPTION
- Runs supabase db push when migrations change on main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI workflow to auto-apply Supabase migrations on pushes to `main` when `apps/mobile/supabase/migrations/**` changes, keeping the database schema in sync. It installs the Supabase CLI `2.75.0`, links the project using secrets, and runs `supabase db push`.

<sup>Written for commit 9b479d18b4fff73309b0711db9012f0def9e032d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

