### PR TITLE
fix(mobile): open homescreen on app launch

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -235,7 +235,7 @@ function RootLayout() {
     } else if (userId && !onboardingComplete && !inOnboarding) {
       router.replace("/(auth)/onboarding");
     } else if (userId && onboardingComplete && inAuthGroup) {
-      router.replace("/(tabs)" as never);
+      router.replace("/(tabs)/(index)" as never);
     }
   }, [userId, segments, isAuthLoading, fontsLoaded, fontsError, router, onboardingComplete]);
 


### PR DESCRIPTION
- Redirect to /(tabs)/(index) instead of /(tabs)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Open the Home screen on app launch by redirecting authenticated, onboarded users to `/(tabs)/(index)` instead of `/(tabs)`, ensuring a default tab loads.

<sup>Written for commit 510ecb7d3a102cc8be194416f2dc5e93d06927d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

