### PR TITLE
feat(transactions): add long-press edit transaction bottom sheet

### DIFF
--- a/apps/mobile/__tests__/setup.ts
+++ b/apps/mobile/__tests__/setup.ts
@@ -141,6 +141,21 @@ vi.mock("@shopify/flash-list", () => ({
   FlashList: "FlashList",
 }));
 
+// Mock react-native-gesture-handler
+vi.mock("react-native-gesture-handler", () => {
+  const gesture = () => ({
+    minDuration: () => gesture(),
+    onBegin: () => gesture(),
+    onStart: () => gesture(),
+    onFinalize: () => gesture(),
+  });
+  return {
+    Gesture: { LongPress: gesture },
+    GestureDetector: "GestureDetector",
+    GestureHandlerRootView: "GestureHandlerRootView",
+  };
+});
+
 // Mock react-native-reanimated
 vi.mock("react-native-reanimated", () => {
   const Animated = {
@@ -156,6 +171,13 @@ vi.mock("react-native-reanimated", () => {
     useSharedValue: (init: any) => ({ value: init }),
     // biome-ignore lint/suspicious/noExplicitAny: mock needs flexible typing
     withTiming: (val: any) => val,
+    // biome-ignore lint/suspicious/noExplicitAny: mock needs flexible typing
+    withRepeat: (val: any) => val,
+    // biome-ignore lint/suspicious/noExplicitAny: mock needs flexible typing
+    withSequence: (...vals: any[]) => vals[0],
+    cancelAnimation: vi.fn(),
+    // biome-ignore lint/suspicious/noExplicitAny: mock needs flexible typing
+    runOnJS: (fn: any) => fn,
   };
 });
 

--- a/apps/mobile/__tests__/transactions/store.test.ts
+++ b/apps/mobile/__tests__/transactions/store.test.ts
@@ -383,7 +383,9 @@ describe("useTransactionStore", () => {
     });
 
     vi.mocked(softDeleteTransaction).mockRejectedValueOnce(new Error("db error"));
-    await useTransactionStore.getState().removeTransaction("tx-1" as TransactionId);
+    await expect(
+      useTransactionStore.getState().removeTransaction("tx-1" as TransactionId)
+    ).rejects.toThrow("db error");
 
     expect(useTransactionStore.getState().pages).toHaveLength(1);
   });

--- a/apps/mobile/app/(tabs)/add.tsx
+++ b/apps/mobile/app/(tabs)/add.tsx
@@ -1,34 +1,14 @@
 import * as Haptics from "expo-haptics";
 import { useRouter } from "expo-router";
-import { useCallback, useEffect, useMemo, useRef } from "react";
-import Animated, {
-  useAnimatedStyle,
-  useSharedValue,
-  withRepeat,
-  withSequence,
-  withTiming,
-} from "react-native-reanimated";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useCallback } from "react";
 import { useShallow } from "zustand/react/shallow";
