### PR TITLE
feat(mobile): add iOS Control Center quick expense widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ out/
 android/
 ios/
 
+# But track Swift source files inside local Expo modules
+!apps/mobile/modules/**/ios/
+
 # EAS
 .eas/
 

--- a/apps/mobile/__tests__/capture-sources/widget-pipeline.test.ts
+++ b/apps/mobile/__tests__/capture-sources/widget-pipeline.test.ts
@@ -1,0 +1,166 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: mock db needs flexible typing
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockInsertTransaction = vi.fn();
+const mockEnqueueSync = vi.fn();
+const mockGetPendingTransactions = vi.fn();
+const mockClearPendingTransactions = vi.fn();
+const mockIsAvailable = vi.fn();
+
+vi.mock("@/features/transactions/lib/repository", () => ({
+  insertTransaction: (...args: any[]) => mockInsertTransaction(...args),
+}));
+
+vi.mock("@/shared/db/enqueue-sync", () => ({
+  enqueueSync: (...args: any[]) => mockEnqueueSync(...args),
+}));
+
+vi.mock("@/modules/expo-app-intents", () => ({
+  getPendingTransactions: (...args: any[]) => mockGetPendingTransactions(...args),
+  clearPendingTransactions: (...args: any[]) => mockClearPendingTransactions(...args),
+  isAvailable: () => mockIsAvailable(),
+}));
+
+const mockGenerateId = vi.fn();
+vi.mock("@/shared/lib/generate-id", () => ({
+  generateId: (...args: any[]) => mockGenerateId(...args),
+  generateTransactionId: () => mockGenerateId("tx"),
+  generateSyncQueueId: () => mockGenerateId("sq"),
+}));
+
+import { processWidgetTransactions } from "@/features/capture-sources/services/widget-pipeline";
+import type { UserId } from "@/shared/types/branded";
+
+const mockDb = {} as any;
+const USER_ID = "user-1" as UserId;
+
+describe("processWidgetTransactions", () => {
+  let idCounter: number;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    idCounter = 0;
+    mockGenerateId.mockImplementation((prefix: string) => {
+      idCounter++;
+      return `${prefix}-${idCounter}`;
+    });
+    mockIsAvailable.mockReturnValue(true);
+    mockGetPendingTransactions.mockResolvedValue([]);
+    mockClearPendingTransactions.mockResolvedValue(undefined);
+  });
+
+  it("early-returns when isAvailable() is false", async () => {
+    mockIsAvailable.mockReturnValue(false);
+
+    await processWidgetTransactions(mockDb, USER_ID);
+
+    expect(mockGetPendingTransactions).not.toHaveBeenCalled();
+    expect(mockInsertTransaction).not.toHaveBeenCalled();
+  });
+
+  it("early-returns when pending list is empty", async () => {
+    mockGetPendingTransactions.mockResolvedValue([]);
+
+    await processWidgetTransactions(mockDb, USER_ID);
+
+    expect(mockInsertTransaction).not.toHaveBeenCalled();
+    expect(mockClearPendingTransactions).not.toHaveBeenCalled();
+  });
+
+  it("saves a single pending transaction with widget source", async () => {
+    mockGetPendingTransactions.mockResolvedValue([
+      { amount: 25000, createdAt: "2026-03-27T10:00:00Z" },
+    ]);
+
+    await processWidgetTransactions(mockDb, USER_ID);
+
+    expect(mockInsertTransaction).toHaveBeenCalledOnce();
+    expect(mockInsertTransaction).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        id: "tx-1",
+        userId: USER_ID,
+        type: "expense",
+        amount: 25000,
+        categoryId: "other",
+        description: "",
+        source: "widget",
+      })
+    );
+  });
+
+  it("enqueues sync for each saved transaction", async () => {
+    mockGetPendingTransactions.mockResolvedValue([
+      { amount: 10000, createdAt: "2026-03-27T10:00:00Z" },
+    ]);
+
+    await processWidgetTransactions(mockDb, USER_ID);
+
+    expect(mockEnqueueSync).toHaveBeenCalledOnce();
+    expect(mockEnqueueSync).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        tableName: "transactions",
+        rowId: "tx-1",
+        operation: "insert",
+      })
+    );
+  });
+
+  it("clears pending transactions after all are processed", async () => {
+    mockGetPendingTransactions.mockResolvedValue([
+      { amount: 10000, createdAt: "2026-03-27T10:00:00Z" },
+      { amount: 20000, createdAt: "2026-03-27T11:00:00Z" },
+    ]);
+
+    await processWidgetTransactions(mockDb, USER_ID);
+
+    expect(mockInsertTransaction).toHaveBeenCalledTimes(2);
+    expect(mockEnqueueSync).toHaveBeenCalledTimes(2);
+    expect(mockClearPendingTransactions).toHaveBeenCalledOnce();
+  });
+
+  it("processes multiple pending transactions with unique IDs", async () => {
+    mockGetPendingTransactions.mockResolvedValue([
+      { amount: 10000, createdAt: "2026-03-27T10:00:00Z" },
+      { amount: 20000, createdAt: "2026-03-27T11:00:00Z" },
+    ]);
+
+    await processWidgetTransactions(mockDb, USER_ID);
+
+    const firstTxCall = mockInsertTransaction.mock.calls[0][1];
+    const secondTxCall = mockInsertTransaction.mock.calls[1][1];
+    expect(firstTxCall.id).toBe("tx-1");
+    expect(secondTxCall.id).toBe("tx-2");
+    expect(firstTxCall.amount).toBe(10000);
+    expect(secondTxCall.amount).toBe(20000);
+  });
+
+  it("uses toIsoDate from item.createdAt for the transaction date", async () => {
+    mockGetPendingTransactions.mockResolvedValue([
+      { amount: 5000, createdAt: "2026-03-15T14:30:00Z" },
+    ]);
+
+    await processWidgetTransactions(mockDb, USER_ID);
+
+    expect(mockInsertTransaction).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        date: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+      })
+    );
+  });
+
+  it("rounds fractional amounts to nearest integer", async () => {
+    mockGetPendingTransactions.mockResolvedValue([
+      { amount: 15000.7, createdAt: "2026-03-27T10:00:00Z" },
+    ]);
+
+    await processWidgetTransactions(mockDb, USER_ID);
+
+    expect(mockInsertTransaction).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({ amount: 15001 })
+    );
+  });
+});

--- a/apps/mobile/__tests__/capture-sources/widget-pipeline.test.ts
+++ b/apps/mobile/__tests__/capture-sources/widget-pipeline.test.ts
@@ -176,4 +176,78 @@ describe("processWidgetTransactions", () => {
       expect.objectContaining({ amount: 15001 })
     );
   });
+
+  it("uses category from pending item when valid", async () => {
+    mockGetPendingTransactions.mockResolvedValue([
+      { id: "cat-test", amount: 8000, createdAt: "2026-03-27T10:00:00Z", category: "food" },
+    ]);
+
+    await processWidgetTransactions(mockDb, USER_ID);
+
+    expect(mockUpsertTransaction).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({ categoryId: "food" })
+    );
+  });
+
+  it("falls back to 'other' when category is invalid", async () => {
+    mockGetPendingTransactions.mockResolvedValue([
+      { id: "bad-cat", amount: 5000, createdAt: "2026-03-27T10:00:00Z", category: "invalid" },
+    ]);
+
+    await processWidgetTransactions(mockDb, USER_ID);
+
+    expect(mockUpsertTransaction).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({ categoryId: "other" })
+    );
+  });
+
+  it("uses type=income when specified", async () => {
+    mockGetPendingTransactions.mockResolvedValue([
+      { id: "income-test", amount: 50000, createdAt: "2026-03-27T10:00:00Z", type: "income" },
+    ]);
+
+    await processWidgetTransactions(mockDb, USER_ID);
+
+    expect(mockUpsertTransaction).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({ type: "income" })
+    );
+  });
+
+  it("uses description from pending item", async () => {
+    mockGetPendingTransactions.mockResolvedValue([
+      {
+        id: "desc-test",
+        amount: 12000,
+        createdAt: "2026-03-27T10:00:00Z",
+        description: "Coffee at Juan Valdez",
+      },
+    ]);
+
+    await processWidgetTransactions(mockDb, USER_ID);
+
+    expect(mockUpsertTransaction).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({ description: "Coffee at Juan Valdez" })
+    );
+  });
+
+  it("defaults optional fields when absent (backward compatible)", async () => {
+    mockGetPendingTransactions.mockResolvedValue([
+      { id: "compat-test", amount: 10000, createdAt: "2026-03-27T10:00:00Z" },
+    ]);
+
+    await processWidgetTransactions(mockDb, USER_ID);
+
+    expect(mockUpsertTransaction).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        type: "expense",
+        categoryId: "other",
+        description: "",
+      })
+    );
+  });
 });

--- a/apps/mobile/__tests__/capture-sources/widget-pipeline.test.ts
+++ b/apps/mobile/__tests__/capture-sources/widget-pipeline.test.ts
@@ -1,14 +1,14 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: mock db needs flexible typing
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockInsertTransaction = vi.fn();
+const mockUpsertTransaction = vi.fn();
 const mockEnqueueSync = vi.fn();
 const mockGetPendingTransactions = vi.fn();
