### PR TITLE
chore(claude): optimize agent context + add i18n skill

### DIFF
--- a/.claude/skills/adding-i18n-strings/SKILL.md
+++ b/.claude/skills/adding-i18n-strings/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: adding-i18n-strings
+description: Use when adding user-facing strings to components or lib/ functions, implementing plurals or string interpolation, or formatting locale-aware dates in Fidy.
+---
+
+# i18n Guide (expo-localization + i18n-js)
+
+## Overview
+
+Spanish-first, English-fallback. All user-facing strings go through the i18n system — never hardcode strings in components or lib/.
+
+## Quick Reference
+
+| Need | Solution |
+|------|----------|
+| Translate in a component | `const { t, locale } = useTranslation()` from `shared/hooks/use-translation.ts` |
+| Category label | `getCategoryLabel(category, locale)` from `shared/i18n/locale-helpers.ts` |
+| Date with locale | `format(date, "MMM d", { locale: getDateFnsLocale(locale) })` |
+| Add new string | Both `es.ts` and `en.ts` — parity enforced by key-parity test |
+| Pure lib/ function with string output | Accept `t` as a param, never import i18n directly |
+| Key format | Dot-separated: `"section.key"` e.g. `"bills.addBill"`, `"common.save"` |
+
+## Patterns
+
+**Plurals:**
+```ts
+// shared/i18n/locales/es.ts
+transactions: { one: "1 transacción", other: "%{count} transacciones" }
+
+// Usage
+t("transactions", { count: n })
+```
+
+**Interpolation:**
+```ts
+// shared/i18n/locales/es.ts
+greeting: "Hola, %{name}"
+
+// Usage
+t("greeting", { name: "Orlando" })
+```
+
+**FREQUENCIES (calendar schema):**
+```ts
+// features/calendar/schema.ts — uses labelKey, not label
+FREQUENCIES.map(freq => t(freq.labelKey))
+```
+
+## Common Mistakes
+
+- Hardcoding a string in a component instead of calling `t()`
+- Adding a key to only one locale file — breaks the key-parity test
+- Importing i18n directly inside `lib/` — pure functions must accept `t` as a parameter
+- Calling `format(date, pattern)` without `{ locale: getDateFnsLocale(locale) }`

--- a/.claude/skills/committing-changes/SKILL.md
+++ b/.claude/skills/committing-changes/SKILL.md
@@ -40,7 +40,7 @@ bun run --cwd apps/mobile typecheck
 ## Step 5 — Tests
 
 ```bash
-cd apps/mobile && npx vitest run
+cd apps/mobile && bunx vitest run
 ```
 
 ## Step 6 — Commit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Tools already chosen:
 - Drizzle ORM
 - Zod
 - date-fns
-- expo-localization + i18n-js (i18n)
+- expo-localization + i18n-js (i18n) — see `adding-i18n-strings` skill for conventions
 
 ## Code Style: Functional Programming
 
@@ -56,15 +56,3 @@ Follow existing `getBalanceAggregate()` pattern in repository. Use SQL `GROUP BY
 
 ### Direct unit tests for pure functions
 New derivation/pure functions get direct unit tests with fixture data. File-source reading pattern (`readFileSync` test pattern) stays for navigation/layout tests only.
-
-### i18n: Spanish-first with English fallback
-All user-facing strings must use the i18n system in `shared/i18n/`. Default locale is `"es"` (Spanish), with `"en"` (English) as fallback. Key conventions:
-- Strings go in `shared/i18n/locales/es.ts` and `en.ts` — **both files must stay in parity** (enforced by key-parity test)
-- Components use `const { t, locale } = useTranslation()` from `shared/hooks/use-translation.ts`
-- Category labels: `getCategoryLabel(category, locale)` from `shared/i18n/locale-helpers.ts`
-- Date formatting: pass `{ locale: getDateFnsLocale(locale) }` to all date-fns `format()` calls
-- Pure functions that return user-facing strings accept `t` as a parameter (never import i18n directly in `lib/`)
-- Translation keys use dot-separated flat structure: `"section.key"` (e.g., `"bills.addBill"`, `"common.save"`)
-- Plurals: `t("key", { count: n })` with `{ one: "...", other: "..." }` in locale files
-- Interpolation: `t("key", { varName: value })` with `%{varName}` in locale strings
-- `FREQUENCIES` in calendar schema uses `labelKey` (translation key) instead of `label` (raw string)


### PR DESCRIPTION
- Remove i18n section from CLAUDE.md (moved to on-demand skill)
- Add adding-i18n-strings skill with Quick Reference, Patterns, Common Mistakes
- Fix npx → bunx in committing-changes skill
- Add skill pointer in CLAUDE.md tech stack entry

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves i18n guidance into a new on-demand skill to streamline agent context and makes a small command fix in the committing-changes skill.

- **New Features**
  - Added `adding-i18n-strings` skill with a Quick Reference, patterns (plurals, interpolation, calendar `FREQUENCIES`), and common mistakes for `expo-localization` + `i18n-js`.
  - Trimmed `CLAUDE.md` and linked to the new skill for i18n conventions.

- **Bug Fixes**
  - Updated committing-changes skill to use `bunx vitest run` instead of `npx`.

<sup>Written for commit 5d8bd00b4d2ae30f7ab7391ea43baf7b9bc31fdc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