-import {
-  CATEGORIES,
-  CategoryPill,
-  getDateLabel,
-  handleNumpadPress,
-  TypeToggle,
-  useTransactionStore,
-} from "@/features/transactions";
-import { FidyNumpad } from "@/shared/components";
-import { Calendar } from "@/shared/components/icons";
-import { Platform, Pressable, Text, TextInput, View } from "@/shared/components/rn";
-import { useAsyncGuard, useThemeColor, useTranslation } from "@/shared/hooks";
-import { getDateFnsLocale } from "@/shared/i18n";
-import { formatInputDisplay, parseDigitsToAmount, trackTransactionCreated } from "@/shared/lib";
+import { TransactionForm, useTransactionStore } from "@/features/transactions";
+import { useAsyncGuard, useTranslation } from "@/shared/hooks";
+import { trackTransactionCreated } from "@/shared/lib";
 
 export default function AddTransactionScreen() {
   const { navigate } = useRouter();
-  const { t, locale } = useTranslation();
-  const { bottom: safeBottom } = useSafeAreaInsets();
+  const { t } = useTranslation();
   const {
     type,
     digits,
@@ -62,204 +42,54 @@ export default function AddTransactionScreen() {
   );
 
   const isEditing = editingId != null;
-
-  const accentRed = useThemeColor("accentRed");
-  const accentGreen = useThemeColor("accentGreen");
-  const secondary = useThemeColor("secondary");
-  const tertiary = useThemeColor("tertiary");
-  const primary = useThemeColor("primary");
-  const borderSubtle = useThemeColor("borderSubtle");
-
-  const amountColor = type === "expense" ? accentRed : accentGreen;
-  const displayAmount = digits.length > 0 ? formatInputDisplay(digits) : "$";
-  const canSave = parseDigitsToAmount(digits) > 0;
-  const buttonBg = canSave ? accentGreen : "#CCCCCC";
-  const dateLabel = useMemo(
-    () => getDateLabel(date, new Date(), t("dates.today"), getDateFnsLocale(locale)),
-    [date, t, locale]
-  );
-
-  const digitsRef = useRef(digits);
-  digitsRef.current = digits;
-
-  const cursorOpacity = useSharedValue(1);
-
-  useEffect(() => {
-    cursorOpacity.value = withRepeat(
-      withSequence(
-        withTiming(1, { duration: 0 }),
-        withTiming(1, { duration: 530 }),
-        withTiming(0, { duration: 0 }),
-        withTiming(0, { duration: 530 })
-      ),
-      -1
-    );
-  }, [cursorOpacity]);
-
-  const cursorStyle = useAnimatedStyle(() => ({
-    opacity: cursorOpacity.value,
-  }));
-
   const { isBusy: isSaving, run: guardedSave } = useAsyncGuard();
 
-  const handleSave = () =>
-    guardedSave(async () => {
-      const result = isEditing ? await updateTransaction(editingId) : await saveTransaction();
-      if (result.success) {
-        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-        if (!isEditing) {
-          trackTransactionCreated({
-            type,
-            category: String(categoryId ?? ""),
-            source: "manual",
-          });
-          resetForm();
+  const handleSave = useCallback(
+    () =>
+      guardedSave(async () => {
+        const result = isEditing ? await updateTransaction(editingId) : await saveTransaction();
+        if (result.success) {
+          Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+          if (!isEditing) {
+            trackTransactionCreated({
+              type,
+              category: String(categoryId ?? ""),
+              source: "manual",
+            });
+            resetForm();
+          }
+          navigate("/(tabs)" as never);
         }
-        navigate("/(tabs)" as never);
-      }
-    });
-
-  const handleKey = useCallback(
-    (key: string) => {
-      setDigits(handleNumpadPress(digitsRef.current, key));
-    },
-    [setDigits]
+      }),
+    [
+      guardedSave,
+      isEditing,
+      editingId,
+      updateTransaction,
+      saveTransaction,
+      type,
+      categoryId,
+      resetForm,
+      navigate,
+    ]
   );
 
   const saveLabel = isEditing ? t("common.save") : t("transactions.saveTransaction");
 
   return (
-    <View style={{ flex: 1 }} className="bg-page dark:bg-page-dark">
-      {/* Top zone: amount display + metadata */}
-      <View style={{ flex: 1, justifyContent: "center", paddingHorizontal: 24, gap: 12 }}>
-        {/* Type toggle + Amount */}
-        <View style={{ alignItems: "center", gap: 4 }}>
-          <TypeToggle value={type} onChange={setType} />
-          <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "center" }}>
-            <Text
-              style={{
-                fontFamily: "Poppins_700Bold",
-                fontSize: 40,
-                color: amountColor,
-              }}
-            >
-              {displayAmount}
-            </Text>
-            <Animated.View
-              style={[
-                {
-                  width: 2,
-                  height: 32,
-                  marginLeft: 2,
-                  borderRadius: 1,
-                  backgroundColor: amountColor,
-                },
-                cursorStyle,
-              ]}
-            />
-          </View>
-        </View>
-
-        {/* Categories */}
-        <View style={{ alignItems: "center", gap: 6 }}>
-          <View
-            style={{ flexDirection: "row", flexWrap: "wrap", justifyContent: "center", gap: 6 }}
-          >
-            {CATEGORIES.map((cat) => (
-              <CategoryPill
-                key={cat.id}
-                category={cat}
-                isSelected={categoryId === cat.id}
-                onPress={() => setCategoryId(cat.id)}
-              />
-            ))}
-          </View>
-        </View>
-
-        {/* Description + Date */}
-        <View style={{ flexDirection: "row", gap: 8 }}>
-          <TextInput
-            style={{
-              flex: 1,
-              height: 36,
-              borderRadius: 10,
-              paddingHorizontal: 12,
-              fontFamily: "Poppins_500Medium",
-              fontSize: 12,
-              color: primary,
-              borderWidth: 1,
-              borderColor: borderSubtle,
-            }}
-            placeholder={t("transactions.descriptionOptional")}
-            placeholderTextColor={tertiary}
-            value={description}
-            onChangeText={setDescription}
-            maxLength={200}
-          />
-          <View
-            style={{
-              height: 36,
-              borderRadius: 10,
-              flexDirection: "row",
-              alignItems: "center",
-              gap: 6,
-              paddingHorizontal: 10,
-              borderWidth: 1,
-              borderColor: borderSubtle,
-            }}
-          >
-            <Calendar size={14} color={secondary} />
-            <Text
-              style={{
-                fontFamily: "Poppins_500Medium",
-                fontSize: 12,
-                color: primary,
-              }}
-            >
-              {dateLabel}
-            </Text>
-          </View>
-        </View>
-      </View>
-
-      {/* Bottom zone: save button + numpad, pinned to bottom */}
-      <View
-        style={{
-          paddingHorizontal: 16,
-          paddingTop: 8,
-          paddingBottom: Platform.OS === "ios" ? safeBottom : 16,
-          gap: 8,
-        }}
-      >
-        {/* Save button */}
-        <Pressable
-          style={{
-            height: 48,
-            borderRadius: 12,
-            backgroundColor: buttonBg,
-            alignItems: "center",
-            justifyContent: "center",
-            opacity: isSaving ? 0.5 : 1,
-          }}
-          onPress={canSave ? handleSave : undefined}
-          disabled={!canSave || isSaving}
-          accessibilityRole="button"
-          accessibilityLabel={saveLabel}
-        >
-          <Text
-            style={{
-              fontFamily: "Poppins_600SemiBold",
-              fontSize: 15,
-              color: "#FFFFFF",
-            }}
-          >
-            {saveLabel}
-          </Text>
-        </Pressable>
-
-        {/* Custom numpad */}
-        <FidyNumpad onKeyPress={handleKey} />
-      </View>
-    </View>
+    <TransactionForm
+      type={type}
+      digits={digits}
+      categoryId={categoryId}
+      description={description}
+      date={date}
+      saveLabel={saveLabel}
+      isSaving={isSaving}
+      onTypeChange={setType}
+      onDigitsChange={setDigits}
+      onCategoryChange={setCategoryId}
+      onDescriptionChange={setDescription}
+      onSave={handleSave}
+    />
   );
 }

--- a/apps/mobile/app/(tabs)/add.tsx
+++ b/apps/mobile/app/(tabs)/add.tsx
@@ -9,72 +9,42 @@ import { trackTransactionCreated } from "@/shared/lib";
 export default function AddTransactionScreen() {
   const { navigate } = useRouter();
   const { t } = useTranslation();
-  const {
-    type,
-    digits,
-    categoryId,
-    description,
-    date,
-    editingId,
-    setType,
-    setDigits,
-    setCategoryId,
-    setDescription,
-    saveTransaction,
-    updateTransaction,
-    resetForm,
-  } = useTransactionStore(
-    useShallow((s) => ({
-      type: s.type,
-      digits: s.digits,
-      categoryId: s.categoryId,
-      description: s.description,
-      date: s.date,
-      editingId: s.editingId,
-      setType: s.setType,
-      setDigits: s.setDigits,
-      setCategoryId: s.setCategoryId,
-      setDescription: s.setDescription,
-      saveTransaction: s.saveTransaction,
-      updateTransaction: s.updateTransaction,
-      resetForm: s.resetForm,
-    }))
-  );
+  const { type, digits, categoryId, description, date, setType, setDigits, setCategoryId, setDescription, saveTransaction, resetForm } =
+    useTransactionStore(
+      useShallow((s) => ({
+        type: s.type,
+        digits: s.digits,
+        categoryId: s.categoryId,
+        description: s.description,
+        date: s.date,
+        setType: s.setType,
+        setDigits: s.setDigits,
+        setCategoryId: s.setCategoryId,
+        setDescription: s.setDescription,
+        saveTransaction: s.saveTransaction,
+        resetForm: s.resetForm,
+      }))
+    );
 
-  const isEditing = editingId != null;
   const { isBusy: isSaving, run: guardedSave } = useAsyncGuard();
 
   const handleSave = useCallback(
     () =>
       guardedSave(async () => {
-        const result = isEditing ? await updateTransaction(editingId) : await saveTransaction();
+        const result = await saveTransaction();
         if (result.success) {
           Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-          if (!isEditing) {
-            trackTransactionCreated({
-              type,
-              category: String(categoryId ?? ""),
-              source: "manual",
-            });
-            resetForm();
-          }
+          trackTransactionCreated({
+            type,
+            category: String(categoryId ?? ""),
+            source: "manual",
+          });
+          resetForm();
           navigate("/(tabs)" as never);
         }
       }),
-    [
-      guardedSave,
-      isEditing,
-      editingId,
-      updateTransaction,
-      saveTransaction,
-      type,
-      categoryId,
-      resetForm,
-      navigate,
-    ]
+    [guardedSave, saveTransaction, type, categoryId, resetForm, navigate]
   );
-
-  const saveLabel = isEditing ? t("common.save") : t("transactions.saveTransaction");
 
   return (
     <TransactionForm
@@ -83,7 +53,7 @@ export default function AddTransactionScreen() {
       categoryId={categoryId}
       description={description}
       date={date}
-      saveLabel={saveLabel}
+      saveLabel={t("transactions.saveTransaction")}
       isSaving={isSaving}
       onTypeChange={setType}
       onDigitsChange={setDigits}

--- a/apps/mobile/app/(tabs)/add.tsx
+++ b/apps/mobile/app/(tabs)/add.tsx
@@ -9,22 +9,33 @@ import { trackTransactionCreated } from "@/shared/lib";
 export default function AddTransactionScreen() {
   const { navigate } = useRouter();
   const { t } = useTranslation();
-  const { type, digits, categoryId, description, date, setType, setDigits, setCategoryId, setDescription, saveTransaction, resetForm } =
-    useTransactionStore(
-      useShallow((s) => ({
-        type: s.type,
-        digits: s.digits,
-        categoryId: s.categoryId,
-        description: s.description,
-        date: s.date,
-        setType: s.setType,
-        setDigits: s.setDigits,
-        setCategoryId: s.setCategoryId,
-        setDescription: s.setDescription,
-        saveTransaction: s.saveTransaction,
-        resetForm: s.resetForm,
-      }))
-    );
+  const {
+    type,
+    digits,
+    categoryId,
+    description,
+    date,
+    setType,
+    setDigits,
+    setCategoryId,
+    setDescription,
+    saveTransaction,
+    resetForm,
+  } = useTransactionStore(
+    useShallow((s) => ({
+      type: s.type,
+      digits: s.digits,
+      categoryId: s.categoryId,
+      description: s.description,
+      date: s.date,
+      setType: s.setType,
+      setDigits: s.setDigits,
+      setCategoryId: s.setCategoryId,
+      setDescription: s.setDescription,
+      saveTransaction: s.saveTransaction,
+      resetForm: s.resetForm,
+    }))
+  );
 
   const { isBusy: isSaving, run: guardedSave } = useAsyncGuard();
 

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -388,6 +388,10 @@ function RootLayout() {
             name="create-category"
             options={{ presentation: "formSheet", sheetAllowedDetents: "fitToContents" }}
           />
+          <Stack.Screen
+            name="edit-transaction"
+            options={{ ...SHEET, sheetAllowedDetents: [0.92] }}
+          />
         </Stack>
         {db && userId && onboardingComplete && (
           <AuthenticatedShell db={db} userId={userId as UserId} />

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -390,7 +390,12 @@ function RootLayout() {
           />
           <Stack.Screen
             name="edit-transaction"
-            options={{ ...SHEET, sheetAllowedDetents: [0.92] }}
+            options={{
+              ...SHEET,
+              sheetAllowedDetents: [0.65],
+              gestureEnabled: false,
+              sheetGrabberVisible: false,
+            }}
           />
         </Stack>
         {db && userId && onboardingComplete && (

--- a/apps/mobile/app/edit-transaction.tsx
+++ b/apps/mobile/app/edit-transaction.tsx
@@ -1,0 +1,82 @@
+import * as Haptics from "expo-haptics";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useState } from "react";
+import type { TransactionType } from "@/features/transactions";
+import { TransactionForm, useTransactionStore } from "@/features/transactions";
+import { useAsyncGuard, useMountEffect, useTranslation } from "@/shared/hooks";
+import type { CategoryId, TransactionId } from "@/shared/types/branded";
+
+export default function EditTransactionScreen() {
+  const { transactionId } = useLocalSearchParams<{ transactionId: string }>();
+  const router = useRouter();
+  const { t } = useTranslation();
+
+  const getTransactionById = useTransactionStore((s) => s.getTransactionById);
+  const updateTransactionDirect = useTransactionStore((s) => s.updateTransactionDirect);
+  const deleteTransaction = useTransactionStore((s) => s.deleteTransaction);
+
+  const [type, setType] = useState<TransactionType>("expense");
+  const [digits, setDigits] = useState("");
+  const [categoryId, setCategoryId] = useState<CategoryId | null>(null);
+  const [description, setDescription] = useState("");
+  const [date, setDate] = useState(new Date());
+  const [loaded, setLoaded] = useState(false);
+
+  useMountEffect(() => {
+    const tx = getTransactionById(transactionId as TransactionId);
+    if (tx) {
+      setType(tx.type);
+      setDigits(String(tx.amount));
+      setCategoryId(tx.categoryId);
+      setDescription(tx.description);
+      setDate(tx.date);
+      setLoaded(true);
+    } else {
+      router.back();
+    }
+  });
+
+  const { isBusy: isSaving, run: guardedSave } = useAsyncGuard();
+
+  const handleSave = () =>
+    guardedSave(async () => {
+      const result = await updateTransactionDirect(transactionId as TransactionId, {
+        type,
+        digits,
+        categoryId,
+        description,
+        date,
+      });
+      if (result.success) {
+        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+        router.back();
+      }
+    });
+
+  const handleDelete = () =>
+    guardedSave(async () => {
+      await deleteTransaction(transactionId as TransactionId);
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+      router.back();
+    });
+
+  if (!loaded) return null;
+
+  return (
+    <TransactionForm
+      type={type}
+      digits={digits}
+      categoryId={categoryId}
+      description={description}
+      date={date}
+      saveLabel={t("common.save")}
+      isSaving={isSaving}
+      onTypeChange={setType}
+      onDigitsChange={setDigits}
+      onCategoryChange={setCategoryId}
+      onDescriptionChange={setDescription}
+      onSave={handleSave}
+      onDelete={handleDelete}
+    />
+  );
+}

--- a/apps/mobile/app/edit-transaction.tsx
+++ b/apps/mobile/app/edit-transaction.tsx
@@ -1,10 +1,17 @@
 import * as Haptics from "expo-haptics";
 import { useLocalSearchParams, useRouter } from "expo-router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { TransactionType } from "@/features/transactions";
 import { TransactionForm, useTransactionStore } from "@/features/transactions";
-import { useAsyncGuard, useMountEffect, useTranslation } from "@/shared/hooks";
+import { InteractionManager } from "@/shared/components/rn";
+import { useAsyncGuard, useTranslation } from "@/shared/hooks";
+import { showErrorToast } from "@/shared/lib";
 import type { CategoryId, TransactionId } from "@/shared/types/branded";
+
+const afterDismiss = () =>
+  new Promise<void>((resolve) => {
+    InteractionManager.runAfterInteractions(() => resolve());
+  });
 
 export default function EditTransactionScreen() {
   const { transactionId } = useLocalSearchParams<{ transactionId: string }>();
@@ -22,7 +29,8 @@ export default function EditTransactionScreen() {
   const [date, setDate] = useState(new Date());
   const [loaded, setLoaded] = useState(false);
 
-  useMountEffect(() => {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: router and getTransactionById are stable refs
+  useEffect(() => {
     const tx = getTransactionById(transactionId as TransactionId);
     if (tx) {
       setType(tx.type);
@@ -34,30 +42,41 @@ export default function EditTransactionScreen() {
     } else {
       router.back();
     }
-  });
+  }, [transactionId]);
 
   const { isBusy: isSaving, run: guardedSave } = useAsyncGuard();
 
   const handleSave = () =>
     guardedSave(async () => {
-      const result = await updateTransactionDirect(transactionId as TransactionId, {
-        type,
-        digits,
-        categoryId,
-        description,
-        date,
-      });
-      if (result.success) {
-        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-        router.back();
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+      router.back();
+      await afterDismiss();
+      try {
+        const result = await updateTransactionDirect(transactionId as TransactionId, {
+          type,
+          digits,
+          categoryId,
+          description,
+          date,
+        });
+        if (!result.success) {
+          showErrorToast(t("transactions.updateFailed"));
+        }
+      } catch {
+        showErrorToast(t("transactions.updateFailed"));
       }
     });
 
   const handleDelete = () =>
     guardedSave(async () => {
-      await deleteTransaction(transactionId as TransactionId);
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       router.back();
+      await afterDismiss();
+      try {
+        await deleteTransaction(transactionId as TransactionId);
+      } catch {
+        showErrorToast(t("transactions.deleteFailed"));
+      }
     });
 
   if (!loaded) return null;
@@ -77,6 +96,7 @@ export default function EditTransactionScreen() {
       onDescriptionChange={setDescription}
       onSave={handleSave}
       onDelete={handleDelete}
+      onClose={() => router.back()}
     />
   );
 }

--- a/apps/mobile/features/dashboard/components/HomeScreen.tsx
+++ b/apps/mobile/features/dashboard/components/HomeScreen.tsx
@@ -142,7 +142,11 @@ export const HomeScreen = () => {
   }, [hasMore, loadNextPage]);
 
   const navigatingRef = useRef(false);
-  useFocusEffect(useCallback(() => { navigatingRef.current = false; }, []));
+  useFocusEffect(
+    useCallback(() => {
+      navigatingRef.current = false;
+    }, [])
+  );
 
   const handleEdit = useCallback(
     (id: TransactionId) => {

--- a/apps/mobile/features/dashboard/components/HomeScreen.tsx
+++ b/apps/mobile/features/dashboard/components/HomeScreen.tsx
@@ -1,5 +1,5 @@
-import { Stack, useRouter } from "expo-router";
-import { memo, useCallback, useMemo } from "react";
+import { Stack, useFocusEffect, useRouter } from "expo-router";
+import { memo, useCallback, useMemo, useRef } from "react";
 import { DetectedTransactionsBanner } from "@/features/capture-sources";
 import {
   EmailConnectBanner,
@@ -141,8 +141,13 @@ export const HomeScreen = () => {
     }
   }, [hasMore, loadNextPage]);
 
+  const navigatingRef = useRef(false);
+  useFocusEffect(useCallback(() => { navigatingRef.current = false; }, []));
+
   const handleEdit = useCallback(
     (id: TransactionId) => {
+      if (navigatingRef.current) return;
+      navigatingRef.current = true;
       push(`/edit-transaction?transactionId=${id}` as never);
     },
     [push]

--- a/apps/mobile/features/dashboard/components/HomeScreen.tsx
+++ b/apps/mobile/features/dashboard/components/HomeScreen.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/features/transactions";
 import { ScreenLayout, TAB_BAR_CLEARANCE, TransactionRow } from "@/shared/components";
 import { Ellipsis } from "@/shared/components/icons";
-import { Alert, FlatList, Platform, Text, View } from "@/shared/components/rn";
+import { FlatList, Platform, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { getCategoryLabel, getDateFnsLocale } from "@/shared/i18n";
 import { formatSignedMoney, toIsoDate } from "@/shared/lib";
@@ -34,12 +34,10 @@ const TransactionItem = memo(function TransactionItem({
   tx,
   showDateHeader,
   onEdit,
-  onDelete,
 }: {
   tx: StoredTransaction;
   showDateHeader: boolean;
   onEdit: () => void;
-  onDelete: () => void;
 }) {
   const { t, locale } = useTranslation();
   const category = CATEGORY_MAP[tx.categoryId];
@@ -63,7 +61,6 @@ const TransactionItem = memo(function TransactionItem({
           category={category ? getCategoryLabel(category, locale) : t("common.other")}
           isPositive={tx.type === "income"}
           onEdit={onEdit}
-          onDelete={onDelete}
         />
       </View>
     </View>
@@ -114,15 +111,12 @@ const ListHeader = memo(function ListHeader({
 
 export const HomeScreen = () => {
   const { push } = useRouter();
-  const { t } = useTranslation();
   const pages = useTransactionStore((s) => s.pages);
   const hasMore = useTransactionStore((s) => s.hasMore);
   const loadNextPage = useTransactionStore((s) => s.loadNextPage);
   const balance = useTransactionStore((s) => s.balance);
   const categorySpending = useTransactionStore((s) => s.categorySpending);
   const dailySpending = useTransactionStore((s) => s.dailySpending);
-  const editTransaction = useTransactionStore((s) => s.editTransaction);
-  const deleteTransaction = useTransactionStore((s) => s.deleteTransaction);
   // phase gates ListEmptyComponent — suppresses "No transactions" during first sync
   const phase = useEmailCaptureStore((s) => s.phase);
   const primaryColor = useThemeColor("primary");
@@ -149,24 +143,9 @@ export const HomeScreen = () => {
 
   const handleEdit = useCallback(
     (id: TransactionId) => {
-      editTransaction(id);
-      push("/(tabs)/add" as never);
+      push(`/edit-transaction?transactionId=${id}` as never);
     },
-    [editTransaction, push]
-  );
-
-  const handleDelete = useCallback(
-    (id: TransactionId) => {
-      Alert.alert(t("transactions.deleteConfirmTitle"), t("transactions.deleteConfirmMessage"), [
-        { text: t("common.cancel"), style: "cancel" },
-        {
-          text: t("common.delete"),
-          style: "destructive",
-          onPress: () => deleteTransaction(id),
-        },
-      ]);
-    },
-    [t, deleteTransaction]
+    [push]
   );
 
   const renderItem = useCallback(
@@ -176,11 +155,10 @@ export const HomeScreen = () => {
           tx={item}
           showDateHeader={dateBreaks.has(item.id)}
           onEdit={() => handleEdit(item.id)}
-          onDelete={() => handleDelete(item.id)}
         />
       );
     },
-    [dateBreaks, handleEdit, handleDelete]
+    [dateBreaks, handleEdit]
   );
 
   const keyExtractor = useCallback((item: StoredTransaction) => item.id, []);

--- a/apps/mobile/features/transactions/components/TransactionForm.tsx
+++ b/apps/mobile/features/transactions/components/TransactionForm.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Animated, {
+  cancelAnimation,
   useAnimatedStyle,
   useSharedValue,
   withRepeat,
@@ -8,8 +9,8 @@ import Animated, {
 } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { FidyNumpad } from "@/shared/components";
-import { Calendar } from "@/shared/components/icons";
-import { Platform, Pressable, Text, TextInput, View } from "@/shared/components/rn";
+import { Calendar, X } from "@/shared/components/icons";
+import { Keyboard, Platform, Pressable, Text, TextInput, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { getDateFnsLocale } from "@/shared/i18n";
 import { formatInputDisplay, parseDigitsToAmount } from "@/shared/lib";
@@ -35,6 +36,7 @@ type TransactionFormProps = {
   readonly onDescriptionChange: (text: string) => void;
   readonly onSave: () => void;
   readonly onDelete?: () => void;
+  readonly onClose?: () => void;
 };
 
 export function TransactionForm({
@@ -51,6 +53,7 @@ export function TransactionForm({
   onDescriptionChange,
   onSave,
   onDelete,
+  onClose,
 }: TransactionFormProps) {
   const { t, locale } = useTranslation();
   const { bottom: safeBottom } = useSafeAreaInsets();
@@ -71,6 +74,8 @@ export function TransactionForm({
     [date, t, locale]
   );
 
+  const [descriptionFocused, setDescriptionFocused] = useState(false);
+
   const digitsRef = useRef(digits);
   digitsRef.current = digits;
 
@@ -86,6 +91,7 @@ export function TransactionForm({
       ),
       -1
     );
+    return () => cancelAnimation(cursorOpacity);
   }, [cursorOpacity]);
 
   const cursorStyle = useAnimatedStyle(() => ({
@@ -100,7 +106,21 @@ export function TransactionForm({
   );
 
   return (
-    <View style={{ flex: 1 }} className="bg-page dark:bg-page-dark">
+    <Pressable style={{ flex: 1 }} className="bg-page dark:bg-page-dark" onPress={Keyboard.dismiss}>
+      {/* Close button (edit mode only) */}
+      {onClose && (
+        <View style={{ alignItems: "flex-end", paddingTop: 12, paddingHorizontal: 16 }}>
+          <Pressable
+            onPress={onClose}
+            hitSlop={12}
+            accessibilityRole="button"
+            accessibilityLabel={t("common.close")}
+          >
+            <X size={24} color={secondary} />
+          </Pressable>
+        </View>
+      )}
+
       {/* Top zone: amount display + metadata */}
       <View style={{ flex: 1, justifyContent: "center", paddingHorizontal: 24, gap: 12 }}>
         {/* Type toggle + Amount */}
@@ -116,18 +136,20 @@ export function TransactionForm({
             >
               {displayAmount}
             </Text>
-            <Animated.View
-              style={[
-                {
-                  width: 2,
-                  height: 32,
-                  marginLeft: 2,
-                  borderRadius: 1,
-                  backgroundColor: amountColor,
-                },
-                cursorStyle,
-              ]}
-            />
+            {!descriptionFocused && (
+              <Animated.View
+                style={[
+                  {
+                    width: 2,
+                    height: 32,
+                    marginLeft: 2,
+                    borderRadius: 1,
+                    backgroundColor: amountColor,
+                  },
+                  cursorStyle,
+                ]}
+              />
+            )}
           </View>
         </View>
 
@@ -165,6 +187,8 @@ export function TransactionForm({
             placeholderTextColor={tertiary}
             value={description}
             onChangeText={onDescriptionChange}
+            onFocus={() => setDescriptionFocused(true)}
+            onBlur={() => setDescriptionFocused(false)}
             maxLength={200}
           />
           <View
@@ -259,6 +283,6 @@ export function TransactionForm({
         {/* Custom numpad */}
         <FidyNumpad onKeyPress={handleKey} />
       </View>
-    </View>
+    </Pressable>
   );
 }

--- a/apps/mobile/features/transactions/components/TransactionForm.tsx
+++ b/apps/mobile/features/transactions/components/TransactionForm.tsx
@@ -1,0 +1,264 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { FidyNumpad } from "@/shared/components";
+import { Calendar } from "@/shared/components/icons";
+import { Platform, Pressable, Text, TextInput, View } from "@/shared/components/rn";
+import { useThemeColor, useTranslation } from "@/shared/hooks";
+import { getDateFnsLocale } from "@/shared/i18n";
+import { formatInputDisplay, parseDigitsToAmount } from "@/shared/lib";
+import type { CategoryId } from "@/shared/types/branded";
+import { CATEGORIES } from "../lib/categories";
+import { getDateLabel } from "../lib/format-date";
+import { handleNumpadPress } from "../lib/handle-numpad-press";
+import type { TransactionType } from "../schema";
+import { CategoryPill } from "./CategoryPill";
+import { TypeToggle } from "./TypeToggle";
+
+type TransactionFormProps = {
+  readonly type: TransactionType;
+  readonly digits: string;
+  readonly categoryId: CategoryId | null;
+  readonly description: string;
+  readonly date: Date;
+  readonly saveLabel: string;
+  readonly isSaving: boolean;
+  readonly onTypeChange: (type: TransactionType) => void;
+  readonly onDigitsChange: (digits: string) => void;
+  readonly onCategoryChange: (id: CategoryId) => void;
+  readonly onDescriptionChange: (text: string) => void;
+  readonly onSave: () => void;
+  readonly onDelete?: () => void;
+};
+
+export function TransactionForm({
+  type,
+  digits,
+  categoryId,
+  description,
+  date,
+  saveLabel,
+  isSaving,
+  onTypeChange,
+  onDigitsChange,
+  onCategoryChange,
+  onDescriptionChange,
+  onSave,
+  onDelete,
+}: TransactionFormProps) {
+  const { t, locale } = useTranslation();
+  const { bottom: safeBottom } = useSafeAreaInsets();
+
+  const accentRed = useThemeColor("accentRed");
+  const accentGreen = useThemeColor("accentGreen");
+  const secondary = useThemeColor("secondary");
+  const tertiary = useThemeColor("tertiary");
+  const primary = useThemeColor("primary");
+  const borderSubtle = useThemeColor("borderSubtle");
+
+  const amountColor = type === "expense" ? accentRed : accentGreen;
+  const displayAmount = digits.length > 0 ? formatInputDisplay(digits) : "$";
+  const canSave = parseDigitsToAmount(digits) > 0;
+  const buttonBg = canSave ? accentGreen : "#CCCCCC";
+  const dateLabel = useMemo(
+    () => getDateLabel(date, new Date(), t("dates.today"), getDateFnsLocale(locale)),
+    [date, t, locale]
+  );
+
+  const digitsRef = useRef(digits);
+  digitsRef.current = digits;
+
+  const cursorOpacity = useSharedValue(1);
+
+  useEffect(() => {
+    cursorOpacity.value = withRepeat(
+      withSequence(
+        withTiming(1, { duration: 0 }),
+        withTiming(1, { duration: 530 }),
+        withTiming(0, { duration: 0 }),
+        withTiming(0, { duration: 530 })
+      ),
+      -1
+    );
+  }, [cursorOpacity]);
+
+  const cursorStyle = useAnimatedStyle(() => ({
+    opacity: cursorOpacity.value,
+  }));
+
+  const handleKey = useCallback(
+    (key: string) => {
+      onDigitsChange(handleNumpadPress(digitsRef.current, key));
+    },
+    [onDigitsChange]
+  );
+
+  return (
+    <View style={{ flex: 1 }} className="bg-page dark:bg-page-dark">
+      {/* Top zone: amount display + metadata */}
+      <View style={{ flex: 1, justifyContent: "center", paddingHorizontal: 24, gap: 12 }}>
+        {/* Type toggle + Amount */}
+        <View style={{ alignItems: "center", gap: 4 }}>
+          <TypeToggle value={type} onChange={onTypeChange} />
+          <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "center" }}>
+            <Text
+              style={{
+                fontFamily: "Poppins_700Bold",
+                fontSize: 40,
+                color: amountColor,
+              }}
+            >
+              {displayAmount}
+            </Text>
+            <Animated.View
+              style={[
+                {
+                  width: 2,
+                  height: 32,
+                  marginLeft: 2,
+                  borderRadius: 1,
+                  backgroundColor: amountColor,
+                },
+                cursorStyle,
+              ]}
+            />
+          </View>
+        </View>
+
+        {/* Categories */}
+        <View style={{ alignItems: "center", gap: 6 }}>
+          <View
+            style={{ flexDirection: "row", flexWrap: "wrap", justifyContent: "center", gap: 6 }}
+          >
+            {CATEGORIES.map((cat) => (
+              <CategoryPill
+                key={cat.id}
+                category={cat}
+                isSelected={categoryId === cat.id}
+                onPress={() => onCategoryChange(cat.id)}
+              />
+            ))}
+          </View>
+        </View>
+
+        {/* Description + Date */}
+        <View style={{ flexDirection: "row", gap: 8 }}>
+          <TextInput
+            style={{
+              flex: 1,
+              height: 36,
+              borderRadius: 10,
+              paddingHorizontal: 12,
+              fontFamily: "Poppins_500Medium",
+              fontSize: 12,
+              color: primary,
+              borderWidth: 1,
+              borderColor: borderSubtle,
+            }}
+            placeholder={t("transactions.descriptionOptional")}
+            placeholderTextColor={tertiary}
+            value={description}
+            onChangeText={onDescriptionChange}
+            maxLength={200}
+          />
+          <View
+            style={{
+              height: 36,
+              borderRadius: 10,
+              flexDirection: "row",
+              alignItems: "center",
+              gap: 6,
+              paddingHorizontal: 10,
+              borderWidth: 1,
+              borderColor: borderSubtle,
+            }}
+          >
+            <Calendar size={14} color={secondary} />
+            <Text
+              style={{
+                fontFamily: "Poppins_500Medium",
+                fontSize: 12,
+                color: primary,
+              }}
+            >
+              {dateLabel}
+            </Text>
+          </View>
+        </View>
+      </View>
+
+      {/* Bottom zone: buttons + numpad, pinned to bottom */}
+      <View
+        style={{
+          paddingHorizontal: 16,
+          paddingTop: 8,
+          paddingBottom: Platform.OS === "ios" ? safeBottom : 16,
+          gap: 8,
+        }}
+      >
+        {/* Action buttons */}
+        <View style={{ flexDirection: "row", gap: 8 }}>
+          {onDelete && (
+            <Pressable
+              style={{
+                height: 48,
+                borderRadius: 12,
+                backgroundColor: `${accentRed}18`,
+                alignItems: "center",
+                justifyContent: "center",
+                paddingHorizontal: 20,
+              }}
+              onPress={onDelete}
+              accessibilityRole="button"
+              accessibilityLabel={t("transactions.deleteTransaction")}
+            >
+              <Text
+                style={{
+                  fontFamily: "Poppins_600SemiBold",
+                  fontSize: 15,
+                  color: accentRed,
+                }}
+              >
+                {t("transactions.deleteTransaction")}
+              </Text>
+            </Pressable>
+          )}
+          <Pressable
+            style={{
+              flex: 1,
+              height: 48,
+              borderRadius: 12,
+              backgroundColor: buttonBg,
+              alignItems: "center",
+              justifyContent: "center",
+              opacity: isSaving ? 0.5 : 1,
+            }}
+            onPress={canSave ? onSave : undefined}
+            disabled={!canSave || isSaving}
+            accessibilityRole="button"
+            accessibilityLabel={saveLabel}
+          >
+            <Text
+              style={{
+                fontFamily: "Poppins_600SemiBold",
+                fontSize: 15,
+                color: "#FFFFFF",
+              }}
+            >
+              {saveLabel}
+            </Text>
+          </Pressable>
+        </View>
+
+        {/* Custom numpad */}
+        <FidyNumpad onKeyPress={handleKey} />
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/features/transactions/index.ts
+++ b/apps/mobile/features/transactions/index.ts
@@ -1,5 +1,6 @@
 export type { CategoryId } from "@/shared/types/branded";
 export { CategoryPill } from "./components/CategoryPill";
+export { TransactionForm } from "./components/TransactionForm";
 export { TypeToggle } from "./components/TypeToggle";
 export { toStoredTransaction, toTransactionRow } from "./lib/build-transaction";
 export type { Category } from "./lib/categories";

--- a/apps/mobile/features/transactions/store.ts
+++ b/apps/mobile/features/transactions/store.ts
@@ -275,9 +275,9 @@ export const useTransactionStore = create<TransactionState & TransactionActions>
           createdAt: now,
         });
         trackTransactionDeleted();
-      } catch {
+      } catch (e) {
         // DB operation failed — keep UI state unchanged
-        return;
+        throw e;
       }
     }
     await get().refresh();

--- a/apps/mobile/features/transactions/store.ts
+++ b/apps/mobile/features/transactions/store.ts
@@ -83,6 +83,18 @@ type TransactionActions = {
   ) => Promise<
     { success: true; transaction: StoredTransaction } | { success: false; error: string }
   >;
+  updateTransactionDirect: (
+    id: TransactionId,
+    fields: {
+      type: TransactionType;
+      digits: string;
+      categoryId: CategoryId | null;
+      description: string;
+      date: Date;
+    }
+  ) => Promise<
+    { success: true; transaction: StoredTransaction } | { success: false; error: string }
+  >;
   deleteTransaction: (id: TransactionId) => Promise<void>;
   addToCache: (tx: StoredTransaction) => void;
   removeFromCache: (id: TransactionId) => void;
@@ -322,6 +334,40 @@ export const useTransactionStore = create<TransactionState & TransactionActions>
 
     trackTransactionEdited({ category: String(transaction.categoryId) });
     get().resetForm();
+    await get().refresh();
+
+    return { success: true as const, transaction };
+  },
+
+  updateTransactionDirect: async (id, fields) => {
+    if (!dbRef || !userIdRef) {
+      return { success: false as const, error: "Store not initialized" };
+    }
+
+    const now = new Date();
+
+    const result = buildTransaction(fields, userIdRef, id, now);
+    if (!result.success) {
+      return { success: false as const, error: result.error };
+    }
+
+    const { transaction } = result;
+
+    try {
+      upsertTransaction(dbRef, toTransactionRow(transaction));
+
+      await enqueueSync(dbRef, {
+        id: generateSyncQueueId(),
+        tableName: "transactions",
+        rowId: id,
+        operation: "update",
+        createdAt: toIsoDateTime(now),
+      });
+    } catch {
+      return { success: false as const, error: "Failed to update transaction" };
+    }
+
+    trackTransactionEdited({ category: String(transaction.categoryId) });
     await get().refresh();
 
     return { success: true as const, transaction };

--- a/apps/mobile/features/transactions/store.ts
+++ b/apps/mobile/features/transactions/store.ts
@@ -264,21 +264,16 @@ export const useTransactionStore = create<TransactionState & TransactionActions>
 
   removeTransaction: async (id) => {
     if (dbRef) {
-      try {
-        const now = toIsoDateTime(new Date());
-        await softDeleteTransaction(dbRef, id, now);
-        await enqueueSync(dbRef, {
-          id: generateSyncQueueId(),
-          tableName: "transactions",
-          rowId: id,
-          operation: "delete",
-          createdAt: now,
-        });
-        trackTransactionDeleted();
-      } catch (e) {
-        // DB operation failed — keep UI state unchanged
-        throw e;
-      }
+      const now = toIsoDateTime(new Date());
+      await softDeleteTransaction(dbRef, id, now);
+      await enqueueSync(dbRef, {
+        id: generateSyncQueueId(),
+        tableName: "transactions",
+        rowId: id,
+        operation: "delete",
+        createdAt: now,
+      });
+      trackTransactionDeleted();
     }
     await get().refresh();
   },

--- a/apps/mobile/shared/components/TransactionRow.tsx
+++ b/apps/mobile/shared/components/TransactionRow.tsx
@@ -1,7 +1,8 @@
+import * as Haptics from "expo-haptics";
 import { useCallback } from "react";
 import type { LucideIcon } from "@/shared/components/icons";
-import { ActionSheetIOS, Platform, Pressable, Text, View } from "@/shared/components/rn";
-import { useThemeColor, useTranslation } from "@/shared/hooks";
+import { Pressable, Text, View } from "@/shared/components/rn";
+import { useThemeColor } from "@/shared/hooks";
 
 type TransactionRowProps = {
   icon: LucideIcon;
@@ -12,7 +13,6 @@ type TransactionRowProps = {
   category: string;
   isPositive?: boolean;
   onEdit?: () => void;
-  onDelete?: () => void;
 };
 
 export function TransactionRow({
@@ -24,34 +24,14 @@ export function TransactionRow({
   category,
   isPositive = false,
   onEdit,
-  onDelete,
 }: TransactionRowProps) {
   const defaultIconBg = useThemeColor("peachLight");
   const iconColor = useThemeColor("tertiary");
-  const { t } = useTranslation();
 
   const handleLongPress = useCallback(() => {
-    if (Platform.OS !== "ios") return;
-
-    const options = [
-      ...(onEdit ? [t("common.edit")] : []),
-      ...(onDelete ? [t("common.delete")] : []),
-      t("common.cancel"),
-    ];
-    const cancelButtonIndex = options.length - 1;
-    const destructiveButtonIndex = onDelete ? options.indexOf(t("common.delete")) : undefined;
-
-    ActionSheetIOS.showActionSheetWithOptions(
-      { options, cancelButtonIndex, destructiveButtonIndex },
-      (buttonIndex) => {
-        const selected = options[buttonIndex];
-        if (selected === t("common.edit")) onEdit?.();
-        if (selected === t("common.delete")) onDelete?.();
-      }
-    );
-  }, [onEdit, onDelete, t]);
-
-  const hasActions = (onEdit || onDelete) && Platform.OS === "ios";
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    onEdit?.();
+  }, [onEdit]);
 
   const content = (
     <View className="flex-row items-center py-3">
@@ -88,7 +68,7 @@ export function TransactionRow({
     </View>
   );
 
-  if (!hasActions) return content;
+  if (!onEdit) return content;
 
   return <Pressable onLongPress={handleLongPress}>{content}</Pressable>;
 }

--- a/apps/mobile/shared/components/TransactionRow.tsx
+++ b/apps/mobile/shared/components/TransactionRow.tsx
@@ -1,7 +1,9 @@
 import * as Haptics from "expo-haptics";
-import { useCallback } from "react";
+import { useMemo, useRef } from "react";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import Animated, { runOnJS, useAnimatedStyle, useSharedValue } from "react-native-reanimated";
 import type { LucideIcon } from "@/shared/components/icons";
-import { Pressable, Text, View } from "@/shared/components/rn";
+import { Text, View } from "@/shared/components/rn";
 import { useThemeColor } from "@/shared/hooks";
 
 type TransactionRowProps = {
@@ -28,10 +30,34 @@ export function TransactionRow({
   const defaultIconBg = useThemeColor("peachLight");
   const iconColor = useThemeColor("tertiary");
 
-  const handleLongPress = useCallback(() => {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-    onEdit?.();
-  }, [onEdit]);
+  const pressed = useSharedValue(false);
+  const onEditRef = useRef(onEdit);
+  onEditRef.current = onEdit;
+
+  const longPress = useMemo(() => {
+    if (!onEdit) return null;
+
+    const fire = () => {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+      onEditRef.current?.();
+    };
+
+    return Gesture.LongPress()
+      .minDuration(100)
+      .onBegin(() => {
+        pressed.value = true;
+      })
+      .onStart(() => {
+        runOnJS(fire)();
+      })
+      .onFinalize(() => {
+        pressed.value = false;
+      });
+  }, [pressed, onEdit]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: pressed.value ? 0.7 : 1,
+  }));
 
   const content = (
     <View className="flex-row items-center py-3">
@@ -68,7 +94,11 @@ export function TransactionRow({
     </View>
   );
 
-  if (!onEdit) return content;
+  if (!longPress) return content;
 
-  return <Pressable onLongPress={handleLongPress}>{content}</Pressable>;
+  return (
+    <GestureDetector gesture={longPress}>
+      <Animated.View style={animatedStyle}>{content}</Animated.View>
+    </GestureDetector>
+  );
 }

--- a/apps/mobile/shared/i18n/locales/en.ts
+++ b/apps/mobile/shared/i18n/locales/en.ts
@@ -51,6 +51,8 @@ const en = {
     noTransactionsHint: "Connect an email account or add transactions manually to get started",
     deleteConfirmTitle: "Delete Transaction",
     deleteConfirmMessage: "Are you sure you want to delete this transaction?",
+    editTransaction: "Edit Transaction",
+    deleteTransaction: "Delete",
   },
 
   // Bills / Calendar

--- a/apps/mobile/shared/i18n/locales/en.ts
+++ b/apps/mobile/shared/i18n/locales/en.ts
@@ -6,6 +6,7 @@ const en = {
     delete: "Delete",
     confirm: "Confirm",
     dismiss: "Dismiss",
+    close: "Close",
     edit: "Edit",
     category: "Category",
     description: "Description",
@@ -53,6 +54,8 @@ const en = {
     deleteConfirmMessage: "Are you sure you want to delete this transaction?",
     editTransaction: "Edit Transaction",
     deleteTransaction: "Delete",
+    updateFailed: "Could not update transaction",
+    deleteFailed: "Could not delete transaction",
   },
 
   // Bills / Calendar

--- a/apps/mobile/shared/i18n/locales/es.ts
+++ b/apps/mobile/shared/i18n/locales/es.ts
@@ -52,6 +52,8 @@ const es = {
       "Conecta una cuenta de correo o agrega transacciones manualmente para comenzar",
     deleteConfirmTitle: "Eliminar Transacción",
     deleteConfirmMessage: "¿Estás seguro de que quieres eliminar esta transacción?",
+    editTransaction: "Editar Transacción",
+    deleteTransaction: "Eliminar",
   },
 
   // Bills / Calendar

--- a/apps/mobile/shared/i18n/locales/es.ts
+++ b/apps/mobile/shared/i18n/locales/es.ts
@@ -6,6 +6,7 @@ const es = {
     delete: "Eliminar",
     confirm: "Confirmar",
     dismiss: "Descartar",
+    close: "Cerrar",
     edit: "Editar",
     category: "Categoría",
     description: "Descripción",
@@ -54,6 +55,8 @@ const es = {
     deleteConfirmMessage: "¿Estás seguro de que quieres eliminar esta transacción?",
     editTransaction: "Editar Transacción",
     deleteTransaction: "Eliminar",
+    updateFailed: "No se pudo actualizar la transacción",
+    deleteFailed: "No se pudo eliminar la transacción",
   },
 
   // Bills / Calendar


### PR DESCRIPTION
- Extract TransactionForm shared component from add screen
- Add edit-transaction formSheet route with local state management
- Add updateTransactionDirect store action (explicit params, no global state pollution)
- Cross-platform long-press with haptics on TransactionRow (replaces iOS-only ActionSheetIOS)
- Include delete button in edit sheet (immediate soft-delete, no confirmation)
- Navigate to edit-transaction route from HomeScreen on long-press
- Add i18n keys for edit/delete transaction (en + es)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cross‑platform long‑press edit flow for transactions using a new form sheet and a shared `TransactionForm`, now using `react-native-gesture-handler` for smoother gestures. Editing happens in `/edit-transaction` with haptic feedback and optimistic save/delete.

- New Features
  - Long‑press a transaction to open the `/edit-transaction` form sheet with `expo-haptics` (iOS + Android).
  - Optimistic edit/delete: sheet closes first, then DB work; error toasts on failure; added Close button.
  - Store exposes `updateTransactionDirect` for explicit field updates.

- Refactors
  - Migrated long‑press to `react-native-gesture-handler` `Gesture.LongPress` with visual press feedback; removed `ActionSheetIOS`.
  - Disabled sheet swipe‑to‑dismiss, hid the grabber, set detent to 65%; added a navigation guard to prevent double openings.
  - Extracted `TransactionForm` as a controlled component; Add screen is a thin wrapper and edits go through `/edit-transaction` only.
  - Propagate delete errors from the store (no silent catch) so callers can handle failures; updated tests with `react-native-gesture-handler` and `react-native-reanimated` mocks.

<sup>Written for commit 5f08e3f4797d7c74089d296d8070c97e81babec0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

