### PR TITLE
fix(mobile): fix transaction dedup and add Sentry telemetry

### DIFF
--- a/.claude/skills/debugging-with-sentry/SKILL.md
+++ b/.claude/skills/debugging-with-sentry/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: debugging-with-sentry
+description: Use when investigating user-reported bugs, silent failures, duplicate transactions, missing data, sync issues, or any production problem. Sentry is the primary observability tool — check it before reading code.
+---
+
+# Debugging with Sentry
+
+Sentry is the primary tool for debugging user issues. Every critical path in the app reports structured events. Before investigating code, check Sentry for the user's event trail.
+
+## Privacy Constraint
+
+Sentry events contain **only structural metadata** — counts, statuses, error types, timing. Never merchant names, amounts, email content, or chat messages. If you need transaction-level detail, you must query the Supabase `transactions` table directly (no `source` column there — it's local-only).
+
+## Quick Reference: Sentry Events
+
+### Pipeline Events (`capturePipelineEvent` — level: info)
+
+Filter by message `pipeline:<source>` in Sentry.
+
+| Message | Key Fields | What It Tells You |
+|---------|-----------|------------------|
+| `pipeline:email` | `batchSize`, `uniqueProviders`, `dedupedInBatch`, `skippedAlreadyProcessed`, `skippedCrossSource`, `saved`, `failed`, `needsReview` | Full email sync outcome. `dedupedInBatch > 0` = duplicate emails in batch (same account connected twice). `uniqueProviders` = how many providers fetched. |
+| `pipeline:notification` | `bankSource`, `parseMethod`, `saved`, `skippedDuplicate`, `parseFailed` | Per-notification outcome. `bankSource` = which bank (e.g., `notification_bancolombia`). `parseMethod` = `regex` or `llm`. |
+| `pipeline:apple_pay` | `saved`, `skippedDuplicate` | Per-intent outcome. |
+| `pipeline:sync_push` | `queued`, `succeeded`, `failed` | Sync push batch result. |
+| `pipeline:sync_pull` | `rowsFetched`, `rowsApplied`, `conflicts`, `failed` | Sync pull batch result. `failed > 0` with repeated events = stuck sync. |
+
+### Warnings (`captureWarning` — level: warning)
+
+| Message | Key Fields | Means |
+|---------|-----------|-------|
+| `email_token_refresh_failed` | `provider`, `httpStatus` | OAuth token died. User's email sync is silently broken. |
+| `gmail_api_list_failed` | `httpStatus` | Gmail API error (401=revoked, 403=quota, 429=rate limit). |
+| `outlook_api_list_failed` | `httpStatus` | Same for Outlook. |
+| `email_adapter_fetch_failed` | `provider`, `errorType` | Email fetch threw an exception. |
+| `email_parse_exception` | `provider`, `errorType` | LLM parse threw during email processing. |
+| `email_retry_parse_exception` | `provider`, `errorType` | LLM parse threw during retry. |
+| `parse_email_api_failed` | `errorMessage`, `hasData` | Edge Function returned error or empty. |
+| `parse_email_validation_failed` | `issueCount` | LLM output failed Zod validation. |
+| `parse_email_api_exception` | `errorType` | Edge Function call threw. |
+| `classify_merchant_failed` | `hasError`, `errorMessage` | Merchant classification Edge Function failed. |
+| `parse_notification_api_failed` | `errorMessage`, `hasData` | Notification Edge Function error. |
+| `parse_notification_validation_failed` | `issueCount` | Notification LLM output failed validation. |
+| `parse_notification_api_exception` | `errorType` | Notification Edge Function threw. |
+| `bank_senders_fetch_failed` | `errorMessage` | Bank senders Supabase query failed, using defaults. |
+| `bank_senders_exception` | `errorType` | Bank senders fetch threw. |
+| `sync_push_entry_failed` | `tableName`, `errorMessage`, `errorCode` | Supabase upsert failed for a specific table. |
+| `sync_push_unknown_table` | `tableName` | Sync queue has entry for unhandled table. |
+| `sync_pull_fetch_failed` | `errorMessage`, `errorCode` | Supabase pull query failed. |
+| `background_sync_failed` | `errorType` | Background sync hook threw. |
+| `auth_restore_failed` | `errorMessage` | Session restore from Supabase failed. |
+| `auth_restore_exception` | `errorType` | Session restore threw. |
+| `auth_signin_failed` | `errorType` | Sign-in OAuth flow threw. |
+| `ai_action_failed` | `actionType`, `errorType` | AI chat action (add/edit/delete) threw. |
+
+### Errors (`captureError` — level: error)
+
+Thrown exceptions from: migration failures, sync conflicts, transaction save errors, email pipeline save errors, background task crashes. These create standard Sentry error events with stack traces.
+
+## Debugging Playbook
+
+### "User reports duplicate transactions"
+1. Filter Sentry for user ID + `pipeline:email`
+2. Check `dedupedInBatch` — if > 0, same account was connected twice
+3. Check `skippedCrossSource` — if 0 with `saved > 1`, dedup didn't catch a pair
+4. Query Supabase `transactions` table for same `user_id + amount + date` pairs
+
+### "User says transactions stopped appearing"
+1. Search for `email_token_refresh_failed` for that user
+2. Check `gmail_api_list_failed` / `outlook_api_list_failed` for HTTP status
+3. Check `pipeline:email` — if `batchSize: 0` repeatedly, emails aren't being fetched
+4. Check `bank_senders_fetch_failed` — if senders list is broken, no emails match
+
+### "User's data isn't syncing"
+1. Filter for `pipeline:sync_push` — check `failed` count
+2. Check `sync_push_entry_failed` for specific `tableName` and `errorCode`
+3. Check `pipeline:sync_pull` — if `failed > 0` in repeated events, sync is stuck
+4. Check `sync_pull_fetch_failed` for Supabase query errors
+
+### "AI chat said it added an expense but nothing showed up"
+1. Search for `ai_action_failed` — check `errorType`
+2. If no warning exists, the action succeeded but might have wrong data
+
+### "User can't log in"
+1. Search for `auth_restore_failed` or `auth_signin_failed`
+2. Check `errorMessage` / `errorType` for Supabase auth details
+
+### "App crashes on launch"
+1. Check for migration errors (standard Sentry error events)
+2. Check `auth_restore_exception` — session restore might be crashing
+
+## User Identity
+
+All Sentry events are tied to a user via `Sentry.setUser({ id: userId })`, set on session change in `_layout.tsx`. Filter by user ID in Sentry to see their full event trail.
+
+## Sentry MCP
+
+A Sentry MCP server is available. Use `ToolSearch` to find `mcp__sentry` tools for querying issues, events, and user trails directly from the conversation without opening the Sentry dashboard.
+
+## Helpers
+
+- `shared/lib/sentry.ts` — `capturePipelineEvent(data)`, `captureWarning(message, context)`, `captureError(error)`, `setSentryUser(userId)`
+- All exported from `shared/lib/index.ts`
+- Data type is `Record<string, string | number | boolean>` — no nested objects, no PII

--- a/apps/mobile/__tests__/capture-sources/dedup.test.ts
+++ b/apps/mobile/__tests__/capture-sources/dedup.test.ts
@@ -148,4 +148,64 @@ describe("findDuplicateTransaction", () => {
 
     expect(result).toBeNull();
   });
+
+  it("matches when DB description contains the incoming merchant (substring)", async () => {
+    mockWhere.mockResolvedValueOnce([{ id: "tx-sub-1", description: "BOLD Natural Medical" }]);
+
+    const { findDuplicateTransaction } = await import("@/features/capture-sources/lib/dedup");
+    const result = await findDuplicateTransaction(
+      mockDb,
+      "user-1",
+      100000,
+      "2026-03-21",
+      "Natural Medical"
+    );
+
+    expect(result).toBe("tx-sub-1");
+  });
+
+  it("matches when incoming merchant contains the DB description (substring)", async () => {
+    mockWhere.mockResolvedValueOnce([{ id: "tx-sub-2", description: "HARISSA" }]);
+
+    const { findDuplicateTransaction } = await import("@/features/capture-sources/lib/dedup");
+    const result = await findDuplicateTransaction(
+      mockDb,
+      "user-1",
+      160100,
+      "2026-03-20",
+      "HARISSA HF2"
+    );
+
+    expect(result).toBe("tx-sub-2");
+  });
+
+  it("does not substring-match when DB description is very short (< 3 chars)", async () => {
+    mockWhere.mockResolvedValueOnce([{ id: "tx-short", description: "AB" }]);
+
+    const { findDuplicateTransaction } = await import("@/features/capture-sources/lib/dedup");
+    const result = await findDuplicateTransaction(
+      mockDb,
+      "user-1",
+      5000,
+      "2026-03-07",
+      "ABC Store"
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("handles null description in DB row without false match", async () => {
+    mockWhere.mockResolvedValueOnce([{ id: "tx-null", description: null }]);
+
+    const { findDuplicateTransaction } = await import("@/features/capture-sources/lib/dedup");
+    const result = await findDuplicateTransaction(
+      mockDb,
+      "user-1",
+      5000,
+      "2026-03-07",
+      "Uber Eats"
+    );
+
+    expect(result).toBeNull();
+  });
 });

--- a/apps/mobile/__tests__/db/client.test.ts
+++ b/apps/mobile/__tests__/db/client.test.ts
@@ -20,6 +20,8 @@ vi.mock("expo-crypto", () => ({
 
 vi.mock("@/shared/lib/sentry", () => ({
   captureError: vi.fn(),
+  capturePipelineEvent: vi.fn(),
+  captureWarning: vi.fn(),
 }));
 
 import { getRandomBytes } from "expo-crypto";

--- a/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
@@ -49,6 +49,8 @@ vi.mock("@/features/email-capture/services/parse-email-api", () => ({
 
 vi.mock("@/shared/lib/sentry", () => ({
   captureError: vi.fn(),
+  capturePipelineEvent: vi.fn(),
+  captureWarning: vi.fn(),
 }));
 
 const mockGenerateId = vi.fn();
@@ -381,6 +383,29 @@ describe("email processing pipeline", () => {
       failed: 0,
       needsReview: 0,
     });
+  });
+
+  it("deduplicates emails with the same externalId within a batch", async () => {
+    // Same externalId appearing twice (e.g., same Gmail account connected twice)
+    const emails = [
+      makeRawEmail({ externalId: "ext-dup", body: "Compra por $64.000 en CHERNIKA SAS" }),
+      makeRawEmail({ externalId: "ext-dup", body: "Compra por $64.000 en CHERNIKA SAS" }),
+    ];
+    mockParseEmailApi.mockResolvedValue({
+      type: "expense",
+      amount: 64000,
+      categoryId: "other",
+      description: "CHERNIKA SAS",
+      date: "2026-03-20",
+      confidence: 0.9,
+    });
+
+    const result = await processEmails(mockDb, USER_ID, emails);
+
+    // Only ONE transaction should be created, second email should be skipped as duplicate
+    expect(mockInsertTransaction).toHaveBeenCalledTimes(1);
+    expect(result.saved + result.needsReview + result.filtered).toBeLessThanOrEqual(1);
+    expect(result.skippedDuplicate).toBeGreaterThanOrEqual(1);
   });
 });
 

--- a/apps/mobile/__tests__/email-capture/retry-integration.test.ts
+++ b/apps/mobile/__tests__/email-capture/retry-integration.test.ts
@@ -22,6 +22,8 @@ vi.mock("@/features/email-capture/services/parse-email-api", () => ({
 
 vi.mock("@/shared/lib/sentry", () => ({
   captureError: vi.fn(),
+  capturePipelineEvent: vi.fn(),
+  captureWarning: vi.fn(),
 }));
 
 const mockFindDuplicateTransaction = vi.fn().mockResolvedValue(null);

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -290,6 +290,24 @@ describe("useEmailCaptureStore", () => {
     expect(useEmailCaptureStore.getState().accounts).toHaveLength(0);
   });
 
+  it("connectEmail rejects duplicate email address", async () => {
+    // Pre-existing account with user@gmail.com
+    useEmailCaptureStore.setState({
+      accounts: [makeAccount({ email: "user@gmail.com" })],
+    });
+
+    mockAdapter.connect.mockResolvedValueOnce({
+      success: true,
+      email: "user@gmail.com",
+    });
+
+    await useEmailCaptureStore.getState().connectEmail("gmail", "client-id");
+
+    // Should NOT insert a duplicate account
+    expect(insertEmailAccount).not.toHaveBeenCalled();
+    expect(useEmailCaptureStore.getState().accounts).toHaveLength(1);
+  });
+
   it("disconnectEmail removes from DB and state", async () => {
     useEmailCaptureStore.setState({
       accounts: [makeAccount()],

--- a/apps/mobile/__tests__/error-handling/error-boundary.test.ts
+++ b/apps/mobile/__tests__/error-handling/error-boundary.test.ts
@@ -6,6 +6,11 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("@sentry/react-native", () => ({
   init: vi.fn(),
   captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  setUser: vi.fn(),
+  withScope: vi.fn((cb: (scope: unknown) => void) =>
+    cb({ setContext: vi.fn(), setLevel: vi.fn() })
+  ),
   ErrorBoundary: "SentryErrorBoundary",
   wrap: vi.fn((component: unknown) => component),
 }));

--- a/apps/mobile/__tests__/error-handling/pipeline-save-error.test.ts
+++ b/apps/mobile/__tests__/error-handling/pipeline-save-error.test.ts
@@ -6,6 +6,8 @@ const mockCaptureError = vi.fn();
 
 vi.mock("@/shared/lib/sentry", () => ({
   captureError: (...args: unknown[]) => mockCaptureError(...args),
+  capturePipelineEvent: vi.fn(),
+  captureWarning: vi.fn(),
 }));
 
 const mockGetProcessedExternalIds = vi.fn().mockResolvedValue(new Set<string>());

--- a/apps/mobile/__tests__/setup.ts
+++ b/apps/mobile/__tests__/setup.ts
@@ -238,6 +238,11 @@ vi.mock("expo-web-browser", () => ({
 vi.mock("@sentry/react-native", () => ({
   init: vi.fn(),
   captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  setUser: vi.fn(),
+  withScope: vi.fn((cb: (scope: unknown) => void) =>
+    cb({ setContext: vi.fn(), setLevel: vi.fn() })
+  ),
   ErrorBoundary: "SentryErrorBoundary",
   wrap: vi.fn((component: unknown) => component),
 }));

--- a/apps/mobile/__tests__/shared/normalize-merchant.test.ts
+++ b/apps/mobile/__tests__/shared/normalize-merchant.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "vitest";
+import { merchantsMatch, normalizeMerchant } from "@/shared/lib/normalize-merchant";
+
+describe("normalizeMerchant", () => {
+  test("lowercases, trims, and collapses whitespace", () => {
+    expect(normalizeMerchant("  UBER   EATS  ")).toBe("uber eats");
+  });
+});
+
+describe("merchantsMatch", () => {
+  test("exact match returns true", () => {
+    expect(merchantsMatch("uber eats", "uber eats")).toBe(true);
+  });
+
+  test("both empty strings match (exact)", () => {
+    expect(merchantsMatch("", "")).toBe(true);
+  });
+
+  test("substring: DB has longer name containing incoming", () => {
+    expect(merchantsMatch("bold natural medical", "natural medical")).toBe(true);
+  });
+
+  test("substring: incoming has longer name containing DB", () => {
+    expect(merchantsMatch("harissa", "harissa hf2")).toBe(true);
+  });
+
+  test("real case: BOLD CHERNIKA SAS vs CHERNIKA SAS", () => {
+    expect(merchantsMatch("bold chernika sas", "chernika sas")).toBe(true);
+  });
+
+  test("real case: Comercio Barranquilla vs Barranquilla", () => {
+    expect(merchantsMatch("comercio barranquilla", "barranquilla")).toBe(true);
+  });
+
+  test("completely different merchants do not match", () => {
+    expect(merchantsMatch("uber eats", "starbucks")).toBe(false);
+  });
+
+  test("short string (< 3 chars) does not substring-match", () => {
+    expect(merchantsMatch("a", "apple store")).toBe(false);
+  });
+
+  test("short string (< 3 chars) still exact-matches", () => {
+    expect(merchantsMatch("ab", "ab")).toBe(true);
+  });
+
+  test("one empty, one non-empty do not match", () => {
+    expect(merchantsMatch("", "starbucks")).toBe(false);
+  });
+
+  test("2-char string does not substring-match longer string", () => {
+    expect(merchantsMatch("el", "el corte ingles")).toBe(false);
+  });
+
+  test("3-char string does substring-match longer string", () => {
+    expect(merchantsMatch("bar", "barranquilla")).toBe(true);
+  });
+});

--- a/apps/mobile/__tests__/sync/sync-pull-integration.test.ts
+++ b/apps/mobile/__tests__/sync/sync-pull-integration.test.ts
@@ -19,6 +19,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/shared/lib/sentry", () => ({
   captureError: vi.fn(),
+  capturePipelineEvent: vi.fn(),
+  captureWarning: vi.fn(),
 }));
 
 import { getUnresolvedConflicts } from "@/features/sync/lib/conflict-repository";

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -48,6 +48,7 @@ import {
   handleRecoverableError,
   initSentry,
   SentryErrorBoundary,
+  setSentryUser,
   wrapWithSentry,
 } from "@/shared/lib";
 import type { UserId } from "@/shared/types/branded";
@@ -123,6 +124,9 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
   useSmsDetection(captureDb, userId);
 
   useEffect(() => {
+    if (migrationsError) {
+      captureError(migrationsError);
+    }
     if (migrationsReady || migrationsError) {
       SplashScreen.hideAsync();
     }
@@ -158,6 +162,7 @@ function RootLayout() {
 
   // Re-check onboarding status when session changes
   useEffect(() => {
+    setSentryUser(userId);
     if (session) {
       const fromStore = getOnboardingCompleteFromStore();
       const fromSession = isOnboardingComplete(session);
@@ -167,7 +172,7 @@ function RootLayout() {
       clearOnboardingFromStore();
       setOnboardingComplete(false);
     }
-  }, [session]);
+  }, [session, userId]);
 
   useEffect(() => {
     if ((fontsLoaded || fontsError) && !isAuthLoading) {

--- a/apps/mobile/features/ai-chat/hooks/use-streaming-chat.ts
+++ b/apps/mobile/features/ai-chat/hooks/use-streaming-chat.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { useTransactionStore } from "@/features/transactions";
-import { parseIsoDate } from "@/shared/lib";
+import { captureWarning, parseIsoDate } from "@/shared/lib";
 import type { IsoDate } from "@/shared/types/branded";
 import { parseActionFromResponse } from "../lib/parse-action";
 import type { ChatAction } from "../schema";
@@ -89,7 +89,14 @@ export function useStreamingChat() {
               await useChatStore.getState().addAssistantMessage(accumulated, action);
 
               if (action && action.type === "add") {
-                await executeAction(action);
+                try {
+                  await executeAction(action);
+                } catch (actionErr) {
+                  captureWarning("ai_action_failed", {
+                    actionType: action.type,
+                    errorType: actionErr instanceof Error ? actionErr.message : "unknown",
+                  });
+                }
               }
 
               resetStreamState();

--- a/apps/mobile/features/auth/store.ts
+++ b/apps/mobile/features/auth/store.ts
@@ -1,6 +1,7 @@
 import type { Session } from "@supabase/supabase-js";
 import { create } from "zustand";
 import { getSupabase } from "@/shared/db";
+import { captureWarning } from "@/shared/lib";
 
 // biome-ignore lint/style/useNamingConvention: OAuth is a proper noun
 type OAuthProvider = "google" | "azure";
@@ -29,11 +30,15 @@ export const useAuthStore = create<AuthState & AuthActions>((set) => ({
       const supabase = getSupabase();
       const { data, error } = await supabase.auth.getSession();
       if (error || !data.session) {
+        if (error) captureWarning("auth_restore_failed", { errorMessage: error.message });
         set({ session: null, isLoading: false });
         return;
       }
       set({ session: data.session, isLoading: false });
-    } catch {
+    } catch (err) {
+      captureWarning("auth_restore_exception", {
+        errorType: err instanceof Error ? err.message : "unknown",
+      });
       set({ session: null, isLoading: false });
     }
   },
@@ -68,8 +73,10 @@ export const useAuthStore = create<AuthState & AuthActions>((set) => ({
           }
         }
       }
-    } catch {
-      // Sign-in failed
+    } catch (err) {
+      captureWarning("auth_signin_failed", {
+        errorType: err instanceof Error ? err.message : "unknown",
+      });
     } finally {
       set({ isSigningIn: false });
     }

--- a/apps/mobile/features/capture-sources/hooks/useNotificationCapture.ts
+++ b/apps/mobile/features/capture-sources/hooks/useNotificationCapture.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { Platform } from "@/shared/components/rn";
 import type { AnyDb } from "@/shared/db";
+import { captureError } from "@/shared/lib";
 import { useCaptureSourcesStore } from "../store";
 import { setupNotificationCapture } from "./setup";
 
@@ -19,7 +20,7 @@ export function useNotificationCapture(db: AnyDb | null, userId: string | null) 
           cleanup = c;
         }
       })
-      .catch((err) => console.warn("[NotificationCapture] setup failed:", err));
+      .catch(captureError);
     return () => {
       cancelled = true;
       cleanup?.();

--- a/apps/mobile/features/capture-sources/hooks/useSmsDetection.ts
+++ b/apps/mobile/features/capture-sources/hooks/useSmsDetection.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { Platform } from "@/shared/components/rn";
 import type { AnyDb } from "@/shared/db";
+import { captureError } from "@/shared/lib";
 import { useCaptureSourcesStore } from "../store";
 import { setupSmsDetection } from "./setup";
 
@@ -21,7 +22,7 @@ export function useSmsDetection(db: AnyDb | null, userId: string | null) {
           cleanup = teardown;
         }
       })
-      .catch((err) => console.warn("[SmsDetection] setup failed:", err));
+      .catch(captureError);
 
     return () => {
       cancelled = true;

--- a/apps/mobile/features/capture-sources/lib/dedup.ts
+++ b/apps/mobile/features/capture-sources/lib/dedup.ts
@@ -1,7 +1,7 @@
 import { and, eq, isNull } from "drizzle-orm";
 import type { AnyDb } from "@/shared/db";
 import { processedCaptures, transactions } from "@/shared/db";
-import { normalizeMerchant } from "@/shared/lib";
+import { merchantsMatch, normalizeMerchant } from "@/shared/lib";
 import type { CopAmount, IsoDate, UserId } from "@/shared/types/branded";
 
 /**
@@ -58,7 +58,7 @@ export async function findDuplicateTransaction(
 
   const match = rows.find((row) => {
     const desc = normalizeMerchant(row.description ?? "");
-    return desc === normalized;
+    return merchantsMatch(desc, normalized);
   });
 
   return match?.id ?? null;

--- a/apps/mobile/features/capture-sources/services/apple-pay-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/apple-pay-pipeline.ts
@@ -7,6 +7,7 @@ import { insertTransaction, isValidCategoryId } from "@/features/transactions";
 import type { AnyDb } from "@/shared/db";
 import { enqueueSync } from "@/shared/db";
 import {
+  capturePipelineEvent,
   generateProcessedCaptureId,
   generateSyncQueueId,
   generateTransactionId,
@@ -40,6 +41,7 @@ export async function processApplePayIntent(
   const fingerprint = captureFingerprint(source, amount, today, intent.merchant);
 
   if (inFlightFingerprints.has(fingerprint)) {
+    capturePipelineEvent({ source: "apple_pay", saved: 0, skippedDuplicate: 1 });
     return { saved: false, skippedDuplicate: true, transactionId: null };
   }
 
@@ -48,6 +50,7 @@ export async function processApplePayIntent(
   try {
     const alreadyProcessed = await isCaptureProcessed(db, fingerprint);
     if (alreadyProcessed) {
+      capturePipelineEvent({ source: "apple_pay", saved: 0, skippedDuplicate: 1 });
       return { saved: false, skippedDuplicate: true, transactionId: null };
     }
     // Cross-source dedup
@@ -66,6 +69,7 @@ export async function processApplePayIntent(
         receivedAt: now,
         createdAt: now,
       });
+      capturePipelineEvent({ source: "apple_pay", saved: 0, skippedDuplicate: 1 });
       return { saved: false, skippedDuplicate: true, transactionId: existingTxId };
     }
 
@@ -118,6 +122,7 @@ export async function processApplePayIntent(
     // Always cache merchant rule (Apple Pay data is high confidence)
     await insertMerchantRule(db, userId, merchantKey, categoryId, now);
 
+    capturePipelineEvent({ source: "apple_pay", saved: 1, skippedDuplicate: 0 });
     return { saved: true, skippedDuplicate: false, transactionId: txId };
   } finally {
     inFlightFingerprints.delete(fingerprint);

--- a/apps/mobile/features/capture-sources/services/notification-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/notification-pipeline.ts
@@ -7,6 +7,7 @@ import { insertTransaction, isValidCategoryId } from "@/features/transactions";
 import type { AnyDb } from "@/shared/db";
 import { enqueueSync } from "@/shared/db";
 import {
+  capturePipelineEvent,
   generateProcessedCaptureId,
   generateSyncQueueId,
   generateTransactionId,
@@ -46,6 +47,7 @@ export async function processNotification(
   const localResult = parseNotificationLocally(notificationText);
 
   // If local parse fails, try cloud LLM
+  const parseMethod = localResult ? "regex" : "llm";
   const parsed = localResult
     ? { ...localResult, categoryId: "other", date: notificationDate, confidence: 0.8 }
     : await (async () => {
@@ -74,6 +76,14 @@ export async function processNotification(
       receivedAt: receivedAt,
       createdAt: toIsoDateTime(new Date()),
     });
+    capturePipelineEvent({
+      source: "notification",
+      bankSource: source,
+      parseMethod,
+      saved: 0,
+      skippedDuplicate: 0,
+      parseFailed: 1,
+    });
     return { saved: false, skippedDuplicate: false, transactionId: null };
   }
 
@@ -83,6 +93,14 @@ export async function processNotification(
   // Guard against concurrent processing of the same fingerprint.
   // Add synchronously before any await to close the race window.
   if (inFlightFingerprints.has(fingerprint)) {
+    capturePipelineEvent({
+      source: "notification",
+      bankSource: source,
+      parseMethod,
+      saved: 0,
+      skippedDuplicate: 1,
+      parseFailed: 0,
+    });
     return { saved: false, skippedDuplicate: true, transactionId: null };
   }
 
@@ -91,6 +109,14 @@ export async function processNotification(
   try {
     const alreadyProcessed = await isCaptureProcessed(db, fingerprint);
     if (alreadyProcessed) {
+      capturePipelineEvent({
+        source: "notification",
+        bankSource: source,
+        parseMethod,
+        saved: 0,
+        skippedDuplicate: 1,
+        parseFailed: 0,
+      });
       return { saved: false, skippedDuplicate: true, transactionId: null };
     }
     // Cross-source dedup
@@ -113,6 +139,14 @@ export async function processNotification(
         confidence: parsed.confidence,
         receivedAt: receivedAt,
         createdAt: toIsoDateTime(new Date()),
+      });
+      capturePipelineEvent({
+        source: "notification",
+        bankSource: source,
+        parseMethod,
+        saved: 0,
+        skippedDuplicate: 1,
+        parseFailed: 0,
       });
       return { saved: false, skippedDuplicate: true, transactionId: existingTxId };
     }
@@ -166,6 +200,13 @@ export async function processNotification(
       await insertMerchantRule(db, userId, merchantKey, finalCategoryId, now);
     }
 
+    capturePipelineEvent({
+      source: "notification",
+      bankSource: source,
+      saved: 1,
+      skippedDuplicate: 0,
+      parseFailed: 0,
+    });
     return { saved: true, skippedDuplicate: false, transactionId: txId };
   } finally {
     inFlightFingerprints.delete(fingerprint);

--- a/apps/mobile/features/capture-sources/services/notification-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/notification-pipeline.ts
@@ -203,6 +203,7 @@ export async function processNotification(
     capturePipelineEvent({
       source: "notification",
       bankSource: source,
+      parseMethod,
       saved: 1,
       skippedDuplicate: 0,
       parseFailed: 0,

--- a/apps/mobile/features/capture-sources/services/parse-notification-api.ts
+++ b/apps/mobile/features/capture-sources/services/parse-notification-api.ts
@@ -3,6 +3,7 @@ import {
   llmOutputSchema,
 } from "@/features/email-capture/services/llm-parser";
 import { getSupabase } from "@/shared/db";
+import { captureWarning } from "@/shared/lib";
 
 export async function parseNotificationApi(
   sanitizedText: string
@@ -13,17 +14,24 @@ export async function parseNotificationApi(
     });
 
     if (error || !data?.success) {
-      console.warn("[parseNotificationApi] edge fn failed:", error?.message ?? "unknown", data);
+      captureWarning("parse_notification_api_failed", {
+        errorMessage: error?.message ?? "unknown",
+        hasData: !!data,
+      });
       return null;
     }
 
     const result = llmOutputSchema.safeParse(data.data);
     if (!result.success) {
-      console.warn("[parseNotificationApi] validation failed:", result.error.issues);
+      captureWarning("parse_notification_validation_failed", {
+        issueCount: result.error.issues.length,
+      });
     }
     return result.success ? result.data : null;
   } catch (err) {
-    console.warn("[parseNotificationApi] exception:", err);
+    captureWarning("parse_notification_api_exception", {
+      errorType: err instanceof Error ? err.message : "unknown",
+    });
     return null;
   }
 }

--- a/apps/mobile/features/email-capture/services/bank-senders-cache.ts
+++ b/apps/mobile/features/email-capture/services/bank-senders-cache.ts
@@ -1,4 +1,5 @@
 import { getSupabase } from "@/shared/db";
+import { captureWarning } from "@/shared/lib";
 import { type BankSender, DEFAULT_BANK_SENDERS } from "../lib/bank-senders";
 
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
@@ -28,7 +29,9 @@ export async function fetchBankSenders(): Promise<readonly BankSender[]> {
     const { data, error } = await getSupabase().from("bank_senders").select("bank, email");
 
     if (error || !data || data.length === 0) {
-      console.warn("[BankSenders] fetch failed or empty, using defaults:", error?.message);
+      captureWarning("bank_senders_fetch_failed", {
+        errorMessage: error?.message ?? "empty_result",
+      });
       return cache.fallback();
     }
 
@@ -39,7 +42,9 @@ export async function fetchBankSenders(): Promise<readonly BankSender[]> {
     cache.set(merged);
     return merged;
   } catch (err) {
-    console.warn("[BankSenders] exception, using defaults:", err);
+    captureWarning("bank_senders_exception", {
+      errorType: err instanceof Error ? err.message : "unknown",
+    });
     return cache.fallback();
   }
 }

--- a/apps/mobile/features/email-capture/services/email-adapter.ts
+++ b/apps/mobile/features/email-capture/services/email-adapter.ts
@@ -1,7 +1,7 @@
 // biome-ignore-all lint/style/useNamingConvention: OAuth/HTTP APIs use snake_case parameter names
 import { CryptoDigestAlgorithm, digest, getRandomBytes } from "expo-crypto";
 import * as SecureStore from "expo-secure-store";
-import { captureError } from "@/shared/lib";
+import { captureError, captureWarning } from "@/shared/lib";
 import type { ConnectResult, EmailProvider, RawEmail } from "../schema";
 import { EMAIL_REDIRECT_URI, getGmailRedirectUri } from "../schema";
 import { fetchGmailEmailsWithToken } from "./gmail-adapter";
@@ -160,7 +160,13 @@ export function createAdapter(config: EmailProviderConfig, fetchFn: FetchEmailsF
         }).toString(),
       });
 
-      if (!refreshResponse.ok) return null;
+      if (!refreshResponse.ok) {
+        captureWarning("email_token_refresh_failed", {
+          provider: config.provider,
+          httpStatus: refreshResponse.status,
+        });
+        return null;
+      }
 
       const data = await refreshResponse.json();
       await SecureStore.setItemAsync(config.tokenKey, data.access_token);

--- a/apps/mobile/features/email-capture/services/email-pipeline.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline.ts
@@ -4,6 +4,8 @@ import type { AnyDb } from "@/shared/db";
 import { enqueueSync } from "@/shared/db";
 import {
   captureError,
+  capturePipelineEvent,
+  captureWarning,
   generateProcessedEmailId,
   generateSyncQueueId,
   generateTransactionId,
@@ -126,15 +128,22 @@ export async function processEmails(
   rawEmails: RawEmail[],
   onProgress?: ProgressCallback
 ): Promise<PipelineResult> {
-  const allExternalIds = rawEmails.map((e) => e.externalId);
+  // Deduplicate by externalId within the batch (same account connected twice
+  // or same email forwarded across providers produces duplicate entries)
+  const uniqueEmails = Array.from(
+    new Map(rawEmails.map((email) => [email.externalId, email])).values()
+  );
+  const dedupedInBatch = rawEmails.length - uniqueEmails.length;
+
+  const allExternalIds = uniqueEmails.map((e) => e.externalId);
   const processedIds = await getProcessedExternalIds(db, allExternalIds);
 
-  const toProcess = rawEmails.filter((email) => !processedIds.has(email.externalId));
-  const skippedDuplicate = rawEmails.length - toProcess.length;
+  const toProcess = uniqueEmails.filter((email) => !processedIds.has(email.externalId));
+  const skippedAlreadyProcessed = uniqueEmails.length - toProcess.length;
 
   const result: PipelineResult = {
     filtered: 0,
-    skippedDuplicate,
+    skippedDuplicate: dedupedInBatch + skippedAlreadyProcessed,
     skippedCrossSource: 0,
     saved: 0,
     failed: 0,
@@ -158,7 +167,10 @@ export async function processEmails(
       try {
         parsed = await parseBody(db, userId, email.body);
       } catch (err) {
-        console.warn(`[EmailCapture] parse threw for "${email.subject}":`, err);
+        captureWarning("email_parse_exception", {
+          provider: email.provider,
+          errorType: err instanceof Error ? err.message : "unknown",
+        });
         parseError = true;
       }
 
@@ -167,7 +179,6 @@ export async function processEmails(
         const failureReason = parseError ? "parse_error" : null;
 
         if (parseError) {
-          console.warn(`[EmailCapture] FAILED "${email.subject}" from ${email.from}: parse_error`);
           result.failed++;
         } else {
           result.filtered++;
@@ -303,6 +314,19 @@ export async function processEmails(
 
   await Promise.all(Array.from({ length: Math.min(Concurrency, total) }, () => worker()));
 
+  const uniqueProviders = new Set(rawEmails.map((e) => e.provider)).size;
+  capturePipelineEvent({
+    source: "email",
+    batchSize: rawEmails.length,
+    uniqueProviders,
+    dedupedInBatch,
+    skippedAlreadyProcessed,
+    skippedCrossSource: result.skippedCrossSource,
+    saved: result.saved,
+    failed: result.failed,
+    needsReview: result.needsReview,
+  });
+
   return result;
 }
 
@@ -329,7 +353,10 @@ export async function processRetries(db: AnyDb, userId: string): Promise<RetryRe
     try {
       parsed = await parseBody(db, userId, email.rawBody);
     } catch (err) {
-      console.warn(`[EmailCapture] retry parse threw for "${email.subject}":`, err);
+      captureWarning("email_retry_parse_exception", {
+        provider: email.provider,
+        errorType: err instanceof Error ? err.message : "unknown",
+      });
       parseError = true;
     }
 

--- a/apps/mobile/features/email-capture/services/gmail-adapter.ts
+++ b/apps/mobile/features/email-capture/services/gmail-adapter.ts
@@ -1,5 +1,5 @@
 // biome-ignore-all lint/style/useNamingConvention: Gmail API uses snake_case
-import { captureError } from "@/shared/lib";
+import { captureError, captureWarning } from "@/shared/lib";
 import type { RawEmail } from "../schema";
 
 export async function fetchGmailEmailsWithToken(
@@ -17,8 +17,7 @@ export async function fetchGmailEmailsWithToken(
   );
 
   if (!listResponse.ok) {
-    const text = await listResponse.text();
-    console.warn(`[Gmail] list failed ${listResponse.status}: ${text.slice(0, 200)}`);
+    captureWarning("gmail_api_list_failed", { httpStatus: listResponse.status });
     return [];
   }
 

--- a/apps/mobile/features/email-capture/services/outlook-adapter.ts
+++ b/apps/mobile/features/email-capture/services/outlook-adapter.ts
@@ -1,4 +1,5 @@
 // biome-ignore-all lint/style/useNamingConvention: Outlook API uses snake_case
+import { captureWarning } from "@/shared/lib";
 import type { RawEmail } from "../schema";
 
 export async function fetchOutlookEmailsWithToken(
@@ -18,7 +19,10 @@ export async function fetchOutlookEmailsWithToken(
     { headers: { Authorization: `Bearer ${token}` } }
   );
 
-  if (!response.ok) return [];
+  if (!response.ok) {
+    captureWarning("outlook_api_list_failed", { httpStatus: response.status });
+    return [];
+  }
 
   const data = await response.json();
   const messages: OutlookMessage[] = data.value ?? [];

--- a/apps/mobile/features/email-capture/services/parse-email-api.ts
+++ b/apps/mobile/features/email-capture/services/parse-email-api.ts
@@ -1,5 +1,6 @@
 import { CATEGORY_IDS } from "@/features/transactions";
 import { getSupabase } from "@/shared/db";
+import { captureWarning } from "@/shared/lib";
 import { type LlmParsedTransaction, llmOutputSchema } from "./llm-parser";
 
 export function stripPii(text: string): string {
@@ -32,7 +33,13 @@ export async function classifyMerchantApi(merchant: string): Promise<string> {
       body: { body: merchant, mode: "classify" },
     });
 
-    if (error || !data?.success) return "other";
+    if (error || !data?.success) {
+      captureWarning("classify_merchant_failed", {
+        hasError: !!error,
+        errorMessage: error?.message ?? "unknown",
+      });
+      return "other";
+    }
 
     const categoryId = data.data?.categoryId;
     return CATEGORY_IDS.includes(categoryId) ? categoryId : "other";
@@ -52,17 +59,24 @@ export async function parseEmailApi(emailBody: string): Promise<LlmParsedTransac
     });
 
     if (error || !data?.success) {
-      console.warn("[parseEmailApi] edge fn failed:", error?.message ?? "unknown", data);
+      captureWarning("parse_email_api_failed", {
+        errorMessage: error?.message ?? "unknown",
+        hasData: !!data,
+      });
       return null;
     }
 
     const result = llmOutputSchema.safeParse(data.data);
     if (!result.success) {
-      console.warn("[parseEmailApi] validation failed:", result.error.issues);
+      captureWarning("parse_email_validation_failed", {
+        issueCount: result.error.issues.length,
+      });
     }
     return result.success ? result.data : null;
   } catch (err) {
-    console.warn("[parseEmailApi] exception:", err);
+    captureWarning("parse_email_api_exception", {
+      errorType: err instanceof Error ? err.message : "unknown",
+    });
     return null;
   }
 }

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -4,6 +4,8 @@ import { useTransactionStore } from "@/features/transactions";
 import type { AnyDb } from "@/shared/db";
 import { enqueueSync, transactions } from "@/shared/db";
 import {
+  captureError,
+  captureWarning,
   generateEmailAccountId,
   generateSyncQueueId,
   normalizeMerchant,
@@ -110,6 +112,10 @@ export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActio
 
     if (!result.success) return;
 
+    // Prevent connecting the same email address twice
+    const alreadyConnected = get().accounts.some((a) => a.email === result.email);
+    if (alreadyConnected) return;
+
     const row: EmailAccountRow = {
       id: generateEmailAccountId(),
       userId: userIdRef as UserId,
@@ -187,7 +193,10 @@ export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActio
             );
             return { account, rawEmails, fetchOk: true };
           } catch (err) {
-            console.warn(`[EmailCapture] ${account.provider} fetch error:`, err);
+            captureWarning("email_adapter_fetch_failed", {
+              provider: account.provider,
+              errorType: err instanceof Error ? err.message : "unknown",
+            });
             return { account, rawEmails: [] as import("./schema").RawEmail[], fetchOk: false };
           }
         })
@@ -258,7 +267,7 @@ export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActio
       // Refresh home screen transactions
       await useTransactionStore.getState().refresh();
     } catch (err) {
-      console.warn("[EmailCapture] fetchAndProcess error:", err);
+      captureError(err);
     } finally {
       // On error (phase never reached 'complete'), clear immediately.
       // On success, auto-clear after 2s so Connected Accounts can show the transition.

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -113,7 +113,9 @@ export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActio
     if (!result.success) return;
 
     // Prevent connecting the same email address twice
-    const alreadyConnected = get().accounts.some((a) => a.email === result.email);
+    const alreadyConnected = get().accounts.some(
+      (a) => a.email.toLowerCase() === result.email.toLowerCase()
+    );
     if (alreadyConnected) return;
 
     const row: EmailAccountRow = {

--- a/apps/mobile/features/sync/hooks/useSync.ts
+++ b/apps/mobile/features/sync/hooks/useSync.ts
@@ -3,6 +3,7 @@ import { useTransactionStore } from "@/features/transactions";
 import { AppState } from "@/shared/components/rn";
 import type { AnyDb } from "@/shared/db";
 import { getSupabase } from "@/shared/db";
+import { captureWarning } from "@/shared/lib";
 import { isOnline, onConnectivityChange } from "../services/networkMonitor";
 import { fullSync } from "../services/syncEngine";
 import { useSyncConflictStore } from "../store";
@@ -36,7 +37,9 @@ export function useSync(db: AnyDb | null, userId: string | null): boolean {
         useSyncConflictStore.getState().loadConflicts();
         if (pullOk) markInitialDone();
       } catch (error) {
-        console.warn("[sync] background sync failed:", error);
+        captureWarning("background_sync_failed", {
+          errorType: error instanceof Error ? error.message : "unknown",
+        });
       } finally {
         isSyncing.current = false;
       }

--- a/apps/mobile/features/sync/services/syncEngine.ts
+++ b/apps/mobile/features/sync/services/syncEngine.ts
@@ -11,7 +11,13 @@ import {
   upsertTransaction,
 } from "@/features/transactions";
 import type { AnyDb } from "@/shared/db";
-import { captureError, generateSyncConflictId, toIsoDateTime } from "@/shared/lib";
+import {
+  captureError,
+  capturePipelineEvent,
+  captureWarning,
+  generateSyncConflictId,
+  toIsoDateTime,
+} from "@/shared/lib";
 import type { BudgetId, SyncQueueId, TransactionId } from "@/shared/types/branded";
 import { hasDataConflict } from "../lib/conflict-detection";
 import { insertConflict } from "../lib/conflict-repository";
@@ -150,25 +156,36 @@ async function processEntry(
     const row = await getTransactionById(db, entry.rowId as TransactionId);
     if (!row) return entry.id;
     const { error } = await supabase.from("transactions").upsert(toSupabaseRow(row));
+    if (error) {
+      captureWarning("sync_push_entry_failed", {
+        tableName: entry.tableName,
+        errorMessage: error.message,
+        errorCode: error.code ?? "unknown",
+      });
+    }
     return error ? null : entry.id;
   }
 
   if (entry.tableName === "budgets") {
     const ok = await processBudgetEntry(db, supabase, entry.rowId);
+    if (!ok) captureWarning("sync_push_entry_failed", { tableName: "budgets" });
     return ok ? entry.id : null;
   }
 
   if (entry.tableName === "goals") {
     const ok = await processGoalEntry(db, supabase, entry.rowId);
+    if (!ok) captureWarning("sync_push_entry_failed", { tableName: "goals" });
     return ok ? entry.id : null;
   }
 
   if (entry.tableName === "goalContributions") {
     const ok = await processContributionEntry(db, supabase, entry.rowId);
+    if (!ok) captureWarning("sync_push_entry_failed", { tableName: "goalContributions" });
     return ok ? entry.id : null;
   }
 
   // Unknown table — keep in queue for future handler
+  captureWarning("sync_push_unknown_table", { tableName: entry.tableName });
   return null;
 }
 
@@ -190,6 +207,13 @@ export async function syncPush(
   if (processedIds.length > 0) {
     await clearSyncEntries(db, processedIds as SyncQueueId[]);
   }
+
+  capturePipelineEvent({
+    source: "sync_push",
+    queued: entries.length,
+    succeeded: processedIds.length,
+    failed: entries.length - processedIds.length,
+  });
 }
 
 export async function syncPull(
@@ -203,12 +227,20 @@ export async function syncPull(
   const query = lastSyncAt ? baseQuery.gte("updated_at", lastSyncAt) : baseQuery;
 
   const { data, error } = await query.order("updated_at", { ascending: true }).limit(1000);
-  if (error || !data) return false;
+  if (error || !data) {
+    captureWarning("sync_pull_fetch_failed", {
+      errorMessage: error?.message ?? "no_data",
+      errorCode: error?.code ?? "unknown",
+    });
+    return false;
+  }
 
   const rows = data as SupabaseTransactionRow[];
 
   // FP exemption: each row may depend on prior upserts for conflict detection.
   let earliestFailure: string | null = null;
+  let failedCount = 0;
+  let conflictCount = 0;
   for (const serverRow of rows) {
     try {
       const localRow = await getTransactionById(db, serverRow.id as TransactionId);
@@ -221,6 +253,7 @@ export async function syncPull(
         // Log conflict after successful upsert to avoid duplicates on retry.
         // Own try/catch so a conflict-logging failure doesn't affect the sync flow.
         if (isConflict) {
+          conflictCount++;
           try {
             insertConflict(db, {
               id: generateSyncConflictId(),
@@ -236,11 +269,20 @@ export async function syncPull(
       }
     } catch (error) {
       captureError(error);
+      failedCount++;
       if (!earliestFailure || serverRow.updated_at < earliestFailure) {
         earliestFailure = serverRow.updated_at;
       }
     }
   }
+
+  capturePipelineEvent({
+    source: "sync_pull",
+    rowsFetched: rows.length,
+    rowsApplied: rows.length - failedCount,
+    conflicts: conflictCount,
+    failed: failedCount,
+  });
 
   // Only advance cursor up to (but not past) the earliest failed row
   // so it gets retried on the next pull. If the earliest row failed,

--- a/apps/mobile/shared/lib/index.ts
+++ b/apps/mobile/shared/lib/index.ts
@@ -29,6 +29,14 @@ export {
   generateUserCategoryId,
   generateUserMemoryId,
 } from "./generate-id";
-export { normalizeMerchant } from "./normalize-merchant";
-export { captureError, initSentry, SentryErrorBoundary, wrapWithSentry } from "./sentry";
+export { merchantsMatch, normalizeMerchant } from "./normalize-merchant";
+export {
+  captureError,
+  capturePipelineEvent,
+  captureWarning,
+  initSentry,
+  SentryErrorBoundary,
+  setSentryUser,
+  wrapWithSentry,
+} from "./sentry";
 export { handleRecoverableError, showErrorToast } from "./toast";

--- a/apps/mobile/shared/lib/normalize-merchant.ts
+++ b/apps/mobile/shared/lib/normalize-merchant.ts
@@ -5,3 +5,17 @@
 export function normalizeMerchant(name: string): string {
   return name.toLowerCase().trim().replace(/\s+/g, " ");
 }
+
+const MIN_SUBSTRING_LENGTH = 3;
+
+/**
+ * Checks whether two normalized merchant names refer to the same merchant.
+ * Exact equality always matches. Substring containment matches only when
+ * both strings are at least MIN_SUBSTRING_LENGTH characters, preventing
+ * spurious matches on very short or empty strings.
+ */
+export function merchantsMatch(a: string, b: string): boolean {
+  if (a === b) return true;
+  if (a.length < MIN_SUBSTRING_LENGTH || b.length < MIN_SUBSTRING_LENGTH) return false;
+  return a.includes(b) || b.includes(a);
+}

--- a/apps/mobile/shared/lib/sentry.ts
+++ b/apps/mobile/shared/lib/sentry.ts
@@ -13,5 +13,30 @@ export function captureError(error: unknown): void {
   Sentry.captureException(error);
 }
 
+export function setSentryUser(userId: string | null): void {
+  Sentry.setUser(userId ? { id: userId } : null);
+}
+
+export function capturePipelineEvent(data: Record<string, string | number | boolean>): void {
+  Sentry.withScope((scope) => {
+    scope.setContext("pipeline", data);
+    scope.setLevel("info");
+    Sentry.captureMessage(`pipeline:${String(data.source)}`);
+  });
+}
+
+export function captureWarning(
+  message: string,
+  context?: Record<string, string | number | boolean>
+): void {
+  Sentry.withScope((scope) => {
+    if (context) {
+      scope.setContext("warning_detail", context);
+    }
+    scope.setLevel("warning");
+    Sentry.captureMessage(message);
+  });
+}
+
 export const SentryErrorBoundary = Sentry.ErrorBoundary;
 export const wrapWithSentry = Sentry.wrap;


### PR DESCRIPTION
- Add merchantsMatch() for substring dedup across capture sources
- Deduplicate emails by externalId within batch before worker pool
- Guard against connecting same email account twice
- Add capturePipelineEvent/captureWarning/setSentryUser to Sentry
- Instrument all pipelines, sync, auth, AI chat, and adapters
- Replace console.warn with captureWarning on all failure paths
- Add debugging-with-sentry skill for future agents

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate transactions by improving cross-source merchant matching and deduplicating emails by `externalId` within a batch. Adds Sentry telemetry with user binding and structured warnings across pipelines, sync, auth, and chat to make production debugging easier.

- **Bug Fixes**
  - Use substring-based merchant matching with length guard to catch cross-source duplicates.
  - Deduplicate emails by `externalId` before worker processing to avoid double saves.
  - Prevent connecting the same email address twice (case-insensitive).

- **New Features**
  - Added Sentry helpers: `capturePipelineEvent`, `captureWarning`, `setSentryUser`.
  - Instrumented email/notification/Apple Pay pipelines, sync push/pull, auth restore/sign-in, and AI actions; notification telemetry includes `parseMethod` (`regex` or `llm`).
  - Replaced console warnings with `captureWarning` on failure paths.
  - Added debugging guide: `.claude/skills/debugging-with-sentry/SKILL.md`.

<sup>Written for commit 8d9a29d0205407024fef930a2c536fedf0942e02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

