### PR TITLE
ci(workflow): fix supabase CLI --project-dir flag

### DIFF
--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "apps/mobile/supabase/migrations/**"
+  workflow_dispatch:
 
 jobs:
   migrate:

--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -19,11 +19,11 @@ jobs:
           version: 2.75.0
 
       - name: Link project
-        run: supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }} --project-dir apps/mobile
+        run: supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }} --workdir apps/mobile
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
       - name: Apply migrations
-        run: supabase db push --project-dir apps/mobile
+        run: supabase db push --workdir apps/mobile
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}


### PR DESCRIPTION
- Replace --project-dir with --workdir in deploy-migrations

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix deploy-migrations workflow by replacing deprecated --project-dir with --workdir in the `supabase` CLI. Runs `supabase link` and `supabase db push` from apps/mobile and adds workflow_dispatch for manual runs.

<sup>Written for commit 72507782f091c7fc072a0eb29041f6e883aa5f61. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