-const mockClearPendingTransactions = vi.fn();
+const mockRemovePendingTransactions = vi.fn();
 const mockIsAvailable = vi.fn();
 
 vi.mock("@/features/transactions/lib/repository", () => ({
-  insertTransaction: (...args: any[]) => mockInsertTransaction(...args),
+  upsertTransaction: (...args: any[]) => mockUpsertTransaction(...args),
 }));
 
 vi.mock("@/shared/db/enqueue-sync", () => ({
@@ -17,14 +17,13 @@ vi.mock("@/shared/db/enqueue-sync", () => ({
 
 vi.mock("@/modules/expo-app-intents", () => ({
   getPendingTransactions: (...args: any[]) => mockGetPendingTransactions(...args),
-  clearPendingTransactions: (...args: any[]) => mockClearPendingTransactions(...args),
+  removePendingTransactions: (...args: any[]) => mockRemovePendingTransactions(...args),
   isAvailable: () => mockIsAvailable(),
 }));
 
 const mockGenerateId = vi.fn();
 vi.mock("@/shared/lib/generate-id", () => ({
   generateId: (...args: any[]) => mockGenerateId(...args),
-  generateTransactionId: () => mockGenerateId("tx"),
   generateSyncQueueId: () => mockGenerateId("sq"),
 }));
 
@@ -46,7 +45,7 @@ describe("processWidgetTransactions", () => {
     });
     mockIsAvailable.mockReturnValue(true);
     mockGetPendingTransactions.mockResolvedValue([]);
-    mockClearPendingTransactions.mockResolvedValue(undefined);
+    mockRemovePendingTransactions.mockResolvedValue(undefined);
   });
 
   it("early-returns when isAvailable() is false", async () => {
@@ -55,7 +54,7 @@ describe("processWidgetTransactions", () => {
     await processWidgetTransactions(mockDb, USER_ID);
 
     expect(mockGetPendingTransactions).not.toHaveBeenCalled();
-    expect(mockInsertTransaction).not.toHaveBeenCalled();
+    expect(mockUpsertTransaction).not.toHaveBeenCalled();
   });
 
   it("early-returns when pending list is empty", async () => {
@@ -63,22 +62,22 @@ describe("processWidgetTransactions", () => {
 
     await processWidgetTransactions(mockDb, USER_ID);
 
-    expect(mockInsertTransaction).not.toHaveBeenCalled();
-    expect(mockClearPendingTransactions).not.toHaveBeenCalled();
+    expect(mockUpsertTransaction).not.toHaveBeenCalled();
+    expect(mockRemovePendingTransactions).not.toHaveBeenCalled();
   });
 
   it("saves a single pending transaction with widget source", async () => {
     mockGetPendingTransactions.mockResolvedValue([
-      { amount: 25000, createdAt: "2026-03-27T10:00:00Z" },
+      { id: "abc-123", amount: 25000, createdAt: "2026-03-27T10:00:00Z" },
     ]);
 
     await processWidgetTransactions(mockDb, USER_ID);
 
-    expect(mockInsertTransaction).toHaveBeenCalledOnce();
-    expect(mockInsertTransaction).toHaveBeenCalledWith(
+    expect(mockUpsertTransaction).toHaveBeenCalledOnce();
+    expect(mockUpsertTransaction).toHaveBeenCalledWith(
       mockDb,
       expect.objectContaining({
-        id: "tx-1",
+        id: "txn-widget-abc-123",
         userId: USER_ID,
         type: "expense",
         amount: 25000,
@@ -89,9 +88,22 @@ describe("processWidgetTransactions", () => {
     );
   });
 
+  it("derives deterministic transaction ID from widget entry ID", async () => {
+    mockGetPendingTransactions.mockResolvedValue([
+      { id: "stable-uuid", amount: 10000, createdAt: "2026-03-27T10:00:00Z" },
+    ]);
+
+    await processWidgetTransactions(mockDb, USER_ID);
+
+    expect(mockUpsertTransaction).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({ id: "txn-widget-stable-uuid" })
+    );
+  });
+
   it("enqueues sync for each saved transaction", async () => {
     mockGetPendingTransactions.mockResolvedValue([
-      { amount: 10000, createdAt: "2026-03-27T10:00:00Z" },
+      { id: "sync-1", amount: 10000, createdAt: "2026-03-27T10:00:00Z" },
     ]);
 
     await processWidgetTransactions(mockDb, USER_ID);
@@ -101,64 +113,65 @@ describe("processWidgetTransactions", () => {
       mockDb,
       expect.objectContaining({
         tableName: "transactions",
-        rowId: "tx-1",
+        rowId: "txn-widget-sync-1",
         operation: "insert",
       })
     );
   });
 
-  it("clears pending transactions after all are processed", async () => {
+  it("removes only processed pending entries after success", async () => {
     mockGetPendingTransactions.mockResolvedValue([
-      { amount: 10000, createdAt: "2026-03-27T10:00:00Z" },
-      { amount: 20000, createdAt: "2026-03-27T11:00:00Z" },
+      { id: "id-a", amount: 10000, createdAt: "2026-03-27T10:00:00Z" },
+      { id: "id-b", amount: 20000, createdAt: "2026-03-27T11:00:00Z" },
     ]);
 
     await processWidgetTransactions(mockDb, USER_ID);
 
-    expect(mockInsertTransaction).toHaveBeenCalledTimes(2);
+    expect(mockUpsertTransaction).toHaveBeenCalledTimes(2);
     expect(mockEnqueueSync).toHaveBeenCalledTimes(2);
-    expect(mockClearPendingTransactions).toHaveBeenCalledOnce();
+    expect(mockRemovePendingTransactions).toHaveBeenCalledOnce();
+    expect(mockRemovePendingTransactions).toHaveBeenCalledWith(["id-a", "id-b"]);
   });
 
   it("processes multiple pending transactions with unique IDs", async () => {
     mockGetPendingTransactions.mockResolvedValue([
-      { amount: 10000, createdAt: "2026-03-27T10:00:00Z" },
-      { amount: 20000, createdAt: "2026-03-27T11:00:00Z" },
+      { id: "uuid-1", amount: 10000, createdAt: "2026-03-27T10:00:00Z" },
+      { id: "uuid-2", amount: 20000, createdAt: "2026-03-27T11:00:00Z" },
     ]);
 
     await processWidgetTransactions(mockDb, USER_ID);
 
-    const firstTxCall = mockInsertTransaction.mock.calls[0][1];
-    const secondTxCall = mockInsertTransaction.mock.calls[1][1];
-    expect(firstTxCall.id).toBe("tx-1");
-    expect(secondTxCall.id).toBe("tx-2");
+    const firstTxCall = mockUpsertTransaction.mock.calls[0][1];
+    const secondTxCall = mockUpsertTransaction.mock.calls[1][1];
+    expect(firstTxCall.id).toBe("txn-widget-uuid-1");
+    expect(secondTxCall.id).toBe("txn-widget-uuid-2");
     expect(firstTxCall.amount).toBe(10000);
     expect(secondTxCall.amount).toBe(20000);
   });
 
-  it("uses toIsoDate from item.createdAt for the transaction date", async () => {
+  it("derives transaction date from item.createdAt", async () => {
     mockGetPendingTransactions.mockResolvedValue([
-      { amount: 5000, createdAt: "2026-03-15T14:30:00Z" },
+      { id: "date-test", amount: 5000, createdAt: "2026-03-15T14:30:00Z" },
     ]);
 
     await processWidgetTransactions(mockDb, USER_ID);
 
-    expect(mockInsertTransaction).toHaveBeenCalledWith(
+    expect(mockUpsertTransaction).toHaveBeenCalledWith(
       mockDb,
       expect.objectContaining({
-        date: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        date: "2026-03-15",
       })
     );
   });
 
   it("rounds fractional amounts to nearest integer", async () => {
     mockGetPendingTransactions.mockResolvedValue([
-      { amount: 15000.7, createdAt: "2026-03-27T10:00:00Z" },
+      { id: "round-test", amount: 15000.7, createdAt: "2026-03-27T10:00:00Z" },
     ]);
 
     await processWidgetTransactions(mockDb, USER_ID);
 
-    expect(mockInsertTransaction).toHaveBeenCalledWith(
+    expect(mockUpsertTransaction).toHaveBeenCalledWith(
       mockDb,
       expect.objectContaining({ amount: 15001 })
     );

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -68,6 +68,7 @@ const config: ExpoConfig & { newArchEnabled?: boolean } = {
         color: "#7CB243",
       },
     ],
+    "./plugins/withFidyWidget",
   ],
   experiments: {
     typedRoutes: true,

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -26,6 +26,7 @@ import {
   useCaptureSourcesStore,
   useNotificationCapture,
   useSmsDetection,
+  useWidgetCapture,
 } from "@/features/capture-sources";
 import { useCategoriesStore } from "@/features/categories";
 import { useEmailCapture, useEmailCaptureStore } from "@/features/email-capture";
@@ -133,6 +134,7 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
   useEmailCapture(captureDb, userId);
   useNotificationCapture(captureDb, userId);
   useApplePayCapture(captureDb, userId);
+  useWidgetCapture(captureDb, userId);
   useSmsDetection(captureDb, userId);
 
   // Global notification handler + push token / response listeners

--- a/apps/mobile/features/capture-sources/hooks/useWidgetCapture.ts
+++ b/apps/mobile/features/capture-sources/hooks/useWidgetCapture.ts
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+import { AppState } from "react-native";
+import { Platform } from "@/shared/components/rn";
+import type { AnyDb } from "@/shared/db";
+import { captureError } from "@/shared/lib";
+import type { UserId } from "@/shared/types/branded";
+import { processWidgetTransactions } from "../services/widget-pipeline";
+
+export function useWidgetCapture(db: AnyDb | null, userId: string | null) {
+  useEffect(() => {
+    if (Platform.OS !== "ios" || !db || !userId) return;
+
+    const uid = userId as UserId;
+
+    // Process on mount (app was just opened or hook was re-enabled)
+    processWidgetTransactions(db, uid).catch(captureError);
+
+    // Process each time app returns to foreground
+    const subscription = AppState.addEventListener("change", (nextState) => {
+      if (nextState === "active") {
+        processWidgetTransactions(db, uid).catch(captureError);
+      }
+    });
+
+    return () => subscription.remove();
+  }, [db, userId]);
+}

--- a/apps/mobile/features/capture-sources/index.ts
+++ b/apps/mobile/features/capture-sources/index.ts
@@ -4,6 +4,7 @@ export { NotificationSetupCard } from "./components/NotificationSetupCard";
 export { useApplePayCapture } from "./hooks/useApplePayCapture";
 export { useNotificationCapture } from "./hooks/useNotificationCapture";
 export { useSmsDetection } from "./hooks/useSmsDetection";
+export { useWidgetCapture } from "./hooks/useWidgetCapture";
 export { findDuplicateTransaction } from "./lib/dedup";
 export type {
   ApplePayIntentData,

--- a/apps/mobile/features/capture-sources/services/widget-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/widget-pipeline.ts
@@ -1,16 +1,15 @@
-import { insertTransaction } from "@/features/transactions";
+import { upsertTransaction } from "@/features/transactions/lib/repository";
 import type { AnyDb } from "@/shared/db";
 import { enqueueSync } from "@/shared/db";
 import {
   captureError,
   capturePipelineEvent,
   generateSyncQueueId,
-  generateTransactionId,
   toIsoDate,
   toIsoDateTime,
   trackTransactionCreated,
 } from "@/shared/lib";
-import type { CategoryId, CopAmount, UserId } from "@/shared/types/branded";
+import type { CategoryId, CopAmount, TransactionId, UserId } from "@/shared/types/branded";
 
 // Dynamic import to avoid Android bundle crash — this module calls
 // requireNativeModule("ExpoAppIntents") which only exists on iOS.
@@ -19,6 +18,10 @@ const loadAppIntents = () =>
 
 // Guard against concurrent invocations (mount + immediate AppState "active").
 let processing = false;
+
+/** Derive a deterministic TransactionId from the widget entry UUID for idempotent retries. */
+const toTransactionId = (widgetEntryId: string): TransactionId =>
+  `txn-widget-${widgetEntryId}` as TransactionId;
 
 export async function processWidgetTransactions(db: AnyDb, userId: UserId): Promise<void> {
   if (processing) return;
@@ -32,14 +35,16 @@ export async function processWidgetTransactions(db: AnyDb, userId: UserId): Prom
     const pending = await mod.getPendingTransactions();
     if (pending.length === 0) return;
 
+    const processedIds: string[] = [];
+
     await Promise.all(
       pending.map(async (item) => {
-        const txId = generateTransactionId();
+        const txId = toTransactionId(item.id);
         const now = toIsoDateTime(new Date());
         const amount = Math.round(item.amount) as CopAmount;
         const date = toIsoDate(new Date(item.createdAt));
 
-        await insertTransaction(db, {
+        upsertTransaction(db, {
           id: txId,
           userId,
           type: "expense",
@@ -65,12 +70,14 @@ export async function processWidgetTransactions(db: AnyDb, userId: UserId): Prom
           category: "other",
           source: "widget",
         });
+
+        processedIds.push(item.id);
       })
     );
 
-    await mod.clearPendingTransactions();
+    await mod.removePendingTransactions(processedIds);
 
-    capturePipelineEvent({ source: "widget", saved: pending.length, skippedDuplicate: 0 });
+    capturePipelineEvent({ source: "widget", saved: processedIds.length, skippedDuplicate: 0 });
   } catch (error) {
     captureError(error);
   } finally {

--- a/apps/mobile/features/capture-sources/services/widget-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/widget-pipeline.ts
@@ -1,3 +1,4 @@
+import { isValidCategoryId } from "@/features/transactions/lib/categories";
 import { upsertTransaction } from "@/features/transactions/lib/repository";
 import type { AnyDb } from "@/shared/db";
 import { enqueueSync } from "@/shared/db";
@@ -43,14 +44,19 @@ export async function processWidgetTransactions(db: AnyDb, userId: UserId): Prom
         const now = toIsoDateTime(new Date());
         const amount = Math.round(item.amount) as CopAmount;
         const date = toIsoDate(new Date(item.createdAt));
+        const categoryId = (
+          item.category && isValidCategoryId(item.category) ? item.category : "other"
+        ) as CategoryId;
+        const type = item.type === "income" ? "income" : "expense";
+        const description = item.description ?? "";
 
         upsertTransaction(db, {
           id: txId,
           userId,
-          type: "expense",
+          type,
           amount,
-          categoryId: "other" as CategoryId,
-          description: "",
+          categoryId,
+          description,
           date,
           source: "widget",
           createdAt: now,
@@ -66,8 +72,8 @@ export async function processWidgetTransactions(db: AnyDb, userId: UserId): Prom
         });
 
         trackTransactionCreated({
-          type: "expense",
-          category: "other",
+          type,
+          category: categoryId,
           source: "widget",
         });
 

--- a/apps/mobile/features/capture-sources/services/widget-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/widget-pipeline.ts
@@ -1,0 +1,79 @@
+import { insertTransaction } from "@/features/transactions";
+import type { AnyDb } from "@/shared/db";
+import { enqueueSync } from "@/shared/db";
+import {
+  captureError,
+  capturePipelineEvent,
+  generateSyncQueueId,
+  generateTransactionId,
+  toIsoDate,
+  toIsoDateTime,
+  trackTransactionCreated,
+} from "@/shared/lib";
+import type { CategoryId, CopAmount, UserId } from "@/shared/types/branded";
+
+// Dynamic import to avoid Android bundle crash — this module calls
+// requireNativeModule("ExpoAppIntents") which only exists on iOS.
+const loadAppIntents = () =>
+  import("@/modules/expo-app-intents") as Promise<typeof import("@/modules/expo-app-intents")>;
+
+// Guard against concurrent invocations (mount + immediate AppState "active").
+let processing = false;
+
+export async function processWidgetTransactions(db: AnyDb, userId: UserId): Promise<void> {
+  if (processing) return;
+  processing = true;
+
+  try {
+    const mod = await loadAppIntents();
+
+    if (!mod.isAvailable()) return;
+
+    const pending = await mod.getPendingTransactions();
+    if (pending.length === 0) return;
+
+    await Promise.all(
+      pending.map(async (item) => {
+        const txId = generateTransactionId();
+        const now = toIsoDateTime(new Date());
+        const amount = Math.round(item.amount) as CopAmount;
+        const date = toIsoDate(new Date(item.createdAt));
+
+        await insertTransaction(db, {
+          id: txId,
+          userId,
+          type: "expense",
+          amount,
+          categoryId: "other" as CategoryId,
+          description: "",
+          date,
+          source: "widget",
+          createdAt: now,
+          updatedAt: now,
+        });
+
+        await enqueueSync(db, {
+          id: generateSyncQueueId(),
+          tableName: "transactions",
+          rowId: txId,
+          operation: "insert",
+          createdAt: now,
+        });
+
+        trackTransactionCreated({
+          type: "expense",
+          category: "other",
+          source: "widget",
+        });
+      })
+    );
+
+    await mod.clearPendingTransactions();
+
+    capturePipelineEvent({ source: "widget", saved: pending.length, skippedDuplicate: 0 });
+  } catch (error) {
+    captureError(error);
+  } finally {
+    processing = false;
+  }
+}

--- a/apps/mobile/modules/expo-app-intents/index.ts
+++ b/apps/mobile/modules/expo-app-intents/index.ts
@@ -1,10 +1,13 @@
 export type {
   DetectBankSmsEvent,
   LogTransactionEvent,
+  PendingWidgetTransaction,
   Subscription,
 } from "./src/index";
 export {
   addDetectBankSmsListener,
   addLogTransactionListener,
+  clearPendingTransactions,
+  getPendingTransactions,
   isAvailable,
 } from "./src/index";

--- a/apps/mobile/modules/expo-app-intents/index.ts
+++ b/apps/mobile/modules/expo-app-intents/index.ts
@@ -7,7 +7,7 @@ export type {
 export {
   addDetectBankSmsListener,
   addLogTransactionListener,
-  clearPendingTransactions,
   getPendingTransactions,
+  removePendingTransactions,
   isAvailable,
 } from "./src/index";

--- a/apps/mobile/modules/expo-app-intents/index.ts
+++ b/apps/mobile/modules/expo-app-intents/index.ts
@@ -8,6 +8,6 @@ export {
   addDetectBankSmsListener,
   addLogTransactionListener,
   getPendingTransactions,
-  removePendingTransactions,
   isAvailable,
+  removePendingTransactions,
 } from "./src/index";

--- a/apps/mobile/modules/expo-app-intents/ios/ExpoAppIntentsModule.swift
+++ b/apps/mobile/modules/expo-app-intents/ios/ExpoAppIntentsModule.swift
@@ -40,7 +40,7 @@ public class ExpoAppIntentsModule: Module {
       }
       let idsToRemove = Set(ids)
       let remaining = array.filter { entry in
-        guard let entryId = entry["id"] as? String else { return true }
+        guard let entryId = entry["id"] as? String else { return false }
         return !idsToRemove.contains(entryId)
       }
       if remaining.isEmpty {

--- a/apps/mobile/modules/expo-app-intents/ios/ExpoAppIntentsModule.swift
+++ b/apps/mobile/modules/expo-app-intents/ios/ExpoAppIntentsModule.swift
@@ -1,0 +1,39 @@
+import ExpoModulesCore
+
+public class ExpoAppIntentsModule: Module {
+  private let suiteName = "group.com.obarbozaa.Fidy"
+  private let pendingTransactionsKey = "pendingWidgetTransactions"
+
+  public func definition() -> ModuleDefinition {
+    Name("ExpoAppIntents")
+
+    Events("onLogTransaction", "onDetectBankSms")
+
+    Function("isAvailable") { () -> Bool in
+      return true
+    }
+
+    AsyncFunction("getPendingTransactions") { () -> [[String: Any]] in
+      guard let defaults = UserDefaults(suiteName: self.suiteName) else {
+        return []
+      }
+      guard let data = defaults.data(forKey: self.pendingTransactionsKey) else {
+        return []
+      }
+      guard
+        let decoded = try? JSONSerialization.jsonObject(with: data),
+        let array = decoded as? [[String: Any]]
+      else {
+        return []
+      }
+      return array
+    }
+
+    AsyncFunction("clearPendingTransactions") { () -> Void in
+      guard let defaults = UserDefaults(suiteName: self.suiteName) else {
+        return
+      }
+      defaults.removeObject(forKey: self.pendingTransactionsKey)
+    }
+  }
+}

--- a/apps/mobile/modules/expo-app-intents/ios/ExpoAppIntentsModule.swift
+++ b/apps/mobile/modules/expo-app-intents/ios/ExpoAppIntentsModule.swift
@@ -29,11 +29,25 @@ public class ExpoAppIntentsModule: Module {
       return array
     }
 
-    AsyncFunction("clearPendingTransactions") { () -> Void in
+    AsyncFunction("removePendingTransactions") { (ids: [String]) -> Void in
       guard let defaults = UserDefaults(suiteName: self.suiteName) else {
         return
       }
-      defaults.removeObject(forKey: self.pendingTransactionsKey)
+      guard let data = defaults.data(forKey: self.pendingTransactionsKey),
+            let decoded = try? JSONSerialization.jsonObject(with: data),
+            let array = decoded as? [[String: Any]] else {
+        return
+      }
+      let idsToRemove = Set(ids)
+      let remaining = array.filter { entry in
+        guard let entryId = entry["id"] as? String else { return true }
+        return !idsToRemove.contains(entryId)
+      }
+      if remaining.isEmpty {
+        defaults.removeObject(forKey: self.pendingTransactionsKey)
+      } else if let encoded = try? JSONSerialization.data(withJSONObject: remaining) {
+        defaults.set(encoded, forKey: self.pendingTransactionsKey)
+      }
     }
   }
 }

--- a/apps/mobile/modules/expo-app-intents/src/ExpoAppIntentsModule.ts
+++ b/apps/mobile/modules/expo-app-intents/src/ExpoAppIntentsModule.ts
@@ -1,6 +1,7 @@
 import { requireNativeModule } from "expo";
 
 export type PendingWidgetTransaction = {
+  id: string;
   amount: number;
   createdAt: string;
 };
@@ -8,7 +9,7 @@ export type PendingWidgetTransaction = {
 export type ExpoAppIntentsModule = {
   isAvailable: () => boolean;
   getPendingTransactions: () => Promise<PendingWidgetTransaction[]>;
-  clearPendingTransactions: () => Promise<void>;
+  removePendingTransactions: (ids: string[]) => Promise<void>;
   addListener: (eventName: string, listener: (...args: never[]) => void) => { remove: () => void };
 };
 

--- a/apps/mobile/modules/expo-app-intents/src/ExpoAppIntentsModule.ts
+++ b/apps/mobile/modules/expo-app-intents/src/ExpoAppIntentsModule.ts
@@ -1,7 +1,14 @@
 import { requireNativeModule } from "expo";
 
+export type PendingWidgetTransaction = {
+  amount: number;
+  createdAt: string;
+};
+
 export type ExpoAppIntentsModule = {
   isAvailable: () => boolean;
+  getPendingTransactions: () => Promise<PendingWidgetTransaction[]>;
+  clearPendingTransactions: () => Promise<void>;
   addListener: (eventName: string, listener: (...args: never[]) => void) => { remove: () => void };
 };
 

--- a/apps/mobile/modules/expo-app-intents/src/ExpoAppIntentsModule.ts
+++ b/apps/mobile/modules/expo-app-intents/src/ExpoAppIntentsModule.ts
@@ -4,6 +4,9 @@ export type PendingWidgetTransaction = {
   id: string;
   amount: number;
   createdAt: string;
+  category?: string;
+  type?: string;
+  description?: string;
 };
 
 export type ExpoAppIntentsModule = {

--- a/apps/mobile/modules/expo-app-intents/src/index.ts
+++ b/apps/mobile/modules/expo-app-intents/src/index.ts
@@ -1,6 +1,8 @@
 import { Platform } from "react-native";
 import ExpoAppIntentsModule from "./ExpoAppIntentsModule";
 
+export type { PendingWidgetTransaction } from "./ExpoAppIntentsModule";
+
 export type LogTransactionEvent = {
   amount: number;
   merchant: string;
@@ -33,4 +35,12 @@ export function isAvailable(): boolean {
   } catch {
     return false;
   }
+}
+
+export function getPendingTransactions() {
+  return ExpoAppIntentsModule.getPendingTransactions();
+}
+
+export function clearPendingTransactions() {
+  return ExpoAppIntentsModule.clearPendingTransactions();
 }

--- a/apps/mobile/modules/expo-app-intents/src/index.ts
+++ b/apps/mobile/modules/expo-app-intents/src/index.ts
@@ -41,6 +41,6 @@ export function getPendingTransactions() {
   return ExpoAppIntentsModule.getPendingTransactions();
 }
 
-export function clearPendingTransactions() {
-  return ExpoAppIntentsModule.clearPendingTransactions();
+export function removePendingTransactions(ids: string[]) {
+  return ExpoAppIntentsModule.removePendingTransactions(ids);
 }

--- a/apps/mobile/plugins/withFidyWidget.js
+++ b/apps/mobile/plugins/withFidyWidget.js
@@ -8,15 +8,13 @@
  *  4. Configures build settings, frameworks, and embed phase
  */
 
-import * as fs from "node:fs";
-import * as path from "node:path";
-import {
-  type ConfigPlugin,
+const fs = require("node:fs");
+const path = require("node:path");
+const {
   createRunOncePlugin,
   withEntitlementsPlist,
   withXcodeProject,
-  type XcodeProject,
-} from "@expo/config-plugins";
+} = require("@expo/config-plugins");
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -44,7 +42,7 @@ const ALL_EXTENSION_FILES = [...SWIFT_FILES, "Info.plist", "widget.entitlements"
 // ---------------------------------------------------------------------------
 
 /** Copy widget source files from targets/widget/ into ios/FidyWidgetExtension/ */
-const copyWidgetFiles = (projectRoot: string): void => {
+const copyWidgetFiles = (projectRoot) => {
   const sourceDir = path.join(projectRoot, "targets", "widget");
   const destDir = path.join(projectRoot, "ios", EXTENSION_NAME);
 
@@ -59,16 +57,10 @@ const copyWidgetFiles = (projectRoot: string): void => {
 // Xcode helpers
 // ---------------------------------------------------------------------------
 
-/** Generate a deterministic-ish UUID for Xcode PBX objects. */
-const generateUuid = (project: XcodeProject): string => project.generateUuid() as string;
+const generateUuid = (project) => project.generateUuid();
 
-/**
- * Add the widget extension target, build settings, frameworks, and embed phase
- * to the Xcode project.
- */
 // Xcode build setting keys use SCREAMING_SNAKE_CASE by convention.
-// useNamingConvention warns on these keys — unavoidable for Xcode interop.
-const EXTENSION_BUILD_SETTINGS: Record<string, string> = {
+const EXTENSION_BUILD_SETTINGS = {
   ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: '""',
   ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME: '""',
   CLANG_ANALYZER_NONNULL: "YES",
@@ -82,7 +74,7 @@ const EXTENSION_BUILD_SETTINGS: Record<string, string> = {
   CODE_SIGN_STYLE: "Automatic",
   CURRENT_PROJECT_VERSION: "1",
   DEBUG_INFORMATION_FORMAT: '"dwarf-with-dsym"',
-  DEVELOPMENT_TEAM: DEVELOPMENT_TEAM,
+  DEVELOPMENT_TEAM,
   GCC_C_LANGUAGE_STANDARD: "gnu17",
   GENERATE_INFOPLIST_FILE: "NO",
   INFOPLIST_FILE: `${EXTENSION_NAME}/Info.plist`,
@@ -96,12 +88,12 @@ const EXTENSION_BUILD_SETTINGS: Record<string, string> = {
   PRODUCT_NAME: '"$(TARGET_NAME)"',
   SKIP_INSTALL: "YES",
   SWIFT_EMIT_LOC_STRINGS: "YES",
-  SWIFT_VERSION: SWIFT_VERSION,
+  SWIFT_VERSION,
   TARGETED_DEVICE_FAMILY: '"1,2"',
 };
 
 /** Reconcile build settings on the extension's Debug/Release configurations. */
-const reconcileBuildSettings = (project: XcodeProject): void => {
+const reconcileBuildSettings = (project) => {
   const configurations = project.pbxXCBuildConfigurationSection();
   for (const key of Object.keys(configurations)) {
     const config = configurations[key];
@@ -117,18 +109,14 @@ const reconcileBuildSettings = (project: XcodeProject): void => {
   }
 };
 
-const addWidgetExtensionTarget = (project: XcodeProject): void => {
-  // ------------------------------------------------------------------
+const addWidgetExtensionTarget = (project) => {
   // 0. Check if the target already exists
-  // ------------------------------------------------------------------
   const existingTargets = project.pbxNativeTargetSection();
   const targetExists = Object.values(existingTargets).some(
-    (t) => typeof t === "object" && t !== null && (t as { name?: string }).name === EXTENSION_NAME
+    (t) => typeof t === "object" && t !== null && t.name === EXTENSION_NAME
   );
 
-  // ------------------------------------------------------------------
   // 1. Create structural elements only if the target doesn't exist
-  // ------------------------------------------------------------------
   if (!targetExists) {
     const target = project.addTarget(
       EXTENSION_NAME,
@@ -137,7 +125,6 @@ const addWidgetExtensionTarget = (project: XcodeProject): void => {
       EXTENSION_BUNDLE_ID
     );
 
-    // Add Swift source files to the target's Sources build phase
     const sourcesBuildPhaseUuid = generateUuid(project);
     project.addBuildPhase(
       SWIFT_FILES.map((f) => `${EXTENSION_NAME}/${f}`),
@@ -148,7 +135,6 @@ const addWidgetExtensionTarget = (project: XcodeProject): void => {
       sourcesBuildPhaseUuid
     );
 
-    // Add a PBXGroup for the extension files
     const groupUuid = generateUuid(project);
     const extensionGroup = project.addPbxGroup(
       ALL_EXTENSION_FILES,
@@ -160,7 +146,6 @@ const addWidgetExtensionTarget = (project: XcodeProject): void => {
     const mainGroupId = project.getFirstProject().firstProject.mainGroup;
     project.addToPbxGroup(extensionGroup.uuid, mainGroupId);
 
-    // Add Frameworks build phase and link WidgetKit + SwiftUI
     const frameworksBuildPhaseUuid = generateUuid(project);
     project.addBuildPhase(
       [],
@@ -180,7 +165,6 @@ const addWidgetExtensionTarget = (project: XcodeProject): void => {
       link: true,
     });
 
-    // Embed the extension in the main app
     const mainTarget = project.getFirstTarget();
     const embedPhaseUuid = generateUuid(project);
     project.addBuildPhase(
@@ -193,10 +177,7 @@ const addWidgetExtensionTarget = (project: XcodeProject): void => {
     );
   }
 
-  // ------------------------------------------------------------------
-  // 2. Always reconcile build settings (handles plugin config changes
-  //    on non-clean prebuilds)
-  // ------------------------------------------------------------------
+  // 2. Always reconcile build settings
   reconcileBuildSettings(project);
 };
 
@@ -204,12 +185,10 @@ const addWidgetExtensionTarget = (project: XcodeProject): void => {
 // Plugin composition
 // ---------------------------------------------------------------------------
 
-/** Add App Group to the main app entitlements. */
-const withAppGroupEntitlement: ConfigPlugin = (config) =>
+const withAppGroupEntitlement = (config) =>
   withEntitlementsPlist(config, (modConfig) => {
     const entitlements = modConfig.modResults;
-    const existingGroups: string[] =
-      (entitlements["com.apple.security.application-groups"] as string[]) ?? [];
+    const existingGroups = entitlements["com.apple.security.application-groups"] ?? [];
 
     if (!existingGroups.includes(APP_GROUP)) {
       entitlements["com.apple.security.application-groups"] = [...existingGroups, APP_GROUP];
@@ -218,8 +197,7 @@ const withAppGroupEntitlement: ConfigPlugin = (config) =>
     return modConfig;
   });
 
-/** Copy files + mutate the Xcode project to include the widget extension. */
-const withWidgetExtensionTarget: ConfigPlugin = (config) =>
+const withWidgetExtensionTarget = (config) =>
   withXcodeProject(config, (modConfig) => {
     const projectRoot = modConfig.modRequest.projectRoot;
     const project = modConfig.modResults;
@@ -230,11 +208,10 @@ const withWidgetExtensionTarget: ConfigPlugin = (config) =>
     return modConfig;
   });
 
-/** Root plugin — composes entitlement + Xcode project modifications. */
-const withFidyWidget: ConfigPlugin = (config) => {
+const withFidyWidget = (config) => {
   const configWithEntitlements = withAppGroupEntitlement(config);
   const configWithExtension = withWidgetExtensionTarget(configWithEntitlements);
   return configWithExtension;
 };
 
-export default createRunOncePlugin(withFidyWidget, "withFidyWidget", "1.0.0");
+module.exports = createRunOncePlugin(withFidyWidget, "withFidyWidget", "1.0.0");

--- a/apps/mobile/plugins/withFidyWidget.js
+++ b/apps/mobile/plugins/withFidyWidget.js
@@ -94,7 +94,7 @@ const EXTENSION_BUILD_SETTINGS = {
 
 /** Reconcile build settings on the extension's Debug/Release configurations. */
 const reconcileBuildSettings = (project) => {
-  // Find the extension target's buildConfigurationList to get its config UUIDs
+  // Find the extension target's buildConfigurationList UUID
   const nativeTargets = project.pbxNativeTargetSection();
   let configListId = null;
   for (const val of Object.values(nativeTargets)) {
@@ -105,24 +105,19 @@ const reconcileBuildSettings = (project) => {
   }
   if (!configListId) return;
 
-  // Get the configuration UUIDs from the XCConfigurationList
-  const configLists = project.pbxXCConfigurationList();
-  const configList = configLists[configListId];
+  // Get the configuration UUIDs from the XCConfigurationList via direct hash access
+  const configLists = project.hash.project.objects.XCConfigurationList;
+  const configList = configLists?.[configListId];
   if (!configList?.buildConfigurations) return;
 
   const configUuids = new Set(configList.buildConfigurations.map((c) => c.value));
 
   // Apply build settings to those specific configurations
-  const configurations = project.pbxXCBuildConfigurationSection();
-  for (const key of Object.keys(configurations)) {
-    if (configUuids.has(key)) {
-      const config = configurations[key];
-      if (typeof config === "object") {
-        config.buildSettings = {
-          ...config.buildSettings,
-          ...EXTENSION_BUILD_SETTINGS,
-        };
-      }
+  const buildConfigs = project.hash.project.objects.XCBuildConfiguration;
+  for (const uuid of configUuids) {
+    const config = buildConfigs?.[uuid];
+    if (typeof config === "object" && config.buildSettings) {
+      Object.assign(config.buildSettings, EXTENSION_BUILD_SETTINGS);
     }
   }
 };

--- a/apps/mobile/plugins/withFidyWidget.js
+++ b/apps/mobile/plugins/withFidyWidget.js
@@ -31,6 +31,8 @@ const SWIFT_FILES = [
   "QuickExpenseIntent.swift",
   "QuickExpenseControl.swift",
   "OpenAddTransactionIntent.swift",
+  "ExpenseSnippetIntent.swift",
+  "SaveExpenseIntent.swift",
   "FidyWidgetBundle.swift",
   "FidyCategory.swift",
   "TransactionKind.swift",

--- a/apps/mobile/plugins/withFidyWidget.js
+++ b/apps/mobile/plugins/withFidyWidget.js
@@ -35,7 +35,7 @@ const SWIFT_FILES = [
   "TransactionKind.swift",
 ];
 
-const ALL_EXTENSION_FILES = [...SWIFT_FILES, "Info.plist", "widget.entitlements"];
+const ALL_EXTENSION_FILES = [...SWIFT_FILES, "widget.entitlements"];
 
 // ---------------------------------------------------------------------------
 // File copying
@@ -51,6 +51,12 @@ const copyWidgetFiles = (projectRoot) => {
   for (const file of ALL_EXTENSION_FILES) {
     fs.copyFileSync(path.join(sourceDir, file), path.join(destDir, file));
   }
+
+  // Copy Info.plist with the name addTarget() expects
+  fs.copyFileSync(
+    path.join(sourceDir, "Info.plist"),
+    path.join(destDir, `${EXTENSION_NAME}-Info.plist`)
+  );
 };
 
 // ---------------------------------------------------------------------------
@@ -76,8 +82,6 @@ const EXTENSION_BUILD_SETTINGS = {
   DEBUG_INFORMATION_FORMAT: '"dwarf-with-dsym"',
   DEVELOPMENT_TEAM,
   GCC_C_LANGUAGE_STANDARD: "gnu17",
-  GENERATE_INFOPLIST_FILE: "NO",
-  INFOPLIST_FILE: `${EXTENSION_NAME}/Info.plist`,
   INFOPLIST_KEY_CFBundleDisplayName: EXTENSION_NAME,
   INFOPLIST_KEY_NSHumanReadableCopyright: '""',
   IPHONEOS_DEPLOYMENT_TARGET: DEPLOYMENT_TARGET,

--- a/apps/mobile/plugins/withFidyWidget.js
+++ b/apps/mobile/plugins/withFidyWidget.js
@@ -14,7 +14,7 @@ const {
   createRunOncePlugin,
   withEntitlementsPlist,
   withXcodeProject,
-} = require("@expo/config-plugins");
+} = require("expo/config-plugins");
 
 // ---------------------------------------------------------------------------
 // Constants

--- a/apps/mobile/plugins/withFidyWidget.js
+++ b/apps/mobile/plugins/withFidyWidget.js
@@ -183,16 +183,63 @@ const addWidgetExtensionTarget = (project) => {
       link: true,
     });
 
+    // Embed the extension in the main app — create the phase with an empty
+    // file list, then manually wire the target's product reference into the
+    // phase so CocoaPods doesn't encounter an orphaned PBXFileReference.
     const mainTarget = project.getFirstTarget();
     const embedPhaseUuid = generateUuid(project);
     project.addBuildPhase(
-      [`${EXTENSION_NAME}.appex`],
+      [],
       "PBXCopyFilesBuildPhase",
       "Embed App Extensions",
       mainTarget.firstTarget.uuid,
       "app_extension",
       embedPhaseUuid
     );
+
+    // Find the target's product reference (the .appex created by addTarget)
+    const nativeTargetEntry = project.pbxNativeTargetSection()[target.uuid];
+    const productRefUuid = nativeTargetEntry?.productReference;
+
+    if (productRefUuid) {
+      // Add product to the Products group so CocoaPods can resolve its parent
+      const productsGroupKey = Object.keys(project.hash.project.objects.PBXGroup || {}).find(
+        (key) => {
+          const group = project.hash.project.objects.PBXGroup[key];
+          return typeof group === "object" && group.name === "Products";
+        }
+      );
+      if (productsGroupKey) {
+        const productsGroup = project.hash.project.objects.PBXGroup[productsGroupKey];
+        const alreadyInGroup = productsGroup.children?.some((c) => c.value === productRefUuid);
+        if (!alreadyInGroup) {
+          productsGroup.children.push({
+            value: productRefUuid,
+            comment: `${EXTENSION_NAME}.appex`,
+          });
+        }
+      }
+
+      // Add a PBXBuildFile referencing the product in the embed phase
+      const buildFileUuid = generateUuid(project);
+      project.hash.project.objects.PBXBuildFile[buildFileUuid] = {
+        isa: "PBXBuildFile",
+        fileRef: productRefUuid,
+        settings: { ATTRIBUTES: ["RemoveHeadersOnCopy"] },
+      };
+      project.hash.project.objects.PBXBuildFile[`${buildFileUuid}_comment`] =
+        `${EXTENSION_NAME}.appex in Embed App Extensions`;
+
+      // Add the build file to the embed phase's files array
+      const copyFilesPhases = project.hash.project.objects.PBXCopyFilesBuildPhase || {};
+      const embedPhase = copyFilesPhases[embedPhaseUuid];
+      if (embedPhase) {
+        embedPhase.files.push({
+          value: buildFileUuid,
+          comment: `${EXTENSION_NAME}.appex in Embed App Extensions`,
+        });
+      }
+    }
   }
 
   // 2. Always reconcile build settings

--- a/apps/mobile/plugins/withFidyWidget.js
+++ b/apps/mobile/plugins/withFidyWidget.js
@@ -35,7 +35,7 @@ const SWIFT_FILES = [
   "TransactionKind.swift",
 ];
 
-const ALL_EXTENSION_FILES = [...SWIFT_FILES, "widget.entitlements"];
+const ALL_EXTENSION_FILES = [...SWIFT_FILES, "Info.plist", "widget.entitlements"];
 
 // ---------------------------------------------------------------------------
 // File copying
@@ -76,9 +76,9 @@ const EXTENSION_BUILD_SETTINGS = {
   DEBUG_INFORMATION_FORMAT: '"dwarf-with-dsym"',
   DEVELOPMENT_TEAM,
   GCC_C_LANGUAGE_STANDARD: "gnu17",
-  GENERATE_INFOPLIST_FILE: "YES",
+  GENERATE_INFOPLIST_FILE: "NO",
+  INFOPLIST_FILE: `${EXTENSION_NAME}/Info.plist`,
   INFOPLIST_KEY_CFBundleDisplayName: EXTENSION_NAME,
-  INFOPLIST_KEY_NSExtension_NSExtensionPointIdentifier: "com.apple.widgetkit-extension",
   INFOPLIST_KEY_NSHumanReadableCopyright: '""',
   IPHONEOS_DEPLOYMENT_TARGET: DEPLOYMENT_TARGET,
   LD_RUNPATH_SEARCH_PATHS:

--- a/apps/mobile/plugins/withFidyWidget.js
+++ b/apps/mobile/plugins/withFidyWidget.js
@@ -35,7 +35,7 @@ const SWIFT_FILES = [
   "TransactionKind.swift",
 ];
 
-const ALL_EXTENSION_FILES = [...SWIFT_FILES, "Info.plist", "widget.entitlements"];
+const ALL_EXTENSION_FILES = [...SWIFT_FILES, "widget.entitlements"];
 
 // ---------------------------------------------------------------------------
 // File copying
@@ -76,9 +76,9 @@ const EXTENSION_BUILD_SETTINGS = {
   DEBUG_INFORMATION_FORMAT: '"dwarf-with-dsym"',
   DEVELOPMENT_TEAM,
   GCC_C_LANGUAGE_STANDARD: "gnu17",
-  GENERATE_INFOPLIST_FILE: "NO",
-  INFOPLIST_FILE: `${EXTENSION_NAME}/Info.plist`,
+  GENERATE_INFOPLIST_FILE: "YES",
   INFOPLIST_KEY_CFBundleDisplayName: EXTENSION_NAME,
+  INFOPLIST_KEY_NSExtension_NSExtensionPointIdentifier: "com.apple.widgetkit-extension",
   INFOPLIST_KEY_NSHumanReadableCopyright: '""',
   IPHONEOS_DEPLOYMENT_TARGET: DEPLOYMENT_TARGET,
   LD_RUNPATH_SEARCH_PATHS:

--- a/apps/mobile/plugins/withFidyWidget.js
+++ b/apps/mobile/plugins/withFidyWidget.js
@@ -138,6 +138,23 @@ const addWidgetExtensionTarget = (project) => {
       EXTENSION_BUNDLE_ID
     );
 
+    // Apply build settings immediately after target creation — the xcode
+    // package creates Debug/Release configs but leaves them sparse.
+    const nativeTarget = project.pbxNativeTargetSection()[target.uuid];
+    const configListId = nativeTarget?.buildConfigurationList;
+    if (configListId) {
+      const configList = project.hash.project.objects.XCConfigurationList?.[configListId];
+      if (configList?.buildConfigurations) {
+        const buildConfigs = project.hash.project.objects.XCBuildConfiguration;
+        for (const ref of configList.buildConfigurations) {
+          const config = buildConfigs?.[ref.value];
+          if (typeof config === "object" && config.buildSettings) {
+            Object.assign(config.buildSettings, EXTENSION_BUILD_SETTINGS);
+          }
+        }
+      }
+    }
+
     const sourcesBuildPhaseUuid = generateUuid(project);
     project.addBuildPhase(
       SWIFT_FILES.map((f) => `${EXTENSION_NAME}/${f}`),

--- a/apps/mobile/plugins/withFidyWidget.js
+++ b/apps/mobile/plugins/withFidyWidget.js
@@ -30,6 +30,7 @@ const SWIFT_VERSION = "6.0";
 const SWIFT_FILES = [
   "QuickExpenseIntent.swift",
   "QuickExpenseControl.swift",
+  "OpenAddTransactionIntent.swift",
   "FidyWidgetBundle.swift",
   "FidyCategory.swift",
   "TransactionKind.swift",

--- a/apps/mobile/plugins/withFidyWidget.js
+++ b/apps/mobile/plugins/withFidyWidget.js
@@ -24,7 +24,7 @@ const EXTENSION_NAME = "FidyWidgetExtension";
 const EXTENSION_BUNDLE_ID = "com.obarbozaa.Fidy.WidgetExtension";
 const APP_GROUP = "group.com.obarbozaa.Fidy";
 const DEVELOPMENT_TEAM = "75P4AX2J5P";
-const DEPLOYMENT_TARGET = "18.0";
+const DEPLOYMENT_TARGET = "26.0";
 const SWIFT_VERSION = "6.0";
 
 const SWIFT_FILES = [

--- a/apps/mobile/plugins/withFidyWidget.js
+++ b/apps/mobile/plugins/withFidyWidget.js
@@ -25,7 +25,7 @@ const EXTENSION_BUNDLE_ID = "com.obarbozaa.Fidy.WidgetExtension";
 const APP_GROUP = "group.com.obarbozaa.Fidy";
 const DEVELOPMENT_TEAM = "75P4AX2J5P";
 const DEPLOYMENT_TARGET = "18.0";
-const SWIFT_VERSION = "5.0";
+const SWIFT_VERSION = "6.0";
 
 const SWIFT_FILES = [
   "QuickExpenseIntent.swift",
@@ -94,17 +94,35 @@ const EXTENSION_BUILD_SETTINGS = {
 
 /** Reconcile build settings on the extension's Debug/Release configurations. */
 const reconcileBuildSettings = (project) => {
+  // Find the extension target's buildConfigurationList to get its config UUIDs
+  const nativeTargets = project.pbxNativeTargetSection();
+  let configListId = null;
+  for (const val of Object.values(nativeTargets)) {
+    if (typeof val === "object" && val !== null && val.name === EXTENSION_NAME) {
+      configListId = val.buildConfigurationList;
+      break;
+    }
+  }
+  if (!configListId) return;
+
+  // Get the configuration UUIDs from the XCConfigurationList
+  const configLists = project.pbxXCConfigurationList();
+  const configList = configLists[configListId];
+  if (!configList?.buildConfigurations) return;
+
+  const configUuids = new Set(configList.buildConfigurations.map((c) => c.value));
+
+  // Apply build settings to those specific configurations
   const configurations = project.pbxXCBuildConfigurationSection();
   for (const key of Object.keys(configurations)) {
-    const config = configurations[key];
-    if (
-      typeof config === "object" &&
-      config.buildSettings?.PRODUCT_BUNDLE_IDENTIFIER === EXTENSION_BUNDLE_ID
-    ) {
-      config.buildSettings = {
-        ...config.buildSettings,
-        ...EXTENSION_BUILD_SETTINGS,
-      };
+    if (configUuids.has(key)) {
+      const config = configurations[key];
+      if (typeof config === "object") {
+        config.buildSettings = {
+          ...config.buildSettings,
+          ...EXTENSION_BUILD_SETTINGS,
+        };
+      }
     }
   }
 };

--- a/apps/mobile/plugins/withFidyWidget.ts
+++ b/apps/mobile/plugins/withFidyWidget.ts
@@ -66,6 +66,17 @@ const generateUuid = (project: XcodeProject): string => project.generateUuid() a
  */
 const addWidgetExtensionTarget = (project: XcodeProject): void => {
   // ------------------------------------------------------------------
+  // 0. Idempotency guard — skip all mutations if the target already exists
+  // ------------------------------------------------------------------
+  const existingTargets = project.pbxNativeTargetSection();
+  const alreadyExists = Object.values(existingTargets).some(
+    (t) => typeof t === "object" && t !== null && (t as { name?: string }).name === EXTENSION_NAME
+  );
+  if (alreadyExists) {
+    return;
+  }
+
+  // ------------------------------------------------------------------
   // 1. Create the extension target
   // ------------------------------------------------------------------
   const target = project.addTarget(

--- a/apps/mobile/plugins/withFidyWidget.ts
+++ b/apps/mobile/plugins/withFidyWidget.ts
@@ -1,0 +1,234 @@
+/**
+ * Expo config plugin that adds the FidyWidgetExtension target to the Xcode project.
+ *
+ * This plugin runs during `npx expo prebuild` and:
+ *  1. Adds App Group entitlement to the main app
+ *  2. Copies Swift sources, Info.plist, and entitlements into ios/FidyWidgetExtension/
+ *  3. Creates the widget extension target in the Xcode project
+ *  4. Configures build settings, frameworks, and embed phase
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import {
+  type ConfigPlugin,
+  createRunOncePlugin,
+  withEntitlementsPlist,
+  withXcodeProject,
+  type XcodeProject,
+} from "@expo/config-plugins";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const EXTENSION_NAME = "FidyWidgetExtension";
+const EXTENSION_BUNDLE_ID = "com.obarbozaa.Fidy.WidgetExtension";
+const APP_GROUP = "group.com.obarbozaa.Fidy";
+const DEVELOPMENT_TEAM = "75P4AX2J5P";
+const DEPLOYMENT_TARGET = "18.0";
+const SWIFT_VERSION = "5.0";
+
+const SWIFT_FILES = [
+  "QuickExpenseIntent.swift",
+  "QuickExpenseControl.swift",
+  "FidyWidgetBundle.swift",
+];
+
+const ALL_EXTENSION_FILES = [...SWIFT_FILES, "Info.plist", "widget.entitlements"];
+
+// ---------------------------------------------------------------------------
+// File copying
+// ---------------------------------------------------------------------------
+
+/** Copy widget source files from targets/widget/ into ios/FidyWidgetExtension/ */
+const copyWidgetFiles = (projectRoot: string): void => {
+  const sourceDir = path.join(projectRoot, "targets", "widget");
+  const destDir = path.join(projectRoot, "ios", EXTENSION_NAME);
+
+  fs.mkdirSync(destDir, { recursive: true });
+
+  for (const file of ALL_EXTENSION_FILES) {
+    fs.copyFileSync(path.join(sourceDir, file), path.join(destDir, file));
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Xcode helpers
+// ---------------------------------------------------------------------------
+
+/** Generate a deterministic-ish UUID for Xcode PBX objects. */
+const generateUuid = (project: XcodeProject): string => project.generateUuid() as string;
+
+/**
+ * Add the widget extension target, build settings, frameworks, and embed phase
+ * to the Xcode project.
+ */
+const addWidgetExtensionTarget = (project: XcodeProject): void => {
+  // ------------------------------------------------------------------
+  // 1. Create the extension target
+  // ------------------------------------------------------------------
+  const target = project.addTarget(
+    EXTENSION_NAME,
+    "app_extension",
+    EXTENSION_NAME,
+    EXTENSION_BUNDLE_ID
+  );
+
+  // ------------------------------------------------------------------
+  // 2. Add Swift source files to the target's Sources build phase
+  // ------------------------------------------------------------------
+  const sourcesBuildPhaseUuid = generateUuid(project);
+  project.addBuildPhase(
+    SWIFT_FILES.map((f) => `${EXTENSION_NAME}/${f}`),
+    "PBXSourcesBuildPhase",
+    "Sources",
+    target.uuid,
+    undefined,
+    sourcesBuildPhaseUuid
+  );
+
+  // ------------------------------------------------------------------
+  // 3. Add a PBXGroup for the extension files
+  // ------------------------------------------------------------------
+  const groupUuid = generateUuid(project);
+  const extensionGroup = project.addPbxGroup(
+    ALL_EXTENSION_FILES,
+    EXTENSION_NAME,
+    EXTENSION_NAME,
+    '"<group>"',
+    { uuid: groupUuid }
+  );
+
+  // Add group to the main (root) group
+  const mainGroupId = project.getFirstProject().firstProject.mainGroup;
+  project.addToPbxGroup(extensionGroup.uuid, mainGroupId);
+
+  // ------------------------------------------------------------------
+  // 4. Add Frameworks build phase and link WidgetKit + SwiftUI
+  // ------------------------------------------------------------------
+  const frameworksBuildPhaseUuid = generateUuid(project);
+  project.addBuildPhase(
+    [],
+    "PBXFrameworksBuildPhase",
+    "Frameworks",
+    target.uuid,
+    undefined,
+    frameworksBuildPhaseUuid
+  );
+
+  project.addFramework("WidgetKit.framework", {
+    target: target.uuid,
+    link: true,
+  });
+  project.addFramework("SwiftUI.framework", {
+    target: target.uuid,
+    link: true,
+  });
+
+  // ------------------------------------------------------------------
+  // 5. Configure build settings for the extension target
+  // ------------------------------------------------------------------
+  // Xcode build setting keys use SCREAMING_SNAKE_CASE by convention.
+  // useNamingConvention warns on these keys — unavoidable for Xcode interop.
+  const extensionBuildSettings: Record<string, string> = {
+    ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: '""',
+    ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME: '""',
+    CLANG_ANALYZER_NONNULL: "YES",
+    CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION: "YES_AGGRESSIVE",
+    CLANG_CXX_LANGUAGE_STANDARD: '"gnu++20"',
+    CLANG_ENABLE_OBJC_WEAK: "YES",
+    CLANG_WARN_DOCUMENTATION_COMMENTS: "YES",
+    CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER: "YES",
+    CLANG_WARN_UNGUARDED_AVAILABILITY: "YES_AGGRESSIVE",
+    CODE_SIGN_ENTITLEMENTS: `${EXTENSION_NAME}/widget.entitlements`,
+    CODE_SIGN_STYLE: "Automatic",
+    CURRENT_PROJECT_VERSION: "1",
+    DEBUG_INFORMATION_FORMAT: '"dwarf-with-dsym"',
+    DEVELOPMENT_TEAM: DEVELOPMENT_TEAM,
+    GCC_C_LANGUAGE_STANDARD: "gnu17",
+    GENERATE_INFOPLIST_FILE: "NO",
+    INFOPLIST_FILE: `${EXTENSION_NAME}/Info.plist`,
+    INFOPLIST_KEY_CFBundleDisplayName: EXTENSION_NAME,
+    INFOPLIST_KEY_NSHumanReadableCopyright: '""',
+    IPHONEOS_DEPLOYMENT_TARGET: DEPLOYMENT_TARGET,
+    LD_RUNPATH_SEARCH_PATHS:
+      '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
+    MARKETING_VERSION: "1.0",
+    PRODUCT_BUNDLE_IDENTIFIER: EXTENSION_BUNDLE_ID,
+    PRODUCT_NAME: '"$(TARGET_NAME)"',
+    SKIP_INSTALL: "YES",
+    SWIFT_EMIT_LOC_STRINGS: "YES",
+    SWIFT_VERSION: SWIFT_VERSION,
+    TARGETED_DEVICE_FAMILY: '"1,2"',
+  };
+
+  // Apply build settings to both Debug and Release configurations
+  const configurations = project.pbxXCBuildConfigurationSection();
+  for (const key of Object.keys(configurations)) {
+    const config = configurations[key];
+    if (
+      typeof config === "object" &&
+      config.buildSettings?.PRODUCT_BUNDLE_IDENTIFIER === EXTENSION_BUNDLE_ID
+    ) {
+      config.buildSettings = {
+        ...config.buildSettings,
+        ...extensionBuildSettings,
+      };
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // 6. Embed the extension in the main app via "Embed App Extensions"
+  // ------------------------------------------------------------------
+  const mainTarget = project.getFirstTarget();
+  const embedPhaseUuid = generateUuid(project);
+
+  project.addBuildPhase(
+    [`${EXTENSION_NAME}.appex`],
+    "PBXCopyFilesBuildPhase",
+    "Embed App Extensions",
+    mainTarget.firstTarget.uuid,
+    "app_extension",
+    embedPhaseUuid
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Plugin composition
+// ---------------------------------------------------------------------------
+
+/** Add App Group to the main app entitlements. */
+const withAppGroupEntitlement: ConfigPlugin = (config) =>
+  withEntitlementsPlist(config, (modConfig) => {
+    const entitlements = modConfig.modResults;
+    const existingGroups: string[] =
+      (entitlements["com.apple.security.application-groups"] as string[]) ?? [];
+
+    if (!existingGroups.includes(APP_GROUP)) {
+      entitlements["com.apple.security.application-groups"] = [...existingGroups, APP_GROUP];
+    }
+
+    return modConfig;
+  });
+
+/** Copy files + mutate the Xcode project to include the widget extension. */
+const withWidgetExtensionTarget: ConfigPlugin = (config) =>
+  withXcodeProject(config, (modConfig) => {
+    const projectRoot = modConfig.modRequest.projectRoot;
+    const project = modConfig.modResults;
+
+    copyWidgetFiles(projectRoot);
+    addWidgetExtensionTarget(project);
+
+    return modConfig;
+  });
+
+/** Root plugin — composes entitlement + Xcode project modifications. */
+const withFidyWidget: ConfigPlugin = (config) => {
+  const configWithEntitlements = withAppGroupEntitlement(config);
+  const configWithExtension = withWidgetExtensionTarget(configWithEntitlements);
+  return configWithExtension;
+};
+
+export default createRunOncePlugin(withFidyWidget, "withFidyWidget", "1.0.0");

--- a/apps/mobile/plugins/withFidyWidget.ts
+++ b/apps/mobile/plugins/withFidyWidget.ts
@@ -33,6 +33,8 @@ const SWIFT_FILES = [
   "QuickExpenseIntent.swift",
   "QuickExpenseControl.swift",
   "FidyWidgetBundle.swift",
+  "FidyCategory.swift",
+  "TransactionKind.swift",
 ];
 
 const ALL_EXTENSION_FILES = [...SWIFT_FILES, "Info.plist", "widget.entitlements"];

--- a/apps/mobile/plugins/withFidyWidget.ts
+++ b/apps/mobile/plugins/withFidyWidget.ts
@@ -64,117 +64,42 @@ const generateUuid = (project: XcodeProject): string => project.generateUuid() a
  * Add the widget extension target, build settings, frameworks, and embed phase
  * to the Xcode project.
  */
-const addWidgetExtensionTarget = (project: XcodeProject): void => {
-  // ------------------------------------------------------------------
-  // 0. Idempotency guard — skip all mutations if the target already exists
-  // ------------------------------------------------------------------
-  const existingTargets = project.pbxNativeTargetSection();
-  const alreadyExists = Object.values(existingTargets).some(
-    (t) => typeof t === "object" && t !== null && (t as { name?: string }).name === EXTENSION_NAME
-  );
-  if (alreadyExists) {
-    return;
-  }
+// Xcode build setting keys use SCREAMING_SNAKE_CASE by convention.
+// useNamingConvention warns on these keys — unavoidable for Xcode interop.
+const EXTENSION_BUILD_SETTINGS: Record<string, string> = {
+  ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: '""',
+  ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME: '""',
+  CLANG_ANALYZER_NONNULL: "YES",
+  CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION: "YES_AGGRESSIVE",
+  CLANG_CXX_LANGUAGE_STANDARD: '"gnu++20"',
+  CLANG_ENABLE_OBJC_WEAK: "YES",
+  CLANG_WARN_DOCUMENTATION_COMMENTS: "YES",
+  CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER: "YES",
+  CLANG_WARN_UNGUARDED_AVAILABILITY: "YES_AGGRESSIVE",
+  CODE_SIGN_ENTITLEMENTS: `${EXTENSION_NAME}/widget.entitlements`,
+  CODE_SIGN_STYLE: "Automatic",
+  CURRENT_PROJECT_VERSION: "1",
+  DEBUG_INFORMATION_FORMAT: '"dwarf-with-dsym"',
+  DEVELOPMENT_TEAM: DEVELOPMENT_TEAM,
+  GCC_C_LANGUAGE_STANDARD: "gnu17",
+  GENERATE_INFOPLIST_FILE: "NO",
+  INFOPLIST_FILE: `${EXTENSION_NAME}/Info.plist`,
+  INFOPLIST_KEY_CFBundleDisplayName: EXTENSION_NAME,
+  INFOPLIST_KEY_NSHumanReadableCopyright: '""',
+  IPHONEOS_DEPLOYMENT_TARGET: DEPLOYMENT_TARGET,
+  LD_RUNPATH_SEARCH_PATHS:
+    '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
+  MARKETING_VERSION: "1.0",
+  PRODUCT_BUNDLE_IDENTIFIER: EXTENSION_BUNDLE_ID,
+  PRODUCT_NAME: '"$(TARGET_NAME)"',
+  SKIP_INSTALL: "YES",
+  SWIFT_EMIT_LOC_STRINGS: "YES",
+  SWIFT_VERSION: SWIFT_VERSION,
+  TARGETED_DEVICE_FAMILY: '"1,2"',
+};
 
-  // ------------------------------------------------------------------
-  // 1. Create the extension target
-  // ------------------------------------------------------------------
-  const target = project.addTarget(
-    EXTENSION_NAME,
-    "app_extension",
-    EXTENSION_NAME,
-    EXTENSION_BUNDLE_ID
-  );
-
-  // ------------------------------------------------------------------
-  // 2. Add Swift source files to the target's Sources build phase
-  // ------------------------------------------------------------------
-  const sourcesBuildPhaseUuid = generateUuid(project);
-  project.addBuildPhase(
-    SWIFT_FILES.map((f) => `${EXTENSION_NAME}/${f}`),
-    "PBXSourcesBuildPhase",
-    "Sources",
-    target.uuid,
-    undefined,
-    sourcesBuildPhaseUuid
-  );
-
-  // ------------------------------------------------------------------
-  // 3. Add a PBXGroup for the extension files
-  // ------------------------------------------------------------------
-  const groupUuid = generateUuid(project);
-  const extensionGroup = project.addPbxGroup(
-    ALL_EXTENSION_FILES,
-    EXTENSION_NAME,
-    EXTENSION_NAME,
-    '"<group>"',
-    { uuid: groupUuid }
-  );
-
-  // Add group to the main (root) group
-  const mainGroupId = project.getFirstProject().firstProject.mainGroup;
-  project.addToPbxGroup(extensionGroup.uuid, mainGroupId);
-
-  // ------------------------------------------------------------------
-  // 4. Add Frameworks build phase and link WidgetKit + SwiftUI
-  // ------------------------------------------------------------------
-  const frameworksBuildPhaseUuid = generateUuid(project);
-  project.addBuildPhase(
-    [],
-    "PBXFrameworksBuildPhase",
-    "Frameworks",
-    target.uuid,
-    undefined,
-    frameworksBuildPhaseUuid
-  );
-
-  project.addFramework("WidgetKit.framework", {
-    target: target.uuid,
-    link: true,
-  });
-  project.addFramework("SwiftUI.framework", {
-    target: target.uuid,
-    link: true,
-  });
-
-  // ------------------------------------------------------------------
-  // 5. Configure build settings for the extension target
-  // ------------------------------------------------------------------
-  // Xcode build setting keys use SCREAMING_SNAKE_CASE by convention.
-  // useNamingConvention warns on these keys — unavoidable for Xcode interop.
-  const extensionBuildSettings: Record<string, string> = {
-    ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: '""',
-    ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME: '""',
-    CLANG_ANALYZER_NONNULL: "YES",
-    CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION: "YES_AGGRESSIVE",
-    CLANG_CXX_LANGUAGE_STANDARD: '"gnu++20"',
-    CLANG_ENABLE_OBJC_WEAK: "YES",
-    CLANG_WARN_DOCUMENTATION_COMMENTS: "YES",
-    CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER: "YES",
-    CLANG_WARN_UNGUARDED_AVAILABILITY: "YES_AGGRESSIVE",
-    CODE_SIGN_ENTITLEMENTS: `${EXTENSION_NAME}/widget.entitlements`,
-    CODE_SIGN_STYLE: "Automatic",
-    CURRENT_PROJECT_VERSION: "1",
-    DEBUG_INFORMATION_FORMAT: '"dwarf-with-dsym"',
-    DEVELOPMENT_TEAM: DEVELOPMENT_TEAM,
-    GCC_C_LANGUAGE_STANDARD: "gnu17",
-    GENERATE_INFOPLIST_FILE: "NO",
-    INFOPLIST_FILE: `${EXTENSION_NAME}/Info.plist`,
-    INFOPLIST_KEY_CFBundleDisplayName: EXTENSION_NAME,
-    INFOPLIST_KEY_NSHumanReadableCopyright: '""',
-    IPHONEOS_DEPLOYMENT_TARGET: DEPLOYMENT_TARGET,
-    LD_RUNPATH_SEARCH_PATHS:
-      '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
-    MARKETING_VERSION: "1.0",
-    PRODUCT_BUNDLE_IDENTIFIER: EXTENSION_BUNDLE_ID,
-    PRODUCT_NAME: '"$(TARGET_NAME)"',
-    SKIP_INSTALL: "YES",
-    SWIFT_EMIT_LOC_STRINGS: "YES",
-    SWIFT_VERSION: SWIFT_VERSION,
-    TARGETED_DEVICE_FAMILY: '"1,2"',
-  };
-
-  // Apply build settings to both Debug and Release configurations
+/** Reconcile build settings on the extension's Debug/Release configurations. */
+const reconcileBuildSettings = (project: XcodeProject): void => {
   const configurations = project.pbxXCBuildConfigurationSection();
   for (const key of Object.keys(configurations)) {
     const config = configurations[key];
@@ -184,25 +109,93 @@ const addWidgetExtensionTarget = (project: XcodeProject): void => {
     ) {
       config.buildSettings = {
         ...config.buildSettings,
-        ...extensionBuildSettings,
+        ...EXTENSION_BUILD_SETTINGS,
       };
     }
   }
+};
 
+const addWidgetExtensionTarget = (project: XcodeProject): void => {
   // ------------------------------------------------------------------
-  // 6. Embed the extension in the main app via "Embed App Extensions"
+  // 0. Check if the target already exists
   // ------------------------------------------------------------------
-  const mainTarget = project.getFirstTarget();
-  const embedPhaseUuid = generateUuid(project);
-
-  project.addBuildPhase(
-    [`${EXTENSION_NAME}.appex`],
-    "PBXCopyFilesBuildPhase",
-    "Embed App Extensions",
-    mainTarget.firstTarget.uuid,
-    "app_extension",
-    embedPhaseUuid
+  const existingTargets = project.pbxNativeTargetSection();
+  const targetExists = Object.values(existingTargets).some(
+    (t) => typeof t === "object" && t !== null && (t as { name?: string }).name === EXTENSION_NAME
   );
+
+  // ------------------------------------------------------------------
+  // 1. Create structural elements only if the target doesn't exist
+  // ------------------------------------------------------------------
+  if (!targetExists) {
+    const target = project.addTarget(
+      EXTENSION_NAME,
+      "app_extension",
+      EXTENSION_NAME,
+      EXTENSION_BUNDLE_ID
+    );
+
+    // Add Swift source files to the target's Sources build phase
+    const sourcesBuildPhaseUuid = generateUuid(project);
+    project.addBuildPhase(
+      SWIFT_FILES.map((f) => `${EXTENSION_NAME}/${f}`),
+      "PBXSourcesBuildPhase",
+      "Sources",
+      target.uuid,
+      undefined,
+      sourcesBuildPhaseUuid
+    );
+
+    // Add a PBXGroup for the extension files
+    const groupUuid = generateUuid(project);
+    const extensionGroup = project.addPbxGroup(
+      ALL_EXTENSION_FILES,
+      EXTENSION_NAME,
+      EXTENSION_NAME,
+      '"<group>"',
+      { uuid: groupUuid }
+    );
+    const mainGroupId = project.getFirstProject().firstProject.mainGroup;
+    project.addToPbxGroup(extensionGroup.uuid, mainGroupId);
+
+    // Add Frameworks build phase and link WidgetKit + SwiftUI
+    const frameworksBuildPhaseUuid = generateUuid(project);
+    project.addBuildPhase(
+      [],
+      "PBXFrameworksBuildPhase",
+      "Frameworks",
+      target.uuid,
+      undefined,
+      frameworksBuildPhaseUuid
+    );
+
+    project.addFramework("WidgetKit.framework", {
+      target: target.uuid,
+      link: true,
+    });
+    project.addFramework("SwiftUI.framework", {
+      target: target.uuid,
+      link: true,
+    });
+
+    // Embed the extension in the main app
+    const mainTarget = project.getFirstTarget();
+    const embedPhaseUuid = generateUuid(project);
+    project.addBuildPhase(
+      [`${EXTENSION_NAME}.appex`],
+      "PBXCopyFilesBuildPhase",
+      "Embed App Extensions",
+      mainTarget.firstTarget.uuid,
+      "app_extension",
+      embedPhaseUuid
+    );
+  }
+
+  // ------------------------------------------------------------------
+  // 2. Always reconcile build settings (handles plugin config changes
+  //    on non-clean prebuilds)
+  // ------------------------------------------------------------------
+  reconcileBuildSettings(project);
 };
 
 // ---------------------------------------------------------------------------

--- a/apps/mobile/shared/i18n/locales/en.ts
+++ b/apps/mobile/shared/i18n/locales/en.ts
@@ -471,6 +471,12 @@ const en = {
     ],
   },
 
+  // Widget
+  widget: {
+    transactionSaved: "Widget expense saved",
+    transactionsSaved: "%{count} widget expenses saved",
+  },
+
   // Search
   search: {
     title: "Search",

--- a/apps/mobile/shared/i18n/locales/es.ts
+++ b/apps/mobile/shared/i18n/locales/es.ts
@@ -473,6 +473,12 @@ const es = {
     ],
   },
 
+  // Widget
+  widget: {
+    transactionSaved: "Gasto del widget guardado",
+    transactionsSaved: "%{count} gastos del widget guardados",
+  },
+
   // Search
   search: {
     title: "Buscar",

--- a/apps/mobile/shared/lib/analytics.ts
+++ b/apps/mobile/shared/lib/analytics.ts
@@ -15,7 +15,7 @@ export function resetAnalyticsUser(): void {
 export function trackTransactionCreated(props: {
   type: "expense" | "income";
   category: string;
-  source: "manual" | "email" | "apple_pay" | "notification" | "ai_chat";
+  source: "manual" | "email" | "apple_pay" | "notification" | "ai_chat" | "widget";
 }): void {
   posthog.capture("transaction_created", props);
 }

--- a/apps/mobile/targets/widget/ExpenseSnippetIntent.swift
+++ b/apps/mobile/targets/widget/ExpenseSnippetIntent.swift
@@ -1,7 +1,6 @@
 import AppIntents
 import SwiftUI
 
-@available(iOS 26.0, *)
 struct ExpenseSnippetIntent: SnippetIntent {
     static let title: LocalizedStringResource = "Expense Amount Picker"
 
@@ -10,7 +9,6 @@ struct ExpenseSnippetIntent: SnippetIntent {
     }
 }
 
-@available(iOS 26.0, *)
 struct ExpenseAmountView: View {
     private let amounts = [
         5_000, 10_000, 15_000, 20_000,

--- a/apps/mobile/targets/widget/ExpenseSnippetIntent.swift
+++ b/apps/mobile/targets/widget/ExpenseSnippetIntent.swift
@@ -1,0 +1,51 @@
+import AppIntents
+import SwiftUI
+
+@available(iOS 26.0, *)
+struct ExpenseSnippetIntent: SnippetIntent {
+    static let title: LocalizedStringResource = "Expense Amount Picker"
+
+    func perform() async throws -> some IntentResult & ShowsSnippetView {
+        return .result(view: ExpenseAmountView())
+    }
+}
+
+@available(iOS 26.0, *)
+struct ExpenseAmountView: View {
+    private let amounts = [
+        5_000, 10_000, 15_000, 20_000,
+        30_000, 50_000, 75_000, 100_000,
+    ]
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Text("Log Expense")
+                .font(.headline)
+
+            LazyVGrid(columns: [
+                GridItem(.flexible()),
+                GridItem(.flexible()),
+                GridItem(.flexible()),
+                GridItem(.flexible()),
+            ], spacing: 8) {
+                ForEach(amounts, id: \.self) { amount in
+                    Button(intent: SaveExpenseIntent(amount: amount)) {
+                        Text(formatAmount(amount))
+                            .font(.callout.weight(.medium))
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 8)
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+        }
+        .padding()
+    }
+
+    private func formatAmount(_ amount: Int) -> String {
+        if amount >= 1000 {
+            return "\(amount / 1000)K"
+        }
+        return "\(amount)"
+    }
+}

--- a/apps/mobile/targets/widget/FidyCategory.swift
+++ b/apps/mobile/targets/widget/FidyCategory.swift
@@ -5,8 +5,8 @@ enum FidyCategory: String, AppEnum {
     case food, transport, entertainment, health, education
     case home, clothing, services, transfer, other
 
-    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Category")
-    static var caseDisplayRepresentations: [FidyCategory: DisplayRepresentation] = [
+    static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Category")
+    static let caseDisplayRepresentations: [FidyCategory: DisplayRepresentation] = [
         .food: "Food",
         .transport: "Transport",
         .entertainment: "Entertainment",

--- a/apps/mobile/targets/widget/FidyCategory.swift
+++ b/apps/mobile/targets/widget/FidyCategory.swift
@@ -1,6 +1,6 @@
 import AppIntents
 
-@available(iOS 18.0, *)
+@available(iOS 26.0, *)
 enum FidyCategory: String, AppEnum {
     case food, transport, entertainment, health, education
     case home, clothing, services, transfer, other

--- a/apps/mobile/targets/widget/FidyCategory.swift
+++ b/apps/mobile/targets/widget/FidyCategory.swift
@@ -1,0 +1,21 @@
+import AppIntents
+
+@available(iOS 18.0, *)
+enum FidyCategory: String, AppEnum {
+    case food, transport, entertainment, health, education
+    case home, clothing, services, transfer, other
+
+    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Category")
+    static var caseDisplayRepresentations: [FidyCategory: DisplayRepresentation] = [
+        .food: "Food",
+        .transport: "Transport",
+        .entertainment: "Entertainment",
+        .health: "Health",
+        .education: "Education",
+        .home: "Home",
+        .clothing: "Clothing",
+        .services: "Services",
+        .transfer: "Transfer",
+        .other: "Other",
+    ]
+}

--- a/apps/mobile/targets/widget/FidyCategory.swift
+++ b/apps/mobile/targets/widget/FidyCategory.swift
@@ -1,6 +1,5 @@
 import AppIntents
 
-@available(iOS 26.0, *)
 enum FidyCategory: String, AppEnum {
     case food, transport, entertainment, health, education
     case home, clothing, services, transfer, other

--- a/apps/mobile/targets/widget/FidyWidgetBundle.swift
+++ b/apps/mobile/targets/widget/FidyWidgetBundle.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+import WidgetKit
+
+@available(iOS 18.0, *)
+@main
+struct FidyWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        QuickExpenseControl()
+    }
+}

--- a/apps/mobile/targets/widget/FidyWidgetBundle.swift
+++ b/apps/mobile/targets/widget/FidyWidgetBundle.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import WidgetKit
 
-@available(iOS 18.0, *)
+@available(iOS 26.0, *)
 @main
 struct FidyWidgetBundle: WidgetBundle {
     var body: some Widget {

--- a/apps/mobile/targets/widget/FidyWidgetBundle.swift
+++ b/apps/mobile/targets/widget/FidyWidgetBundle.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import WidgetKit
 
-@available(iOS 26.0, *)
 @main
 struct FidyWidgetBundle: WidgetBundle {
     var body: some Widget {

--- a/apps/mobile/targets/widget/Info.plist
+++ b/apps/mobile/targets/widget/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.widgetkit-extension</string>
+    </dict>
+</dict>
+</plist>

--- a/apps/mobile/targets/widget/Info.plist
+++ b/apps/mobile/targets/widget/Info.plist
@@ -2,6 +2,24 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleDisplayName</key>
+    <string>FidyWidgetExtension</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$(MARKETING_VERSION)</string>
+    <key>CFBundleVersion</key>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
     <key>NSExtension</key>
     <dict>
         <key>NSExtensionPointIdentifier</key>

--- a/apps/mobile/targets/widget/OpenAddTransactionIntent.swift
+++ b/apps/mobile/targets/widget/OpenAddTransactionIntent.swift
@@ -1,12 +1,11 @@
 import AppIntents
 
-@available(iOS 18.0, *)
+@available(iOS 26.0, *)
 struct OpenAddTransactionIntent: AppIntent {
-    static let title: LocalizedStringResource = "Open Add Transaction"
-    static let description = IntentDescription("Opens Fidy to the Add Transaction screen.")
-    static let openAppWhenRun = true
+    static let title: LocalizedStringResource = "Log Expense"
+    static let description = IntentDescription("Quickly log an expense from Control Center.")
 
-    func perform() async throws -> some IntentResult {
-        return .result()
+    func perform() async throws -> some IntentResult & ShowsSnippetIntent {
+        return .result(snippetIntent: ExpenseSnippetIntent())
     }
 }

--- a/apps/mobile/targets/widget/OpenAddTransactionIntent.swift
+++ b/apps/mobile/targets/widget/OpenAddTransactionIntent.swift
@@ -1,0 +1,12 @@
+import AppIntents
+
+@available(iOS 18.0, *)
+struct OpenAddTransactionIntent: AppIntent {
+    static let title: LocalizedStringResource = "Open Add Transaction"
+    static let description = IntentDescription("Opens Fidy to the Add Transaction screen.")
+    static let openAppWhenRun = true
+
+    func perform() async throws -> some IntentResult {
+        return .result()
+    }
+}

--- a/apps/mobile/targets/widget/OpenAddTransactionIntent.swift
+++ b/apps/mobile/targets/widget/OpenAddTransactionIntent.swift
@@ -1,6 +1,5 @@
 import AppIntents
 
-@available(iOS 26.0, *)
 struct OpenAddTransactionIntent: AppIntent {
     static let title: LocalizedStringResource = "Log Expense"
     static let description = IntentDescription("Quickly log an expense from Control Center.")

--- a/apps/mobile/targets/widget/QuickExpenseControl.swift
+++ b/apps/mobile/targets/widget/QuickExpenseControl.swift
@@ -2,7 +2,7 @@ import AppIntents
 import SwiftUI
 import WidgetKit
 
-@available(iOS 18.0, *)
+@available(iOS 26.0, *)
 struct QuickExpenseControl: ControlWidget {
     static let kind: String = "com.obarbozaa.Fidy.QuickExpenseControl"
 
@@ -13,6 +13,6 @@ struct QuickExpenseControl: ControlWidget {
             }
         }
         .displayName("Log Expense")
-        .description("Opens Fidy to quickly log an expense.")
+        .description("Quickly log an expense from Control Center.")
     }
 }

--- a/apps/mobile/targets/widget/QuickExpenseControl.swift
+++ b/apps/mobile/targets/widget/QuickExpenseControl.swift
@@ -1,0 +1,30 @@
+import AppIntents
+import SwiftUI
+import WidgetKit
+
+@available(iOS 18.0, *)
+struct QuickExpenseControl: ControlWidget {
+    static let kind: String = "com.obarbozaa.Fidy.QuickExpenseControl"
+
+    var body: some ControlWidgetConfiguration {
+        StaticControlConfiguration(
+            kind: Self.kind,
+            provider: QuickExpenseControlProvider()
+        ) { _ in
+            ControlWidgetButton(action: QuickExpenseIntent()) {
+                Label("Fidy", systemImage: "dollarsign.circle.fill")
+            }
+        }
+        .displayName("Log Expense")
+        .description("Quickly log an expense from Control Center.")
+    }
+}
+
+@available(iOS 18.0, *)
+struct QuickExpenseControlProvider: ControlValueProvider {
+    typealias Value = Bool
+
+    var previewValue: Bool { false }
+
+    func currentValue() async throws -> Bool { false }
+}

--- a/apps/mobile/targets/widget/QuickExpenseControl.swift
+++ b/apps/mobile/targets/widget/QuickExpenseControl.swift
@@ -2,7 +2,6 @@ import AppIntents
 import SwiftUI
 import WidgetKit
 
-@available(iOS 26.0, *)
 struct QuickExpenseControl: ControlWidget {
     static let kind: String = "com.obarbozaa.Fidy.QuickExpenseControl"
 

--- a/apps/mobile/targets/widget/QuickExpenseControl.swift
+++ b/apps/mobile/targets/widget/QuickExpenseControl.swift
@@ -7,24 +7,12 @@ struct QuickExpenseControl: ControlWidget {
     static let kind: String = "com.obarbozaa.Fidy.QuickExpenseControl"
 
     var body: some ControlWidgetConfiguration {
-        StaticControlConfiguration(
-            kind: Self.kind,
-            provider: QuickExpenseControlProvider()
-        ) { _ in
-            ControlWidgetButton(action: QuickExpenseIntent()) {
+        StaticControlConfiguration(kind: Self.kind) {
+            ControlWidgetButton(action: OpenAddTransactionIntent()) {
                 Label("Fidy", systemImage: "dollarsign.circle.fill")
             }
         }
         .displayName("Log Expense")
-        .description("Quickly log an expense from Control Center.")
+        .description("Opens Fidy to quickly log an expense.")
     }
-}
-
-@available(iOS 18.0, *)
-struct QuickExpenseControlProvider: ControlValueProvider {
-    typealias Value = Bool
-
-    var previewValue: Bool { false }
-
-    func currentValue() async throws -> Bool { false }
 }

--- a/apps/mobile/targets/widget/QuickExpenseIntent.swift
+++ b/apps/mobile/targets/widget/QuickExpenseIntent.swift
@@ -1,0 +1,42 @@
+import AppIntents
+import Foundation
+
+@available(iOS 18.0, *)
+struct QuickExpenseIntent: AppIntent {
+    static var title: LocalizedStringResource = "Log Quick Expense"
+    static var description = IntentDescription("Log an expense amount from Control Center.")
+
+    @Parameter(title: "Amount")
+    var amount: Int
+
+    func perform() async throws -> some IntentResult {
+        let defaults = UserDefaults(suiteName: "group.com.obarbozaa.Fidy")
+
+        let existing: [[String: Any]] = {
+            guard
+                let data = defaults?.data(forKey: "pendingWidgetTransactions"),
+                let decoded = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+            else { return [] }
+            return decoded
+        }()
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        let timestamp = formatter.string(from: Date())
+
+        let newEntry: [String: Any] = [
+            "id": UUID().uuidString,
+            "amount": amount,
+            "createdAt": timestamp
+        ]
+
+        let updated = existing + [newEntry]
+
+        if let encoded = try? JSONSerialization.data(withJSONObject: updated) {
+            defaults?.set(encoded, forKey: "pendingWidgetTransactions")
+            defaults?.synchronize()
+        }
+
+        return .result()
+    }
+}

--- a/apps/mobile/targets/widget/QuickExpenseIntent.swift
+++ b/apps/mobile/targets/widget/QuickExpenseIntent.swift
@@ -3,8 +3,8 @@ import Foundation
 
 @available(iOS 18.0, *)
 struct QuickExpenseIntent: AppIntent {
-    static var title: LocalizedStringResource = "Log Quick Expense"
-    static var description = IntentDescription("Log an expense amount from Control Center.")
+    static let title: LocalizedStringResource = "Log Quick Expense"
+    static let description = IntentDescription("Log an expense amount from Control Center.")
 
     @Parameter(title: "Amount")
     var amount: Int

--- a/apps/mobile/targets/widget/QuickExpenseIntent.swift
+++ b/apps/mobile/targets/widget/QuickExpenseIntent.swift
@@ -4,10 +4,10 @@ import Foundation
 @available(iOS 18.0, *)
 struct QuickExpenseIntent: AppIntent {
     static let title: LocalizedStringResource = "Log Quick Expense"
-    static let description = IntentDescription("Log an expense amount from Control Center.")
+    static let description = IntentDescription("Log an expense amount without opening Fidy.")
 
-    @Parameter(title: "Amount", requestValueDialog: "How much?")
-    var amount: Int?
+    @Parameter(title: "Amount")
+    var amount: Int
 
     @Parameter(title: "Category", default: .other)
     var category: FidyCategory?
@@ -27,14 +27,8 @@ struct QuickExpenseIntent: AppIntent {
     }
 
     func perform() async throws -> some IntentResult {
-        let resolvedAmount: Int
-        if let amount, amount > 0 {
-            resolvedAmount = amount
-        } else {
-            resolvedAmount = try await $amount.requestValue("How much?")
-            guard resolvedAmount > 0 else {
-                throw $amount.needsValueError("Please enter a positive amount.")
-            }
+        guard amount > 0 else {
+            throw $amount.needsValueError("Please enter a positive amount.")
         }
 
         let defaults = UserDefaults(suiteName: "group.com.obarbozaa.Fidy")
@@ -53,7 +47,7 @@ struct QuickExpenseIntent: AppIntent {
 
         let newEntry: [String: Any] = [
             "id": UUID().uuidString,
-            "amount": resolvedAmount,
+            "amount": amount,
             "category": (category ?? .other).rawValue,
             "type": (type ?? .expense).rawValue,
             "description": descriptionText ?? "",

--- a/apps/mobile/targets/widget/QuickExpenseIntent.swift
+++ b/apps/mobile/targets/widget/QuickExpenseIntent.swift
@@ -10,6 +10,10 @@ struct QuickExpenseIntent: AppIntent {
     var amount: Int
 
     func perform() async throws -> some IntentResult {
+        guard amount > 0 else {
+            throw $amount.needsValueError("Please enter a positive amount.")
+        }
+
         let defaults = UserDefaults(suiteName: "group.com.obarbozaa.Fidy")
 
         let existing: [[String: Any]] = {

--- a/apps/mobile/targets/widget/QuickExpenseIntent.swift
+++ b/apps/mobile/targets/widget/QuickExpenseIntent.swift
@@ -18,6 +18,14 @@ struct QuickExpenseIntent: AppIntent {
     @Parameter(title: "Description")
     var descriptionText: String?
 
+    static var parameterSummary: some ParameterSummary {
+        Summary("Log \(\.$amount) expense") {
+            \.$category
+            \.$type
+            \.$descriptionText
+        }
+    }
+
     func perform() async throws -> some IntentResult {
         guard amount > 0 else {
             throw $amount.needsValueError("Please enter a positive amount.")

--- a/apps/mobile/targets/widget/QuickExpenseIntent.swift
+++ b/apps/mobile/targets/widget/QuickExpenseIntent.swift
@@ -1,7 +1,6 @@
 import AppIntents
 import Foundation
 
-@available(iOS 26.0, *)
 struct QuickExpenseIntent: AppIntent {
     static let title: LocalizedStringResource = "Log Quick Expense"
     static let description = IntentDescription("Log an expense amount without opening Fidy.")

--- a/apps/mobile/targets/widget/QuickExpenseIntent.swift
+++ b/apps/mobile/targets/widget/QuickExpenseIntent.swift
@@ -6,8 +6,8 @@ struct QuickExpenseIntent: AppIntent {
     static let title: LocalizedStringResource = "Log Quick Expense"
     static let description = IntentDescription("Log an expense amount from Control Center.")
 
-    @Parameter(title: "Amount")
-    var amount: Int
+    @Parameter(title: "Amount", requestValueDialog: "How much?")
+    var amount: Int?
 
     @Parameter(title: "Category", default: .other)
     var category: FidyCategory?
@@ -27,8 +27,14 @@ struct QuickExpenseIntent: AppIntent {
     }
 
     func perform() async throws -> some IntentResult {
-        guard amount > 0 else {
-            throw $amount.needsValueError("Please enter a positive amount.")
+        let resolvedAmount: Int
+        if let amount, amount > 0 {
+            resolvedAmount = amount
+        } else {
+            resolvedAmount = try await $amount.requestValue("How much?")
+            guard resolvedAmount > 0 else {
+                throw $amount.needsValueError("Please enter a positive amount.")
+            }
         }
 
         let defaults = UserDefaults(suiteName: "group.com.obarbozaa.Fidy")
@@ -47,7 +53,7 @@ struct QuickExpenseIntent: AppIntent {
 
         let newEntry: [String: Any] = [
             "id": UUID().uuidString,
-            "amount": amount,
+            "amount": resolvedAmount,
             "category": (category ?? .other).rawValue,
             "type": (type ?? .expense).rawValue,
             "description": descriptionText ?? "",

--- a/apps/mobile/targets/widget/QuickExpenseIntent.swift
+++ b/apps/mobile/targets/widget/QuickExpenseIntent.swift
@@ -9,6 +9,15 @@ struct QuickExpenseIntent: AppIntent {
     @Parameter(title: "Amount")
     var amount: Int
 
+    @Parameter(title: "Category", default: .other)
+    var category: FidyCategory?
+
+    @Parameter(title: "Type", default: .expense)
+    var type: TransactionKind?
+
+    @Parameter(title: "Description")
+    var descriptionText: String?
+
     func perform() async throws -> some IntentResult {
         guard amount > 0 else {
             throw $amount.needsValueError("Please enter a positive amount.")
@@ -31,14 +40,16 @@ struct QuickExpenseIntent: AppIntent {
         let newEntry: [String: Any] = [
             "id": UUID().uuidString,
             "amount": amount,
-            "createdAt": timestamp
+            "category": (category ?? .other).rawValue,
+            "type": (type ?? .expense).rawValue,
+            "description": descriptionText ?? "",
+            "createdAt": timestamp,
         ]
 
         let updated = existing + [newEntry]
 
         if let encoded = try? JSONSerialization.data(withJSONObject: updated) {
             defaults?.set(encoded, forKey: "pendingWidgetTransactions")
-            defaults?.synchronize()
         }
 
         return .result()

--- a/apps/mobile/targets/widget/SaveExpenseIntent.swift
+++ b/apps/mobile/targets/widget/SaveExpenseIntent.swift
@@ -2,34 +2,20 @@ import AppIntents
 import Foundation
 
 @available(iOS 26.0, *)
-struct QuickExpenseIntent: AppIntent {
-    static let title: LocalizedStringResource = "Log Quick Expense"
-    static let description = IntentDescription("Log an expense amount without opening Fidy.")
+struct SaveExpenseIntent: AppIntent {
+    static let title: LocalizedStringResource = "Save Quick Expense"
 
     @Parameter(title: "Amount")
     var amount: Int
 
-    @Parameter(title: "Category", default: .other)
-    var category: FidyCategory?
+    init() {}
 
-    @Parameter(title: "Type", default: .expense)
-    var type: TransactionKind?
-
-    @Parameter(title: "Description")
-    var descriptionText: String?
-
-    static var parameterSummary: some ParameterSummary {
-        Summary("Log \(\.$amount) expense") {
-            \.$category
-            \.$type
-            \.$descriptionText
-        }
+    init(amount: Int) {
+        self.amount = amount
     }
 
     func perform() async throws -> some IntentResult {
-        guard amount > 0 else {
-            throw $amount.needsValueError("Please enter a positive amount.")
-        }
+        guard amount > 0 else { return .result() }
 
         let defaults = UserDefaults(suiteName: "group.com.obarbozaa.Fidy")
 
@@ -43,15 +29,14 @@ struct QuickExpenseIntent: AppIntent {
 
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
-        let timestamp = formatter.string(from: Date())
 
         let newEntry: [String: Any] = [
             "id": UUID().uuidString,
             "amount": amount,
-            "category": (category ?? .other).rawValue,
-            "type": (type ?? .expense).rawValue,
-            "description": descriptionText ?? "",
-            "createdAt": timestamp,
+            "category": "other",
+            "type": "expense",
+            "description": "",
+            "createdAt": formatter.string(from: Date()),
         ]
 
         let updated = existing + [newEntry]

--- a/apps/mobile/targets/widget/SaveExpenseIntent.swift
+++ b/apps/mobile/targets/widget/SaveExpenseIntent.swift
@@ -1,7 +1,6 @@
 import AppIntents
 import Foundation
 
-@available(iOS 26.0, *)
 struct SaveExpenseIntent: AppIntent {
     static let title: LocalizedStringResource = "Save Quick Expense"
 

--- a/apps/mobile/targets/widget/TransactionKind.swift
+++ b/apps/mobile/targets/widget/TransactionKind.swift
@@ -1,0 +1,12 @@
+import AppIntents
+
+@available(iOS 18.0, *)
+enum TransactionKind: String, AppEnum {
+    case expense, income
+
+    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Type")
+    static var caseDisplayRepresentations: [TransactionKind: DisplayRepresentation] = [
+        .expense: "Expense",
+        .income: "Income",
+    ]
+}

--- a/apps/mobile/targets/widget/TransactionKind.swift
+++ b/apps/mobile/targets/widget/TransactionKind.swift
@@ -1,6 +1,6 @@
 import AppIntents
 
-@available(iOS 18.0, *)
+@available(iOS 26.0, *)
 enum TransactionKind: String, AppEnum {
     case expense, income
 

--- a/apps/mobile/targets/widget/TransactionKind.swift
+++ b/apps/mobile/targets/widget/TransactionKind.swift
@@ -4,8 +4,8 @@ import AppIntents
 enum TransactionKind: String, AppEnum {
     case expense, income
 
-    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Type")
-    static var caseDisplayRepresentations: [TransactionKind: DisplayRepresentation] = [
+    static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Type")
+    static let caseDisplayRepresentations: [TransactionKind: DisplayRepresentation] = [
         .expense: "Expense",
         .income: "Income",
     ]

--- a/apps/mobile/targets/widget/TransactionKind.swift
+++ b/apps/mobile/targets/widget/TransactionKind.swift
@@ -1,6 +1,5 @@
 import AppIntents
 
-@available(iOS 26.0, *)
 enum TransactionKind: String, AppEnum {
     case expense, income
 

--- a/apps/mobile/targets/widget/widget.entitlements
+++ b/apps/mobile/targets/widget/widget.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.com.obarbozaa.Fidy</string>
+    </array>
+</dict>
+</plist>

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -17,5 +17,6 @@
     "expo-env.d.ts",
     "nativewind-env.d.ts",
     "modules/**/*.ts"
-  ]
+  ],
+  "exclude": ["plugins"]
 }

--- a/biome.json
+++ b/biome.json
@@ -74,6 +74,16 @@
           }
         }
       }
+    },
+    {
+      "includes": ["apps/mobile/plugins/**"],
+      "linter": {
+        "rules": {
+          "style": {
+            "useNamingConvention": "off"
+          }
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
- Add WidgetKit ControlWidget for iOS 18 Control Center
- Create AppIntent that prompts for amount via system UI
- Write pending transactions to App Group shared UserDefaults
- Process pending transactions on app foreground via widget pipeline
- Add Expo config plugin for widget extension target setup
- Add native module methods for reading/clearing pending queue
- Add concurrency guard to prevent duplicate processing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an iOS Control Center quick expense control with an inline snippet to log expenses fast, plus a Shortcuts/Siri intent that saves expenses without opening the app. Entries are queued via the App Group and processed on app open/foreground with deterministic IDs, upserts, and sync to avoid duplicates.

- **New Features**
  - Control Center: `QuickExpenseControl` shows an interactive `ExpenseSnippetIntent` (iOS 26+) with common amounts (5K–100K); tapping saves instantly via `SaveExpenseIntent` (no app open).
  - Shortcuts: `QuickExpenseIntent` (Swift 6) validates positive amount, supports optional category/type/description with `parameterSummary`, rounds amounts, and saves with source "widget".
  - Offline pipeline + native/infra: `useWidgetCapture` + `processWidgetTransactions` with a concurrency guard, deterministic IDs from widget entry IDs, upsert + sync enqueue, date from `createdAt`, category validation with "other" fallback; remove only processed entries; drop malformed items; `expo-app-intents` exposes `isAvailable`, `getPendingTransactions`, `removePendingTransactions`; config plugin `withFidyWidget` (CommonJS) adds the widget target and App Group, applies Swift 6.0, embeds the `.appex`, is idempotent across prebuilds, and reconciles build settings via `expo/config-plugins`.
  - Stability: Widget extension targets iOS 26.0 and removes `@available` guards to ensure AppIntents metadata registers correctly.

- **Migration**
  - Control Center snippet requires iOS 26+ and Xcode 16+.
  - Ensure App Group `group.com.obarbozaa.Fidy` is in the provisioning profile.
  - Run `npx expo prebuild` (or an EAS iOS build) to apply `./plugins/withFidyWidget`.
  - If using a different Apple team, set the Development Team in Xcode or update `DEVELOPMENT_TEAM` in `withFidyWidget`.

<sup>Written for commit 0b23efb7232014c11ab0f1f13846edfaca85470e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

