### PR TITLE
fix(dashboard): scope balance to current month

### DIFF
--- a/apps/mobile/__tests__/transactions/repository-pagination.test.ts
+++ b/apps/mobile/__tests__/transactions/repository-pagination.test.ts
@@ -135,7 +135,8 @@ describe("getSpendingByCategoryAggregate", () => {
     mockSelect.mockReturnValue({ from: mockFrom });
     mockFrom.mockReturnValue({ where: mockWhere });
     mockWhere.mockReturnValue({ groupBy: mockGroupBy });
-    mockGroupBy.mockReturnValue({ all: mockAll });
+    mockGroupBy.mockReturnValue({ orderBy: mockOrderBy });
+    mockOrderBy.mockReturnValue({ all: mockAll });
   });
 
   it("returns spending grouped by category", async () => {

--- a/apps/mobile/__tests__/transactions/store.test.ts
+++ b/apps/mobile/__tests__/transactions/store.test.ts
@@ -25,6 +25,7 @@ vi.mock("@/shared/db/enqueue-sync", () => ({
 
 import {
   getBalanceAggregate,
+  getSpendingByCategoryAggregate,
   getTransactionsPaginated,
   insertTransaction,
   softDeleteTransaction,
@@ -158,7 +159,7 @@ describe("useTransactionStore", () => {
 
     // refresh calls getTransactionsPaginated and aggregate functions
     expect(getTransactionsPaginated).toHaveBeenCalled();
-    expect(getBalanceAggregate).toHaveBeenCalled();
+    expect(getSpendingByCategoryAggregate).toHaveBeenCalled();
   });
 
   it("saveTransaction fails with zero amount", async () => {
@@ -427,5 +428,18 @@ describe("useTransactionStore", () => {
     useTransactionStore.getState().removeFromCache("tx-1" as TransactionId);
 
     expect(useTransactionStore.getState().pages).toHaveLength(0);
+  });
+
+  it("loadAggregates derives balance from current month category spending totals", () => {
+    vi.mocked(getSpendingByCategoryAggregate).mockReturnValueOnce([
+      { categoryId: "food" as CategoryId, total: 50000 as CopAmount },
+      { categoryId: "transport" as CategoryId, total: 30000 as CopAmount },
+    ]);
+
+    useTransactionStore.getState().loadAggregates();
+
+    const state = useTransactionStore.getState();
+    expect(state.balance).toBe(80000);
+    expect(getBalanceAggregate).not.toHaveBeenCalled();
   });
 });

--- a/apps/mobile/features/dashboard/components/BalanceSection.tsx
+++ b/apps/mobile/features/dashboard/components/BalanceSection.tsx
@@ -1,6 +1,5 @@
-import { TrendingUp } from "@/shared/components/icons";
 import { Text, View } from "@/shared/components/rn";
-import { useThemeColor } from "@/shared/hooks";
+import { useTranslation } from "@/shared/hooks";
 import { formatMoney } from "@/shared/lib";
 import type { CopAmount } from "@/shared/types/branded";
 
@@ -9,22 +8,16 @@ type BalanceSectionProps = {
 };
 
 export const BalanceSection = ({ balance }: BalanceSectionProps) => {
-  const greenColor = useThemeColor("accentGreen");
+  const { t } = useTranslation();
 
   return (
     <View className="items-center gap-1 py-4">
       <Text className="font-poppins-medium text-label uppercase tracking-widest text-tertiary dark:text-tertiary-dark">
-        TOTAL BALANCE
+        {t("dashboard.spentThisMonth")}
       </Text>
       <Text className="font-poppins-bold text-balance text-primary dark:text-primary-dark">
         {formatMoney(balance as CopAmount)}
       </Text>
-      <View className="flex-row items-center gap-1">
-        <TrendingUp size={14} color={greenColor} />
-        <Text className="font-poppins-medium text-label text-accent-green dark:text-accent-green-dark">
-          +2.4% this month
-        </Text>
-      </View>
     </View>
   );
 };

--- a/apps/mobile/features/dashboard/components/ChartSection.tsx
+++ b/apps/mobile/features/dashboard/components/ChartSection.tsx
@@ -54,6 +54,8 @@ const toCategoryRows = (categories: readonly CategorySpendingItem[], locale: str
     };
   });
 
+const MAX_VISIBLE_CATEGORIES = 5;
+const OTHERS_COLOR = "#6B6B6B";
 const LINE_CHART_WIDTH = 140;
 
 const CarouselDots = ({ activeIndex }: { readonly activeIndex: number }) => {
@@ -87,8 +89,22 @@ export const ChartSection = ({
   const [slideWidth, setSlideWidth] = useState(0);
   const secondaryColor = useThemeColor("secondary");
 
-  const segments = toSegments(categorySpending, totalSpent);
-  const rows = toCategoryRows(categorySpending, locale);
+  const visible = categorySpending.slice(0, MAX_VISIBLE_CATEGORIES);
+  const remaining = categorySpending.slice(MAX_VISIBLE_CATEGORIES);
+  const remainingTotal = remaining.reduce((sum, c) => sum + c.total, 0);
+
+  const visibleSegments = toSegments(visible, totalSpent);
+  const segments =
+    remaining.length > 0
+      ? [
+          ...visibleSegments,
+          {
+            percentage: totalSpent === 0 ? 0 : (remainingTotal / totalSpent) * 100,
+            color: OTHERS_COLOR,
+          },
+        ]
+      : visibleSegments;
+  const rows = toCategoryRows(visible, locale);
 
   const dailyTotal = dailySpending.reduce((sum, d) => sum + d.total, 0);
   const dayCount = dailySpending.length === 0 ? 1 : dailySpending.length;
@@ -134,6 +150,13 @@ export const ChartSection = ({
                     amount={row.amount}
                   />
                 ))}
+                {remaining.length > 0 && (
+                  <CategoryRow
+                    color={OTHERS_COLOR}
+                    name={t("chart.moreCategories", { count: remaining.length })}
+                    amount={formatMoney(remainingTotal as CopAmount)}
+                  />
+                )}
               </View>
             </View>
 

--- a/apps/mobile/features/dashboard/components/HomeScreen.tsx
+++ b/apps/mobile/features/dashboard/components/HomeScreen.tsx
@@ -87,11 +87,6 @@ const ListHeader = memo(function ListHeader({
   const { push } = useRouter();
   const connectEmail = useEmailCaptureStore((s) => s.connectEmail);
 
-  const totalSpent = useMemo(
-    () => categorySpending.reduce((sum, c) => sum + c.total, 0),
-    [categorySpending]
-  );
-
   return (
     <View className="gap-4 px-4">
       <EmailConnectBanner
@@ -110,7 +105,7 @@ const ListHeader = memo(function ListHeader({
       <ChartSection
         categorySpending={categorySpending}
         dailySpending={dailySpending}
-        totalSpent={totalSpent}
+        totalSpent={balance}
         onPress={() => push("/analytics" as never)}
       />
     </View>

--- a/apps/mobile/features/transactions/lib/repository.ts
+++ b/apps/mobile/features/transactions/lib/repository.ts
@@ -71,6 +71,7 @@ export function getSpendingByCategoryAggregate(
       )
     )
     .groupBy(transactions.categoryId)
+    .orderBy(desc(sum(transactions.amount)))
     .all();
 }
 

--- a/apps/mobile/features/transactions/store.ts
+++ b/apps/mobile/features/transactions/store.ts
@@ -13,7 +13,6 @@ import {
 import type { CategoryId, CopAmount, IsoDate, TransactionId, UserId } from "@/shared/types/branded";
 import { buildTransaction, toStoredTransaction, toTransactionRow } from "./lib/build-transaction";
 import {
-  getBalanceAggregate,
   getDailySpendingAggregate,
   getSpendingByCategoryAggregate,
   getTransactionById,
@@ -173,8 +172,8 @@ export const useTransactionStore = create<TransactionState & TransactionActions>
       const startDate = toIsoDate(thirtyDaysAgo);
       const endDate = toIsoDate(now);
 
-      const balance = getBalanceAggregate(dbRef, userIdRef);
       const categorySpending = getSpendingByCategoryAggregate(dbRef, userIdRef, currentMonth);
+      const balance = categorySpending.reduce((sum, c) => sum + c.total, 0) as CopAmount;
       const dailySpending = getDailySpendingAggregate(dbRef, userIdRef, startDate, endDate);
 
       set({ balance, categorySpending, dailySpending });

--- a/apps/mobile/shared/i18n/locales/en.ts
+++ b/apps/mobile/shared/i18n/locales/en.ts
@@ -357,6 +357,7 @@ const en = {
     avgPerDay: "Avg/day",
     thisMonthTotal: "This month total",
     spent: "spent",
+    moreCategories: "%{count}+ more",
   },
 
   // AI Chat

--- a/apps/mobile/shared/i18n/locales/en.ts
+++ b/apps/mobile/shared/i18n/locales/en.ts
@@ -36,6 +36,11 @@ const en = {
     menu: "Menu",
   },
 
+  // Dashboard
+  dashboard: {
+    spentThisMonth: "Spent this month",
+  },
+
   // Transactions
   transactions: {
     expense: "Expense",

--- a/apps/mobile/shared/i18n/locales/es.ts
+++ b/apps/mobile/shared/i18n/locales/es.ts
@@ -359,6 +359,7 @@ const es = {
     avgPerDay: "Prom/día",
     thisMonthTotal: "Total del mes",
     spent: "gastado",
+    moreCategories: "%{count}+ más",
   },
 
   // AI Chat

--- a/apps/mobile/shared/i18n/locales/es.ts
+++ b/apps/mobile/shared/i18n/locales/es.ts
@@ -36,6 +36,11 @@ const es = {
     menu: "Menú",
   },
 
+  // Dashboard
+  dashboard: {
+    spentThisMonth: "Gastado este mes",
+  },
+
   // Transactions
   transactions: {
     expense: "Gasto",


### PR DESCRIPTION
- Derive balance from category spending totals instead of lifetime aggregate
- Replace hardcoded label with i18n key
- Remove fake trend indicator
- Eliminate redundant totalSpent useMemo in ListHeader

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope the dashboard balance to the current month by deriving it from category totals. Also limit the donut chart to the top 5 categories and group the rest into an “others” bucket.

- **Bug Fixes**
  - Derive `balance` from current-month category totals via `getSpendingByCategoryAggregate`; stop using lifetime `getBalanceAggregate`.
  - Pass `balance` to `ChartSection` as `totalSpent` and remove redundant `useMemo`.
  - Replace hardcoded label with `dashboard.spentThisMonth` i18n key (en/es).
  - Remove trend indicator from `BalanceSection`.
  - Update tests to use category-based aggregate and validate balance calculation.

- **New Features**
  - Sort category spending by amount in SQL and limit donut chart to top 5.
  - Merge remaining categories into an “others” segment and show “X+ more” row with combined total (`chart.moreCategories` i18n, en/es).

<sup>Written for commit 87435fdf620cadd9a25aaa766848fb5e6e124f4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

