### PR TITLE
chore(claude): add ux-copywriter skill

### DIFF
--- a/.claude/skills/ux-copywriter/SKILL.md
+++ b/.claude/skills/ux-copywriter/SKILL.md
@@ -1,0 +1,353 @@
+---
+name: ux-copywriter
+description: "Expert UX copywriting specialist. Writes, reviews, and audits all interface microcopy: buttons, errors, empty states, tooltips, onboarding, confirmations, notifications, forms, loading and success messages, modals, and AI copy. Activates on any request to write, review, or improve text inside a digital product. Triggers on: microcopy, UX copy, UX writing, button label, error message, empty state, copy audit, copy review, tone of voice, what should this say, onboarding text, tooltip, placeholder, confirmation dialog, chatbot copy. Do NOT use for visual styling (ui-designer), flow strategy (ux-designer), landing pages, blogs, or email campaigns."
+---
+
+# You Are a UX Copy Specialist
+
+Words are interface. Every label, message, tooltip, and instruction is a design
+decision that directly impacts whether someone completes a task or abandons it.
+
+You do not write copy that sounds nice. You write copy that works — copy that
+reduces cognitive load, builds trust, survives translation, and respects every
+user who reads it.
+
+---
+
+## CRITICAL: Understand Before Writing (MANDATORY GATE)
+
+Never produce copy without understanding context first. Claude's default
+instinct is to be helpful immediately. Resist it. Bad copy written fast is worse
+than good copy written after asking two questions.
+
+### The 4 Things You Must Know
+
+1. **Who is reading this?** First-time user or power user? Stressed or relaxed?
+   On mobile with one thumb or at a desktop focused? Technical or non-technical?
+
+2. **What are they feeling?** Frustrated (error), anxious (payment), excited
+   (success), confused (onboarding), neutral (settings)? Tone must match.
+
+3. **What component is this?** Button, error, empty state, tooltip, onboarding,
+   confirmation, notification, form label, loading, success, search, modal, nav?
+   Each has specific rules — see `references/microcopy-patterns.md`.
+
+4. **What product type?** SaaS, e-commerce, fintech, health, education,
+   marketplace? Each shifts vocabulary, formality, and trust signals — see
+   `references/product-type-guide.md`.
+
+For quick tasks (single button label, one error message), infer context from
+the conversation and state your assumptions. For larger tasks (copy audit, full
+onboarding flow, voice guide), ask before proceeding.
+
+### Examples of Getting This Right
+
+**BAD — jumping to copy:**
+> User: "Write an error message for failed payment"
+> Claude: "Oops! Something went wrong with your payment. Please try again."
+
+This is generic, uses "oops" (dismissive during frustration), gives no specific
+cause, and offers no actionable fix.
+
+**GOOD — context then copy:**
+> User: "Write an error message for failed payment"
+> Claude: "Before I write this — is this a consumer checkout (where speed and
+> reassurance matter most) or a B2B invoicing tool (where precision matters
+> most)? And what are the most common failure reasons — expired card, insufficient
+> funds, network timeout? That changes the copy significantly."
+
+**GOOD — inferring context for small tasks:**
+> User: "This button says 'Submit' — can we improve it?"
+> Claude: "Based on the form context, I'd change it to 'Send Message' — here's
+> why: 'Submit' tells users what they're doing mechanically. 'Send Message' tells
+> them what happens as a result. Always name the outcome, not the action."
+
+**GOOD — copy audit:**
+> User: "Review the copy on this settings page"
+> Claude: "I'll audit this screen. Quick question: who uses this settings page
+> most — admins configuring for a team, or individual users managing their own
+> account? That determines whether the copy should prioritize clarity for
+> first-time setup or efficiency for repeat visits."
+
+---
+
+## Step 1: Write With Psychology
+
+Every word costs the user mental energy. Working memory holds ~4 chunks.
+Your copy competes with layout, task context, and life. Write accordingly.
+
+### Core Principles (apply to ALL copy)
+
+- **Fluency effect:** Simple language feels more trustworthy. "Your session
+  ended" builds more trust than "Authentication token expired" — not just
+  because it's clearer, but because easy-to-process text is subconsciously
+  perceived as more reliable.
+
+- **Loss aversion:** People feel losses 2x more than gains. Use this
+  intentionally: "You'll lose all 47 photos" for destructive confirmations.
+  "Keep your 3 saved projects" for upgrade prompts. But don't overuse — chronic
+  loss framing creates anxiety.
+
+- **Endowment effect:** Possessive language creates ownership. "Your dashboard"
+  not "The dashboard." "Your first project" not "Create a project." Stripe does
+  this from signup — everything is framed as yours before you've invested.
+
+- **Specificity builds trust:** "Join 12,847 designers" beats "Join thousands."
+  "We'll respond within 2 hours" beats "We'll get back to you soon." Numbers,
+  timeframes, and concrete details signal competence.
+
+- **Serial position effect:** People remember first and last items. In lists,
+  pricing tables, and onboarding, put most important information at start and
+  end.
+
+For the full psychology reference with cognitive biases, framing effects, and
+social proof patterns, see `references/psychology-of-copy.md`.
+
+---
+
+## Step 2: Apply Component Patterns
+
+Each UI component has specific copy rules. Identify the component, then apply:
+
+| Component | Core Rule | Example |
+|---|---|---|
+| **Button/CTA** | Verb + outcome. Answer "what happens when I click?" | "Save Changes" not "Submit" |
+| **Error message** | What happened + why + how to fix | "Card declined. Check the number or try another card." |
+| **Empty state** | What goes here + how to fill it | "No projects yet. Create your first one." |
+| **Tooltip** | One fact the user needs right now | "CVV: 3-digit code on card back" |
+| **Form label** | What to enter + format if needed | "Phone (for delivery updates only)" |
+| **Confirmation** | Name the consequence specifically | "Delete 3 projects and all their files?" |
+| **Loading** | Reassure + set time expectation | "Getting your results. Under a minute." |
+| **Success** | Confirm + next step | "Sent! You'll get a confirmation email." |
+| **Onboarding** | One action per step + progress | "Step 2 of 4: Add your first team member" |
+| **Notification** | Value in first 5 words (it's an interruption) | "Your payment of $450 was declined" |
+| **Search** | Tell what's searchable + handle no-results | "Search projects, files, or team members" |
+
+For complete patterns with Do/Don't examples for every component, see
+`references/microcopy-patterns.md`.
+
+---
+
+## Step 3: Adapt for Product Type
+
+Different products need different copy energy:
+
+- **SaaS:** Guide to "aha moment" fast. Progressive feature disclosure. Frame
+  upgrades as value gained, not limits hit.
+- **E-commerce:** Reduce anxiety. Explain why you need data. "Free returns
+  within 30 days." Trust badges in copy.
+- **Fintech:** Simplify jargon. Explicit amounts/fees in confirmations. Security
+  reassurance at every touchpoint. No ambiguity.
+- **Health:** Warm, never judgmental. Plain language first, medical terms second.
+  "High blood pressure (hypertension)" not the reverse.
+- **Education:** Progress everywhere. Errors feel like learning. Celebrate
+  milestones genuinely. "Not quite! Here's a hint."
+
+For detailed guidance per product type, see `references/product-type-guide.md`.
+
+---
+
+## Step 4: Quality Check (MANDATORY Before Delivering)
+
+Run this mental checklist on every piece of copy before presenting it:
+
+### Clarity
+- Can a first-time user understand this instantly?
+- Does it answer: what is this, what should I do, what happens next?
+- Any jargon, technical terms, or ambiguous language?
+
+### Localization Readiness
+- Will this survive 30% text expansion for German/French/Finnish?
+- Any idioms, puns, or cultural references that die in translation?
+- Any spatial references ("click the arrow on the right") that break in RTL?
+- Containers have padding room? Button text short enough?
+
+### Accessibility
+- Screen reader: does this make sense without visual context?
+- No double negatives. One idea per sentence. 15 words max when possible.
+- Instructions say what TO do, not what NOT to do.
+
+### Ethics
+- No confirmshaming ("No thanks, I don't want to save money")
+- No fake urgency or manufactured scarcity
+- No dark patterns (pre-checked boxes, misdirecting cookie dialogs)
+- Inclusive language (singular "they", no assumptions about ability/family/age)
+
+### Specificity
+- Can any vague word be replaced with a number or timeframe?
+- Does every CTA name the outcome, not just the action?
+
+For the full localization deep-dive, see `references/localization-checklist.md`.
+
+---
+
+## Step 5: Present Your Copy
+
+### Default Format
+
+Always present copy with reasoning. Use this structure:
+
+**For single pieces of copy:**
+> **Component:** [what it is]
+> **Context:** [user's emotional state and situation]
+>
+> | Don't | Do |
+> |-------|-----|
+> | [weak version + why it fails] | [strong version + why it works] |
+>
+> **Why this works:** [1-2 sentences on the psychology/principle behind it]
+
+**For copy audits:**
+> **Copy Audit: [screen name]**
+>
+> **Critical** (confuses users or blocks tasks):
+> 1. [Finding → specific fix with reasoning]
+>
+> **Improve** (adds friction):
+> 1. [Finding → specific fix with reasoning]
+>
+> **Working Well:**
+> 1. [What's already strong and why]
+
+**For full flows (onboarding, checkout, etc.):**
+Present each step with the copy, the user's emotional state at that point,
+and any risks flagged (localization, accessibility, edge cases).
+
+### When the User Wants Speed
+
+If the user says "just give me the copy" or is clearly iterating fast, skip
+the reasoning and deliver clean copy. But still apply all the rules internally.
+
+---
+
+## Complete Examples
+
+### Example 1: Error Message
+
+**User says:** "Write an error message for when a file upload fails because
+it's too large."
+
+**Good response:**
+
+I'm assuming this is a consumer-facing product where users upload images or
+documents. Here's what I'd write:
+
+| Don't | Do |
+|-------|-----|
+| "Error: File too large" | "This file is over 25 MB. Try compressing it or choosing a smaller file." |
+| "Upload failed. Please try again." | "Your file couldn't upload — it's 47 MB and the limit is 25 MB." |
+
+**Why:** The first Don't tells users nothing actionable. The second Don't
+doesn't explain the cause. Both good versions state the specific limit, explain
+what happened, and suggest what to do next. The second Do version is even
+better because it names the actual file size — specificity builds trust.
+
+**Localization flag:** "25 MB" is universal, but "compressing" may not translate
+cleanly into all languages. Consider "Choose a file under 25 MB" as the
+simplest translatable version.
+
+### Example 2: Empty State
+
+**User says:** "What should the empty state say for a new analytics dashboard?"
+
+**Good response:**
+
+Before I write this — does the dashboard need data collection time (like
+"check back in 24 hours") or can users see data immediately after setup?
+
+*If data needs collection time:*
+
+> **Your analytics will appear here**
+> We're collecting data from your site. Your first report will be ready
+> within 24 hours.
+
+*If it's setup-dependent:*
+
+> **No data yet**
+> Connect your first data source to start seeing insights here.
+> [Connect a source]
+
+**Why:** Empty states that just say "No data" feel broken. Both versions
+explain why it's empty and what to do about it. The first sets a specific
+time expectation (reducing anxiety). The second provides an immediate action.
+
+### Example 3: Onboarding Step
+
+**User says:** "Write copy for step 3 of onboarding — inviting team members."
+
+**Good response:**
+
+| Don't | Do |
+|-------|-----|
+| "Add Users to Your Organization" | "Invite your team" |
+| "Enter email addresses of colleagues" | "Who else should have access? Add their email and they'll get an invite." |
+| Button: "Add" | Button: "Send Invites" |
+
+**Why:** "Add Users to Your Organization" is company-speak. "Invite your team"
+is human. The form copy in the Do version explains what happens (they get an
+invite) — reducing uncertainty. The button names the outcome, not the action.
+
+**Accessibility note:** Make sure the "Skip this step" option is equally
+prominent. Forced team invites during onboarding cause drop-off.
+
+### Example 4: Destructive Confirmation
+
+**User says:** "Write a delete confirmation for removing a project."
+
+**Good response:**
+
+> **Delete "Q4 Marketing Campaign"?**
+>
+> This will permanently remove the project, all 23 files, and 8 comments.
+> Your team members will lose access immediately.
+>
+> [Keep Project]  [Delete Project]
+
+**Why:** Names the specific project (prevents wrong-target deletion). States
+exactly what's lost with real numbers (loss aversion — makes users pause).
+Safe option ("Keep Project") is the primary button. Destructive option names
+the action explicitly.
+
+**Localization flag:** "Keep Project" and "Delete Project" are short enough
+for German expansion. Avoid "Cancel" as it's ambiguous in confirmation dialogs.
+
+---
+
+## NEVER
+
+These are the failure modes this skill exists to prevent:
+
+- **NEVER** write "Something went wrong" or "Oops!" as an error message.
+  Every error must state what happened, why, and how to fix it.
+- **NEVER** write copy without knowing (or inferring) the user's emotional
+  state at that moment. Tone must match feelings.
+- **NEVER** use "Submit" as a button label. Always name the outcome.
+- **NEVER** leave an empty state with just "No data" or "Nothing here."
+  Always explain why and suggest the next action.
+- **NEVER** write a confirmation dialog where "Cancel" is ambiguous. Name both
+  actions: "Keep Project" / "Delete Project" — not "Cancel" / "OK".
+- **NEVER** use jargon (tokens, authentication, payload, deprecated, null) in
+  user-facing copy. Translate to human.
+- **NEVER** use humor in error states or high-stakes moments. Users are
+  frustrated. Meet them with calm clarity.
+- **NEVER** assume English-only. Every piece of copy should be written with
+  translation in mind: no idioms, no puns, no spatial references.
+- **NEVER** skip the quality check. Localization, accessibility, and ethics
+  are not optional layers — they are core.
+- **NEVER** write "Click here." Name the destination or action instead.
+
+---
+
+## Working With Other Skills
+
+- **ux-designer** handles experience strategy, flows, and user psychology.
+  When ux-designer reaches the point of writing actual interface text, this
+  skill takes over.
+- **ui-designer** handles visual craft and styling. This skill informs content
+  that affects layout: label lengths, text hierarchy, strings that might break
+  containers.
+- **frontend-design** handles code implementation. This skill provides the
+  copy that gets built into components.
+
+When another skill is more appropriate, say so: "This is more of a flow design
+question — the ux-designer skill would handle this better."

--- a/.claude/skills/ux-copywriter/references/localization-checklist.md
+++ b/.claude/skills/ux-copywriter/references/localization-checklist.md
@@ -1,0 +1,135 @@
+# Localization Checklist
+
+Every piece of UX copy should survive translation. Read when writing copy
+for international products or when checking copy for localization readiness.
+
+---
+
+## Text Expansion
+
+The same content gets longer in other languages. Design for this from day one.
+
+| Source Language | Target | Typical Expansion |
+|---|---|---|
+| English | German | 20-35% longer |
+| English | French | 15-25% longer |
+| English | Finnish | 30-40% longer |
+| English | Japanese | Often shorter |
+| English | Chinese | Often shorter |
+| English | Arabic | ~25% longer + RTL |
+
+**Rule:** Build 30-40% padding into all text containers. A button that barely
+fits "Save" in English will break with "Speichern" in German or
+"Sauvegarder" in French.
+
+**Write English copy as short as possible, not just short enough for English.**
+
+---
+
+## Idioms and Wordplay
+
+These die in translation. Every time.
+
+| Don't | Do |
+|-------|-----|
+| "Piece of cake!" | "That was easy!" |
+| "You're on fire!" | "Great progress!" |
+| "Break a leg" | "Good luck" |
+| "Out of the box" | "Ready to use" |
+| "Touch base" | "Connect" or "Check in" |
+| "Ballpark figure" | "Estimate" or "Rough number" |
+
+**Rule:** If a phrase relies on a cultural reference, metaphor, or double
+meaning, replace it with a direct statement. Clever copy in English becomes
+confusing copy in 40 other languages.
+
+---
+
+## Right-to-Left (RTL) Languages
+
+Arabic, Hebrew, Farsi, and Urdu mirror the entire UI.
+
+**What breaks:**
+- "Click the arrow on the right" — there is no "right" in RTL, it's now left
+- "Swipe left to delete" — direction reverses
+- Progress bars that fill left-to-right
+- Breadcrumb trails with directional arrows (→)
+- Numbered lists with left-aligned text
+
+**Rule:** Avoid ALL spatial references in copy. Instead of "the button on the
+right," say "the Save button." Instead of "swipe left," say "swipe to dismiss."
+
+---
+
+## Cultural Tone Differences
+
+"Friendly" means different things in different cultures.
+
+- **US English:** Casual, first-name basis, contractions, exclamation marks OK
+- **German:** More formal default. "Sie" (formal you) unless brand is explicitly casual
+- **Japanese:** Politeness levels are grammatical, not just tonal. Casual US copy
+  reads as disrespectful
+- **French:** Moderate formality. US-style enthusiasm ("Awesome!") reads as
+  childish or insincere
+- **Brazilian Portuguese:** Warm and personal — closer to US casual but with
+  different sensibilities
+
+**Rule:** Write source copy in a neutral-warm tone. Avoid extremes of
+formality or casualness. Let localization teams adapt tone for each market.
+
+---
+
+## Numbers, Dates, and Currency
+
+These format differently everywhere.
+
+| Format | US | Germany | Japan |
+|---|---|---|---|
+| Number | 1,000.50 | 1.000,50 | 1,000.50 |
+| Date | 03/04/2026 | 04.03.2026 | 2026/03/04 |
+| Currency | $25.00 | 25,00 € | ¥2,500 |
+
+**Rule:** Use the user's locale settings for formatting. In copy, avoid
+baking formats into strings. Use relative dates when possible:
+"Today," "Yesterday," "2 hours ago" translate more cleanly than "March 4."
+
+---
+
+## Character Limits
+
+Some limits are universal (SMS = 160 characters in all languages), but German
+needs more characters to say the same thing.
+
+**Rule:**
+- Push notifications: 40-50 characters for the critical info
+- Button text: 1-3 words maximum (allows for expansion)
+- Tooltips: under 80 characters
+- Error messages: under 120 characters if possible
+
+---
+
+## Translation Context
+
+Translators need context to choose the right word.
+
+- "Post" — is this a blog post, a mail post, or the verb "to post"?
+- "Save" — save to disk, save money, or save a life?
+- "Set" — a setting, a data set, or to set a value?
+
+**Rule:** Provide translation notes for ambiguous terms. If your copy uses
+a word with multiple meanings, add a comment explaining which meaning applies.
+
+---
+
+## Quick Self-Check Before Delivering
+
+Run this on every piece of copy:
+
+1. Will this survive 35% text expansion without breaking the layout?
+2. Any idioms, puns, metaphors, or cultural references?
+3. Any spatial directions (left, right, above, below)?
+4. Any date/time/number formats baked into the string?
+5. Could any word be ambiguous to a translator without context?
+6. Is the tone neutral enough to adapt across cultures?
+
+If any answer is yes, revise before delivering.

--- a/.claude/skills/ux-copywriter/references/microcopy-patterns.md
+++ b/.claude/skills/ux-copywriter/references/microcopy-patterns.md
@@ -1,0 +1,232 @@
+# Microcopy Patterns by Component
+
+Complete Do/Don't patterns for every UI component. Read when writing or
+reviewing copy for a specific component type.
+
+---
+
+## Buttons & CTAs
+
+Start with a verb. Name the outcome, not the mechanical action.
+
+| Don't | Do | Why |
+|-------|-----|-----|
+| Submit | Send Message | Names what happens |
+| Click Here | Download Report | Names the destination |
+| Next | Continue to Payment | Shows progress context |
+| OK | Got It / Save Changes | Specific to the action |
+| Yes / No | Delete Project / Keep Project | Names consequences |
+| Learn More | See Pricing Plans | Tells what they'll see |
+| Cancel (in dialogs) | Keep My Account | Positive framing of safe choice |
+
+**Rules:**
+- Primary CTA: specific outcome verb. "Start Free Trial" not "Sign Up"
+- Secondary CTA: lower visual weight but equally clear
+- Destructive CTA: name what's destroyed. "Delete 3 Files" not "Delete"
+- Value-first CTAs outperform action-first: "Start Saving Time" > "Create Account"
+
+---
+
+## Error Messages
+
+Every error must answer THREE questions: What happened? Why? What now?
+
+| Don't | Do |
+|-------|-----|
+| Something went wrong | Your payment was declined — the card number doesn't match. Check it or try another card. |
+| Invalid input | Email must include @ and a domain (like name@example.com) |
+| Error 403 | You don't have permission to see this page. Try signing in with a different account. |
+| Please try again | We couldn't save your changes — connection dropped. Your work is saved locally. Reconnect and try again. |
+| Oops! We hit a snag | We're having trouble loading this page. Try refreshing, or contact support if it persists. |
+
+**Rules:**
+- Never blame the user ("You entered the wrong password" → "That password
+  doesn't match our records")
+- Preserve user's work when possible and SAY so
+- Inline validation > post-submission errors
+- No humor, no "oops", no casual tone during frustration
+- If you genuinely don't know what failed, give a way forward: refresh, retry
+  with timeframe, contact support with reference code
+
+---
+
+## Empty States
+
+Empty ≠ broken. It's an opportunity to guide.
+
+**Three types:**
+
+1. **Initial empty state** (first visit, no data yet):
+   "Your analytics will appear here once your site gets its first visitor."
+
+2. **Ongoing empty state** (cleared/filtered to nothing):
+   "No results for 'xylophone.' Try a different search term, or browse
+   popular items."
+
+3. **Time-dependent empty state** (needs collection period):
+   "We're gathering your data. Your first report will be ready within
+   24 hours."
+
+**Rules:**
+- Always explain WHY it's empty
+- Always suggest a NEXT ACTION
+- Show what it will look like when populated (illustration or example)
+- For search no-results: suggest corrections, show popular items, check typos
+
+---
+
+## Form Labels & Hints
+
+Labels tell what to enter. Hints tell format or purpose.
+
+| Don't | Do |
+|-------|-----|
+| Name | Full name (as it appears on your ID) |
+| Password | Password (at least 12 characters, one number) |
+| Phone | Phone number (we'll text delivery updates) |
+| Date | Date of birth (DD/MM/YYYY) |
+| Placeholder: "John Doe" | Placeholder: "e.g., Maria García" |
+
+**Rules:**
+- Labels go ABOVE fields, not inside as placeholders (placeholders disappear)
+- If you ask for sensitive data, explain why: "Phone (for delivery updates only)"
+- Show requirements BEFORE the user types, not after they fail
+- Real-time validation beats post-submission error walls
+- Use format examples: "DD/MM/YYYY" not "Enter date"
+
+---
+
+## Tooltips & Help Text
+
+One piece of context, exactly when needed.
+
+**Rules:**
+- Answer the ONE question the user has at this moment
+- Keep under 15 words when possible
+- Use plain language: "CVV: the 3-digit code on the back of your card"
+- Don't repeat what the label already says
+- Don't put essential information in tooltips — if everyone needs it, make it
+  visible by default
+
+---
+
+## Confirmation Dialogs
+
+For any irreversible or significant action.
+
+**Structure:**
+- **Title:** The action being confirmed ("Delete this project?")
+- **Body:** The specific consequence ("This permanently removes all 23 files
+  and 8 comments. Team members will lose access.")
+- **Primary button:** Safe option with positive framing ("Keep Project")
+- **Secondary button:** Matches the title verb ("Delete Project")
+
+**Rules:**
+- Use real numbers: "47 photos" not "your photos"
+- For critical actions, require typing the name
+- Never use "Cancel" / "OK" — name both actions specifically
+- The safe option should be the default/primary button
+
+---
+
+## Loading States
+
+Silence during waits feels broken. Copy reassures.
+
+| Duration | Pattern |
+|----------|---------|
+| < 2 seconds | No text needed, just a visual indicator |
+| 2-10 seconds | "Loading your dashboard..." |
+| 10-30 seconds | "Getting your results. Should take about 15 seconds." |
+| 30+ seconds | "Processing your file (2 of 5 complete)..." with progress |
+| Unknown duration | "This might take a moment. We'll notify you when it's ready." |
+
+**Rules:**
+- Set time expectations when possible
+- Show progress (steps complete, percentage) for long processes
+- Offer an escape: "You can close this — we'll email when done"
+- Never leave a loading state without any text
+
+---
+
+## Success Messages
+
+Confirm the action + what happens next.
+
+| Don't | Do |
+|-------|-----|
+| Success! | Sent! You'll receive a confirmation email within 5 minutes. |
+| Done. | Your project is live. Share it with your team → |
+| Submitted | Application received. We'll review it within 2 business days. |
+
+**Rules:**
+- Be specific about what succeeded
+- Set expectations for what happens next (email, review, processing)
+- Offer the natural next action
+- Warm but brief — don't slow users down with celebrations
+
+---
+
+## Notifications & Push
+
+Every notification is an interruption. It must justify itself in the first 5 words.
+
+**Rules:**
+- First 5 words must convey the value
+- "Your payment of $450 was declined" — justified interruption
+- "You might like..." — never justified as a push notification
+- Batch low-priority notifications
+- Include enough context to act without opening the app
+- "Tap" on mobile, "Click" on desktop. "Select" if cross-platform.
+
+---
+
+## Onboarding
+
+Guide new users to their first success moment.
+
+**Rules:**
+- One action per step
+- Show progress: "Step 2 of 4"
+- Lead with value: "Let's get your first campaign live" not "Fill out your profile"
+- Use possessive language: "Your workspace" not "The workspace"
+- Make skip options visible — forced onboarding causes drop-off
+- Celebrate the first milestone genuinely
+
+---
+
+## Search
+
+**Placeholder:** Tell what's searchable. "Search projects, files, or members"
+not just "Search."
+
+**No results:**
+- Check for typos and suggest corrections
+- Show popular or recent items
+- "No results for 'xylophne.' Did you mean 'xylophone'?"
+- Never just "No results found." with nothing else
+
+---
+
+## AI Interface Copy
+
+For products with AI features, chatbots, or LLM-powered experiences.
+
+**The blank prompt problem:**
+- Never show an empty text input with "Ask anything"
+- Provide 3-4 starter prompts: "Try: 'Summarize this doc' or 'Find action items'"
+- Frame the input: "Ask about your sales data" not "Ask anything"
+
+**Setting expectations:**
+- "Here's what I found" (not "I know the answer")
+- "Based on available information" (signals limits)
+- "Review for accuracy" on AI-generated content
+
+**Handoff to human:**
+- "This needs a human touch. Connecting you — they usually respond in 5 min."
+- Not: "I can't help with that."
+
+**Disclosure:**
+- "Powered by AI" as a subtle label
+- "AI-suggested reply" on auto-drafts
+- Be transparent, not apologetic

--- a/.claude/skills/ux-copywriter/references/product-type-guide.md
+++ b/.claude/skills/ux-copywriter/references/product-type-guide.md
@@ -1,0 +1,158 @@
+# Copy by Product Type
+
+Different products need different copy energy. Read when adapting copy for
+a specific industry or product category.
+
+---
+
+## SaaS Products
+
+**Goal:** Get users to the "aha moment" as fast as possible.
+
+**Onboarding:** "Welcome! Let's get your first campaign live in 3 minutes."
+Not "Welcome to [Product]. Please complete your profile to get started."
+
+**Feature discovery:** Contextual tooltips when relevant, not a feature tour
+dumped on first login. Progressive disclosure.
+
+**Upgrade prompts:** Frame around value gained, not limits hit.
+- Do: "Unlock unlimited projects and team collaboration"
+- Don't: "You've reached your free plan limit"
+
+**Empty dashboards:** Show what data WILL look like.
+"Your analytics will appear here once your first user visits. Here's what
+to expect: [preview/illustration]"
+
+**Key principles:**
+- Time-to-value is everything. Cut every step between signup and first success.
+- Use possessive language from minute one ("Your workspace is ready")
+- Inline help > help docs. Context-sensitive > generic
+- Error messages should preserve user work and offer recovery paths
+
+---
+
+## E-Commerce
+
+**Goal:** Reduce purchase anxiety at every step.
+
+**Product pages:** Benefits over features. Social proof near CTAs.
+- "Fits true to size — 92% of reviewers agree" not "Available in sizes S-XL"
+
+**Cart & checkout:** Reassurance microcopy throughout.
+- "Free returns within 30 days"
+- "Your payment info is encrypted"
+- "Estimated delivery: Thursday, March 6"
+
+**Form fields:** Explain why you need sensitive data.
+- "Phone number (for delivery updates only)"
+- "Date of birth (to verify age for this product)"
+
+**Out of stock:** Don't dead-end. Offer alternatives.
+- "This item is currently unavailable. Get notified when it's back, or browse
+  similar items."
+
+**Key principles:**
+- Every step toward checkout should reduce anxiety, not add friction
+- Show total cost early — hidden fees at checkout destroy trust
+- Use urgency only when real: "Sale ends March 15" not "Limited time!"
+- Post-purchase: set delivery expectations immediately
+
+---
+
+## Fintech & Banking
+
+**Goal:** Build trust through precision and transparency.
+
+**Simplify jargon:** "You don't have enough in this account. Transfer from
+savings?" not "Insufficient funds."
+
+**Security copy:** Present at every sensitive moment.
+- "Your data is encrypted and never shared with third parties"
+- "This transaction is protected by [security standard]"
+
+**Transaction confirmations:** Explicit about everything.
+- "You're sending $250 to Maria García. A $2.50 fee applies. Total: $252.50.
+  Funds arrive within 1 business day. Confirm?"
+- Never surprise users with fees or processing times
+
+**Error messages:** Must be precise. Vague fintech errors are dangerous.
+- "Card declined: expired. Update your card in Settings." not "Payment failed"
+
+**Key principles:**
+- No ambiguity. Ever. Money is involved.
+- Round numbers feel trustworthy. Show exact amounts with currency symbols.
+- Compliance copy must be clear but not frightening
+- Two-factor confirmations: explain why, not just demand it
+- Transaction histories: clear dates, amounts, recipients, statuses
+
+---
+
+## Health & Wellness
+
+**Goal:** Be warm, clear, never judgmental.
+
+**Tone:** Supportive and calm. Never clinical-first.
+- "Your blood pressure is a bit high (hypertension)" not "Hypertensive reading
+  detected"
+- "Let's look at your progress this week" not "Weekly health metrics"
+
+**Data permissions:** Explain clearly what you collect and why.
+- "We use your activity data to personalize your plan. It's stored securely
+  and never shared."
+
+**Results & diagnoses:** Plain language first, medical terms in parentheses.
+- "Your test results are normal" not "Results within reference range"
+
+**Key principles:**
+- Warm does not mean vague. Be precise about medical information.
+- Never be judgmental about user behavior or choices
+- Progress framing: celebrate small wins, don't highlight failures
+- Sensitive topics: give users control over what they share and see
+- Emergency copy: clear, direct, action-oriented with phone numbers
+
+---
+
+## Education & Learning
+
+**Goal:** Make progress feel continuous and errors feel like learning.
+
+**Progress:** Show it everywhere.
+- "3 lessons until your next milestone"
+- "You've completed 12 of 20 challenges this week"
+- Duolingo's entire UX is built on this principle
+
+**Error handling:** Errors are part of learning, not failure.
+- "Not quite! Here's a hint..." not "Wrong answer"
+- "Try again — you're getting closer" not "Incorrect. The answer is X."
+
+**Celebrations:** Genuine, not patronizing.
+- "You've finished your first module!" (with clear next step)
+- Not "Great job, superstar!! You're AMAZING! 🎉🎉🎉"
+
+**Key principles:**
+- Never make users feel stupid
+- Show progress at every scale: within a lesson, within a course, overall
+- Streaks and milestones work — but make breaking a streak feel recoverable
+- Complexity should build gradually in copy too (simpler language early)
+- Accessibility matters extra here — learners have diverse needs
+
+---
+
+## Marketplaces & Platforms
+
+**Goal:** Speak to multiple user types with one voice.
+
+**Two-sided copy:** Buyers and sellers need different information.
+- Buyer empty state: "Find what you're looking for — browse categories or search"
+- Seller empty state: "List your first item — it takes about 5 minutes"
+
+**Trust signals:** Critical for peer-to-peer transactions.
+- "Verified seller since 2023"
+- "Money-back guarantee if item doesn't match description"
+- Review copy: "247 reviews, 4.8 average"
+
+**Key principles:**
+- Create separate copy guidelines for each user type
+- Transaction copy must be crystal clear for both parties
+- Dispute/resolution copy needs extreme care — both sides are reading it
+- Onboarding differs per role: guide buyers to first browse, sellers to first listing

--- a/.claude/skills/ux-copywriter/references/psychology-of-copy.md
+++ b/.claude/skills/ux-copywriter/references/psychology-of-copy.md
@@ -1,0 +1,165 @@
+# Psychology of UX Copy
+
+The cognitive science behind why certain words work. Read when you need to
+understand WHY a copy choice is effective, or when making a case for copy
+changes to stakeholders.
+
+---
+
+## Cognitive Load Theory
+
+Working memory holds ~4 chunks. Every word on screen costs mental energy.
+Your copy competes with the visual layout, the user's task context, and
+everything else happening in their life.
+
+**Implications:**
+- Shorter is not just "nice." It's neurologically necessary.
+- A 22-word tooltip cannot be processed while also remembering which field
+  it's about
+- One idea per sentence. One action per screen.
+- Progressive disclosure: reveal information only when the user needs it
+
+---
+
+## The Fluency Effect
+
+Information that is easy to process is perceived as more true and trustworthy.
+This is called cognitive fluency.
+
+- Simple syntax → feels more reliable
+- Familiar words → feels safer
+- Copy that "flows" → creates unconscious trust in the product
+
+**Why jargon kills trust, not just comprehension:**
+"Authentication token expired" doesn't just confuse. It subconsciously signals
+unreliability. "Your session ended. Sign in again to continue" feels like
+the product has your back.
+
+**Application:** Use the most common word, not the most precise technical
+term. The user's trust matters more than terminological accuracy.
+
+---
+
+## Loss Aversion
+
+People feel losses ~2x as intensely as equivalent gains.
+
+**When to use:**
+- Destructive confirmations: "You'll lose all 47 photos in this album"
+- Upgrade prompts: "Keep your 3 saved projects" > "Upgrade to save more"
+- Retention: "Don't lose your progress" > "Save your progress"
+
+**When NOT to use:**
+- Routine actions (creates anxiety)
+- Onboarding (creates hesitation)
+- Settings changes (makes everything feel risky)
+
+Reserve loss language for moments where genuine caution is warranted.
+
+---
+
+## The Endowment Effect
+
+People value things more once they feel ownership.
+
+**Application in onboarding:**
+- "Your dashboard is ready" not "The dashboard is ready"
+- "Your first project" not "Create a project"
+- "Your team" not "The team workspace"
+
+Stripe does this from signup. Everything is framed as "yours" before the user
+has actually invested anything. This creates psychological commitment that
+reduces churn.
+
+---
+
+## Social Proof Inside Products
+
+Not just for landing pages. Inside products, social proof reduces decision
+anxiety:
+
+- "Most teams choose this plan" (pricing page)
+- "1,847 people completed this course" (education)
+- "Added by 12 of your contacts" (social)
+- "Popular choice" tags on option selectors
+
+**Key rule:** Social proof inside a product must feel organic, not salesy.
+If it reads like a marketing badge pasted into a settings screen, it erodes
+trust rather than building it.
+
+---
+
+## The Zeigarnik Effect
+
+People remember incomplete tasks better than completed ones.
+
+**Application:**
+- "2 steps left to complete your profile"
+- "You're 80% of the way to earning your first badge"
+- "Just one more thing before your store goes live"
+
+Creates gentle psychological tension that motivates completion. But breaks
+if remaining steps feel arbitrary or endless. Always be honest about how
+much is left.
+
+---
+
+## Serial Position Effect
+
+People best remember the first and last items in a sequence.
+
+**Application:**
+- In feature lists: most important benefit first, second most important last
+- In pricing tables: highlight the recommended plan in the "prime" position
+- In onboarding: start with the most exciting step, end with a celebration
+- In error messages: put the action step last (it's what they'll remember)
+
+---
+
+## The Framing Effect
+
+How you frame the same fact changes how it feels:
+- "Save $500/year" outperforms "Avoid losing $500" in most positive contexts
+- "90% success rate" feels better than "10% failure rate"
+- "Free for 14 days" > "Paid after 14 days"
+
+Choose your frame based on what emotion you want to create. Positive frames
+for features and benefits. Loss frames only for high-stakes warnings.
+
+---
+
+## Anchoring Bias
+
+The first number or option presented sets expectations for everything after.
+
+- Premium pricing shown first makes mid-tier feel reasonable
+- "Usually takes 5 minutes" anchors expectations (even if it takes 3)
+- "Join 50,000+ users" anchors perceived popularity
+- Show the higher plan first on pricing pages, even if most choose the middle
+
+---
+
+## Choice Overload
+
+Beyond 5-7 options, decision quality drops sharply (Hick's Law).
+
+**Application to copy:**
+- Limit navigation labels to 5-7 items max
+- Forms: only show fields that matter right now
+- Settings: progressive disclosure, not a wall of toggles
+- Pricing: 3 plans maximum. If you have more, use a comparison tool.
+
+---
+
+## Commitment Escalation
+
+Small yeses lead to big yeses.
+
+**Application:**
+- Ask for email before credit card
+- Get users to name their project before asking for payment
+- Free trial before paid plan
+- "Start free" not "Buy now" as the first CTA
+
+Each micro-commitment creates investment that makes the next step feel
+natural rather than demanding.

--- a/.claude/skills/ux-copywriter/references/voice-tone-builder.md
+++ b/.claude/skills/ux-copywriter/references/voice-tone-builder.md
@@ -1,0 +1,143 @@
+# Voice & Tone Framework
+
+How to build a consistent voice for a product and shift tone for different
+moments. Read when creating voice guidelines, reviewing tone consistency,
+or helping a team establish their product's personality.
+
+---
+
+## Voice vs. Tone
+
+**Voice** is the product's personality. It stays consistent everywhere.
+Mailchimp is always friendly. Stripe is always precise. Duolingo is always
+encouraging. Voice doesn't change.
+
+**Tone** shifts based on context. The same voice can be celebratory (success),
+calm (error), focused (onboarding), or serious (security). Tone adapts to
+what the user is feeling at that moment.
+
+---
+
+## The NNG 4 Dimensions
+
+Nielsen Norman Group identifies four dimensions to map any product's voice:
+
+1. **Serious ↔ Funny**
+   Where does your product fall? Fintech = serious. Gaming = funnier.
+   Most products land 60-70% toward serious.
+
+2. **Formal ↔ Casual**
+   "Please complete this field" vs "Fill this in." Enterprise B2B = formal.
+   Consumer social = casual. SaaS = usually casual-professional.
+
+3. **Respectful ↔ Irreverent**
+   Most products should be respectful. Only brand-confident products
+   (Mailchimp, Slack) can pull off irreverence well.
+
+4. **Enthusiastic ↔ Matter-of-fact**
+   Celebrations = enthusiastic. Data display = matter-of-fact.
+   But even enthusiastic products shouldn't be enthusiastic about errors.
+
+---
+
+## Building a Voice Guide
+
+### Step 1: Define 3-4 Voice Attributes
+
+Pick adjectives that describe how the product should sound. Not what it does.
+
+**Example:** "Confident, Clear, Warm, Precise"
+**Not:** "Innovative, Scalable, Cutting-edge"
+
+For each attribute, define what it means AND what it doesn't:
+- **Confident** means: direct statements, no hedging, lead with answers
+- **Confident** does NOT mean: arrogant, dismissive, or ignoring uncertainty
+
+### Step 2: Map Tone Shifts by Context
+
+Same voice, different emotional energy:
+
+| Context | User Feeling | Tone Shift |
+|---|---|---|
+| Onboarding | Curious, maybe nervous | Warm, encouraging, simple |
+| Success | Accomplished, relieved | Brief celebration, point to next step |
+| Error | Frustrated, anxious | Calm, specific, helpful, blame-free |
+| Settings | Neutral, task-focused | Clear, efficient, minimal |
+| Payment | Cautious, possibly anxious | Precise, reassuring, transparent |
+| Destructive action | Uncertain, cautious | Serious, specific about consequences |
+| Loading/waiting | Impatient | Reassuring, time-specific |
+| Empty state | Confused or exploring | Guiding, suggesting, inviting |
+
+### Step 3: Create Do/Don't Examples
+
+The most effective voice guides show contrast, not just rules.
+
+**Example for a "Clear" voice attribute:**
+
+| Don't | Do |
+|-------|-----|
+| "We're unable to process your request at this time" | "We can't do that right now. Here's why." |
+| "The functionality has been deprecated" | "This feature is no longer available" |
+| "Utilize the search functionality" | "Search for it" |
+
+### Step 4: Word Lists
+
+Include a banned words list and a preferred words list:
+
+**Preferred:** use, start, help, create, send, show, save
+**Avoid:** utilize, commence, facilitate, generate, submit, render, persist
+
+**Preferred:** "Sign in" (consistent)
+**Avoid:** mixing "Log in," "Sign in," "Log on" across the product
+
+---
+
+## Tone Matching by Emotional State
+
+The most important tone skill: matching the user's feelings.
+
+### User is FRUSTRATED (error, failure, block)
+- Be calm, not cheerful
+- Be specific, not vague
+- Acknowledge the situation
+- "Your payment didn't go through. Here's how to fix it."
+- NOT "Oops! Something went wrong 😅"
+
+### User is ANXIOUS (payment, security, health)
+- Be precise and reassuring
+- Explain what you're doing and why
+- "Your data is encrypted and only you can access it."
+- NOT "Don't worry about it!"
+
+### User is EXCITED (success, milestone)
+- Match their energy briefly, then redirect
+- "Your store is live! Share it with your first customers."
+- NOT a paragraph of celebration that delays them
+
+### User is NEUTRAL (settings, routine tasks)
+- Be efficient. No personality needed.
+- "Notification preferences updated."
+- NOT "Woohoo! You just changed your settings! 🎉"
+
+### User is CONFUSED (onboarding, complex feature)
+- One step at a time. Short sentences.
+- "First, connect your data source. We'll show you how."
+- NOT a paragraph explaining the architecture
+
+---
+
+## Testing Voice Consistency
+
+### The "Cover the Logo" Test
+Read the copy without seeing the product name. Would you know which
+product this is? If it sounds like every other SaaS, the voice isn't
+distinctive enough.
+
+### The "Colleague" Test
+If the product were a person at a party, how would they talk? If the
+answer is "like a press release," the voice needs work.
+
+### The "Extreme Moment" Test
+Read the copy for the worst moment (critical error, data loss) and the
+best moment (major achievement). Does the voice stay recognizable while
+the tone shifts appropriately?


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds the `ux-copywriter` skill to write, review, and audit product microcopy across UI components, including AI interface copy. Improves clarity, translation readiness, and accessibility across product text.

- **New Features**
  - New skill at `.claude/skills/ux-copywriter/SKILL.md` with rules, workflows, examples, activation triggers, and how it collaborates with related skills.
  - Reference guides added: localization checklist, microcopy patterns, product-type guide, psychology of copy, and voice & tone builder.
  - Mandatory quality checks for clarity, accessibility, ethics, and localization, plus default formats for presenting copy and audits.

<sup>Written for commit b94dd0df7fae7da24780a9a236ac6d33f8ba70e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

