### PR TITLE
feat(dashboard): add Zustand store for period state

### DIFF
--- a/apps/mobile/__tests__/dashboard/derive.test.ts
+++ b/apps/mobile/__tests__/dashboard/derive.test.ts
@@ -1,16 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { computeDashboardRange, deriveCategoryPercents } from "@/features/dashboard/lib/derive";
-import type { CategoryId, CopAmount } from "@/shared/types/branded";
-
-// ---------------------------------------------------------------------------
-// Fixture builders
-// ---------------------------------------------------------------------------
-
-const makeCategorySpending = (items: ReadonlyArray<{ categoryId: string; total: number }>) =>
-  items.map((item) => ({
-    categoryId: item.categoryId as CategoryId,
-    total: item.total as CopAmount,
-  }));
+import { computeDashboardRange } from "@/features/dashboard/lib/derive";
 
 // ---------------------------------------------------------------------------
 // computeDashboardRange
@@ -116,70 +105,5 @@ describe("computeDashboardRange", () => {
     expect(result.spending.end).toMatch(/^\d{4}-\d{2}-\d{2}$/);
     expect(result.lineChart.start).toMatch(/^\d{4}-\d{2}-\d{2}$/);
     expect(result.lineChart.end).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// deriveCategoryPercents
-// ---------------------------------------------------------------------------
-
-describe("deriveCategoryPercents", () => {
-  it("computes correct percent for a single category (100%)", () => {
-    const categories = makeCategorySpending([{ categoryId: "food", total: 500000 }]);
-    const result = deriveCategoryPercents(categories, 500000 as CopAmount);
-    expect(result).toHaveLength(1);
-    expect(result[0]?.categoryId).toBe("food");
-    expect(result[0]?.total).toBe(500000);
-    expect(result[0]?.percent).toBe(100);
-  });
-
-  it("computes correct percents for multiple categories", () => {
-    const categories = makeCategorySpending([
-      { categoryId: "food", total: 300000 },
-      { categoryId: "transport", total: 100000 },
-      { categoryId: "entertainment", total: 100000 },
-    ]);
-    const result = deriveCategoryPercents(categories, 500000 as CopAmount);
-    const byId = new Map(result.map((item) => [item.categoryId, item]));
-    expect(byId.get("food" as CategoryId)?.percent).toBe(60);
-    expect(byId.get("transport" as CategoryId)?.percent).toBe(20);
-    expect(byId.get("entertainment" as CategoryId)?.percent).toBe(20);
-  });
-
-  it("returns empty array when categories is empty", () => {
-    const result = deriveCategoryPercents([], 0 as CopAmount);
-    expect(result).toHaveLength(0);
-  });
-
-  it("returns percent=0 for all categories when totalSpent is 0", () => {
-    const categories = makeCategorySpending([
-      { categoryId: "food", total: 0 },
-      { categoryId: "transport", total: 0 },
-    ]);
-    const result = deriveCategoryPercents(categories, 0 as CopAmount);
-    expect(result.every((item) => item.percent === 0)).toBe(true);
-  });
-
-  it("rounds percents to nearest integer", () => {
-    // 100000 / 300000 = 33.333...% -> rounds to 33
-    const categories = makeCategorySpending([
-      { categoryId: "food", total: 100000 },
-      { categoryId: "transport", total: 100000 },
-      { categoryId: "other", total: 100000 },
-    ]);
-    const result = deriveCategoryPercents(categories, 300000 as CopAmount);
-    expect(result.every((item) => item.percent === 33)).toBe(true);
-  });
-
-  it("preserves original category fields in returned items", () => {
-    const categories = makeCategorySpending([
-      { categoryId: "food", total: 250000 },
-      { categoryId: "transport", total: 250000 },
-    ]);
-    const result = deriveCategoryPercents(categories, 500000 as CopAmount);
-    expect(result[0]?.categoryId).toBe("food");
-    expect(result[0]?.total).toBe(250000);
-    expect(result[1]?.categoryId).toBe("transport");
-    expect(result[1]?.total).toBe(250000);
   });
 });

--- a/apps/mobile/__tests__/dashboard/derive.test.ts
+++ b/apps/mobile/__tests__/dashboard/derive.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import { computeDashboardRange, deriveCategoryPercents } from "@/features/dashboard/lib/derive";
+import type { CategoryId, CopAmount } from "@/shared/types/branded";
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+const makeCategorySpending = (items: ReadonlyArray<{ categoryId: string; total: number }>) =>
+  items.map((item) => ({
+    categoryId: item.categoryId as CategoryId,
+    total: item.total as CopAmount,
+  }));
+
+// ---------------------------------------------------------------------------
+// computeDashboardRange
+// ---------------------------------------------------------------------------
+
+describe("computeDashboardRange", () => {
+  // Reference: today = 2026-03-23 (Monday)
+  const today = new Date(2026, 2, 23); // March 23 2026
+
+  // -- "today" period --
+
+  it("today: spending range is today–today", () => {
+    const result = computeDashboardRange("today", today);
+    expect(result.spending.start).toBe("2026-03-23");
+    expect(result.spending.end).toBe("2026-03-23");
+  });
+
+  it("today: lineChart range is today-6d–today (7-day context)", () => {
+    const result = computeDashboardRange("today", today);
+    expect(result.lineChart.start).toBe("2026-03-17");
+    expect(result.lineChart.end).toBe("2026-03-23");
+  });
+
+  // -- "week" period --
+
+  it("week: spending range is today-6d–today", () => {
+    const result = computeDashboardRange("week", today);
+    expect(result.spending.start).toBe("2026-03-17");
+    expect(result.spending.end).toBe("2026-03-23");
+  });
+
+  it("week: lineChart range is today-6d–today", () => {
+    const result = computeDashboardRange("week", today);
+    expect(result.lineChart.start).toBe("2026-03-17");
+    expect(result.lineChart.end).toBe("2026-03-23");
+  });
+
+  // -- "month" period --
+
+  it("month: spending range is 1st–last of current calendar month", () => {
+    const result = computeDashboardRange("month", today);
+    expect(result.spending.start).toBe("2026-03-01");
+    expect(result.spending.end).toBe("2026-03-31");
+  });
+
+  it("month: lineChart range is today-29d–today", () => {
+    const result = computeDashboardRange("month", today);
+    expect(result.lineChart.start).toBe("2026-02-22");
+    expect(result.lineChart.end).toBe("2026-03-23");
+  });
+
+  // -- Month boundaries --
+
+  it("month boundary: first day of month spending covers full calendar month", () => {
+    const firstOfMonth = new Date(2026, 2, 1); // March 1 2026
+    const result = computeDashboardRange("month", firstOfMonth);
+    expect(result.spending.start).toBe("2026-03-01");
+    expect(result.spending.end).toBe("2026-03-31");
+  });
+
+  it("month boundary: last day of month spending covers full calendar month", () => {
+    const lastOfMonth = new Date(2026, 2, 31); // March 31 2026
+    const result = computeDashboardRange("month", lastOfMonth);
+    expect(result.spending.start).toBe("2026-03-01");
+    expect(result.spending.end).toBe("2026-03-31");
+  });
+
+  it("month boundary: first day of month lineChart starts 29 days before", () => {
+    const firstOfMonth = new Date(2026, 2, 1); // March 1 2026
+    const result = computeDashboardRange("month", firstOfMonth);
+    expect(result.lineChart.start).toBe("2026-01-31");
+    expect(result.lineChart.end).toBe("2026-03-01");
+  });
+
+  it("month boundary: February (non-leap year) has correct last day", () => {
+    const febDay = new Date(2026, 1, 15); // February 15 2026
+    const result = computeDashboardRange("month", febDay);
+    expect(result.spending.start).toBe("2026-02-01");
+    expect(result.spending.end).toBe("2026-02-28");
+  });
+
+  it("month boundary: February (leap year) has correct last day", () => {
+    const febDay = new Date(2028, 1, 15); // February 15 2028 (leap year)
+    const result = computeDashboardRange("month", febDay);
+    expect(result.spending.start).toBe("2028-02-01");
+    expect(result.spending.end).toBe("2028-02-29");
+  });
+
+  // -- Cross-month boundary for week --
+
+  it("week: spending range crosses month boundary correctly", () => {
+    const startOfMonth = new Date(2026, 2, 2); // March 2 2026
+    const result = computeDashboardRange("week", startOfMonth);
+    expect(result.spending.start).toBe("2026-02-24");
+    expect(result.spending.end).toBe("2026-03-02");
+  });
+
+  // -- IsoDate format --
+
+  it("returns IsoDate strings (YYYY-MM-DD format)", () => {
+    const result = computeDashboardRange("today", today);
+    expect(result.spending.start).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(result.spending.end).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(result.lineChart.start).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(result.lineChart.end).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deriveCategoryPercents
+// ---------------------------------------------------------------------------
+
+describe("deriveCategoryPercents", () => {
+  it("computes correct percent for a single category (100%)", () => {
+    const categories = makeCategorySpending([{ categoryId: "food", total: 500000 }]);
+    const result = deriveCategoryPercents(categories, 500000 as CopAmount);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.categoryId).toBe("food");
+    expect(result[0]?.total).toBe(500000);
+    expect(result[0]?.percent).toBe(100);
+  });
+
+  it("computes correct percents for multiple categories", () => {
+    const categories = makeCategorySpending([
+      { categoryId: "food", total: 300000 },
+      { categoryId: "transport", total: 100000 },
+      { categoryId: "entertainment", total: 100000 },
+    ]);
+    const result = deriveCategoryPercents(categories, 500000 as CopAmount);
+    const byId = new Map(result.map((item) => [item.categoryId, item]));
+    expect(byId.get("food" as CategoryId)?.percent).toBe(60);
+    expect(byId.get("transport" as CategoryId)?.percent).toBe(20);
+    expect(byId.get("entertainment" as CategoryId)?.percent).toBe(20);
+  });
+
+  it("returns empty array when categories is empty", () => {
+    const result = deriveCategoryPercents([], 0 as CopAmount);
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns percent=0 for all categories when totalSpent is 0", () => {
+    const categories = makeCategorySpending([
+      { categoryId: "food", total: 0 },
+      { categoryId: "transport", total: 0 },
+    ]);
+    const result = deriveCategoryPercents(categories, 0 as CopAmount);
+    expect(result.every((item) => item.percent === 0)).toBe(true);
+  });
+
+  it("rounds percents to nearest integer", () => {
+    // 100000 / 300000 = 33.333...% -> rounds to 33
+    const categories = makeCategorySpending([
+      { categoryId: "food", total: 100000 },
+      { categoryId: "transport", total: 100000 },
+      { categoryId: "other", total: 100000 },
+    ]);
+    const result = deriveCategoryPercents(categories, 300000 as CopAmount);
+    expect(result.every((item) => item.percent === 33)).toBe(true);
+  });
+
+  it("preserves original category fields in returned items", () => {
+    const categories = makeCategorySpending([
+      { categoryId: "food", total: 250000 },
+      { categoryId: "transport", total: 250000 },
+    ]);
+    const result = deriveCategoryPercents(categories, 500000 as CopAmount);
+    expect(result[0]?.categoryId).toBe("food");
+    expect(result[0]?.total).toBe(250000);
+    expect(result[1]?.categoryId).toBe("transport");
+    expect(result[1]?.total).toBe(250000);
+  });
+});

--- a/apps/mobile/features/analytics/lib/derive.ts
+++ b/apps/mobile/features/analytics/lib/derive.ts
@@ -1,4 +1,4 @@
-import { toIsoDate } from "@/shared/lib/format-date";
+import { offsetDate, toIsoDate } from "@/shared/lib/format-date";
 import type { CategoryId, CopAmount, IsoDate } from "@/shared/types/branded";
 
 export type AnalyticsPeriod = "W" | "M" | "Q" | "Y";
@@ -32,10 +32,6 @@ export type PeriodDelta = {
     readonly increased: boolean;
   }>;
 };
-
-/** Returns a Date offset by `days` relative to `base` (negative = in the past). */
-const offsetDate = (base: Date, days: number): Date =>
-  new Date(base.getFullYear(), base.getMonth(), base.getDate() + days);
 
 /**
  * Computes a percentage change from `prev` to `curr`, rounded to nearest integer.

--- a/apps/mobile/features/dashboard/lib/derive.ts
+++ b/apps/mobile/features/dashboard/lib/derive.ts
@@ -1,5 +1,5 @@
-import { toIsoDate } from "@/shared/lib/format-date";
-import type { CategoryId, CopAmount, IsoDate } from "@/shared/types/branded";
+import { offsetDate, toIsoDate } from "@/shared/lib/format-date";
+import type { IsoDate } from "@/shared/types/branded";
 
 export type DashboardPeriod = "today" | "week" | "month";
 
@@ -12,16 +12,6 @@ export type DashboardRange = {
   readonly spending: DateRange;
   readonly lineChart: DateRange;
 };
-
-export type CategoryPercent = {
-  readonly categoryId: CategoryId;
-  readonly total: CopAmount;
-  readonly percent: number;
-};
-
-/** Returns a Date offset by `days` relative to `base` (negative = in the past). */
-const offsetDate = (base: Date, days: number): Date =>
-  new Date(base.getFullYear(), base.getMonth(), base.getDate() + days);
 
 /** Returns the last day of the month for a given date. */
 const lastDayOfMonth = (date: Date): Date => new Date(date.getFullYear(), date.getMonth() + 1, 0);
@@ -67,19 +57,4 @@ export function computeDashboardRange(period: DashboardPeriod, today: Date): Das
     spending: spendingRange[period],
     lineChart: lineChartRange[period],
   };
-}
-
-/**
- * Pure derivation: add a `percent` field to each category based on its share
- * of totalSpent. Rounds to nearest integer. Returns 0% for all when totalSpent is 0.
- */
-export function deriveCategoryPercents(
-  categories: ReadonlyArray<{ readonly categoryId: CategoryId; readonly total: CopAmount }>,
-  totalSpent: CopAmount
-): ReadonlyArray<CategoryPercent> {
-  return categories.map((item) => ({
-    categoryId: item.categoryId,
-    total: item.total,
-    percent: totalSpent === 0 ? 0 : Math.round((item.total / totalSpent) * 100),
-  }));
 }

--- a/apps/mobile/features/dashboard/lib/derive.ts
+++ b/apps/mobile/features/dashboard/lib/derive.ts
@@ -1,0 +1,85 @@
+import { toIsoDate } from "@/shared/lib/format-date";
+import type { CategoryId, CopAmount, IsoDate } from "@/shared/types/branded";
+
+export type DashboardPeriod = "today" | "week" | "month";
+
+type DateRange = {
+  readonly start: IsoDate;
+  readonly end: IsoDate;
+};
+
+export type DashboardRange = {
+  readonly spending: DateRange;
+  readonly lineChart: DateRange;
+};
+
+export type CategoryPercent = {
+  readonly categoryId: CategoryId;
+  readonly total: CopAmount;
+  readonly percent: number;
+};
+
+/** Returns a Date offset by `days` relative to `base` (negative = in the past). */
+const offsetDate = (base: Date, days: number): Date =>
+  new Date(base.getFullYear(), base.getMonth(), base.getDate() + days);
+
+/** Returns the last day of the month for a given date. */
+const lastDayOfMonth = (date: Date): Date => new Date(date.getFullYear(), date.getMonth() + 1, 0);
+
+/** Returns the first day of the month for a given date. */
+const firstDayOfMonth = (date: Date): Date => new Date(date.getFullYear(), date.getMonth(), 1);
+
+/**
+ * Pure derivation: compute spending and lineChart date ranges for a given
+ * DashboardPeriod relative to today.
+ *
+ * Spending ranges:
+ * - today:  today–today
+ * - week:   today-6d–today
+ * - month:  1st–last of current calendar month
+ *
+ * LineChart ranges:
+ * - today:  today-6d–today (7-day context)
+ * - week:   today-6d–today
+ * - month:  today-29d–today
+ */
+export function computeDashboardRange(period: DashboardPeriod, today: Date): DashboardRange {
+  const todayIso = toIsoDate(today);
+  const sixDaysAgo = toIsoDate(offsetDate(today, -6));
+  const twentyNineDaysAgo = toIsoDate(offsetDate(today, -29));
+
+  const spendingRange: Record<DashboardPeriod, DateRange> = {
+    today: { start: todayIso, end: todayIso },
+    week: { start: sixDaysAgo, end: todayIso },
+    month: {
+      start: toIsoDate(firstDayOfMonth(today)),
+      end: toIsoDate(lastDayOfMonth(today)),
+    },
+  };
+
+  const lineChartRange: Record<DashboardPeriod, DateRange> = {
+    today: { start: sixDaysAgo, end: todayIso },
+    week: { start: sixDaysAgo, end: todayIso },
+    month: { start: twentyNineDaysAgo, end: todayIso },
+  };
+
+  return {
+    spending: spendingRange[period],
+    lineChart: lineChartRange[period],
+  };
+}
+
+/**
+ * Pure derivation: add a `percent` field to each category based on its share
+ * of totalSpent. Rounds to nearest integer. Returns 0% for all when totalSpent is 0.
+ */
+export function deriveCategoryPercents(
+  categories: ReadonlyArray<{ readonly categoryId: CategoryId; readonly total: CopAmount }>,
+  totalSpent: CopAmount
+): ReadonlyArray<CategoryPercent> {
+  return categories.map((item) => ({
+    categoryId: item.categoryId,
+    total: item.total,
+    percent: totalSpent === 0 ? 0 : Math.round((item.total / totalSpent) * 100),
+  }));
+}

--- a/apps/mobile/features/dashboard/store.ts
+++ b/apps/mobile/features/dashboard/store.ts
@@ -1,0 +1,101 @@
+import { create } from "zustand";
+import type { CategoryBreakdownItem } from "@/features/analytics/lib/derive";
+import { deriveCategoryBreakdown } from "@/features/analytics/lib/derive";
+import {
+  getIncomeExpenseForPeriod,
+  getSpendingByCategoryForPeriod,
+} from "@/features/analytics/lib/repository";
+import { useTransactionStore } from "@/features/transactions";
+import { getDailySpendingAggregate } from "@/features/transactions/lib/repository";
+import type { AnyDb } from "@/shared/db";
+import type { CopAmount, IsoDate, UserId } from "@/shared/types/branded";
+import type { DashboardPeriod } from "./lib/derive";
+import { computeDashboardRange } from "./lib/derive";
+
+// Module-level refs: Zustand doesn't serialize DB connections, so we keep them outside the store.
+let dbRef: AnyDb | null = null;
+let userIdRef: UserId | null = null;
+let unsubscribeTxStore: (() => void) | null = null;
+// Track previous pages reference to skip form-field state changes
+let prevPagesRef: unknown = null;
+
+type DashboardState = {
+  readonly period: DashboardPeriod;
+  readonly periodSpent: CopAmount;
+  readonly periodCategorySpending: ReadonlyArray<CategoryBreakdownItem>;
+  readonly periodDailySpending: ReadonlyArray<{ date: IsoDate; total: CopAmount }>;
+  readonly isLoading: boolean;
+};
+
+type DashboardActions = {
+  initStore(db: AnyDb, userId: UserId): void;
+  setPeriod(period: DashboardPeriod): void;
+  loadDashboard(): Promise<void>;
+};
+
+export const useDashboardStore = create<DashboardState & DashboardActions>((set, get) => ({
+  period: "month",
+  periodSpent: 0 as CopAmount,
+  periodCategorySpending: [],
+  periodDailySpending: [],
+  isLoading: false,
+
+  initStore: (db, userId) => {
+    dbRef = db;
+    userIdRef = userId;
+    // Subscribe to transaction store changes to auto-refresh dashboard
+    if (unsubscribeTxStore) unsubscribeTxStore();
+    prevPagesRef = useTransactionStore.getState().pages;
+    unsubscribeTxStore = useTransactionStore.subscribe(() => {
+      // Only refresh when transaction data changes, not form field edits
+      const currentPages = useTransactionStore.getState().pages;
+      if (currentPages === prevPagesRef) return;
+      prevPagesRef = currentPages;
+      if (!get().isLoading) {
+        get()
+          .loadDashboard()
+          .catch(() => {});
+      }
+    });
+  },
+
+  setPeriod: (period) => {
+    set({ period });
+    get()
+      .loadDashboard()
+      .catch(() => {});
+  },
+
+  loadDashboard: async () => {
+    if (!dbRef || !userIdRef) return;
+    const db = dbRef;
+    const userId = userIdRef;
+    set({ isLoading: true });
+    try {
+      const { spending, lineChart } = computeDashboardRange(get().period, new Date());
+
+      // Not parallel — synchronous SQLite must be called sequentially
+      const incomeExpense = getIncomeExpenseForPeriod(db, userId, spending.start, spending.end);
+      const categorySpending = getSpendingByCategoryForPeriod(
+        db,
+        userId,
+        spending.start,
+        spending.end
+      );
+      const dailySpending = getDailySpendingAggregate(db, userId, lineChart.start, lineChart.end);
+
+      const periodSpent = incomeExpense.expenses;
+      const periodCategorySpending = deriveCategoryBreakdown(categorySpending, periodSpent);
+
+      set({
+        periodSpent,
+        periodCategorySpending,
+        periodDailySpending: dailySpending,
+        isLoading: false,
+      });
+    } catch (error) {
+      console.error("[dashboard] loadDashboard failed:", error);
+      set({ isLoading: false });
+    }
+  },
+}));

--- a/apps/mobile/shared/i18n/locales/en.ts
+++ b/apps/mobile/shared/i18n/locales/en.ts
@@ -646,6 +646,16 @@ const en = {
     totalSpending: "Total spending",
     noData: "Not enough data for this period",
   },
+
+  dashboard: {
+    spentToday: "Spent today",
+    spentThisWeek: "Spent this week",
+    spentThisMonth: "Spent this month",
+    today: "Today",
+    week: "Week",
+    month: "Month",
+    byCategory: "By category",
+  },
 } as const;
 
 export default en;

--- a/apps/mobile/shared/i18n/locales/es.ts
+++ b/apps/mobile/shared/i18n/locales/es.ts
@@ -652,6 +652,16 @@ const es = {
     totalSpending: "Gasto total",
     noData: "No hay suficientes datos para este periodo",
   },
+
+  dashboard: {
+    spentToday: "Gastado hoy",
+    spentThisWeek: "Gastado esta semana",
+    spentThisMonth: "Gastado este mes",
+    today: "Hoy",
+    week: "Semana",
+    month: "Mes",
+    byCategory: "Por categoría",
+  },
 } as const;
 
 export default es;

