### PR TITLE
feat(mobile): search & filter transactions

### DIFF
--- a/apps/mobile/__tests__/search/date-presets.test.ts
+++ b/apps/mobile/__tests__/search/date-presets.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { DATE_PRESETS, getDatePresetRange } from "../../features/search/lib/date-presets";
+
+// Fixed date: Wednesday, March 18, 2026
+const TODAY = new Date(2026, 2, 18);
+
+describe("DATE_PRESETS", () => {
+  it("has four presets", () => {
+    expect(DATE_PRESETS).toHaveLength(4);
+  });
+
+  it("today preset returns same date for from and to", () => {
+    const preset = DATE_PRESETS.find((p) => p.key === "today");
+    const range = preset?.getRange(TODAY);
+    expect(range).toEqual({ from: "2026-03-18", to: "2026-03-18" });
+  });
+
+  it("thisWeek preset returns Monday to today", () => {
+    const preset = DATE_PRESETS.find((p) => p.key === "thisWeek");
+    const range = preset?.getRange(TODAY);
+    expect(range).toEqual({ from: "2026-03-16", to: "2026-03-18" });
+  });
+
+  it("thisMonth preset returns 1st of month to today", () => {
+    const preset = DATE_PRESETS.find((p) => p.key === "thisMonth");
+    const range = preset?.getRange(TODAY);
+    expect(range).toEqual({ from: "2026-03-01", to: "2026-03-18" });
+  });
+
+  it("lastMonth preset returns full previous month", () => {
+    const preset = DATE_PRESETS.find((p) => p.key === "lastMonth");
+    const range = preset?.getRange(TODAY);
+    expect(range).toEqual({ from: "2026-02-01", to: "2026-02-28" });
+  });
+
+  it("lastMonth handles month with 31 days", () => {
+    // April 15, 2026 — last month is March (31 days)
+    const april15 = new Date(2026, 3, 15);
+    const preset = DATE_PRESETS.find((p) => p.key === "lastMonth");
+    const range = preset?.getRange(april15);
+    expect(range).toEqual({ from: "2026-03-01", to: "2026-03-31" });
+  });
+
+  it("thisWeek on Monday returns Monday as both from and to", () => {
+    // Monday, March 16, 2026
+    const monday = new Date(2026, 2, 16);
+    const preset = DATE_PRESETS.find((p) => p.key === "thisWeek");
+    const range = preset?.getRange(monday);
+    expect(range).toEqual({ from: "2026-03-16", to: "2026-03-16" });
+  });
+});
+
+describe("getDatePresetRange", () => {
+  it("returns range for known key", () => {
+    const range = getDatePresetRange("today", TODAY);
+    expect(range).toEqual({ from: "2026-03-18", to: "2026-03-18" });
+  });
+
+  it("returns null for unknown key", () => {
+    expect(getDatePresetRange("nextYear", TODAY)).toBeNull();
+  });
+});

--- a/apps/mobile/__tests__/search/filters.test.ts
+++ b/apps/mobile/__tests__/search/filters.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { countActiveFilters, hasActiveFilters } from "../../features/search/lib/filters";
+import type { SearchFilters } from "../../features/search/lib/types";
+import { EMPTY_FILTERS } from "../../features/search/lib/types";
+
+const withFilters = (overrides: Partial<SearchFilters>): SearchFilters => ({
+  ...EMPTY_FILTERS,
+  ...overrides,
+});
+
+describe("hasActiveFilters", () => {
+  it("returns false for EMPTY_FILTERS", () => {
+    expect(hasActiveFilters(EMPTY_FILTERS)).toBe(false);
+  });
+
+  it("returns true when query is non-empty", () => {
+    expect(hasActiveFilters(withFilters({ query: "coffee" }))).toBe(true);
+  });
+
+  it("returns false for whitespace-only query", () => {
+    expect(hasActiveFilters(withFilters({ query: "   " }))).toBe(false);
+  });
+
+  it("returns true when categoryIds is non-empty", () => {
+    expect(hasActiveFilters(withFilters({ categoryIds: ["food"] }))).toBe(true);
+  });
+
+  it("returns false for empty categoryIds array", () => {
+    expect(hasActiveFilters(withFilters({ categoryIds: [] }))).toBe(false);
+  });
+
+  it("returns true when dateFrom is set", () => {
+    expect(hasActiveFilters(withFilters({ dateFrom: "2026-03-01" }))).toBe(true);
+  });
+
+  it("returns true when dateTo is set", () => {
+    expect(hasActiveFilters(withFilters({ dateTo: "2026-03-31" }))).toBe(true);
+  });
+
+  it("returns true when amountMinCents is set", () => {
+    expect(hasActiveFilters(withFilters({ amountMinCents: 100 }))).toBe(true);
+  });
+
+  it("returns true when amountMaxCents is set", () => {
+    expect(hasActiveFilters(withFilters({ amountMaxCents: 5000 }))).toBe(true);
+  });
+
+  it("returns true when type is expense", () => {
+    expect(hasActiveFilters(withFilters({ type: "expense" }))).toBe(true);
+  });
+
+  it("returns true when type is income", () => {
+    expect(hasActiveFilters(withFilters({ type: "income" }))).toBe(true);
+  });
+
+  it("returns false when type is all", () => {
+    expect(hasActiveFilters(withFilters({ type: "all" }))).toBe(false);
+  });
+});
+
+describe("countActiveFilters", () => {
+  it("returns 0 for EMPTY_FILTERS", () => {
+    expect(countActiveFilters(EMPTY_FILTERS)).toBe(0);
+  });
+
+  it("counts query as one dimension", () => {
+    expect(countActiveFilters(withFilters({ query: "test" }))).toBe(1);
+  });
+
+  it("counts categoryIds as one dimension", () => {
+    expect(countActiveFilters(withFilters({ categoryIds: ["food", "transport"] }))).toBe(1);
+  });
+
+  it("counts dateFrom and dateTo together as one dimension", () => {
+    expect(countActiveFilters(withFilters({ dateFrom: "2026-03-01", dateTo: "2026-03-31" }))).toBe(
+      1
+    );
+  });
+
+  it("counts dateFrom alone as one dimension", () => {
+    expect(countActiveFilters(withFilters({ dateFrom: "2026-03-01" }))).toBe(1);
+  });
+
+  it("counts amount range as one dimension", () => {
+    expect(countActiveFilters(withFilters({ amountMinCents: 100, amountMaxCents: 5000 }))).toBe(1);
+  });
+
+  it("counts type as one dimension", () => {
+    expect(countActiveFilters(withFilters({ type: "expense" }))).toBe(1);
+  });
+
+  it("counts all five dimensions correctly", () => {
+    const allActive = withFilters({
+      query: "coffee",
+      categoryIds: ["food"],
+      dateFrom: "2026-03-01",
+      amountMinCents: 100,
+      type: "expense",
+    });
+    expect(countActiveFilters(allActive)).toBe(5);
+  });
+
+  it("does not count whitespace-only query", () => {
+    expect(countActiveFilters(withFilters({ query: "  " }))).toBe(0);
+  });
+});

