### PR TITLE
feat(goals): add pace indicator chip to GoalCard

### DIFF
--- a/apps/mobile/__tests__/goals/derive.test.ts
+++ b/apps/mobile/__tests__/goals/derive.test.ts
@@ -10,11 +10,13 @@ vi.mock("date-fns", async (importOriginal) => {
 const FIXED_NOW = new Date("2026-03-19T12:00:00.000Z");
 vi.useFakeTimers({ now: FIXED_NOW });
 
+import type { CopAmount } from "@/shared/types/branded";
 import {
   computeMedian,
   deriveBudgetNudges,
   deriveDebtProjection,
   deriveGoalAlerts,
+  deriveGoalCardStatus,
   deriveGoalPaceGuidance,
   deriveGoalProgress,
   deriveGoalProjection,
@@ -666,5 +668,50 @@ describe("deriveGoalPaceGuidance", () => {
     const result = deriveGoalPaceGuidance(goal, 0, true, FIXED_NOW);
     // elapsedDays = max(0, negative) = 0 → expectedNow = 0 → delta = 0 → pace_ahead with 0
     expect(result).toEqual({ type: "pace_ahead", amountAhead: 0 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deriveGoalCardStatus
+// ---------------------------------------------------------------------------
+
+describe("deriveGoalCardStatus", () => {
+  it("returns completed when isComplete is true", () => {
+    const progress = { percentComplete: 100, remaining: 0, isComplete: true };
+    const result = deriveGoalCardStatus(progress, null);
+    expect(result).toEqual({ kind: "completed" });
+  });
+
+  it("returns pace_ahead with amount when paceGuidance is pace_ahead", () => {
+    const progress = { percentComplete: 60, remaining: 400_000, isComplete: false };
+    const paceGuidance = { type: "pace_ahead" as const, amountAhead: 320_000 as CopAmount };
+    const result = deriveGoalCardStatus(progress, paceGuidance);
+    expect(result).toEqual({ kind: "pace_ahead", amount: 320_000 });
+  });
+
+  it("returns pace_behind with amount when paceGuidance is pace_behind with reason below_pace", () => {
+    const progress = { percentComplete: 30, remaining: 700_000, isComplete: false };
+    const paceGuidance = { type: "pace_behind" as const, amountBehind: 450_000 as CopAmount, reason: "below_pace" as const };
+    const result = deriveGoalCardStatus(progress, paceGuidance);
+    expect(result).toEqual({ kind: "pace_behind", amount: 450_000 });
+  });
+
+  it("returns start_saving when paceGuidance is pace_behind with reason no_contributions", () => {
+    const progress = { percentComplete: 0, remaining: 1_000_000, isComplete: false };
+    const paceGuidance = { type: "pace_behind" as const, amountBehind: 0 as CopAmount, reason: "no_contributions" as const };
+    const result = deriveGoalCardStatus(progress, paceGuidance);
+    expect(result).toEqual({ kind: "start_saving" });
+  });
+
+  it("returns almost_there when no paceGuidance and percentComplete >= 75", () => {
+    const progress = { percentComplete: 80, remaining: 200_000, isComplete: false };
+    const result = deriveGoalCardStatus(progress, null);
+    expect(result).toEqual({ kind: "almost_there" });
+  });
+
+  it("returns null when no paceGuidance and percentComplete < 75", () => {
+    const progress = { percentComplete: 40, remaining: 600_000, isComplete: false };
+    const result = deriveGoalCardStatus(progress, null);
+    expect(result).toBeNull();
   });
 });

--- a/apps/mobile/__tests__/goals/derive.test.ts
+++ b/apps/mobile/__tests__/goals/derive.test.ts
@@ -10,7 +10,6 @@ vi.mock("date-fns", async (importOriginal) => {
 const FIXED_NOW = new Date("2026-03-19T12:00:00.000Z");
 vi.useFakeTimers({ now: FIXED_NOW });
 
-import type { CopAmount } from "@/shared/types/branded";
 import {
   computeMedian,
   deriveBudgetNudges,
@@ -23,6 +22,7 @@ import {
   deriveInstallmentProgress,
   deriveMonthlyMilestones,
 } from "@/features/goals/lib/derive";
+import type { CopAmount } from "@/shared/types/branded";
 
 // ---------------------------------------------------------------------------
 // deriveGoalProgress
@@ -691,14 +691,22 @@ describe("deriveGoalCardStatus", () => {
 
   it("returns pace_behind with amount when paceGuidance is pace_behind with reason below_pace", () => {
     const progress = { percentComplete: 30, remaining: 700_000, isComplete: false };
-    const paceGuidance = { type: "pace_behind" as const, amountBehind: 450_000 as CopAmount, reason: "below_pace" as const };
+    const paceGuidance = {
+      type: "pace_behind" as const,
+      amountBehind: 450_000 as CopAmount,
+      reason: "below_pace" as const,
+    };
     const result = deriveGoalCardStatus(progress, paceGuidance);
     expect(result).toEqual({ kind: "pace_behind", amount: 450_000 });
   });
 
   it("returns start_saving when paceGuidance is pace_behind with reason no_contributions", () => {
     const progress = { percentComplete: 0, remaining: 1_000_000, isComplete: false };
-    const paceGuidance = { type: "pace_behind" as const, amountBehind: 0 as CopAmount, reason: "no_contributions" as const };
+    const paceGuidance = {
+      type: "pace_behind" as const,
+      amountBehind: 0 as CopAmount,
+      reason: "no_contributions" as const,
+    };
     const result = deriveGoalCardStatus(progress, paceGuidance);
     expect(result).toEqual({ kind: "start_saving" });
   });
@@ -713,5 +721,24 @@ describe("deriveGoalCardStatus", () => {
     const progress = { percentComplete: 40, remaining: 600_000, isComplete: false };
     const result = deriveGoalCardStatus(progress, null);
     expect(result).toBeNull();
+  });
+
+  it("returns almost_there when percentComplete is exactly 75 (boundary hit)", () => {
+    const progress = { percentComplete: 75, remaining: 250_000, isComplete: false };
+    const result = deriveGoalCardStatus(progress, null);
+    expect(result).toEqual({ kind: "almost_there" });
+  });
+
+  it("returns null when percentComplete is 74 (just below boundary)", () => {
+    const progress = { percentComplete: 74, remaining: 260_000, isComplete: false };
+    const result = deriveGoalCardStatus(progress, null);
+    expect(result).toBeNull();
+  });
+
+  it("returns completed when isComplete is true even with non-null paceGuidance (completed always wins)", () => {
+    const progress = { percentComplete: 100, remaining: 0, isComplete: true };
+    const paceGuidance = { type: "pace_ahead" as const, amountAhead: 100_000 as CopAmount };
+    const result = deriveGoalCardStatus(progress, paceGuidance);
+    expect(result).toEqual({ kind: "completed" });
   });
 });

--- a/apps/mobile/features/goals/components/GoalCard.tsx
+++ b/apps/mobile/features/goals/components/GoalCard.tsx
@@ -3,6 +3,7 @@ import { Pressable, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatMoney } from "@/shared/lib";
 import type { CopAmount } from "@/shared/types/branded";
+import { deriveGoalCardStatus } from "../lib/derive";
 import type { GoalWithProgress } from "../store";
 
 type GoalCardProps = {
@@ -18,17 +19,14 @@ function GoalCardInner({ goalWithProgress, onPress, onAddPayment }: GoalCardProp
   const secondaryColor = useThemeColor("secondary");
   const accentGreen = useThemeColor("accentGreen");
   const accentGreenLight = useThemeColor("accentGreenLight");
+  const accentRed = useThemeColor("accentRed");
   const borderColor = useThemeColor("borderSubtle");
 
-  const { goal, currentAmount, progress, installments } = goalWithProgress;
+  const { goal, currentAmount, progress, installments, paceGuidance } = goalWithProgress;
 
   const progressWidth = Math.min(progress.percentComplete, 100);
 
-  const statusText = progress.isComplete
-    ? t("goals.card.completed")
-    : progress.percentComplete >= 75
-      ? t("goals.card.almostThere")
-      : null;
+  const cardStatus = deriveGoalCardStatus(progress, paceGuidance);
 
   return (
     <Pressable
@@ -66,10 +64,55 @@ function GoalCardInner({ goalWithProgress, onPress, onAddPayment }: GoalCardProp
               })
             : ""}
         </Text>
-        {statusText != null ? (
+        {cardStatus === null ? null : cardStatus.kind === "completed" ? (
           <Text style={{ fontFamily: "Poppins_600SemiBold", fontSize: 12, color: accentGreen }}>
-            {statusText}
+            {t("goals.card.completed")}
           </Text>
+        ) : cardStatus.kind === "almost_there" ? (
+          <Text style={{ fontFamily: "Poppins_600SemiBold", fontSize: 12, color: accentGreen }}>
+            {t("goals.card.almostThere")}
+          </Text>
+        ) : cardStatus.kind === "pace_ahead" ? (
+          <View
+            style={{
+              paddingVertical: 3,
+              paddingHorizontal: 8,
+              borderRadius: 8,
+              backgroundColor: `${accentGreen}26`,
+            }}
+          >
+            <Text style={{ fontFamily: "Poppins_600SemiBold", fontSize: 11, color: accentGreen }}>
+              {t("goals.card.paceAhead", { amount: formatMoney(cardStatus.amount) })}
+            </Text>
+          </View>
+        ) : cardStatus.kind === "pace_behind" ? (
+          <View
+            style={{
+              paddingVertical: 3,
+              paddingHorizontal: 8,
+              borderRadius: 8,
+              backgroundColor: `${accentRed}26`,
+            }}
+          >
+            <Text style={{ fontFamily: "Poppins_600SemiBold", fontSize: 11, color: accentRed }}>
+              {t("goals.card.paceBehind", { amount: formatMoney(cardStatus.amount) })}
+            </Text>
+          </View>
+        ) : cardStatus.kind === "start_saving" ? (
+          <View
+            style={{
+              paddingVertical: 3,
+              paddingHorizontal: 8,
+              borderRadius: 8,
+              backgroundColor: `${secondaryColor}26`,
+            }}
+          >
+            <Text
+              style={{ fontFamily: "Poppins_600SemiBold", fontSize: 11, color: secondaryColor }}
+            >
+              {t("goals.card.startSaving")}
+            </Text>
+          </View>
         ) : null}
       </View>
 

--- a/apps/mobile/features/goals/components/GoalCard.tsx
+++ b/apps/mobile/features/goals/components/GoalCard.tsx
@@ -30,17 +30,12 @@ function GoalCardInner({ goalWithProgress, onPress, onAddPayment }: GoalCardProp
 
   const renderStatus = () => {
     if (cardStatus === null) return null;
-    if (cardStatus.kind === "completed") {
+    if (cardStatus.kind === "completed" || cardStatus.kind === "almost_there") {
+      const label =
+        cardStatus.kind === "completed" ? t("goals.card.completed") : t("goals.card.almostThere");
       return (
         <Text style={{ fontFamily: "Poppins_600SemiBold", fontSize: 12, color: accentGreen }}>
-          {t("goals.card.completed")}
-        </Text>
-      );
-    }
-    if (cardStatus.kind === "almost_there") {
-      return (
-        <Text style={{ fontFamily: "Poppins_600SemiBold", fontSize: 12, color: accentGreen }}>
-          {t("goals.card.almostThere")}
+          {label}
         </Text>
       );
     }

--- a/apps/mobile/features/goals/components/GoalCard.tsx
+++ b/apps/mobile/features/goals/components/GoalCard.tsx
@@ -28,6 +28,51 @@ function GoalCardInner({ goalWithProgress, onPress, onAddPayment }: GoalCardProp
 
   const cardStatus = deriveGoalCardStatus(progress, paceGuidance);
 
+  const renderStatus = () => {
+    if (cardStatus === null) return null;
+    if (cardStatus.kind === "completed") {
+      return (
+        <Text style={{ fontFamily: "Poppins_600SemiBold", fontSize: 12, color: accentGreen }}>
+          {t("goals.card.completed")}
+        </Text>
+      );
+    }
+    if (cardStatus.kind === "almost_there") {
+      return (
+        <Text style={{ fontFamily: "Poppins_600SemiBold", fontSize: 12, color: accentGreen }}>
+          {t("goals.card.almostThere")}
+        </Text>
+      );
+    }
+    // Pace chip variants
+    const chipColor =
+      cardStatus.kind === "pace_ahead"
+        ? accentGreen
+        : cardStatus.kind === "pace_behind"
+          ? accentRed
+          : secondaryColor;
+    const chipLabel =
+      cardStatus.kind === "pace_ahead"
+        ? t("goals.card.paceAhead", { amount: formatMoney(cardStatus.amount) })
+        : cardStatus.kind === "pace_behind"
+          ? t("goals.card.paceBehind", { amount: formatMoney(cardStatus.amount) })
+          : t("goals.card.startSaving");
+    return (
+      <View
+        style={{
+          paddingVertical: 3,
+          paddingHorizontal: 8,
+          borderRadius: 8,
+          backgroundColor: `${chipColor}26`,
+        }}
+      >
+        <Text style={{ fontFamily: "Poppins_600SemiBold", fontSize: 11, color: chipColor }}>
+          {chipLabel}
+        </Text>
+      </View>
+    );
+  };
+
   return (
     <Pressable
       style={{
@@ -64,56 +109,7 @@ function GoalCardInner({ goalWithProgress, onPress, onAddPayment }: GoalCardProp
               })
             : ""}
         </Text>
-        {cardStatus === null ? null : cardStatus.kind === "completed" ? (
-          <Text style={{ fontFamily: "Poppins_600SemiBold", fontSize: 12, color: accentGreen }}>
-            {t("goals.card.completed")}
-          </Text>
-        ) : cardStatus.kind === "almost_there" ? (
-          <Text style={{ fontFamily: "Poppins_600SemiBold", fontSize: 12, color: accentGreen }}>
-            {t("goals.card.almostThere")}
-          </Text>
-        ) : cardStatus.kind === "pace_ahead" ? (
-          <View
-            style={{
-              paddingVertical: 3,
-              paddingHorizontal: 8,
-              borderRadius: 8,
-              backgroundColor: `${accentGreen}26`,
-            }}
-          >
-            <Text style={{ fontFamily: "Poppins_600SemiBold", fontSize: 11, color: accentGreen }}>
-              {t("goals.card.paceAhead", { amount: formatMoney(cardStatus.amount) })}
-            </Text>
-          </View>
-        ) : cardStatus.kind === "pace_behind" ? (
-          <View
-            style={{
-              paddingVertical: 3,
-              paddingHorizontal: 8,
-              borderRadius: 8,
-              backgroundColor: `${accentRed}26`,
-            }}
-          >
-            <Text style={{ fontFamily: "Poppins_600SemiBold", fontSize: 11, color: accentRed }}>
-              {t("goals.card.paceBehind", { amount: formatMoney(cardStatus.amount) })}
-            </Text>
-          </View>
-        ) : cardStatus.kind === "start_saving" ? (
-          <View
-            style={{
-              paddingVertical: 3,
-              paddingHorizontal: 8,
-              borderRadius: 8,
-              backgroundColor: `${secondaryColor}26`,
-            }}
-          >
-            <Text
-              style={{ fontFamily: "Poppins_600SemiBold", fontSize: 11, color: secondaryColor }}
-            >
-              {t("goals.card.startSaving")}
-            </Text>
-          </View>
-        ) : null}
+        {renderStatus()}
       </View>
 
       {/* Progress bar */}

--- a/apps/mobile/features/goals/lib/derive.ts
+++ b/apps/mobile/features/goals/lib/derive.ts
@@ -368,3 +368,35 @@ export function deriveGoalPaceGuidance(
     ? { type: "pace_ahead", amountAhead: Math.round(delta) as CopAmount }
     : { type: "pace_behind", amountBehind: Math.round(-delta) as CopAmount, reason: "below_pace" };
 }
+
+// ---------------------------------------------------------------------------
+// 9. deriveGoalCardStatus
+// ---------------------------------------------------------------------------
+
+export type GoalCardStatus =
+  | { readonly kind: "completed" }
+  | { readonly kind: "pace_ahead"; readonly amount: CopAmount }
+  | { readonly kind: "pace_behind"; readonly amount: CopAmount }
+  | { readonly kind: "start_saving" }
+  | { readonly kind: "almost_there" };
+
+export function deriveGoalCardStatus(
+  progress: GoalProgress,
+  paceGuidance: GoalPaceGuidance | null
+): GoalCardStatus | null {
+  if (progress.isComplete) return { kind: "completed" };
+
+  if (paceGuidance !== null) {
+    if (paceGuidance.type === "pace_ahead") {
+      return { kind: "pace_ahead", amount: paceGuidance.amountAhead };
+    }
+    if (paceGuidance.reason === "below_pace") {
+      return { kind: "pace_behind", amount: paceGuidance.amountBehind };
+    }
+    return { kind: "start_saving" };
+  }
+
+  if (progress.percentComplete >= 75) return { kind: "almost_there" };
+
+  return null;
+}

--- a/apps/mobile/features/goals/lib/derive.ts
+++ b/apps/mobile/features/goals/lib/derive.ts
@@ -390,7 +390,6 @@ export function deriveGoalCardStatus(
     if (paceGuidance.type === "pace_ahead") {
       return { kind: "pace_ahead", amount: paceGuidance.amountAhead };
     }
-    // paceGuidance is now narrowed to pace_behind
     if (paceGuidance.reason === "no_contributions") {
       return { kind: "start_saving" };
     }

--- a/apps/mobile/features/goals/lib/derive.ts
+++ b/apps/mobile/features/goals/lib/derive.ts
@@ -390,10 +390,11 @@ export function deriveGoalCardStatus(
     if (paceGuidance.type === "pace_ahead") {
       return { kind: "pace_ahead", amount: paceGuidance.amountAhead };
     }
-    if (paceGuidance.reason === "below_pace") {
-      return { kind: "pace_behind", amount: paceGuidance.amountBehind };
+    // paceGuidance is now narrowed to pace_behind
+    if (paceGuidance.reason === "no_contributions") {
+      return { kind: "start_saving" };
     }
-    return { kind: "start_saving" };
+    return { kind: "pace_behind", amount: paceGuidance.amountBehind };
   }
 
   if (progress.percentComplete >= 75) return { kind: "almost_there" };

--- a/apps/mobile/shared/i18n/locales/en.ts
+++ b/apps/mobile/shared/i18n/locales/en.ts
@@ -188,6 +188,9 @@ const en = {
       almostThere: "Almost there!",
       completed: "Completed!",
       addPayment: "+ Add Payment",
+      paceAhead: "↑ Ahead %{amount}",
+      paceBehind: "↓ Behind %{amount}",
+      startSaving: "Start saving",
     },
     detail: {
       contributions: "Contributions",

--- a/apps/mobile/shared/i18n/locales/es.ts
+++ b/apps/mobile/shared/i18n/locales/es.ts
@@ -189,6 +189,9 @@ const es = {
       almostThere: "¡Ya casi!",
       completed: "¡Completado!",
       addPayment: "+ Agregar Pago",
+      paceAhead: "↑ Adelante %{amount}",
+      paceBehind: "↓ Atrás %{amount}",
+      startSaving: "Empieza a ahorrar",
     },
     detail: {
       contributions: "Contribuciones",

--- a/apps/mobile/shared/i18n/locales/es.ts
+++ b/apps/mobile/shared/i18n/locales/es.ts
@@ -189,8 +189,8 @@ const es = {
       almostThere: "¡Ya casi!",
       completed: "¡Completado!",
       addPayment: "+ Agregar Pago",
-      paceAhead: "↑ Adelante %{amount}",
-      paceBehind: "↓ Atrás %{amount}",
+      paceAhead: "↑ Adelantado %{amount}",
+      paceBehind: "↓ Atrasado %{amount}",
       startSaving: "Empieza a ahorrar",
     },
     detail: {


### PR DESCRIPTION
- adds deriveGoalCardStatus pure function with TDD tests
- renders ahead/behind/nudge chip in status row
- i18n strings in en/es

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pace indicator chip to GoalCard to show when a goal is ahead, behind, or needs a nudge. Moves status logic into `deriveGoalCardStatus` and localizes labels (EN/ES).

- **New Features**
  - Render pace chip: green ahead, red behind, gray start saving; keep “Completed” and “Almost there”.
  - Add `deriveGoalCardStatus(progress, paceGuidance)`; completed wins; >=75% => almost_there; no_contributions => start_saving.
  - Add i18n keys: `goals.card.paceAhead`, `goals.card.paceBehind`, `goals.card.startSaving`; ES uses “Adelantado/Atrasado”.
  - Unit tests cover all branches and boundaries (75%, 74%).

<sup>Written for commit 4f2dc6d537586148af8e395a881629e20f3ec656. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

