### PR TITLE
fix(mobile): gate capture hooks behind initial sync

### DIFF
--- a/apps/mobile/__tests__/sync/syncEngine.test.ts
+++ b/apps/mobile/__tests__/sync/syncEngine.test.ts
@@ -296,20 +296,22 @@ describe("syncEngine", () => {
       const mockSupabase = createMockSupabase({ data: [], error: null });
 
       const { fullSync } = await import("@/features/sync/services/syncEngine");
-      await fullSync(mockDb, mockSupabase, "user-1");
+      const result = await fullSync(mockDb, mockSupabase, "user-1");
 
+      expect(result).toBe(true);
       expect(mockGetSyncMeta).toHaveBeenCalled();
       expect(mockGetQueuedSyncEntries).toHaveBeenCalled();
       expect(mockSetSyncMeta).toHaveBeenCalled();
     });
 
-    it("skips push when pull fails", async () => {
+    it("skips push when pull fails and returns false", async () => {
       mockGetSyncMeta.mockResolvedValueOnce(null);
       const mockSupabase = createMockSupabase({ data: null, error: { message: "fail" } });
 
       const { fullSync } = await import("@/features/sync/services/syncEngine");
-      await fullSync(mockDb, mockSupabase, "user-1");
+      const result = await fullSync(mockDb, mockSupabase, "user-1");
 
+      expect(result).toBe(false);
       expect(mockGetSyncMeta).toHaveBeenCalled();
       expect(mockGetQueuedSyncEntries).not.toHaveBeenCalled();
     });

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -95,11 +95,12 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: string }) {
     }
   }, [migrationsReady, db, userId]);
 
-  useSync(migrationsReady ? db : null, userId);
-  useEmailCapture(migrationsReady ? db : null, userId);
-  useNotificationCapture(migrationsReady ? db : null, userId);
-  useApplePayCapture(migrationsReady ? db : null, userId);
-  useSmsDetection(migrationsReady ? db : null, userId);
+  const initialSyncDone = useSync(migrationsReady ? db : null, userId);
+  const captureDb = initialSyncDone ? db : null;
+  useEmailCapture(captureDb, userId);
+  useNotificationCapture(captureDb, userId);
+  useApplePayCapture(captureDb, userId);
+  useSmsDetection(captureDb, userId);
 
   useEffect(() => {
     if (migrationsReady || migrationsError) {

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -96,7 +96,7 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: string }) {
   }, [migrationsReady, db, userId]);
 
   const initialSyncDone = useSync(migrationsReady ? db : null, userId);
-  const captureDb = initialSyncDone ? db : null;
+  const captureDb = initialSyncDone && migrationsReady ? db : null;
   useEmailCapture(captureDb, userId);
   useNotificationCapture(captureDb, userId);
   useApplePayCapture(captureDb, userId);

--- a/apps/mobile/features/sync/hooks/useSync.ts
+++ b/apps/mobile/features/sync/hooks/useSync.ts
@@ -28,20 +28,17 @@ export function useSync(db: AnyDb | null, userId: string | null): boolean {
     const runSync = async () => {
       if (isSyncing.current) return;
       const online = await isOnline();
-      if (!online) {
-        markInitialDone();
-        return;
-      }
+      if (!online) return;
       isSyncing.current = true;
       try {
         await fullSync(db, supabase, userId);
         await useTransactionStore.getState().refresh();
         useSyncConflictStore.getState().loadConflicts();
+        markInitialDone();
       } catch (error) {
         console.warn("[sync] background sync failed:", error);
       } finally {
         isSyncing.current = false;
-        markInitialDone();
       }
     };
 

--- a/apps/mobile/features/sync/hooks/useSync.ts
+++ b/apps/mobile/features/sync/hooks/useSync.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTransactionStore } from "@/features/transactions";
 import { AppState } from "@/shared/components/rn";
 import type { AnyDb } from "@/shared/db";
@@ -7,18 +7,31 @@ import { isOnline, onConnectivityChange } from "../services/networkMonitor";
 import { fullSync } from "../services/syncEngine";
 import { useSyncConflictStore } from "../store";
 
-export function useSync(db: AnyDb | null, userId: string | null) {
+export function useSync(db: AnyDb | null, userId: string | null): boolean {
   const isSyncing = useRef(false);
+  const [initialSyncDone, setInitialSyncDone] = useState(false);
 
   useEffect(() => {
     if (!db || !userId) return;
 
+    setInitialSyncDone(false);
     const supabase = getSupabase();
+    const hasCompletedInitialRun = { current: false };
+
+    const markInitialDone = () => {
+      if (!hasCompletedInitialRun.current) {
+        hasCompletedInitialRun.current = true;
+        setInitialSyncDone(true);
+      }
+    };
 
     const runSync = async () => {
       if (isSyncing.current) return;
       const online = await isOnline();
-      if (!online) return;
+      if (!online) {
+        markInitialDone();
+        return;
+      }
       isSyncing.current = true;
       try {
         await fullSync(db, supabase, userId);
@@ -28,6 +41,7 @@ export function useSync(db: AnyDb | null, userId: string | null) {
         console.warn("[sync] background sync failed:", error);
       } finally {
         isSyncing.current = false;
+        markInitialDone();
       }
     };
 
@@ -46,4 +60,6 @@ export function useSync(db: AnyDb | null, userId: string | null) {
       unsubscribeNet();
     };
   }, [db, userId]);
+
+  return initialSyncDone;
 }

--- a/apps/mobile/features/sync/hooks/useSync.ts
+++ b/apps/mobile/features/sync/hooks/useSync.ts
@@ -31,10 +31,10 @@ export function useSync(db: AnyDb | null, userId: string | null): boolean {
       if (!online) return;
       isSyncing.current = true;
       try {
-        await fullSync(db, supabase, userId);
+        const pullOk = await fullSync(db, supabase, userId);
         await useTransactionStore.getState().refresh();
         useSyncConflictStore.getState().loadConflicts();
-        markInitialDone();
+        if (pullOk) markInitialDone();
       } catch (error) {
         console.warn("[sync] background sync failed:", error);
       } finally {

--- a/apps/mobile/features/sync/services/syncEngine.ts
+++ b/apps/mobile/features/sync/services/syncEngine.ts
@@ -178,9 +178,14 @@ export async function syncPull(
   return true;
 }
 
-export async function fullSync(db: AnyDb, supabase: SupabaseClient, userId: string): Promise<void> {
+export async function fullSync(
+  db: AnyDb,
+  supabase: SupabaseClient,
+  userId: string
+): Promise<boolean> {
   const pullOk = await syncPull(db, supabase, userId);
   if (pullOk) {
     await syncPush(db, supabase, userId);
   }
+  return pullOk;
 }


### PR DESCRIPTION
- useSync returns initialSyncDone boolean
- capture hooks receive null db until first sync completes
- prevents duplicate transactions on reinstall

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate capture hooks behind the first successful pull to prevent duplicate transactions after reinstall. `useSync` now returns `initialSyncDone`; captures wait for it and migrations to finish.

- **Bug Fixes**
  - `fullSync` returns a `pullOk` boolean; `useSync` marks `initialSyncDone` only when the pull succeeds (push may still run).
  - In the mobile layout, email/notification/Apple Pay/SMS captures receive `null` until both `migrationsReady` and `initialSyncDone`, then switch to the real db.
  - Updated sync tests to assert the `fullSync` return value and confirm push is skipped when pull fails.

<sup>Written for commit d82f03e85790cfa0bc2a25bff0dc7ed5eda0c865. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

