### PR TITLE
feat(categories): add i18n strings and categoryId schema factory

### DIFF
--- a/apps/mobile/features/transactions/schema.ts
+++ b/apps/mobile/features/transactions/schema.ts
@@ -5,10 +5,14 @@ import { isValidCategoryId } from "./lib/categories";
 export const transactionTypeSchema = z.enum(["expense", "income"]);
 export type TransactionType = z.infer<typeof transactionTypeSchema>;
 
-export const categoryIdSchema = z
-  .string()
-  .refine(isValidCategoryId, { message: "Invalid category ID" })
-  .transform((s) => s as CategoryId);
+export function makeCategoryIdSchema(isValid: (id: string) => boolean) {
+  return z
+    .string()
+    .refine(isValid, { message: "Invalid category ID" })
+    .transform((s) => s as CategoryId);
+}
+
+export const categoryIdSchema = makeCategoryIdSchema(isValidCategoryId);
 
 export const createTransactionSchema = z.object({
   type: transactionTypeSchema,

--- a/apps/mobile/shared/i18n/locales/en.ts
+++ b/apps/mobile/shared/i18n/locales/en.ts
@@ -130,6 +130,31 @@ const en = {
     },
   },
 
+  // Categories
+  categories: {
+    title: "Categories",
+    settingsRow: "Categories",
+    builtInSection: "DEFAULT",
+    customSection: "CUSTOM",
+    addCategory: "+ Add category",
+    noCustomCategories: "No custom categories yet",
+    create: {
+      title: "New category",
+      nameLabel: "Category name",
+      namePlaceholder: "e.g. Pets",
+      iconLabel: "Choose an icon",
+      colorLabel: "Choose a color",
+      submit: "Create category",
+    },
+    errors: {
+      nameTooShort: "Name must be at least 2 characters",
+      nameTooLong: "Name must be under 32 characters",
+      iconRequired: "Please select an icon",
+      colorRequired: "Please select a color",
+      saveFailed: "Could not save category",
+    },
+  },
+
   // Goals
   goals: {
     title: "Goals",

--- a/apps/mobile/shared/i18n/locales/es.ts
+++ b/apps/mobile/shared/i18n/locales/es.ts
@@ -131,6 +131,31 @@ const es = {
     },
   },
 
+  // Categorías
+  categories: {
+    title: "Categorías",
+    settingsRow: "Categorías",
+    builtInSection: "PREDETERMINADAS",
+    customSection: "PERSONALIZADAS",
+    addCategory: "+ Agregar categoría",
+    noCustomCategories: "Aún no hay categorías personalizadas",
+    create: {
+      title: "Nueva categoría",
+      nameLabel: "Nombre de la categoría",
+      namePlaceholder: "ej. Mascotas",
+      iconLabel: "Elige un ícono",
+      colorLabel: "Elige un color",
+      submit: "Crear categoría",
+    },
+    errors: {
+      nameTooShort: "El nombre debe tener al menos 2 caracteres",
+      nameTooLong: "El nombre debe tener menos de 32 caracteres",
+      iconRequired: "Por favor selecciona un ícono",
+      colorRequired: "Por favor selecciona un color",
+      saveFailed: "No se pudo guardar la categoría",
+    },
+  },
+
   // Metas
   goals: {
     title: "Metas",


### PR DESCRIPTION
- Add makeCategoryIdSchema factory for dynamic validation support
- Add categories i18n strings for EN and ES locales

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a factory for dynamic category ID validation and adds category UI strings for English and Spanish. This enables flexible validators and completes copy for the categories flow.

- **New Features**
  - Added `makeCategoryIdSchema(isValid)` and used it to build `categoryIdSchema` with `isValidCategoryId`.
  - Added categories i18n keys in `en` and `es` (sections, create form labels/placeholders, validation errors, empty state, actions).

<sup>Written for commit 3e983d46ee9061156a2eb23202b5689bdb7d7e2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

