### PR TITLE
docs(mobile): add branded types convention to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,10 @@ Follow React's ["You Might Not Need an Effect"](https://react.dev/learn/you-migh
 - Reanimated animations (`withRepeat`, `withSequence`)
 - App bootstrap in `_layout.tsx` (routing, splash screen)
 
+## Code Style: Branded Types
+
+All IDs, temporal strings, and money amounts use branded types from `shared/types/branded.ts`. Never use plain `string` or `number` for these in function signatures. Use typed ID generators (`generateTransactionId()`, etc.), temporal constructors (`toIsoDate()`, `toMonth()`, `toIsoDateTime()`), and `$type<>()` on Drizzle schema columns. New entities need a branded type, a typed generator, and Drizzle `$type<>()` annotations.
+
 ## Architectural Decisions
 
 ### Calendar-month budgets only


### PR DESCRIPTION
- Add branded types section to CLAUDE.md for AI agent guidance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the branded types convention in CLAUDE.md to enforce consistent typing for IDs, dates, and money. Use `shared/types/branded.ts` for types, typed ID generators and temporal constructors, and Drizzle `$type<>()`; new entities must include these.

<sup>Written for commit 9c551a53846e94a69022253ab09ec6f8984cc630. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