--- a/apps/mobile/__tests__/search/repository.test.ts
+++ b/apps/mobile/__tests__/search/repository.test.ts
@@ -1,0 +1,177 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: mock db needs flexible typing
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SearchFilters } from "../../features/search/lib/types";
+import { EMPTY_FILTERS } from "../../features/search/lib/types";
+
+const _mockRun = vi.fn();
+const mockAll = vi.fn().mockReturnValue([]);
+const mockGet = vi.fn().mockReturnValue(null);
+const mockSelect = vi.fn().mockReturnThis();
+const mockFrom = vi.fn().mockReturnThis();
+const mockWhere = vi.fn().mockReturnThis();
+const mockOrderBy = vi.fn().mockReturnThis();
+const mockLimit = vi.fn().mockReturnThis();
+const mockOffset = vi.fn().mockReturnThis();
+
+const mockDb = {
+  select: mockSelect,
+} as any;
+
+const withFilters = (overrides: Partial<SearchFilters>): SearchFilters => ({
+  ...EMPTY_FILTERS,
+  ...overrides,
+});
+
+describe("search repository", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAll.mockReturnValue([]);
+    mockGet.mockReturnValue({ count: 0, totalCents: 0 });
+    mockSelect.mockReturnValue({ from: mockFrom });
+    mockFrom.mockReturnValue({ where: mockWhere });
+    mockWhere.mockReturnValue({
+      orderBy: mockOrderBy,
+      get: mockGet,
+      all: mockAll,
+    });
+    mockOrderBy.mockReturnValue({ limit: mockLimit, all: mockAll });
+    mockLimit.mockReturnValue({ offset: mockOffset });
+    mockOffset.mockReturnValue({ all: mockAll });
+  });
+
+  it("searchTransactionsPaginated calls db with limit+1 for hasMore detection", async () => {
+    const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
+
+    searchTransactionsPaginated(mockDb, "user-1", EMPTY_FILTERS, 30, 0);
+
+    expect(mockSelect).toHaveBeenCalled();
+    expect(mockFrom).toHaveBeenCalled();
+    expect(mockWhere).toHaveBeenCalled();
+    expect(mockOrderBy).toHaveBeenCalled();
+    expect(mockLimit).toHaveBeenCalledWith(31);
+    expect(mockOffset).toHaveBeenCalledWith(0);
+    expect(mockAll).toHaveBeenCalled();
+  });
+
+  it("searchTransactionsPaginated passes correct offset", async () => {
+    const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
+
+    searchTransactionsPaginated(mockDb, "user-1", EMPTY_FILTERS, 30, 60);
+
+    expect(mockOffset).toHaveBeenCalledWith(60);
+  });
+
+  it("searchTransactionsAggregate returns count and totalCents", async () => {
+    mockGet.mockReturnValueOnce({ count: 5, totalCents: 15000 });
+
+    const { searchTransactionsAggregate } = await import("../../features/search/lib/repository");
+
+    const result = searchTransactionsAggregate(mockDb, "user-1", EMPTY_FILTERS);
+
+    expect(result).toEqual({ count: 5, totalCents: 15000 });
+  });
+
+  it("searchTransactionsAggregate returns zeros when no results", async () => {
+    mockGet.mockReturnValueOnce(null);
+
+    const { searchTransactionsAggregate } = await import("../../features/search/lib/repository");
+
+    const result = searchTransactionsAggregate(mockDb, "user-1", EMPTY_FILTERS);
+
+    expect(result).toEqual({ count: 0, totalCents: 0 });
+  });
+
+  it("applies query filter via LIKE when query is non-empty", async () => {
+    const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
+
+    searchTransactionsPaginated(mockDb, "user-1", withFilters({ query: "coffee" }), 30, 0);
+
+    expect(mockWhere).toHaveBeenCalled();
+  });
+
+  it("does not apply LIKE filter when query is empty", async () => {
+    const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
+
+    searchTransactionsPaginated(mockDb, "user-1", EMPTY_FILTERS, 30, 0);
+
+    expect(mockWhere).toHaveBeenCalled();
+  });
+
+  it("applies categoryIds filter via inArray", async () => {
+    const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
+
+    searchTransactionsPaginated(
+      mockDb,
+      "user-1",
+      withFilters({ categoryIds: ["food", "transport"] }),
+      30,
+      0
+    );
+
+    expect(mockWhere).toHaveBeenCalled();
+  });
+
+  it("applies date range filters", async () => {
+    const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
+
+    searchTransactionsPaginated(
+      mockDb,
+      "user-1",
+      withFilters({ dateFrom: "2026-03-01", dateTo: "2026-03-31" }),
+      30,
+      0
+    );
+
+    expect(mockWhere).toHaveBeenCalled();
+  });
+
+  it("applies amount range filters", async () => {
+    const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
+
+    searchTransactionsPaginated(
+      mockDb,
+      "user-1",
+      withFilters({ amountMinCents: 100, amountMaxCents: 5000 }),
+      30,
+      0
+    );
+
+    expect(mockWhere).toHaveBeenCalled();
+  });
+
+  it("applies type filter when not all", async () => {
+    const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
+
+    searchTransactionsPaginated(mockDb, "user-1", withFilters({ type: "expense" }), 30, 0);
+
+    expect(mockWhere).toHaveBeenCalled();
+  });
+
+  it("does not apply type filter when type is all", async () => {
+    const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
+
+    searchTransactionsPaginated(mockDb, "user-1", withFilters({ type: "all" }), 30, 0);
+
+    expect(mockWhere).toHaveBeenCalled();
+  });
+
+  it("returns rows from paginated query", async () => {
+    const mockRows = [
+      { id: "tx-1", description: "Coffee", amountCents: 500 },
+      { id: "tx-2", description: "Lunch", amountCents: 1500 },
+    ];
+    mockAll.mockReturnValueOnce(mockRows);
+
+    const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
+
+    const result = searchTransactionsPaginated(
+      mockDb,
+      "user-1",
+      withFilters({ query: "o" }),
+      30,
+      0
+    );
+
+    expect(result).toEqual(mockRows);
+  });
+});

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -25,6 +25,7 @@ import {
   useSmsDetection,
 } from "@/features/capture-sources";
 import { useEmailCapture, useEmailCaptureStore } from "@/features/email-capture";
+import { useSearchStore } from "@/features/search";
 import { useSync, useSyncConflictStore } from "@/features/sync";
 import { useTransactionStore } from "@/features/transactions";
 import { ErrorFallback } from "@/shared/components";
