### PR TITLE
feat(mobile): add guidance data to budget alerts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,9 @@
 
 The role of this file is to describe common mistakes and confusion points that agents might encounter as they work in this project. If you ever encounter something in the project that surprises you, please alert the developer working with you and indicate that this is the case in this CLAUDE.md file to help prevent future agents from having the same issue
 
-## Committing Changes
+## Opening MRs
 
-Before committing, use the `committing-changes` skill.
+Before committing, use the `opening-mr` skill.
 
 ## Tech Stack
 

--- a/apps/mobile/__tests__/budget/derive.test.ts
+++ b/apps/mobile/__tests__/budget/derive.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type { BudgetProgress } from "@/features/budget/lib/derive";
 import {
+  computeDaysLeft,
   deriveAutoSuggestBudgets,
   deriveBudgetAlerts,
   deriveBudgetProgress,
   deriveBudgetSummary,
 } from "@/features/budget/lib/derive";
-import type { BudgetId, CategoryId, CopAmount } from "@/shared/types/branded";
+import type { BudgetId, CategoryId, CopAmount, Month } from "@/shared/types/branded";
 
 const makeBudget = (overrides: { id?: string; categoryId?: string; amount?: number } = {}) => ({
   id: "budget-1" as BudgetId,
@@ -201,7 +202,7 @@ describe("deriveAutoSuggestBudgets", () => {
 describe("deriveBudgetAlerts", () => {
   it("returns alert for budget at 80%", () => {
     const progresses = [makeProgress({ percentUsed: 80, isNearLimit: true })];
-    const result = deriveBudgetAlerts(progresses, new Set());
+    const result = deriveBudgetAlerts(progresses, new Set(), 15);
     expect(result).toHaveLength(1);
     expect(result[0].threshold).toBe(80);
     expect(result[0].budgetId).toBe("budget-1");
@@ -211,7 +212,7 @@ describe("deriveBudgetAlerts", () => {
 
   it("returns alert for budget at 100%+", () => {
     const progresses = [makeProgress({ percentUsed: 110, isOverBudget: true, isNearLimit: true })];
-    const result = deriveBudgetAlerts(progresses, new Set());
+    const result = deriveBudgetAlerts(progresses, new Set(), 15);
     // Both 80 and 100 thresholds crossed
     expect(result).toHaveLength(2);
     expect(result.map((a) => a.threshold)).toContain(80);
@@ -221,21 +222,21 @@ describe("deriveBudgetAlerts", () => {
   it("excludes acknowledged alerts", () => {
     const progresses = [makeProgress({ percentUsed: 80, isNearLimit: true })];
     const acknowledged = new Set(["budget-1:80"]);
-    const result = deriveBudgetAlerts(progresses, acknowledged);
+    const result = deriveBudgetAlerts(progresses, acknowledged, 15);
     expect(result).toHaveLength(0);
   });
 
   it("only excludes the specific acknowledged threshold, not all", () => {
     const progresses = [makeProgress({ percentUsed: 110, isOverBudget: true, isNearLimit: true })];
     const acknowledged = new Set(["budget-1:80"]);
-    const result = deriveBudgetAlerts(progresses, acknowledged);
+    const result = deriveBudgetAlerts(progresses, acknowledged, 15);
     expect(result).toHaveLength(1);
     expect(result[0].threshold).toBe(100);
   });
 
   it("returns both 80 and 100 alerts for same budget if both crossed", () => {
     const progresses = [makeProgress({ percentUsed: 100, isNearLimit: true, isOverBudget: false })];
-    const result = deriveBudgetAlerts(progresses, new Set());
+    const result = deriveBudgetAlerts(progresses, new Set(), 15);
     expect(result).toHaveLength(2);
     const thresholds = result.map((a) => a.threshold);
     expect(thresholds).toContain(80);
@@ -244,12 +245,78 @@ describe("deriveBudgetAlerts", () => {
 
   it("returns empty when all under 80%", () => {
     const progresses = [makeProgress({ percentUsed: 70, isNearLimit: false })];
-    const result = deriveBudgetAlerts(progresses, new Set());
+    const result = deriveBudgetAlerts(progresses, new Set(), 15);
     expect(result).toHaveLength(0);
   });
 
   it("returns empty array for empty progresses", () => {
-    const result = deriveBudgetAlerts([], new Set());
+    const result = deriveBudgetAlerts([], new Set(), 15);
     expect(result).toHaveLength(0);
+  });
+
+  it("includes suggestionKey for known category", () => {
+    const progresses = [makeProgress({ percentUsed: 80, isNearLimit: true })];
+    const result = deriveBudgetAlerts(progresses, new Set(), 15);
+    expect(result[0].suggestionKey).toBe("guidance.budgetAlert80.food");
+  });
+
+  it("returns undefined suggestionKey for unknown category", () => {
+    const progresses = [
+      makeProgress({ percentUsed: 80, isNearLimit: true, categoryId: "custom-cat" as CategoryId }),
+    ];
+    const result = deriveBudgetAlerts(progresses, new Set(), 15);
+    expect(result[0].suggestionKey).toBeUndefined();
+  });
+
+  it("passes daysLeft through to alerts", () => {
+    const progresses = [makeProgress({ percentUsed: 80, isNearLimit: true })];
+    const result = deriveBudgetAlerts(progresses, new Set(), 0);
+    expect(result[0].daysLeft).toBe(0);
+  });
+
+  it("includes suggestionKey for non-food category at 100%", () => {
+    const progresses = [
+      makeProgress({
+        percentUsed: 110,
+        isOverBudget: true,
+        isNearLimit: true,
+        categoryId: "transport" as CategoryId,
+      }),
+    ];
+    const result = deriveBudgetAlerts(progresses, new Set(), 15);
+    const alert100 = result.find((a) => a.threshold === 100);
+    expect(alert100?.suggestionKey).toBe("guidance.budgetAlert100.transport");
+  });
+
+  it("includes remainingAmount from progress", () => {
+    const progresses = [
+      makeProgress({ percentUsed: 80, isNearLimit: true, remaining: 100000 as CopAmount }),
+    ];
+    const result = deriveBudgetAlerts(progresses, new Set(), 15);
+    expect(result[0].remainingAmount).toBe(100000);
+  });
+
+  it("includes correct suggestionKey for 100% threshold", () => {
+    const progresses = [makeProgress({ percentUsed: 100, isNearLimit: true, isOverBudget: false })];
+    const result = deriveBudgetAlerts(progresses, new Set(), 15);
+    const alert100 = result.find((a) => a.threshold === 100);
+    expect(alert100?.suggestionKey).toBe("guidance.budgetAlert100.food");
+  });
+});
+
+describe("computeDaysLeft", () => {
+  it("returns days remaining in month", () => {
+    // March 21 → March 31 = 10 days left
+    expect(computeDaysLeft("2026-03" as Month, new Date(2026, 2, 21))).toBe(10);
+  });
+
+  it("returns 0 on last day of month", () => {
+    // March 31 is the last day → 0 days left
+    expect(computeDaysLeft("2026-03" as Month, new Date(2026, 2, 31))).toBe(0);
+  });
+
+  it("clamps to 0 for past months", () => {
+    // January 2026 is in the past relative to March 15, 2026 → 0
+    expect(computeDaysLeft("2026-01" as Month, new Date(2026, 2, 15))).toBe(0);
   });
 });

--- a/apps/mobile/__tests__/setup.ts
+++ b/apps/mobile/__tests__/setup.ts
@@ -126,18 +126,22 @@ vi.mock("expo-sqlite", () => ({
 }));
 
 // Mock date-fns
-vi.mock("date-fns", () => ({
-  format: (date: Date, fmt: string) => {
-    if (fmt === "PP") return "Mar 1, 2026";
-    if (fmt === "MMM d, yyyy") return "Mar 1, 2026";
-    if (fmt === "yyyy-MM-dd") return "2026-03-01";
-    if (fmt === "MMMM d") return "March 1";
-    return date.toISOString();
-  },
-  parse: (dateStr: string, _fmt: string, _ref: Date) => new Date(dateStr),
-  isToday: () => true,
-  isYesterday: () => false,
-}));
+vi.mock("date-fns", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("date-fns")>();
+  return {
+    ...actual,
+    format: (date: Date, fmt: string) => {
+      if (fmt === "PP") return "Mar 1, 2026";
+      if (fmt === "MMM d, yyyy") return "Mar 1, 2026";
+      if (fmt === "yyyy-MM-dd") return "2026-03-01";
+      if (fmt === "MMMM d") return "March 1";
+      return date.toISOString();
+    },
+    parse: (dateStr: string, _fmt: string, _ref: Date) => new Date(dateStr),
+    isToday: () => true,
+    isYesterday: () => false,
+  };
+});
 
 // Mock expo-router
 export const mockReplace = vi.fn();

--- a/apps/mobile/features/budget/lib/derive.ts
+++ b/apps/mobile/features/budget/lib/derive.ts
@@ -1,4 +1,5 @@
-import type { BudgetId, CategoryId, CopAmount } from "@/shared/types/branded";
+import { differenceInCalendarDays, endOfMonth } from "date-fns";
+import type { BudgetId, CategoryId, CopAmount, Month } from "@/shared/types/branded";
 
 export type BudgetProgress = {
   readonly budgetId: BudgetId;
@@ -16,6 +17,9 @@ export type BudgetAlert = {
   readonly categoryId: CategoryId;
   readonly threshold: 80 | 100;
   readonly percentUsed: number;
+  readonly suggestionKey: string | undefined;
+  readonly daysLeft: number;
+  readonly remainingAmount: CopAmount;
 };
 
 export type BudgetSuggestion = {
@@ -92,12 +96,49 @@ export function deriveAutoSuggestBudgets(
 }
 
 /**
+ * Pure helper: returns the number of calendar days remaining in the given
+ * budget month, clamped to 0 (never negative).
+ */
+export const computeDaysLeft = (month: Month, today: Date): number => {
+  const [year, m] = month.split("-").map(Number);
+  return Math.max(0, differenceInCalendarDays(endOfMonth(new Date(year, m - 1, 1)), today));
+};
+
+/**
+ * Category IDs that have dedicated suggestion i18n keys (guidance.budgetAlertNN.xxx).
+ * Intentionally separate from CATEGORIES — custom categories (#8) won't have suggestions.
+ */
+const SUGGESTION_CATEGORY_IDS: ReadonlySet<string> = new Set([
+  "food",
+  "transport",
+  "entertainment",
+  "health",
+  "education",
+  "home",
+  "clothing",
+  "services",
+  "transfer",
+  "other",
+]);
+
+/**
+ * Returns the i18n key for a budget alert suggestion if the category is known,
+ * otherwise returns undefined.
+ */
+const getSuggestionKey = (threshold: 80 | 100, categoryId: CategoryId): string | undefined =>
+  SUGGESTION_CATEGORY_IDS.has(categoryId)
+    ? `guidance.budgetAlert${threshold}.${categoryId}`
+    : undefined;
+
+/**
  * Pure derivation: generate alerts for budgets that have crossed 80% or 100%.
  * Acknowledged alerts (keyed as "budgetId:threshold") are excluded.
+ * daysLeft must be >= 0 (caller is responsible — use computeDaysLeft).
  */
 export function deriveBudgetAlerts(
   progresses: readonly BudgetProgress[],
-  acknowledgedAlerts: ReadonlySet<string>
+  acknowledgedAlerts: ReadonlySet<string>,
+  daysLeft: number
 ): readonly BudgetAlert[] {
   return progresses.flatMap((p) =>
     ([80, 100] as const)
@@ -108,6 +149,9 @@ export function deriveBudgetAlerts(
         categoryId: p.categoryId,
         threshold,
         percentUsed: p.percentUsed,
+        suggestionKey: getSuggestionKey(threshold, p.categoryId),
+        daysLeft,
+        remainingAmount: p.remaining,
       }))
   );
 }

--- a/apps/mobile/features/budget/store.ts
+++ b/apps/mobile/features/budget/store.ts
@@ -9,6 +9,7 @@ import { generateBudgetId, generateSyncQueueId, toIsoDateTime } from "@/shared/l
 import type { BudgetId, CategoryId, CopAmount, Month, UserId } from "@/shared/types/branded";
 import type { BudgetAlert, BudgetProgress, BudgetSuggestion } from "./lib/derive";
 import {
+  computeDaysLeft,
   deriveAutoSuggestBudgets,
   deriveBudgetAlerts,
   deriveBudgetProgress,
@@ -130,7 +131,8 @@ export const useBudgetStore = create<BudgetState & BudgetActions>((set, get) => 
         deriveBudgetProgress(b, spendingMap.get(b.categoryId) ?? (0 as CopAmount))
       );
       const summary = deriveBudgetSummary(progresses);
-      const newPendingAlerts = deriveBudgetAlerts(progresses, acknowledgedAlerts);
+      const daysLeft = computeDaysLeft(currentMonth, new Date());
+      const newPendingAlerts = deriveBudgetAlerts(progresses, acknowledgedAlerts, daysLeft);
       set({ budgetProgress: progresses, summary, pendingAlerts: newPendingAlerts });
 
       // Schedule push notifications for truly new alerts (best-effort, don't block)


### PR DESCRIPTION
- Extend BudgetAlert with suggestionKey, daysLeft, remainingAmount
- Add computeDaysLeft pure helper using date-fns endOfMonth
- Add suggestion key resolution for all 10 categories
- Update store to compute and pass daysLeft
- Rename committing-changes skill to opening-mr in CLAUDE.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds guidance metadata to budget alerts so we can show contextual suggestions and time them better. Alerts now include a suggestion key, days left in the month, and remaining amount.

- **New Features**
  - Extend `BudgetAlert` with `suggestionKey`, `daysLeft`, and `remainingAmount`.
  - Add pure `computeDaysLeft(month, today)` using `date-fns`.
  - Generate i18n suggestion keys for 10 known categories; custom categories return `undefined`.
  - Store computes `daysLeft` for the current month and passes it to `deriveBudgetAlerts`.

- **Migration**
  - `deriveBudgetAlerts` now takes `daysLeft`: `deriveBudgetAlerts(progresses, acknowledgedAlerts, daysLeft)`. Use `computeDaysLeft(month, new Date())`.

<sup>Written for commit e04b4b6148cd45d63b8c65d40890ef00e17b8a52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

