### PR TITLE
feat(mobile): add first-week placeholder to Notification Center

### DIFF
--- a/apps/mobile/__tests__/notifications/first-week.test.ts
+++ b/apps/mobile/__tests__/notifications/first-week.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { isFirstWeek } from "@/features/notifications/lib/first-week";
+
+const daysAgo = (n: number): string => new Date(Date.now() - n * 86_400_000).toISOString();
+
+describe("isFirstWeek", () => {
+  it("returns true when account is 3 days old", () => {
+    expect(isFirstWeek(daysAgo(3), new Date())).toBe(true);
+  });
+
+  it("returns false when account is exactly 7 days old", () => {
+    expect(isFirstWeek(daysAgo(7), new Date())).toBe(false);
+  });
+
+  it("returns false when account is 10 days old", () => {
+    expect(isFirstWeek(daysAgo(10), new Date())).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isFirstWeek("", new Date())).toBe(false);
+  });
+
+  it("returns false for a malformed date string", () => {
+    expect(isFirstWeek("not-a-date", new Date())).toBe(false);
+  });
+});

--- a/apps/mobile/__tests__/notifications/first-week.test.ts
+++ b/apps/mobile/__tests__/notifications/first-week.test.ts
@@ -1,26 +1,27 @@
 import { describe, expect, it } from "vitest";
 import { isFirstWeek } from "@/features/notifications/lib/first-week";
 
-const daysAgo = (n: number): string => new Date(Date.now() - n * 86_400_000).toISOString();
+const NOW = new Date("2026-03-23T12:00:00.000Z");
+const daysAgo = (n: number): string => new Date(NOW.getTime() - n * 86_400_000).toISOString();
 
 describe("isFirstWeek", () => {
   it("returns true when account is 3 days old", () => {
-    expect(isFirstWeek(daysAgo(3), new Date())).toBe(true);
+    expect(isFirstWeek(daysAgo(3), NOW)).toBe(true);
   });
 
   it("returns false when account is exactly 7 days old", () => {
-    expect(isFirstWeek(daysAgo(7), new Date())).toBe(false);
+    expect(isFirstWeek(daysAgo(7), NOW)).toBe(false);
   });
 
   it("returns false when account is 10 days old", () => {
-    expect(isFirstWeek(daysAgo(10), new Date())).toBe(false);
+    expect(isFirstWeek(daysAgo(10), NOW)).toBe(false);
   });
 
   it("returns false for empty string", () => {
-    expect(isFirstWeek("", new Date())).toBe(false);
+    expect(isFirstWeek("", NOW)).toBe(false);
   });
 
   it("returns false for a malformed date string", () => {
-    expect(isFirstWeek("not-a-date", new Date())).toBe(false);
+    expect(isFirstWeek("not-a-date", NOW)).toBe(false);
   });
 });

--- a/apps/mobile/features/notifications/components/NotificationsScreen.tsx
+++ b/apps/mobile/features/notifications/components/NotificationsScreen.tsx
@@ -2,10 +2,12 @@ import { Stack, useRouter } from "expo-router";
 import { useCallback, useMemo } from "react";
 import { Platform } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useAuthStore } from "@/features/auth";
 import { ScreenLayout } from "@/shared/components";
 import { Pressable, SectionList, StyleSheet, Text, View } from "@/shared/components/rn";
 import { useMountEffect, useThemeColor, useTranslation } from "@/shared/hooks";
 import { deriveNotificationDisplay, groupNotificationsBySection } from "../lib/display";
+import { isFirstWeek } from "../lib/first-week";
 import type { NotificationDisplay } from "../lib/types";
 import { useNotificationStore } from "../store";
 import { NotificationCard } from "./NotificationCard";
@@ -20,6 +22,8 @@ export const NotificationsScreen = () => {
   const accentRed = useThemeColor("accentRed");
   const { bottom } = useSafeAreaInsets();
   const hasNotifications = notifications.length > 0;
+  const accountCreatedAt = useAuthStore((s) => s.session?.user.created_at ?? "");
+  const firstWeek = isFirstWeek(accountCreatedAt, new Date());
 
   const handleClearAll = useCallback(() => {
     useNotificationStore.getState().clearAll();
@@ -70,7 +74,10 @@ export const NotificationsScreen = () => {
         />
       )}
       {!isLoading && sections.length === 0 ? (
-        <NotificationEmptyState />
+        <NotificationEmptyState
+          titleKey={firstWeek ? "notifications.firstWeekTitle" : "notifications.emptyTitle"}
+          subtitleKey={firstWeek ? "notifications.firstWeekMessage" : "notifications.emptySubtitle"}
+        />
       ) : (
         <SectionList
           sections={sections}

--- a/apps/mobile/features/notifications/lib/first-week.ts
+++ b/apps/mobile/features/notifications/lib/first-week.ts
@@ -1,0 +1,6 @@
+import { differenceInDays } from "date-fns";
+
+export function isFirstWeek(accountCreatedAt: string, now: Date): boolean {
+  if (!accountCreatedAt) return false;
+  return differenceInDays(now, new Date(accountCreatedAt)) < 7;
+}


### PR DESCRIPTION
- add isFirstWeek() pure function in notifications/lib/
- show warm "Getting to know you" message when account < 7 days old
- add unit tests for first-week detection (5 cases)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a friendly first-week empty state in the Notification Center for accounts created within the last 7 days. Adds a helper to detect first-week accounts and tests for boundary and invalid inputs.

- **New Features**
  - Added `isFirstWeek(accountCreatedAt: string, now: Date)` in `notifications/lib/first-week` using `date-fns`, with unit tests for boundary and invalid inputs.
  - When the list is empty and `isFirstWeek` is true, `NotificationEmptyState` uses `notifications.firstWeekTitle` and `notifications.firstWeekMessage`.

- **Bug Fixes**
  - Fixed the boundary test to use a shared fixed `NOW` for both inputs, ensuring the exactly-7-days case is validated correctly.

<sup>Written for commit 2a692fa81cc6471ec4266f643690db7ca1fc5386. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

