### PR TITLE
feat(mobile): silent email sync on home screen

### DIFF
--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -635,51 +635,53 @@ describe("useEmailCaptureStore", () => {
     it("auto-clears phase after 2s timeout when phase is complete", async () => {
       vi.useFakeTimers();
 
-      useEmailCaptureStore.setState({
-        accounts: [
+      try {
+        useEmailCaptureStore.setState({
+          accounts: [
+            {
+              id: "ea-1",
+              userId: mockUserId,
+              provider: "gmail",
+              email: "test@gmail.com",
+              lastFetchedAt: null,
+              createdAt: "2026-03-05T10:00:00Z",
+            },
+          ],
+        });
+
+        mockAdapter.fetchEmails.mockResolvedValueOnce([
           {
-            id: "ea-1",
-            userId: mockUserId,
+            externalId: "ext-1",
+            from: "b@b.com",
+            subject: "A",
+            body: "b",
+            receivedAt: "2026-03-10T00:00:00Z",
             provider: "gmail",
-            email: "test@gmail.com",
-            lastFetchedAt: null,
-            createdAt: "2026-03-05T10:00:00Z",
           },
-        ],
-      });
+        ]);
+        vi.mocked(processEmails).mockResolvedValueOnce({
+          filtered: 0,
+          skippedDuplicate: 0,
+          skippedCrossSource: 0,
+          saved: 1,
+          failed: 0,
+          needsReview: 0,
+        });
+        vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
+        vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
 
-      mockAdapter.fetchEmails.mockResolvedValueOnce([
-        {
-          externalId: "ext-1",
-          from: "b@b.com",
-          subject: "A",
-          body: "b",
-          receivedAt: "2026-03-10T00:00:00Z",
-          provider: "gmail",
-        },
-      ]);
-      vi.mocked(processEmails).mockResolvedValueOnce({
-        filtered: 0,
-        skippedDuplicate: 0,
-        skippedCrossSource: 0,
-        saved: 1,
-        failed: 0,
-        needsReview: 0,
-      });
-      vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
-      vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
+        await useEmailCaptureStore.getState().fetchAndProcess("g", "o");
 
-      await useEmailCaptureStore.getState().fetchAndProcess("g", "o");
+        // Phase should be "complete" immediately after
+        expect(useEmailCaptureStore.getState().phase).toBe("complete");
 
-      // Phase should be "complete" immediately after
-      expect(useEmailCaptureStore.getState().phase).toBe("complete");
-
-      // After 2s, phase should auto-clear
-      vi.advanceTimersByTime(2000);
-      expect(useEmailCaptureStore.getState().phase).toBeNull();
-      expect(useEmailCaptureStore.getState().progress).toBeNull();
-
-      vi.useRealTimers();
+        // After 2s, phase should auto-clear
+        vi.advanceTimersByTime(2000);
+        expect(useEmailCaptureStore.getState().phase).toBeNull();
+        expect(useEmailCaptureStore.getState().progress).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("preserves complete phase immediately after fetchAndProcess", async () => {

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -632,7 +632,57 @@ describe("useEmailCaptureStore", () => {
       expect(updatedAccount.lastFetchedAt).not.toBeNull();
     });
 
-    it("does not clear phase when phase is complete", async () => {
+    it("auto-clears phase after 2s timeout when phase is complete", async () => {
+      vi.useFakeTimers();
+
+      useEmailCaptureStore.setState({
+        accounts: [
+          {
+            id: "ea-1",
+            userId: mockUserId,
+            provider: "gmail",
+            email: "test@gmail.com",
+            lastFetchedAt: null,
+            createdAt: "2026-03-05T10:00:00Z",
+          },
+        ],
+      });
+
+      mockAdapter.fetchEmails.mockResolvedValueOnce([
+        {
+          externalId: "ext-1",
+          from: "b@b.com",
+          subject: "A",
+          body: "b",
+          receivedAt: "2026-03-10T00:00:00Z",
+          provider: "gmail",
+        },
+      ]);
+      vi.mocked(processEmails).mockResolvedValueOnce({
+        filtered: 0,
+        skippedDuplicate: 0,
+        skippedCrossSource: 0,
+        saved: 1,
+        failed: 0,
+        needsReview: 0,
+      });
+      vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
+      vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
+
+      await useEmailCaptureStore.getState().fetchAndProcess("g", "o");
+
+      // Phase should be "complete" immediately after
+      expect(useEmailCaptureStore.getState().phase).toBe("complete");
+
+      // After 2s, phase should auto-clear
+      vi.advanceTimersByTime(2000);
+      expect(useEmailCaptureStore.getState().phase).toBeNull();
+      expect(useEmailCaptureStore.getState().progress).toBeNull();
+
+      vi.useRealTimers();
+    });
+
+    it("preserves complete phase immediately after fetchAndProcess", async () => {
       useEmailCaptureStore.setState({
         accounts: [
           {
@@ -777,20 +827,6 @@ describe("useEmailCaptureStore", () => {
       expect(useEmailCaptureStore.getState().phase).toBeNull();
       expect(useEmailCaptureStore.getState().progress).toBeNull();
       expect(useEmailCaptureStore.getState().isFetching).toBe(false);
-    });
-  });
-
-  describe("clearProgress", () => {
-    it("resets phase and progress to null", () => {
-      useEmailCaptureStore.setState({
-        phase: "complete",
-        progress: { total: 10, completed: 10, saved: 5, failed: 0, needsReview: 2 },
-      });
-
-      useEmailCaptureStore.getState().clearProgress();
-
-      expect(useEmailCaptureStore.getState().phase).toBeNull();
-      expect(useEmailCaptureStore.getState().progress).toBeNull();
     });
   });
 

--- a/apps/mobile/app/(tabs)/connected-accounts.tsx
+++ b/apps/mobile/app/(tabs)/connected-accounts.tsx
@@ -1,5 +1,13 @@
 import { formatDistanceToNow } from "date-fns";
 import { useRouter } from "expo-router";
+import { useEffect } from "react";
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from "react-native-reanimated";
 import { ApplePaySetupCard, NotificationSetupCard } from "@/features/capture-sources";
 import {
   getGmailClientId,
@@ -16,10 +24,9 @@ export default function ConnectedAccountsScreen() {
   const { navigate } = useRouter();
   const { t } = useTranslation();
   const accounts = useEmailCaptureStore((s) => s.accounts);
+  const isFetching = useEmailCaptureStore((s) => s.isFetching);
   const connectEmail = useEmailCaptureStore((s) => s.connectEmail);
   const disconnectEmail = useEmailCaptureStore((s) => s.disconnectEmail);
-  const greenColor = useThemeColor("accentGreen");
-  const tertiaryColor = useThemeColor("tertiary");
 
   const gmailAccount = accounts.find((a) => a.provider === "gmail");
   const outlookAccount = accounts.find((a) => a.provider === "outlook");
@@ -44,8 +51,7 @@ export default function ConnectedAccountsScreen() {
           <AccountCard
             provider="Gmail"
             account={gmailAccount}
-            greenColor={greenColor}
-            tertiaryColor={tertiaryColor}
+            isSyncing={isFetching && !!gmailAccount}
             onConnect={() => connectEmail("gmail", getGmailClientId())}
             onDisconnect={() => gmailAccount && disconnectEmail(gmailAccount.id)}
           />
@@ -53,8 +59,7 @@ export default function ConnectedAccountsScreen() {
           <AccountCard
             provider="Outlook"
             account={outlookAccount}
-            greenColor={greenColor}
-            tertiaryColor={tertiaryColor}
+            isSyncing={isFetching && !!outlookAccount}
             onConnect={() => connectEmail("outlook", getOutlookClientId())}
             onDisconnect={() => outlookAccount && disconnectEmail(outlookAccount.id)}
           />
@@ -71,29 +76,45 @@ export default function ConnectedAccountsScreen() {
 type AccountCardProps = {
   provider: string;
   account: { email: string; lastFetchedAt?: string | null } | undefined;
-  greenColor: string;
-  tertiaryColor: string;
+  isSyncing: boolean;
   onConnect: () => void;
   onDisconnect: () => void;
 };
 
-function AccountCard({
-  provider,
-  account,
-  greenColor,
-  tertiaryColor,
-  onConnect,
-  onDisconnect,
-}: AccountCardProps) {
+function AccountCard({ provider, account, isSyncing, onConnect, onDisconnect }: AccountCardProps) {
   const { t, locale } = useTranslation();
   const iconColor = useThemeColor("primary");
+  const greenColor = useThemeColor("accentGreen");
+  const tertiaryColor = useThemeColor("tertiary");
+
+  const dotOpacity = useSharedValue(1);
+
+  useEffect(() => {
+    if (isSyncing) {
+      dotOpacity.value = withRepeat(
+        withSequence(withTiming(0.3, { duration: 600 }), withTiming(1, { duration: 600 })),
+        -1
+      );
+    } else {
+      dotOpacity.value = withTiming(1, { duration: 300 });
+    }
+  }, [isSyncing, dotOpacity]);
+
+  const dotAnimatedStyle = useAnimatedStyle(() => ({
+    opacity: dotOpacity.value,
+  }));
 
   if (account) {
     return (
       <View className="rounded-chart bg-card p-5 dark:bg-card-dark" style={{ gap: 14 }}>
         <View className="flex-row items-center justify-between">
           <View className="flex-row items-center" style={{ gap: 12 }}>
-            <View style={{ width: 10, height: 10, borderRadius: 5, backgroundColor: greenColor }} />
+            <Animated.View
+              style={[
+                { width: 10, height: 10, borderRadius: 5, backgroundColor: greenColor },
+                dotAnimatedStyle,
+              ]}
+            />
             <Text className="font-poppins-semibold text-section text-primary dark:text-primary-dark">
               {provider}
             </Text>
@@ -110,14 +131,16 @@ function AccountCard({
         </Text>
 
         <Text className="font-poppins-medium text-caption text-tertiary dark:text-tertiary-dark">
-          {account.lastFetchedAt
-            ? t("connectedAccounts.lastSynced", {
-                time: formatDistanceToNow(new Date(account.lastFetchedAt), {
-                  addSuffix: true,
-                  locale: getDateFnsLocale(locale),
-                }),
-              })
-            : t("connectedAccounts.notSyncedYet")}
+          {isSyncing
+            ? t("connectedAccounts.syncing")
+            : account.lastFetchedAt
+              ? t("connectedAccounts.lastSynced", {
+                  time: formatDistanceToNow(new Date(account.lastFetchedAt), {
+                    addSuffix: true,
+                    locale: getDateFnsLocale(locale),
+                  }),
+                })
+              : t("connectedAccounts.notSyncedYet")}
         </Text>
 
         <Pressable

--- a/apps/mobile/features/dashboard/components/HomeScreen.tsx
+++ b/apps/mobile/features/dashboard/components/HomeScreen.tsx
@@ -3,9 +3,7 @@ import { memo, useCallback, useMemo, useState } from "react";
 import { useSharedValue } from "react-native-reanimated";
 import { DetectedTransactionsBanner } from "@/features/capture-sources";
 import {
-  buildProgressDisplay,
   EmailConnectBanner,
-  EmailProgressCard,
   FailedEmailsBanner,
   getGmailClientId,
   getOutlookClientId,
@@ -96,21 +94,11 @@ const ListHeader = memo(function ListHeader({
   onBalanceLayout,
 }: ListHeaderProps) {
   const { push } = useRouter();
-  const { t, locale } = useTranslation();
   const connectEmail = useEmailCaptureStore((s) => s.connectEmail);
-  const phase = useEmailCaptureStore((s) => s.phase);
-  const progress = useEmailCaptureStore((s) => s.progress);
-  const clearProgress = useEmailCaptureStore((s) => s.clearProgress);
 
   const totalSpentCents = useMemo(
     () => categorySpending.reduce((sum, c) => sum + c.totalCents, 0),
     [categorySpending]
-  );
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: locale triggers recompute when language changes
-  const progressDisplay = useMemo(
-    () => (phase ? buildProgressDisplay(phase, progress, [], t) : null),
-    [phase, progress, t, locale]
   );
 
   return (
@@ -122,10 +110,7 @@ const ListHeader = memo(function ListHeader({
         }}
       />
       <FailedEmailsBanner onPress={() => push("/failed-emails" as never)} />
-      {phase && progressDisplay && (
-        <EmailProgressCard phase={phase} display={progressDisplay} onComplete={clearProgress} />
-      )}
-      {!phase && <NeedsReviewBanner onPress={() => push("/needs-review" as never)} />}
+      <NeedsReviewBanner onPress={() => push("/needs-review" as never)} />
       <SyncConflictBanner onPress={() => push("/sync-conflicts" as never)} />
       {Platform.OS === "ios" && (
         <DetectedTransactionsBanner onPress={() => push("/connected-accounts" as never)} />
@@ -149,6 +134,7 @@ export const HomeScreen = () => {
   const balanceCents = useTransactionStore((s) => s.balanceCents);
   const categorySpending = useTransactionStore((s) => s.categorySpending);
   const dailySpending = useTransactionStore((s) => s.dailySpending);
+  // phase gates ListEmptyComponent — suppresses "No transactions" during first sync
   const phase = useEmailCaptureStore((s) => s.phase);
 
   const scrollY = useSharedValue(0);

--- a/apps/mobile/features/email-capture/index.ts
+++ b/apps/mobile/features/email-capture/index.ts
@@ -1,11 +1,9 @@
 export { EmailConnectBanner } from "./components/EmailConnectBanner";
-export { EmailProgressCard } from "./components/EmailProgressCard";
 export { FailedEmailsBanner } from "./components/FailedEmailsBanner";
 export { default as NeedsReviewScreen } from "./components/NeedsReviewScreen";
 export { useEmailCapture } from "./hooks/useEmailCapture";
 export type { BankSender } from "./lib/bank-senders";
 export { insertMerchantRule, lookupMerchantRule } from "./lib/merchant-rules";
-export { buildProgressDisplay } from "./lib/progress-phases";
 export type { ProcessedEmailRow } from "./lib/repository";
 export type { EmailProvider } from "./schema";
 export { getGmailClientId, getOutlookClientId } from "./schema";

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -25,6 +25,7 @@ import { type ProgressCallback, processEmails, processRetries } from "./services
 
 let dbRef: AnyDb | null = null;
 let userIdRef: string | null = null;
+let autoClearTimer: ReturnType<typeof setTimeout> | null = null;
 
 type EmailCaptureState = {
   accounts: EmailAccountRow[];
@@ -46,7 +47,6 @@ type EmailCaptureActions = {
   connectEmail: (provider: EmailProvider, clientId: string) => Promise<void>;
   disconnectEmail: (id: string) => Promise<void>;
   fetchAndProcess: (gmailClientId: string, outlookClientId: string) => Promise<void>;
-  clearProgress: () => void;
   confirmReview: (processedEmailId: string, categoryId: string) => Promise<void>;
 };
 
@@ -83,8 +83,6 @@ export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActio
   },
 
   dismissBanner: () => set({ bannerDismissed: true }),
-
-  clearProgress: () => set({ phase: null, progress: null }),
 
   dismissFailedEmail: async (id) => {
     if (!dbRef) return;
@@ -137,8 +135,11 @@ export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActio
       return;
     }
 
-    // Clear any stale progress state from a previous run (e.g. if clearProgress
-    // wasn't called before this sync was triggered by AppState change)
+    // Clear any stale progress/timer from a previous run
+    if (autoClearTimer) {
+      clearTimeout(autoClearTimer);
+      autoClearTimer = null;
+    }
     set({ isFetching: true, phase: null, progress: null });
 
     try {
@@ -193,7 +194,6 @@ export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActio
           progress: { total: 0, completed: 0, saved: 0, failed: 0, needsReview: 0 },
         });
       } else if (showProgress) {
-        set({ phase: "fetching" });
         set({ phase: "processing" });
 
         let lastRefreshedSaved = 0;
@@ -248,13 +248,19 @@ export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActio
     } catch (err) {
       console.warn("[EmailCapture] fetchAndProcess error:", err);
     } finally {
-      // If phase is 'complete', let the component handle cleanup via clearProgress.
-      // Only force-clear on error (phase never reached 'complete').
+      // On error (phase never reached 'complete'), clear immediately.
+      // On success, auto-clear after 2s so Connected Accounts can show the transition.
       const currentPhase = get().phase;
       if (currentPhase !== "complete") {
         set({ isFetching: false, progress: null, phase: null });
       } else {
         set({ isFetching: false });
+        autoClearTimer = setTimeout(() => {
+          autoClearTimer = null;
+          if (get().phase === "complete") {
+            set({ phase: null, progress: null });
+          }
+        }, 2000);
       }
     }
   },

--- a/apps/mobile/shared/i18n/locales/en.ts
+++ b/apps/mobile/shared/i18n/locales/en.ts
@@ -152,6 +152,7 @@ const en = {
     disconnect: "Disconnect",
     lastSynced: "Last synced: %{time}",
     notSyncedYet: "Not synced yet",
+    syncing: "Syncing...",
   },
 
   // Failed Emails

--- a/apps/mobile/shared/i18n/locales/es.ts
+++ b/apps/mobile/shared/i18n/locales/es.ts
@@ -153,6 +153,7 @@ const es = {
     disconnect: "Desconectar",
     lastSynced: "Última sincronización: %{time}",
     notSyncedYet: "No sincronizado aún",
+    syncing: "Sincronizando...",
   },
 
   // Failed Emails


### PR DESCRIPTION
- Remove EmailProgressCard from home screen
- Add pulsing dot + "Syncing..." text to AccountCard
- Auto-clear progress in store after 2s timeout
- Clean up unused clearProgress action and exports

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make email syncing silent on the Home screen and show a subtle per-account indicator on Connected Accounts. Progress now auto-clears 2s after completion, and the old progress card is removed.

- New Features
  - Show a pulsing dot and "Syncing..." on each connected email account; fall back to last synced/not synced when idle.
  - Auto-clear email capture phase/progress 2 seconds after a successful sync; clear immediately on errors and reset stale timers on new runs.
  - Removed the Home screen progress card; sync runs quietly and the empty state stays hidden during the first sync.

- Refactors
  - Removed `EmailProgressCard`, `buildProgressDisplay`, and the `clearProgress` store action and exports.
  - Updated `connected-accounts` to drive the indicator with `isFetching` and `react-native-reanimated`.
  - Added i18n `connectedAccounts.syncing` in `en` and `es`; hardened tests with auto-clear assertions and try/finally timer guards.

<sup>Written for commit f9db4d68c709539f3cfc2ab3e6e597274ed0dd9e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