--- a/apps/mobile/shared/lib/format-date.ts
+++ b/apps/mobile/shared/lib/format-date.ts
@@ -42,3 +42,10 @@ export function toMonth(date: Date): Month {
 export function toIsoDateTime(date: Date): IsoDateTime {
   return date.toISOString() as IsoDateTime;
 }
+
+/**
+ * Returns a Date offset by `days` relative to `base` (negative = in the past).
+ */
+export function offsetDate(base: Date, days: number): Date {
+  return new Date(base.getFullYear(), base.getMonth(), base.getDate() + days);
+}

--- a/apps/mobile/shared/lib/index.ts
+++ b/apps/mobile/shared/lib/index.ts
@@ -21,7 +21,14 @@ export {
 } from "./analytics";
 export type { CurrencyConfig } from "./currency";
 export { getActiveCurrency } from "./currency";
-export { formatDateDisplay, parseIsoDate, toIsoDate, toIsoDateTime, toMonth } from "./format-date";
+export {
+  formatDateDisplay,
+  offsetDate,
+  parseIsoDate,
+  toIsoDate,
+  toIsoDateTime,
+  toMonth,
+} from "./format-date";
 export {
   cleanDigitInput,
   formatInputDisplay,


### PR DESCRIPTION
- Add useDashboardStore with period, periodSpent, categorySpending, dailySpending state
- Auto-refresh on transaction store pages changes
- Add dashboard i18n keys (en/es)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `zustand` dashboard store for period state and derived spending data. The dashboard auto-refreshes on transaction updates and includes new i18n strings.

- **New Features**
  - Added useDashboardStore with period, periodSpent, category breakdown, daily totals, and loading state.
  - Auto-refreshes when transaction pages change; ignores form field edits to avoid unnecessary reloads.
  - Added computeDashboardRange to derive spending and line-chart ranges for today/week/month.
  - Added dashboard i18n keys in en/es and unit tests for date ranges and month boundaries.

- **Refactors**
  - Moved offsetDate to shared date utils and re-exported from shared/lib.
  - Updated analytics derive to use the shared helper and removed duplicate code.

<sup>Written for commit 532df68c893490ea9969d62ed2b860a6bbd929d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

