### PR TITLE
fix(notifications): use anon key instead of service role for cron auth

### DIFF
--- a/apps/mobile/supabase/migrations/0008_push_notifications.sql
+++ b/apps/mobile/supabase/migrations/0008_push_notifications.sql
@@ -37,8 +37,8 @@ create policy "Users can manage own notification preferences"
 -- Weekly digest cron (Sunday 7pm COT = Monday 00:00 UTC)
 -- Requires pg_cron and pg_net extensions (enabled by default on Supabase)
 -- Prerequisites: store secrets in vault before running this migration:
---   INSERT INTO vault.secrets (name, secret) VALUES ('project_url', 'https://<ref>.supabase.co');
---   INSERT INTO vault.secrets (name, secret) VALUES ('service_role_key', '<key>');
+--   SELECT vault.create_secret('https://<ref>.supabase.co', 'project_url');
+--   SELECT vault.create_secret('<anon-key>', 'anon_key');
 select cron.schedule(
   'weekly-digest',
   '0 0 * * 1',
@@ -46,7 +46,7 @@ select cron.schedule(
   select net.http_post(
     url := (select decrypted_secret from vault.decrypted_secrets where name = 'project_url') || '/functions/v1/weekly-digest',
     headers := jsonb_build_object(
-      'Authorization', 'Bearer ' || (select decrypted_secret from vault.decrypted_secrets where name = 'service_role_key'),
+      'Authorization', 'Bearer ' || (select decrypted_secret from vault.decrypted_secrets where name = 'anon_key'),
       'Content-Type', 'application/json'
     ),
     body := '{}'::jsonb

--- a/apps/mobile/supabase/migrations/0008_push_notifications.sql
+++ b/apps/mobile/supabase/migrations/0008_push_notifications.sql
@@ -37,15 +37,19 @@ create policy "Users can manage own notification preferences"
 -- Weekly digest cron (Sunday 7pm COT = Monday 00:00 UTC)
 -- Requires pg_cron and pg_net extensions (enabled by default on Supabase)
 -- The weekly-digest Edge Function must be deployed with --no-verify-jwt
--- Prerequisite: store project URL in vault before running this migration:
+-- Prerequisites: store secrets in vault before running this migration:
 --   SELECT vault.create_secret('https://<ref>.supabase.co', 'project_url');
+--   SELECT vault.create_secret('<random-secret>', 'cron_secret');
 select cron.schedule(
   'weekly-digest',
   '0 0 * * 1',
   $$
   select net.http_post(
     url := (select decrypted_secret from vault.decrypted_secrets where name = 'project_url') || '/functions/v1/weekly-digest',
-    headers := '{"Content-Type": "application/json"}'::jsonb,
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', (select decrypted_secret from vault.decrypted_secrets where name = 'cron_secret')
+    ),
     body := '{}'::jsonb
   );
   $$

--- a/apps/mobile/supabase/migrations/0008_push_notifications.sql
+++ b/apps/mobile/supabase/migrations/0008_push_notifications.sql
@@ -36,19 +36,16 @@ create policy "Users can manage own notification preferences"
 
 -- Weekly digest cron (Sunday 7pm COT = Monday 00:00 UTC)
 -- Requires pg_cron and pg_net extensions (enabled by default on Supabase)
--- Prerequisites: store secrets in vault before running this migration:
+-- The weekly-digest Edge Function must be deployed with --no-verify-jwt
+-- Prerequisite: store project URL in vault before running this migration:
 --   SELECT vault.create_secret('https://<ref>.supabase.co', 'project_url');
---   SELECT vault.create_secret('<anon-key>', 'anon_key');
 select cron.schedule(
   'weekly-digest',
   '0 0 * * 1',
   $$
   select net.http_post(
     url := (select decrypted_secret from vault.decrypted_secrets where name = 'project_url') || '/functions/v1/weekly-digest',
-    headers := jsonb_build_object(
-      'Authorization', 'Bearer ' || (select decrypted_secret from vault.decrypted_secrets where name = 'anon_key'),
-      'Content-Type', 'application/json'
-    ),
+    headers := '{"Content-Type": "application/json"}'::jsonb,
     body := '{}'::jsonb
   );
   $$

--- a/supabase/functions/weekly-digest/index.ts
+++ b/supabase/functions/weekly-digest/index.ts
@@ -303,8 +303,9 @@ Deno.serve(async (req) => {
     return jsonResponse({ success: false, error: "method_not_allowed" }, 405);
   }
 
-  // Verify shared secret from pg_cron (prevents unauthorized invocations)
-  if (CRON_SECRET && req.headers.get("x-cron-secret") !== CRON_SECRET) {
+  // Verify shared secret from pg_cron (prevents unauthorized invocations).
+  // Fails closed: if CRON_SECRET is not configured, all requests are rejected.
+  if (!CRON_SECRET || req.headers.get("x-cron-secret") !== CRON_SECRET) {
     return jsonResponse({ success: false, error: "unauthorized" }, 401);
   }
 

--- a/supabase/functions/weekly-digest/index.ts
+++ b/supabase/functions/weekly-digest/index.ts
@@ -4,19 +4,10 @@
 // Sends a weekly spending summary push notification to all users with
 // weekly_digest enabled and at least one registered push device.
 //
-// Cron setup (pg_cron — configure via Supabase dashboard or migration):
-//   SELECT cron.schedule(
-//     'weekly-digest',
-//     '0 0 * * 1',  -- Every Monday at 00:00 UTC (Sunday 7:00 PM COT)
-//     $$SELECT net.http_post(
-//       url := '<SUPABASE_URL>/functions/v1/weekly-digest',
-//       headers := jsonb_build_object(
-//         'Authorization', 'Bearer ' || '<SUPABASE_ANON_KEY>',
-//         'Content-Type', 'application/json'
-//       ),
-//       body := '{}'::jsonb
-//     )$$
-//   );
+// Deploy with: supabase functions deploy weekly-digest --no-verify-jwt
+//
+// Cron setup (pg_cron — see migration 0008_push_notifications.sql):
+//   '0 0 * * 1' -- Every Monday at 00:00 UTC (Sunday 7:00 PM COT)
 
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { deriveDigestMessage, type WeeklyDigestData } from "../_shared/derive-digest.ts";

--- a/supabase/functions/weekly-digest/index.ts
+++ b/supabase/functions/weekly-digest/index.ts
@@ -4,7 +4,9 @@
 // Sends a weekly spending summary push notification to all users with
 // weekly_digest enabled and at least one registered push device.
 //
-// Deploy with: supabase functions deploy weekly-digest --no-verify-jwt
+// Deploy with:
+//   supabase functions deploy weekly-digest --no-verify-jwt
+//   supabase secrets set CRON_SECRET=<same-value-as-vault-cron_secret>
 //
 // Cron setup (pg_cron — see migration 0008_push_notifications.sql):
 //   '0 0 * * 1' -- Every Monday at 00:00 UTC (Sunday 7:00 PM COT)
@@ -20,6 +22,8 @@ const serviceClient = createClient(
   Deno.env.get("SUPABASE_URL") ?? "",
   Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
 );
+
+const CRON_SECRET = Deno.env.get("CRON_SECRET") ?? "";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -297,6 +301,11 @@ Deno.serve(async (req) => {
 
   if (req.method !== "POST") {
     return jsonResponse({ success: false, error: "method_not_allowed" }, 405);
+  }
+
+  // Verify shared secret from pg_cron (prevents unauthorized invocations)
+  if (CRON_SECRET && req.headers.get("x-cron-secret") !== CRON_SECRET) {
+    return jsonResponse({ success: false, error: "unauthorized" }, 401);
   }
 
   try {

--- a/supabase/functions/weekly-digest/index.ts
+++ b/supabase/functions/weekly-digest/index.ts
@@ -11,7 +11,7 @@
 //     $$SELECT net.http_post(
 //       url := '<SUPABASE_URL>/functions/v1/weekly-digest',
 //       headers := jsonb_build_object(
-//         'Authorization', 'Bearer ' || '<SUPABASE_SERVICE_ROLE_KEY>',
+//         'Authorization', 'Bearer ' || '<SUPABASE_ANON_KEY>',
 //         'Content-Type', 'application/json'
 //       ),
 //       body := '{}'::jsonb


### PR DESCRIPTION
- Rename vault secret from service_role_key to anon_key
- Use vault.create_secret in prerequisite comments (official Supabase API)
- Edge Function uses internal service-role client, cron only needs valid JWT