@@ -55,6 +56,7 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: string }) {
   useEffect(() => {
     if (migrationsReady) {
       useTransactionStore.getState().initStore(db, userId);
+      useSearchStore.getState().initStore(db, userId);
       useEmailCaptureStore.getState().initStore(db, userId);
       useCaptureSourcesStore.getState().initStore(db, userId);
       useChatStore.getState().initStore(db, userId);
@@ -163,6 +165,7 @@ function RootLayout() {
             name="day-detail"
             options={{ presentation: "formSheet", sheetAllowedDetents: "fitToContents" }}
           />
+          <Stack.Screen name="search" />
         </Stack>
         {db && userId && <AuthenticatedShell db={db} userId={userId} />}
       </SentryErrorBoundary>

--- a/apps/mobile/app/search.tsx
+++ b/apps/mobile/app/search.tsx
@@ -1,0 +1,3 @@
+import { SearchScreen } from "@/features/search";
+
+export default SearchScreen;

--- a/apps/mobile/features/dashboard/components/HomeScreen.tsx
+++ b/apps/mobile/features/dashboard/components/HomeScreen.tsx
@@ -11,6 +11,7 @@ import {
   getOutlookClientId,
   useEmailCaptureStore,
 } from "@/features/email-capture";
+import { SearchAction } from "@/features/search";
 import { SyncConflictBanner } from "@/features/sync";
 import {
   CATEGORY_MAP,
@@ -209,7 +210,12 @@ export const HomeScreen = () => {
   return (
     <ScreenLayout
       title="fidy"
-      rightActions={<BellAction />}
+      rightActions={
+        <View className="flex-row items-center" style={{ gap: 12 }}>
+          <SearchAction />
+          <BellAction />
+        </View>
+      }
       headerOverlay={
         <CompactBalanceBar
           balanceCents={balanceCents}

--- a/apps/mobile/features/search/components/AmountFilter.tsx
+++ b/apps/mobile/features/search/components/AmountFilter.tsx
@@ -1,0 +1,64 @@
+import { Text, TextInput, View } from "@/shared/components/rn";
+import { useThemeColor, useTranslation } from "@/shared/hooks";
+
+type AmountFilterProps = {
+  minDigits: string;
+  maxDigits: string;
+  onChangeMin: (digits: string) => void;
+  onChangeMax: (digits: string) => void;
+};
+
+export const AmountFilter = ({
+  minDigits,
+  maxDigits,
+  onChangeMin,
+  onChangeMax,
+}: AmountFilterProps) => {
+  const { t } = useTranslation();
+  const primary = useThemeColor("primary");
+  const secondary = useThemeColor("secondary");
+  const peachLight = useThemeColor("peachLight");
+
+  const handleMinChange = (text: string) => {
+    const cleaned = text.replace(/\D/g, "");
+    onChangeMin(cleaned);
+  };
+
+  const handleMaxChange = (text: string) => {
+    const cleaned = text.replace(/\D/g, "");
+    onChangeMax(cleaned);
+  };
+
+  return (
+    <View className="flex-row gap-3 p-4">
+      <View className="flex-1">
+        <Text className="font-poppins-medium text-caption text-secondary dark:text-secondary-dark mb-1">
+          {t("search.min")}
+        </Text>
+        <TextInput
+          className="h-10 rounded-lg px-3 font-poppins-medium text-body"
+          style={{ backgroundColor: peachLight, color: primary }}
+          value={minDigits}
+          onChangeText={handleMinChange}
+          keyboardType="number-pad"
+          placeholder="0"
+          placeholderTextColor={secondary}
+        />
+      </View>
+      <View className="flex-1">
+        <Text className="font-poppins-medium text-caption text-secondary dark:text-secondary-dark mb-1">
+          {t("search.max")}
+        </Text>
+        <TextInput
+          className="h-10 rounded-lg px-3 font-poppins-medium text-body"
+          style={{ backgroundColor: peachLight, color: primary }}
+          value={maxDigits}
+          onChangeText={handleMaxChange}
+          keyboardType="number-pad"
+          placeholder="0"
+          placeholderTextColor={secondary}
+        />
+      </View>
+    </View>
+  );
+};

--- a/apps/mobile/features/search/components/CategoryFilter.tsx
+++ b/apps/mobile/features/search/components/CategoryFilter.tsx
@@ -1,0 +1,69 @@
+import * as Haptics from "expo-haptics";
+import { memo } from "react";
+import { CATEGORIES, CATEGORY_ROWS, type Category } from "@/features/transactions";
+import { Check } from "@/shared/components/icons";
+import { Pressable, View } from "@/shared/components/rn";
+import { useThemeColor, useTranslation } from "@/shared/hooks";
+import { getCategoryLabel } from "@/shared/i18n";
+
+type CategoryFilterProps = {
+  selectedIds: readonly string[];
+  onToggle: (categoryId: string) => void;
+};
+
+const FilterPill = memo(
+  ({
+    category,
+    isSelected,
+    onPress,
+  }: {
+    category: Category;
+    isSelected: boolean;
+    onPress: () => void;
+  }) => {
+    const { locale } = useTranslation();
+    const peachLight = useThemeColor("peachLight");
+    const Icon = category.icon;
+
+    const handlePress = () => {
+      Haptics.selectionAsync();
+      onPress();
+    };
+
+    return (
+      <Pressable
+        className="h-8 w-8 items-center justify-center rounded-full"
+        style={{ backgroundColor: isSelected ? category.color : peachLight }}
+        onPress={handlePress}
+        accessibilityRole="button"
+        accessibilityState={{ selected: isSelected }}
+        accessibilityLabel={getCategoryLabel(category, locale)}
+      >
+        {isSelected ? (
+          <Check size={16} color="#FFFFFF" />
+        ) : (
+          <Icon size={16} color={category.color} />
+        )}
+      </Pressable>
+    );
+  }
+);
+
+FilterPill.displayName = "FilterPill";
+
+export const CategoryFilter = ({ selectedIds, onToggle }: CategoryFilterProps) => (
+  <View className="gap-3 p-4">
+    {CATEGORY_ROWS.map((row, rowIdx) => (
+      <View key={CATEGORIES[rowIdx * 5]?.id ?? rowIdx} className="flex-row justify-around">
+        {row.map((cat) => (
+          <FilterPill
+            key={cat.id}
+            category={cat}
+            isSelected={selectedIds.includes(cat.id)}
+            onPress={() => onToggle(cat.id)}
+          />
+        ))}
+      </View>
+    ))}
+  </View>
+);

--- a/apps/mobile/features/search/components/DateFilter.tsx
+++ b/apps/mobile/features/search/components/DateFilter.tsx
@@ -1,0 +1,96 @@
+import * as Haptics from "expo-haptics";
+import { Pressable, Text, TextInput, View } from "@/shared/components/rn";
+import { useThemeColor, useTranslation } from "@/shared/hooks";
+import { DATE_PRESETS, getDatePresetRange } from "../lib/date-presets";
+
+type DateFilterProps = {
+  dateFrom: string | null;
+  dateTo: string | null;
+  onChangeRange: (from: string | null, to: string | null) => void;
+};
+
+export const DateFilter = ({ dateFrom, dateTo, onChangeRange }: DateFilterProps) => {
+  const { t } = useTranslation();
+  const primary = useThemeColor("primary");
+  const secondary = useThemeColor("secondary");
+  const peachLight = useThemeColor("peachLight");
+  const accentGreen = useThemeColor("accentGreen");
+
+  const activePresetKey =
+    DATE_PRESETS.find((p) => {
+      const range = p.getRange(new Date());
+      return range.from === dateFrom && range.to === dateTo;
+    })?.key ?? null;
+
+  const handlePreset = (key: string) => {
+    Haptics.selectionAsync();
+    if (activePresetKey === key) {
+      onChangeRange(null, null);
+      return;
+    }
+    const range = getDatePresetRange(key, new Date());
+    if (range) {
+      onChangeRange(range.from, range.to);
+    }
+  };
+
+  return (
+    <View className="p-4 gap-3">
+      <View className="flex-row flex-wrap gap-2">
+        {DATE_PRESETS.map((preset) => {
+          const isActive = activePresetKey === preset.key;
+          return (
+            <Pressable
+              key={preset.key}
+              className="h-8 rounded-full px-4 items-center justify-center"
+              style={{
+                backgroundColor: isActive ? accentGreen : peachLight,
+              }}
+              onPress={() => handlePreset(preset.key)}
+            >
+              <Text
+                className="font-poppins-medium text-caption"
+                style={{ color: isActive ? "#FFFFFF" : primary }}
+              >
+                {t(preset.labelKey)}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+      <Text className="font-poppins-medium text-caption text-secondary dark:text-secondary-dark">
+        {t("search.customRange")}
+      </Text>
+      <View className="flex-row gap-3">
+        <View className="flex-1">
+          <Text className="font-poppins-medium text-caption text-secondary dark:text-secondary-dark mb-1">
+            {t("search.from")}
+          </Text>
+          <TextInput
+            className="h-10 rounded-lg px-3 font-poppins-medium text-body"
+            style={{ backgroundColor: peachLight, color: primary }}
+            value={dateFrom ?? ""}
+            onChangeText={(text) => onChangeRange(text.length > 0 ? text : null, dateTo)}
+            placeholder="YYYY-MM-DD"
+            placeholderTextColor={secondary}
+            autoCapitalize="none"
+          />
+        </View>
+        <View className="flex-1">
+          <Text className="font-poppins-medium text-caption text-secondary dark:text-secondary-dark mb-1">
+            {t("search.to")}
+          </Text>
+          <TextInput
+            className="h-10 rounded-lg px-3 font-poppins-medium text-body"
+            style={{ backgroundColor: peachLight, color: primary }}
+            value={dateTo ?? ""}
+            onChangeText={(text) => onChangeRange(dateFrom, text.length > 0 ? text : null)}
+            placeholder="YYYY-MM-DD"
+            placeholderTextColor={secondary}
+            autoCapitalize="none"
+          />
+        </View>
+      </View>
+    </View>
+  );
+};

--- a/apps/mobile/features/search/components/FilterChipRow.tsx
+++ b/apps/mobile/features/search/components/FilterChipRow.tsx
@@ -1,0 +1,107 @@
+import * as Haptics from "expo-haptics";
+import { Pressable, ScrollView, Text } from "@/shared/components/rn";
+import { useThemeColor, useTranslation } from "@/shared/hooks";
+import { hasActiveFilters } from "../lib/filters";
+import type { SearchFilters } from "../lib/types";
+
+export type FilterKey = "category" | "dateRange" | "amount" | "type";
+
+type FilterChipRowProps = {
+  filters: SearchFilters;
+  activePanel: FilterKey | null;
+  onTogglePanel: (key: FilterKey) => void;
+  onClearAll: () => void;
+};
+
+type ChipConfig = {
+  readonly key: FilterKey;
+  readonly labelKey: string;
+  readonly isActive: (filters: SearchFilters) => boolean;
+};
+
+const CHIPS: readonly ChipConfig[] = [
+  {
+    key: "category",
+    labelKey: "search.category",
+    isActive: (f) => f.categoryIds.length > 0,
+  },
+  {
+    key: "dateRange",
+    labelKey: "search.dateRange",
+    isActive: (f) => f.dateFrom !== null || f.dateTo !== null,
+  },
+  {
+    key: "amount",
+    labelKey: "search.amount",
+    isActive: (f) => f.amountMinCents !== null || f.amountMaxCents !== null,
+  },
+  {
+    key: "type",
+    labelKey: "search.type",
+    isActive: (f) => f.type !== "all",
+  },
+];
+
+export const FilterChipRow = ({
+  filters,
+  activePanel,
+  onTogglePanel,
+  onClearAll,
+}: FilterChipRowProps) => {
+  const { t } = useTranslation();
+  const primary = useThemeColor("primary");
+  const peachLight = useThemeColor("peachLight");
+  const accentGreen = useThemeColor("accentGreen");
+  const accentRed = useThemeColor("accentRed");
+
+  const showClear = hasActiveFilters(filters);
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={{ paddingHorizontal: 16, gap: 8 }}
+      className="pt-2 pb-8"
+    >
+      {CHIPS.map((chip) => {
+        const isActive = chip.isActive(filters);
+        const isOpen = activePanel === chip.key;
+        return (
+          <Pressable
+            key={chip.key}
+            className="h-8 rounded-full px-4 items-center justify-center"
+            style={{
+              backgroundColor: isActive ? accentGreen : peachLight,
+              borderWidth: isOpen ? 1.5 : 0,
+              borderColor: isOpen ? primary : "transparent",
+            }}
+            onPress={() => {
+              Haptics.selectionAsync();
+              onTogglePanel(chip.key);
+            }}
+          >
+            <Text
+              className="font-poppins-medium text-caption"
+              style={{ color: isActive ? "#FFFFFF" : primary }}
+            >
+              {t(chip.labelKey)}
+            </Text>
+          </Pressable>
+        );
+      })}
+      {showClear && (
+        <Pressable
+          className="h-8 rounded-full px-4 items-center justify-center"
+          onPress={() => {
+            Haptics.selectionAsync();
+            onClearAll();
+          }}
+        >
+          <Text className="font-poppins-medium text-caption" style={{ color: accentRed }}>
+            {t("search.clearAll")}
+          </Text>
+        </Pressable>
+      )}
+    </ScrollView>
+  );
+};

--- a/apps/mobile/features/search/components/ResultsSummary.tsx
+++ b/apps/mobile/features/search/components/ResultsSummary.tsx
@@ -1,0 +1,23 @@
+import { formatCents } from "@/features/transactions";
+import { Text, View } from "@/shared/components/rn";
+import { useTranslation } from "@/shared/hooks";
+import type { SearchSummary } from "../lib/types";
+
+type ResultsSummaryProps = {
+  summary: SearchSummary;
+};
+
+export const ResultsSummary = ({ summary }: ResultsSummaryProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <View className="px-4 py-2">
+      <Text className="font-poppins-medium text-caption text-secondary dark:text-secondary-dark">
+        {t("search.resultsSummary", {
+          count: summary.count,
+          total: formatCents(summary.totalCents),
+        })}
+      </Text>
+    </View>
+  );
+};

--- a/apps/mobile/features/search/components/SearchAction.tsx
+++ b/apps/mobile/features/search/components/SearchAction.tsx
@@ -1,0 +1,15 @@
+import { useRouter } from "expo-router";
+import { Search } from "@/shared/components/icons";
+import { Pressable } from "@/shared/components/rn";
+import { useThemeColor } from "@/shared/hooks";
+
+export const SearchAction = () => {
+  const { push } = useRouter();
+  const iconColor = useThemeColor("primary");
+
+  return (
+    <Pressable onPress={() => push("/search" as never)} hitSlop={12}>
+      <Search size={22} color={iconColor} />
+    </Pressable>
+  );
+};

--- a/apps/mobile/features/search/components/SearchEmptyState.tsx
+++ b/apps/mobile/features/search/components/SearchEmptyState.tsx
@@ -1,0 +1,24 @@
+import { Pressable, Text, View } from "@/shared/components/rn";
+import { useThemeColor, useTranslation } from "@/shared/hooks";
+
+type SearchEmptyStateProps = {
+  onClearFilters: () => void;
+};
+
+export const SearchEmptyState = ({ onClearFilters }: SearchEmptyStateProps) => {
+  const { t } = useTranslation();
+  const accentGreen = useThemeColor("accentGreen");
+
+  return (
+    <View className="items-center justify-center px-8 pt-16">
+      <Text className="font-poppins-semibold text-body text-secondary dark:text-secondary-dark">
+        {t("search.noResults")}
+      </Text>
+      <Pressable onPress={onClearFilters} className="mt-4">
+        <Text className="font-poppins-semibold text-body" style={{ color: accentGreen }}>
+          {t("search.clearFilters")}
+        </Text>
+      </Pressable>
+    </View>
+  );
+};

--- a/apps/mobile/features/search/components/SearchScreen.tsx
+++ b/apps/mobile/features/search/components/SearchScreen.tsx
@@ -133,6 +133,7 @@ export const SearchScreen = () => {
   );
 
   const handleClearAll = useCallback(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
     setInputText("");
     setMinDigits("");
     setMaxDigits("");

--- a/apps/mobile/features/search/components/SearchScreen.tsx
+++ b/apps/mobile/features/search/components/SearchScreen.tsx
@@ -1,0 +1,294 @@
+import { useRouter } from "expo-router";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  CATEGORY_MAP,
+  formatSignedAmount,
+  makeDateLabel,
+  type StoredTransaction,
+} from "@/features/transactions";
+import { ScreenLayout, TAB_BAR_CLEARANCE, TransactionRow } from "@/shared/components";
+import { Ellipsis } from "@/shared/components/icons";
+import { FlatList, Text, TextInput, View } from "@/shared/components/rn";
+import { useThemeColor, useTranslation } from "@/shared/hooks";
+import { getCategoryLabel, getDateFnsLocale } from "@/shared/i18n";
+import { toIsoDate } from "@/shared/lib";
+import { amountDigitsToCents } from "../lib/amount-utils";
+import { hasActiveFilters } from "../lib/filters";
+import type { SearchFilters } from "../lib/types";
+import { useSearchStore } from "../store";
+import { AmountFilter } from "./AmountFilter";
+import { CategoryFilter } from "./CategoryFilter";
+import { DateFilter } from "./DateFilter";
+import { FilterChipRow, type FilterKey } from "./FilterChipRow";
+import { ResultsSummary } from "./ResultsSummary";
+import { SearchEmptyState } from "./SearchEmptyState";
+import { TypeFilter } from "./TypeFilter";
+
+const DEBOUNCE_MS = 300;
+
+const SearchTransactionItem = memo(function SearchTransactionItem({
+  tx,
+  showDateHeader,
+}: {
+  tx: StoredTransaction;
+  showDateHeader: boolean;
+}) {
+  const { t, locale } = useTranslation();
+  const category = CATEGORY_MAP[tx.categoryId];
+  return (
+    <View>
+      {showDateHeader && (
+        <View className="px-4 pt-4 pb-1">
+          <Text className="font-poppins-semibold text-caption text-secondary dark:text-secondary-dark">
+            {makeDateLabel(
+              tx.date,
+              t("dates.today"),
+              t("dates.yesterday"),
+              getDateFnsLocale(locale)
+            )}
+          </Text>
+        </View>
+      )}
+      <View className="px-4">
+        <TransactionRow
+          icon={category?.icon ?? Ellipsis}
+          name={tx.description || t("common.unknown")}
+          amount={formatSignedAmount(tx.amountCents, tx.type)}
+          category={category ? getCategoryLabel(category, locale) : t("common.other")}
+          isPositive={tx.type === "income"}
+        />
+      </View>
+    </View>
+  );
+});
+
+export const SearchScreen = () => {
+  const { back } = useRouter();
+  const { t } = useTranslation();
+  const primary = useThemeColor("primary");
+  const secondary = useThemeColor("secondary");
+  const peachLight = useThemeColor("peachLight");
+
+  const filters = useSearchStore((s) => s.filters);
+  const results = useSearchStore((s) => s.results);
+  const hasMore = useSearchStore((s) => s.hasMore);
+  const summary = useSearchStore((s) => s.summary);
+  const setQuery = useSearchStore((s) => s.setQuery);
+  const setFilters = useSearchStore((s) => s.setFilters);
+  const clearFilters = useSearchStore((s) => s.clearFilters);
+  const loadNextPage = useSearchStore((s) => s.loadNextPage);
+  const executeSearch = useSearchStore((s) => s.executeSearch);
+  const reset = useSearchStore((s) => s.reset);
+
+  const [inputText, setInputText] = useState("");
+  const [activePanel, setActivePanel] = useState<FilterKey | null>(null);
+  const [minDigits, setMinDigits] = useState("");
+  const [maxDigits, setMaxDigits] = useState("");
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inputRef = useRef<TextInput>(null);
+
+  // Auto-focus on mount
+  useEffect(() => {
+    const timer = setTimeout(() => inputRef.current?.focus(), 100);
+    return () => clearTimeout(timer);
+  }, []);
+
+  // Run initial search on mount
+  useEffect(() => {
+    executeSearch();
+  }, [executeSearch]);
+
+  // Clean up on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      reset();
+    };
+  }, [reset]);
+
+  const handleTextChange = useCallback(
+    (text: string) => {
+      setInputText(text);
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        setQuery(text);
+      }, DEBOUNCE_MS);
+    },
+    [setQuery]
+  );
+
+  const handleTogglePanel = useCallback((key: FilterKey) => {
+    setActivePanel((prev) => (prev === key ? null : key));
+  }, []);
+
+  const handleCategoryToggle = useCallback(
+    (categoryId: string) => {
+      const current = useSearchStore.getState().filters.categoryIds;
+      const next = current.includes(categoryId)
+        ? current.filter((id) => id !== categoryId)
+        : [...current, categoryId];
+      setFilters({ categoryIds: next });
+    },
+    [setFilters]
+  );
+
+  const handleClearAll = useCallback(() => {
+    setInputText("");
+    setMinDigits("");
+    setMaxDigits("");
+    setActivePanel(null);
+    clearFilters();
+  }, [clearFilters]);
+
+  const handleMinChange = useCallback(
+    (digits: string) => {
+      setMinDigits(digits);
+      setFilters({ amountMinCents: amountDigitsToCents(digits) });
+    },
+    [setFilters]
+  );
+
+  const handleMaxChange = useCallback(
+    (digits: string) => {
+      setMaxDigits(digits);
+      setFilters({ amountMaxCents: amountDigitsToCents(digits) });
+    },
+    [setFilters]
+  );
+
+  const handleDateRangeChange = useCallback(
+    (from: string | null, to: string | null) => setFilters({ dateFrom: from, dateTo: to }),
+    [setFilters]
+  );
+
+  const handleTypeChange = useCallback(
+    (type: SearchFilters["type"]) => setFilters({ type }),
+    [setFilters]
+  );
+
+  const handleEndReached = useCallback(() => {
+    if (hasMore) loadNextPage();
+  }, [hasMore, loadNextPage]);
+
+  const dateBreaks = useMemo(() => {
+    const breaks = new Set<string>();
+    let lastDateKey: string | null = null;
+    results.forEach((tx) => {
+      const dateKey = toIsoDate(tx.date);
+      if (dateKey !== lastDateKey) {
+        breaks.add(tx.id);
+        lastDateKey = dateKey;
+      }
+    });
+    return breaks;
+  }, [results]);
+
+  const renderItem = useCallback(
+    ({ item }: { item: StoredTransaction }) => (
+      <SearchTransactionItem tx={item} showDateHeader={dateBreaks.has(item.id)} />
+    ),
+    [dateBreaks]
+  );
+
+  const keyExtractor = useCallback((item: StoredTransaction) => item.id, []);
+
+  const showSummary = summary && hasActiveFilters(filters);
+
+  const filterPanel = useMemo(() => {
+    if (activePanel === "category") {
+      return <CategoryFilter selectedIds={filters.categoryIds} onToggle={handleCategoryToggle} />;
+    }
+    if (activePanel === "dateRange") {
+      return (
+        <DateFilter
+          dateFrom={filters.dateFrom}
+          dateTo={filters.dateTo}
+          onChangeRange={handleDateRangeChange}
+        />
+      );
+    }
+    if (activePanel === "amount") {
+      return (
+        <AmountFilter
+          minDigits={minDigits}
+          maxDigits={maxDigits}
+          onChangeMin={handleMinChange}
+          onChangeMax={handleMaxChange}
+        />
+      );
+    }
+    if (activePanel === "type") {
+      return (
+        <View className="p-4 items-center">
+          <TypeFilter value={filters.type} onChange={handleTypeChange} />
+        </View>
+      );
+    }
+    return null;
+  }, [
+    activePanel,
+    filters.categoryIds,
+    filters.dateFrom,
+    filters.dateTo,
+    filters.type,
+    minDigits,
+    maxDigits,
+    handleCategoryToggle,
+    handleDateRangeChange,
+    handleMinChange,
+    handleMaxChange,
+    handleTypeChange,
+  ]);
+
+  return (
+    <ScreenLayout title={t("search.title")} variant="sub" onBack={back}>
+      <View className="px-4 pb-2">
+        <TextInput
+          ref={inputRef}
+          className="h-10 rounded-lg px-3 font-poppins-medium text-body"
+          style={{ backgroundColor: peachLight, color: primary }}
+          value={inputText}
+          onChangeText={handleTextChange}
+          placeholder={t("search.placeholder")}
+          placeholderTextColor={secondary}
+          autoCapitalize="none"
+          autoCorrect={false}
+          returnKeyType="search"
+        />
+      </View>
+      <FlatList
+        data={results}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        onEndReached={handleEndReached}
+        onEndReachedThreshold={0.3}
+        ListHeaderComponent={
+          <>
+            <FilterChipRow
+              filters={filters}
+              activePanel={activePanel}
+              onTogglePanel={handleTogglePanel}
+              onClearAll={handleClearAll}
+            />
+            {filterPanel && (
+              <View
+                className="mx-4 mb-3 rounded-xl bg-card dark:bg-card-dark"
+                style={{ overflow: "hidden" }}
+              >
+                {filterPanel}
+              </View>
+            )}
+            {showSummary && <ResultsSummary summary={summary} />}
+          </>
+        }
+        ListEmptyComponent={
+          hasActiveFilters(filters) ? (
+            <SearchEmptyState onClearFilters={handleClearAll} />
+          ) : undefined
+        }
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ paddingBottom: TAB_BAR_CLEARANCE }}
+      />
+    </ScreenLayout>
+  );
+};

--- a/apps/mobile/features/search/components/TypeFilter.tsx
+++ b/apps/mobile/features/search/components/TypeFilter.tsx
@@ -1,0 +1,74 @@
+import * as Haptics from "expo-haptics";
+import { Pressable, Text, View } from "@/shared/components/rn";
+import { useThemeColor, useTranslation } from "@/shared/hooks";
+
+type FilterType = "all" | "expense" | "income";
+
+type TypeFilterProps = {
+  value: FilterType;
+  onChange: (type: FilterType) => void;
+};
+
+export const TypeFilter = ({ value, onChange }: TypeFilterProps) => {
+  const { t } = useTranslation();
+  const accentRed = useThemeColor("accentRed");
+  const accentGreen = useThemeColor("accentGreen");
+  const secondary = useThemeColor("secondary");
+
+  const handlePress = (type: FilterType) => {
+    if (type !== value) {
+      Haptics.selectionAsync();
+      onChange(type);
+    }
+  };
+
+  const getStyle = (type: FilterType) => {
+    if (type !== value) return undefined;
+    if (type === "expense") return { backgroundColor: accentRed };
+    if (type === "income") return { backgroundColor: accentGreen };
+    return { backgroundColor: secondary };
+  };
+
+  const getColor = (type: FilterType) => {
+    if (type === value) return "#FFFFFF";
+    return secondary;
+  };
+
+  return (
+    <View className="h-10 flex-row rounded-full bg-peach-light p-[3px] dark:bg-peach-light-dark">
+      <Pressable
+        className="flex-1 items-center justify-center rounded-full"
+        style={getStyle("all")}
+        onPress={() => handlePress("all")}
+        accessibilityRole="button"
+        accessibilityState={{ selected: value === "all" }}
+      >
+        <Text className="font-poppins-semibold text-[14px]" style={{ color: getColor("all") }}>
+          {t("search.allTypes")}
+        </Text>
+      </Pressable>
+      <Pressable
+        className="flex-1 items-center justify-center rounded-full"
+        style={getStyle("expense")}
+        onPress={() => handlePress("expense")}
+        accessibilityRole="button"
+        accessibilityState={{ selected: value === "expense" }}
+      >
+        <Text className="font-poppins-semibold text-[14px]" style={{ color: getColor("expense") }}>
+          {t("transactions.expense")}
+        </Text>
+      </Pressable>
+      <Pressable
+        className="flex-1 items-center justify-center rounded-full"
+        style={getStyle("income")}
+        onPress={() => handlePress("income")}
+        accessibilityRole="button"
+        accessibilityState={{ selected: value === "income" }}
+      >
+        <Text className="font-poppins-semibold text-[14px]" style={{ color: getColor("income") }}>
+          {t("transactions.income")}
+        </Text>
+      </Pressable>
+    </View>
+  );
+};

--- a/apps/mobile/features/search/index.ts
+++ b/apps/mobile/features/search/index.ts
@@ -1,0 +1,6 @@
+export { SearchAction } from "./components/SearchAction";
+export { SearchScreen } from "./components/SearchScreen";
+export { countActiveFilters, hasActiveFilters } from "./lib/filters";
+export type { SearchFilters, SearchSummary } from "./lib/types";
+export { EMPTY_FILTERS } from "./lib/types";
+export { useSearchStore } from "./store";

--- a/apps/mobile/features/search/lib/amount-utils.ts
+++ b/apps/mobile/features/search/lib/amount-utils.ts
@@ -1,0 +1,7 @@
+import { digitsToCents } from "@/features/transactions";
+
+/** Convert display digits to cents for filter, or null if empty. */
+export function amountDigitsToCents(digits: string): number | null {
+  if (digits.length === 0) return null;
+  return digitsToCents(digits);
+}

--- a/apps/mobile/features/search/lib/date-presets.ts
+++ b/apps/mobile/features/search/lib/date-presets.ts
@@ -1,0 +1,57 @@
+import { toIsoDate } from "@/shared/lib";
+
+/** Monday-based start of week (avoids date-fns import in test-mocked environment). */
+function mondayOfWeek(date: Date): Date {
+  const day = date.getDay();
+  // Sunday=0 → offset 6, Monday=1 → 0, Tuesday=2 → 1, etc.
+  const offset = day === 0 ? 6 : day - 1;
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() - offset);
+}
+
+export type DatePreset = {
+  readonly key: string;
+  readonly labelKey: string;
+  readonly getRange: (today: Date) => { from: string; to: string };
+};
+
+export const DATE_PRESETS: readonly DatePreset[] = [
+  {
+    key: "today",
+    labelKey: "search.today",
+    getRange: (today) => {
+      const iso = toIsoDate(today);
+      return { from: iso, to: iso };
+    },
+  },
+  {
+    key: "thisWeek",
+    labelKey: "search.thisWeek",
+    getRange: (today) => ({
+      from: toIsoDate(mondayOfWeek(today)),
+      to: toIsoDate(today),
+    }),
+  },
+  {
+    key: "thisMonth",
+    labelKey: "search.thisMonth",
+    getRange: (today) => ({
+      from: toIsoDate(new Date(today.getFullYear(), today.getMonth(), 1)),
+      to: toIsoDate(today),
+    }),
+  },
+  {
+    key: "lastMonth",
+    labelKey: "search.lastMonth",
+    getRange: (today) => {
+      const firstOfCurrent = new Date(today.getFullYear(), today.getMonth(), 1);
+      const lastOfPrev = new Date(firstOfCurrent.getTime() - 1);
+      const firstOfPrev = new Date(lastOfPrev.getFullYear(), lastOfPrev.getMonth(), 1);
+      return { from: toIsoDate(firstOfPrev), to: toIsoDate(lastOfPrev) };
+    },
+  },
+];
+
+export function getDatePresetRange(key: string, today: Date): { from: string; to: string } | null {
+  const preset = DATE_PRESETS.find((p) => p.key === key);
+  return preset ? preset.getRange(today) : null;
+}

--- a/apps/mobile/features/search/lib/filters.ts
+++ b/apps/mobile/features/search/lib/filters.ts
@@ -1,0 +1,24 @@
+import type { SearchFilters } from "./types";
+
+export function hasActiveFilters(filters: SearchFilters): boolean {
+  return (
+    filters.query.trim().length > 0 ||
+    filters.categoryIds.length > 0 ||
+    filters.dateFrom !== null ||
+    filters.dateTo !== null ||
+    filters.amountMinCents !== null ||
+    filters.amountMaxCents !== null ||
+    filters.type !== "all"
+  );
+}
+
+export function countActiveFilters(filters: SearchFilters): number {
+  const dimensions = [
+    filters.query.trim().length > 0,
+    filters.categoryIds.length > 0,
+    filters.dateFrom !== null || filters.dateTo !== null,
+    filters.amountMinCents !== null || filters.amountMaxCents !== null,
+    filters.type !== "all",
+  ];
+  return dimensions.filter(Boolean).length;
+}

--- a/apps/mobile/features/search/lib/repository.ts
+++ b/apps/mobile/features/search/lib/repository.ts
@@ -1,0 +1,60 @@
+import { and, count, desc, eq, gte, inArray, isNull, like, lte, sql } from "drizzle-orm";
+import type { AnyDb } from "@/shared/db";
+import { transactions } from "@/shared/db";
+import type { SearchFilters, SearchSummary } from "./types";
+
+function buildSearchConditions(userId: string, filters: SearchFilters) {
+  const trimmedQuery = filters.query.trim();
+  return [
+    eq(transactions.userId, userId),
+    isNull(transactions.deletedAt),
+    ...(trimmedQuery.length > 0 ? [like(transactions.description, `%${trimmedQuery}%`)] : []),
+    ...(filters.categoryIds.length > 0
+      ? [inArray(transactions.categoryId, [...filters.categoryIds])]
+      : []),
+    ...(filters.dateFrom !== null ? [gte(transactions.date, filters.dateFrom)] : []),
+    ...(filters.dateTo !== null ? [lte(transactions.date, filters.dateTo)] : []),
+    ...(filters.amountMinCents !== null
+      ? [gte(transactions.amountCents, filters.amountMinCents)]
+      : []),
+    ...(filters.amountMaxCents !== null
+      ? [lte(transactions.amountCents, filters.amountMaxCents)]
+      : []),
+    ...(filters.type !== "all" ? [eq(transactions.type, filters.type)] : []),
+  ];
+}
+
+export function searchTransactionsPaginated(
+  db: AnyDb,
+  userId: string,
+  filters: SearchFilters,
+  limit: number,
+  offset: number
+) {
+  const conditions = buildSearchConditions(userId, filters);
+  return db
+    .select()
+    .from(transactions)
+    .where(and(...conditions))
+    .orderBy(desc(transactions.date), desc(transactions.createdAt))
+    .limit(limit + 1)
+    .offset(offset)
+    .all();
+}
+
+export function searchTransactionsAggregate(
+  db: AnyDb,
+  userId: string,
+  filters: SearchFilters
+): SearchSummary {
+  const conditions = buildSearchConditions(userId, filters);
+  const row = db
+    .select({
+      count: count(),
+      totalCents: sql<number>`COALESCE(SUM(${transactions.amountCents}), 0)`,
+    })
+    .from(transactions)
+    .where(and(...conditions))
+    .get();
+  return { count: row?.count ?? 0, totalCents: row?.totalCents ?? 0 };
+}

--- a/apps/mobile/features/search/lib/types.ts
+++ b/apps/mobile/features/search/lib/types.ts
@@ -1,0 +1,24 @@
+export type SearchFilters = {
+  readonly query: string;
+  readonly categoryIds: readonly string[];
+  readonly dateFrom: string | null; // ISO "YYYY-MM-DD"
+  readonly dateTo: string | null;
+  readonly amountMinCents: number | null;
+  readonly amountMaxCents: number | null;
+  readonly type: "all" | "expense" | "income";
+};
+
+export type SearchSummary = {
+  readonly count: number;
+  readonly totalCents: number;
+};
+
+export const EMPTY_FILTERS: SearchFilters = {
+  query: "",
+  categoryIds: [],
+  dateFrom: null,
+  dateTo: null,
+  amountMinCents: null,
+  amountMaxCents: null,
+  type: "all",
+};

--- a/apps/mobile/features/search/store.ts
+++ b/apps/mobile/features/search/store.ts
@@ -1,0 +1,107 @@
+import { create } from "zustand";
+import type { StoredTransaction } from "@/features/transactions";
+import { toStoredTransaction } from "@/features/transactions";
+import type { AnyDb } from "@/shared/db";
+import { searchTransactionsAggregate, searchTransactionsPaginated } from "./lib/repository";
+import type { SearchFilters, SearchSummary } from "./lib/types";
+import { EMPTY_FILTERS } from "./lib/types";
+
+const PAGE_SIZE = 30;
+
+let dbRef: AnyDb | null = null;
+let userIdRef: string | null = null;
+
+type SearchState = {
+  filters: SearchFilters;
+  results: StoredTransaction[];
+  offset: number;
+  hasMore: boolean;
+  summary: SearchSummary | null;
+  isSearching: boolean;
+};
+
+type SearchActions = {
+  initStore: (db: AnyDb, userId: string) => void;
+  setQuery: (query: string) => void;
+  setFilters: (partial: Partial<SearchFilters>) => void;
+  clearFilters: () => void;
+  executeSearch: () => void;
+  loadNextPage: () => void;
+  reset: () => void;
+};
+
+const INITIAL_STATE: SearchState = {
+  filters: EMPTY_FILTERS,
+  results: [],
+  offset: 0,
+  hasMore: false,
+  summary: null,
+  isSearching: false,
+};
+
+export const useSearchStore = create<SearchState & SearchActions>((set, get) => ({
+  ...INITIAL_STATE,
+
+  initStore: (db, userId) => {
+    dbRef = db;
+    userIdRef = userId;
+  },
+
+  setQuery: (query) => {
+    set((s) => ({ filters: { ...s.filters, query } }));
+    get().executeSearch();
+  },
+
+  setFilters: (partial) => {
+    set((s) => ({ filters: { ...s.filters, ...partial } }));
+    get().executeSearch();
+  },
+
+  clearFilters: () => {
+    set({ filters: EMPTY_FILTERS });
+    get().executeSearch();
+  },
+
+  executeSearch: () => {
+    if (!dbRef || !userIdRef) return;
+    set({ isSearching: true });
+    try {
+      const { filters } = get();
+      const rows = searchTransactionsPaginated(dbRef, userIdRef, filters, PAGE_SIZE, 0);
+      const hasMore = rows.length > PAGE_SIZE;
+      const pageData = hasMore ? rows.slice(0, PAGE_SIZE) : rows;
+      const summary = searchTransactionsAggregate(dbRef, userIdRef, filters);
+      set({
+        results: pageData.map(toStoredTransaction),
+        offset: pageData.length,
+        hasMore,
+        summary,
+        isSearching: false,
+      });
+    } catch {
+      set({ isSearching: false });
+    }
+  },
+
+  loadNextPage: () => {
+    if (!dbRef || !userIdRef) return;
+    const { hasMore, offset, filters } = get();
+    if (!hasMore) return;
+    try {
+      const rows = searchTransactionsPaginated(dbRef, userIdRef, filters, PAGE_SIZE, offset);
+      const moreAvailable = rows.length > PAGE_SIZE;
+      const pageData = moreAvailable ? rows.slice(0, PAGE_SIZE) : rows;
+      set((s) => ({
+        results: [...s.results, ...pageData.map(toStoredTransaction)],
+        offset: s.offset + pageData.length,
+        hasMore: moreAvailable,
+      }));
+    } catch {
+      // Keep existing state
+    }
+  },
+
+  reset: () => {
+    set(INITIAL_STATE);
+  },
+}));

--- a/apps/mobile/features/transactions/index.ts
+++ b/apps/mobile/features/transactions/index.ts
@@ -2,7 +2,13 @@ export { CategoryPill } from "./components/CategoryPill";
 export { TypeToggle } from "./components/TypeToggle";
 export { toStoredTransaction, toTransactionRow } from "./lib/build-transaction";
 export type { Category, CategoryId } from "./lib/categories";
-export { CATEGORIES, CATEGORY_IDS, CATEGORY_MAP, isValidCategoryId } from "./lib/categories";
+export {
+  CATEGORIES,
+  CATEGORY_IDS,
+  CATEGORY_MAP,
+  CATEGORY_ROWS,
+  isValidCategoryId,
+} from "./lib/categories";
 export {
   centsToDisplay,
   digitsToCents,

--- a/apps/mobile/shared/i18n/locales/en.ts
+++ b/apps/mobile/shared/i18n/locales/en.ts
@@ -258,7 +258,7 @@ const en = {
     clearAll: "Clear all",
     noResults: "No transactions match",
     clearFilters: "Clear filters",
-    resultsSummary: "%{count} transactions . %{total} total",
+    resultsSummary: "%{count} transactions · %{total} total",
     today: "Today",
     thisWeek: "This week",
     thisMonth: "This month",

--- a/apps/mobile/shared/i18n/locales/en.ts
+++ b/apps/mobile/shared/i18n/locales/en.ts
@@ -247,6 +247,30 @@ const en = {
     ],
   },
 
+  // Search
+  search: {
+    title: "Search",
+    placeholder: "Search transactions...",
+    category: "Category",
+    dateRange: "Date range",
+    amount: "Amount",
+    type: "Type",
+    clearAll: "Clear all",
+    noResults: "No transactions match",
+    clearFilters: "Clear filters",
+    resultsSummary: "%{count} transactions . %{total} total",
+    today: "Today",
+    thisWeek: "This week",
+    thisMonth: "This month",
+    lastMonth: "Last month",
+    customRange: "Custom range",
+    from: "From",
+    to: "To",
+    min: "Min",
+    max: "Max",
+    allTypes: "All",
+  },
+
   // Detected Transactions Banner
   detectedTransactions: {
     count: {

--- a/apps/mobile/shared/i18n/locales/es.ts
+++ b/apps/mobile/shared/i18n/locales/es.ts
@@ -259,7 +259,7 @@ const es = {
     clearAll: "Limpiar todo",
     noResults: "No hay transacciones",
     clearFilters: "Limpiar filtros",
-    resultsSummary: "%{count} transacciones . %{total} total",
+    resultsSummary: "%{count} transacciones · %{total} total",
     today: "Hoy",
     thisWeek: "Esta semana",
     thisMonth: "Este mes",

--- a/apps/mobile/shared/i18n/locales/es.ts
+++ b/apps/mobile/shared/i18n/locales/es.ts
@@ -248,6 +248,30 @@ const es = {
     ],
   },
 
+  // Search
+  search: {
+    title: "Buscar",
+    placeholder: "Buscar transacciones...",
+    category: "Categoría",
+    dateRange: "Rango de fechas",
+    amount: "Monto",
+    type: "Tipo",
+    clearAll: "Limpiar todo",
+    noResults: "No hay transacciones",
+    clearFilters: "Limpiar filtros",
+    resultsSummary: "%{count} transacciones . %{total} total",
+    today: "Hoy",
+    thisWeek: "Esta semana",
+    thisMonth: "Este mes",
+    lastMonth: "Mes pasado",
+    customRange: "Rango personalizado",
+    from: "Desde",
+    to: "Hasta",
+    min: "Mín",
+    max: "Máx",
+    allTypes: "Todos",
+  },
+
   // Detected Transactions Banner (already Spanish)
   detectedTransactions: {
     count: {


### PR DESCRIPTION
- Full-screen search with text, category, date, amount, type filters
- TDD pure functions + repository with 42 new tests
- i18n strings in both EN and ES

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a full-screen transaction search on mobile with debounced text, category/date/amount/type filters, and infinite scroll. Also fixes a stale debounce when clearing filters and updates the results summary separator.

- **New Features**
  - New Search screen (`/search`) opened from the home header via `SearchAction`.
  - Debounced query input (300ms) with filter chips and panels:
    - Category pills, Date presets (Today/This week/This month/Last month) + custom range, Amount min/max, Type (All/Expense/Income).
  - Paginated results with infinite scroll (limit+1 for hasMore), date headers, and a results summary (count + total).
  - New `useSearchStore` (Zustand) with `searchTransactionsPaginated` and `searchTransactionsAggregate`; store is initialized in `_layout`.
  - 42 tests covering date presets, filter counting, and repository behavior.
  - New i18n strings for EN and ES.

- **Bug Fixes**
  - Cancel pending debounce timer when clearing filters to prevent stale queries.
  - Results summary uses a middle dot (·) separator in EN/ES strings.

<sup>Written for commit fb5223126d4d267fe26840dbbd6ce9e5c91ff010. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

