### PR TITLE
fix(test): add null guards for noUncheckedIndexedAccess

### DIFF
--- a/apps/mobile/__tests__/analytics/derive.test.ts
+++ b/apps/mobile/__tests__/analytics/derive.test.ts
@@ -11,7 +11,7 @@ import type { CategoryId, CopAmount } from "@/shared/types/branded";
 // Fixture builders
 // ---------------------------------------------------------------------------
 
-const makeCategorySpending = (items: ReadonlyArray<{ categoryId: string; total: number }>) =>
+const makeCategorySpending = (items: readonly { categoryId: string; total: number }[]) =>
   items.map((item) => ({
     categoryId: item.categoryId as CategoryId,
     total: item.total as CopAmount,

--- a/apps/mobile/__tests__/analytics/repository.test.ts
+++ b/apps/mobile/__tests__/analytics/repository.test.ts
@@ -156,8 +156,8 @@ describe("analytics repository", () => {
       );
 
       expect(result).toEqual(mockRows);
-      expect(result[0].categoryId).toBe("food");
-      expect(result[0].total).toBe(200000);
+      expect(result[0]?.categoryId).toBe("food");
+      expect(result[0]?.total).toBe(200000);
     });
   });
 });

--- a/apps/mobile/__tests__/budget/derive.test.ts
+++ b/apps/mobile/__tests__/budget/derive.test.ts
@@ -140,7 +140,7 @@ describe("deriveAutoSuggestBudgets", () => {
     const existing = new Set<CategoryId>(["food" as CategoryId, "entertainment" as CategoryId]);
     const result = deriveAutoSuggestBudgets(spending, existing);
     expect(result).toHaveLength(1);
-    expect(result[0].categoryId).toBe("transport");
+    expect(result[0]?.categoryId).toBe("transport");
   });
 
   it("rounds < 100k COP up to nearest 1,000 COP (18,900 → 19,000)", () => {
@@ -148,7 +148,7 @@ describe("deriveAutoSuggestBudgets", () => {
       [{ categoryId: "food" as CategoryId, total: 18900 as CopAmount }], // 18,900 COP
       new Set()
     );
-    expect(result[0].suggestedAmount).toBe(19000);
+    expect(result[0]?.suggestedAmount).toBe(19000);
   });
 
   it("rounds < 100k COP (5,234 → 6,000)", () => {
@@ -156,7 +156,7 @@ describe("deriveAutoSuggestBudgets", () => {
       [{ categoryId: "transport" as CategoryId, total: 5234 as CopAmount }], // 5,234 COP
       new Set()
     );
-    expect(result[0].suggestedAmount).toBe(6000);
+    expect(result[0]?.suggestedAmount).toBe(6000);
   });
 
   it("rounds 100k-1M COP up to nearest 10,000 COP (187,500 → 190,000)", () => {
@@ -164,7 +164,7 @@ describe("deriveAutoSuggestBudgets", () => {
       [{ categoryId: "entertainment" as CategoryId, total: 187500 as CopAmount }], // 187,500 COP
       new Set()
     );
-    expect(result[0].suggestedAmount).toBe(190000);
+    expect(result[0]?.suggestedAmount).toBe(190000);
   });
 
   it("rounds >= 1M COP up to nearest 100,000 COP (1,850,000 → 1,900,000)", () => {
@@ -172,7 +172,7 @@ describe("deriveAutoSuggestBudgets", () => {
       [{ categoryId: "home" as CategoryId, total: 1850000 as CopAmount }], // 1,850,000 COP
       new Set()
     );
-    expect(result[0].suggestedAmount).toBe(1900000);
+    expect(result[0]?.suggestedAmount).toBe(1900000);
   });
 
   it("does not round exact multiples", () => {
@@ -180,7 +180,7 @@ describe("deriveAutoSuggestBudgets", () => {
       [{ categoryId: "food" as CategoryId, total: 20000 as CopAmount }], // 20,000 COP exact
       new Set()
     );
-    expect(result[0].suggestedAmount).toBe(20000);
+    expect(result[0]?.suggestedAmount).toBe(20000);
   });
 
   it("returns empty array when no spending data", () => {
@@ -204,17 +204,17 @@ describe("deriveBudgetAlerts", () => {
     const progresses = [makeProgress({ percentUsed: 80, isNearLimit: true })];
     const result = deriveBudgetAlerts(progresses, new Set(), 15);
     expect(result).toHaveLength(1);
-    expect(result[0].threshold).toBe(80);
-    expect(result[0].budgetId).toBe("budget-1");
-    expect(result[0].categoryId).toBe("food");
-    expect(result[0].percentUsed).toBe(80);
+    expect(result[0]?.threshold).toBe(80);
+    expect(result[0]?.budgetId).toBe("budget-1");
+    expect(result[0]?.categoryId).toBe("food");
+    expect(result[0]?.percentUsed).toBe(80);
   });
 
   it("returns only 100% alert when budget is over 100% (80% is superseded)", () => {
     const progresses = [makeProgress({ percentUsed: 110, isOverBudget: true, isNearLimit: true })];
     const result = deriveBudgetAlerts(progresses, new Set(), 15);
     expect(result).toHaveLength(1);
-    expect(result[0].threshold).toBe(100);
+    expect(result[0]?.threshold).toBe(100);
   });
 
   it("excludes acknowledged alerts", () => {
@@ -229,14 +229,14 @@ describe("deriveBudgetAlerts", () => {
     const acknowledged = new Set(["budget-1:80"]);
     const result = deriveBudgetAlerts(progresses, acknowledged, 15);
     expect(result).toHaveLength(1);
-    expect(result[0].threshold).toBe(100);
+    expect(result[0]?.threshold).toBe(100);
   });
 
   it("returns only 100% alert when exactly at 100% (80% superseded)", () => {
     const progresses = [makeProgress({ percentUsed: 100, isNearLimit: true, isOverBudget: false })];
     const result = deriveBudgetAlerts(progresses, new Set(), 15);
     expect(result).toHaveLength(1);
-    expect(result[0].threshold).toBe(100);
+    expect(result[0]?.threshold).toBe(100);
   });
 
   it("returns empty when all under 80%", () => {
@@ -253,7 +253,7 @@ describe("deriveBudgetAlerts", () => {
   it("includes suggestionKey for known category", () => {
     const progresses = [makeProgress({ percentUsed: 80, isNearLimit: true })];
     const result = deriveBudgetAlerts(progresses, new Set(), 15);
-    expect(result[0].suggestionKey).toBe("guidance.budgetAlert80.food");
+    expect(result[0]?.suggestionKey).toBe("guidance.budgetAlert80.food");
   });
 
   it("returns undefined suggestionKey for unknown category", () => {
@@ -261,13 +261,13 @@ describe("deriveBudgetAlerts", () => {
       makeProgress({ percentUsed: 80, isNearLimit: true, categoryId: "custom-cat" as CategoryId }),
     ];
     const result = deriveBudgetAlerts(progresses, new Set(), 15);
-    expect(result[0].suggestionKey).toBeUndefined();
+    expect(result[0]?.suggestionKey).toBeUndefined();
   });
 
   it("passes daysLeft through to alerts", () => {
     const progresses = [makeProgress({ percentUsed: 80, isNearLimit: true })];
     const result = deriveBudgetAlerts(progresses, new Set(), 0);
-    expect(result[0].daysLeft).toBe(0);
+    expect(result[0]?.daysLeft).toBe(0);
   });
 
   it("includes suggestionKey for non-food category at 100%", () => {
@@ -289,7 +289,7 @@ describe("deriveBudgetAlerts", () => {
       makeProgress({ percentUsed: 80, isNearLimit: true, remaining: 100000 as CopAmount }),
     ];
     const result = deriveBudgetAlerts(progresses, new Set(), 15);
-    expect(result[0].remainingAmount).toBe(100000);
+    expect(result[0]?.remainingAmount).toBe(100000);
   });
 
   it("includes correct suggestionKey for 100% threshold", () => {

--- a/apps/mobile/__tests__/calendar/calendar-utils.test.ts
+++ b/apps/mobile/__tests__/calendar/calendar-utils.test.ts
@@ -59,9 +59,9 @@ describe("getMonthGrid", () => {
     const grid = getMonthGrid(2026, 2);
     // First 6 cells should be null (Mon-Sat padding), then day 1 on Sunday
     for (let i = 0; i < 6; i++) {
-      expect(grid[0][i].day).toBeNull();
+      expect(grid[0]?.[i]?.day).toBeNull();
     }
-    expect(grid[0][6].day).toBe(1);
+    expect(grid[0]?.[6]?.day).toBe(1);
   });
 
   test("last row pads nulls after last day of month", () => {
@@ -69,8 +69,8 @@ describe("getMonthGrid", () => {
     const grid = getMonthGrid(2026, 1);
     const lastWeek = grid[grid.length - 1];
     // Day 28 should be on Saturday (index 5), Sunday (index 6) should be null
-    expect(lastWeek[5].day).toBe(28);
-    expect(lastWeek[6].day).toBeNull();
+    expect(lastWeek![5]?.day).toBe(28);
+    expect(lastWeek![6]?.day).toBeNull();
   });
 
   test("all non-null cells have correct date objects", () => {

--- a/apps/mobile/__tests__/calendar/notifications.test.ts
+++ b/apps/mobile/__tests__/calendar/notifications.test.ts
@@ -39,25 +39,25 @@ describe("computeUpcomingOccurrences", () => {
   test("returns monthly occurrences for monthly frequency", () => {
     const bill = makeBill({ frequency: "monthly", startDate: new Date(2025, 0, 15) });
     const occurrences = computeUpcomingOccurrences(bill, 3, new Date(2025, 0, 15));
-    expect(occurrences[0].getDate()).toBe(15);
-    expect(occurrences[1].getDate()).toBe(15);
-    expect(occurrences[2].getDate()).toBe(15);
+    expect(occurrences[0]?.getDate()).toBe(15);
+    expect(occurrences[1]?.getDate()).toBe(15);
+    expect(occurrences[2]?.getDate()).toBe(15);
   });
 
   test("returns weekly occurrences for weekly frequency", () => {
     const bill = makeBill({ frequency: "weekly", startDate: new Date(2025, 0, 6) }); // Monday
     const occurrences = computeUpcomingOccurrences(bill, 3, new Date(2025, 0, 6));
     // Each occurrence should be 7 days apart
-    expect(occurrences[1].getTime() - occurrences[0].getTime()).toBe(7 * 24 * 60 * 60 * 1000);
-    expect(occurrences[2].getTime() - occurrences[1].getTime()).toBe(7 * 24 * 60 * 60 * 1000);
+    expect(occurrences[1]!.getTime() - occurrences[0]!.getTime()).toBe(7 * 24 * 60 * 60 * 1000);
+    expect(occurrences[2]!.getTime() - occurrences[1]!.getTime()).toBe(7 * 24 * 60 * 60 * 1000);
   });
 
   test("returns yearly occurrences for yearly frequency", () => {
     const bill = makeBill({ frequency: "yearly", startDate: new Date(2025, 2, 22) });
     const occurrences = computeUpcomingOccurrences(bill, 3, new Date(2025, 2, 22));
-    expect(occurrences[0].getFullYear()).toBe(2025);
-    expect(occurrences[1].getFullYear()).toBe(2026);
-    expect(occurrences[2].getFullYear()).toBe(2027);
+    expect(occurrences[0]?.getFullYear()).toBe(2025);
+    expect(occurrences[1]?.getFullYear()).toBe(2026);
+    expect(occurrences[2]?.getFullYear()).toBe(2027);
   });
 
   test("returns empty array for 0 count", () => {

--- a/apps/mobile/__tests__/calendar/store.test.ts
+++ b/apps/mobile/__tests__/calendar/store.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { useCalendarStore } from "@/features/calendar/store";
+import { useTransactionStore } from "@/features/transactions/store";
 import type {
   BillId,
   BillPaymentId,
@@ -10,29 +12,26 @@ import type {
   UserId,
 } from "@/shared/types/branded";
 
-// Mock the calendar repository module
+// Mock the calendar repository module (all fns are synchronous Drizzle wrappers)
 vi.mock("@/features/calendar/lib/repository", () => ({
-  insertBill: vi.fn().mockResolvedValue(undefined),
-  getAllBills: vi.fn().mockResolvedValue([]),
-  updateBill: vi.fn().mockResolvedValue(undefined),
-  deleteBill: vi.fn().mockResolvedValue(undefined),
-  insertBillPayment: vi.fn().mockResolvedValue(undefined),
-  getBillPaymentsForMonth: vi.fn().mockResolvedValue([]),
-  deleteBillPayment: vi.fn().mockResolvedValue(undefined),
+  insertBill: vi.fn(),
+  getAllBills: vi.fn().mockReturnValue([]),
+  updateBill: vi.fn(),
+  deleteBill: vi.fn(),
+  insertBillPayment: vi.fn(),
+  getBillPaymentsForMonth: vi.fn().mockReturnValue([]),
+  deleteBillPayment: vi.fn(),
 }));
 
-// Mock the transaction repository module
+// Mock the transaction repository module (all fns are synchronous Drizzle wrappers)
 vi.mock("@/features/transactions/lib/repository", () => ({
-  insertTransaction: vi.fn().mockResolvedValue(undefined),
-  softDeleteTransaction: vi.fn().mockResolvedValue(undefined),
+  insertTransaction: vi.fn(),
+  softDeleteTransaction: vi.fn(),
 }));
 
 vi.mock("@/shared/db/enqueue-sync", () => ({
-  enqueueSync: vi.fn().mockResolvedValue(undefined),
+  enqueueSync: vi.fn(),
 }));
-
-import { useCalendarStore } from "@/features/calendar/store";
-import { useTransactionStore } from "@/features/transactions/store";
 
 const mockDb = { transaction: (fn: (tx: unknown) => void) => fn(mockDb) } as never;
 const mockUserId = "user-1" as UserId;
@@ -76,7 +75,7 @@ describe("useCalendarStore", () => {
       .addBill("Netflix", "35000", "monthly", "services" as CategoryId, testDate);
     expect(result).toBe(true);
     expect(useCalendarStore.getState().bills).toHaveLength(1);
-    const bill = useCalendarStore.getState().bills[0];
+    const bill = useCalendarStore.getState().bills[0]!;
     expect(bill.name).toBe("Netflix");
     expect(bill.amount).toBe(35000);
     expect(bill.frequency).toBe("monthly");
@@ -112,7 +111,7 @@ describe("useCalendarStore", () => {
       .addBill("Netflix", "50.000", "monthly", "services" as CategoryId, testDate);
     expect(result).toBe(true);
     const bills = useCalendarStore.getState().bills;
-    expect(bills[0].amount).toBe(50000);
+    expect(bills[0]?.amount).toBe(50000);
   });
 
   test("addBill returns false for non-numeric amount", async () => {
@@ -163,7 +162,7 @@ describe("useCalendarStore", () => {
 
   test("loadBills populates bills from DB rows", async () => {
     const { getAllBills } = await import("@/features/calendar/lib/repository");
-    vi.mocked(getAllBills).mockResolvedValueOnce([
+    vi.mocked(getAllBills).mockReturnValueOnce([
       {
         id: "bill-1" as BillId,
         userId: "user-1" as UserId,
@@ -183,14 +182,16 @@ describe("useCalendarStore", () => {
     const { bills, isLoading } = useCalendarStore.getState();
     expect(isLoading).toBe(false);
     expect(bills).toHaveLength(1);
-    expect(bills[0].name).toBe("Netflix");
-    expect(bills[0].startDate).toBeInstanceOf(Date);
-    expect(bills[0].isActive).toBe(true);
+    expect(bills[0]?.name).toBe("Netflix");
+    expect(bills[0]?.startDate).toBeInstanceOf(Date);
+    expect(bills[0]?.isActive).toBe(true);
   });
 
   test("loadBills sets isLoading false on error", async () => {
     const { getAllBills } = await import("@/features/calendar/lib/repository");
-    vi.mocked(getAllBills).mockRejectedValueOnce(new Error("DB error"));
+    vi.mocked(getAllBills).mockImplementationOnce(() => {
+      throw new Error("DB error");
+    });
 
     await expect(useCalendarStore.getState().loadBills()).rejects.toThrow("DB error");
 
@@ -211,7 +212,9 @@ describe("useCalendarStore", () => {
 
   test("addBill returns false when insertBill throws", async () => {
     const { insertBill } = await import("@/features/calendar/lib/repository");
-    vi.mocked(insertBill).mockRejectedValueOnce(new Error("DB write error"));
+    vi.mocked(insertBill).mockImplementationOnce(() => {
+      throw new Error("DB write error");
+    });
 
     const result = await useCalendarStore
       .getState()
@@ -227,11 +230,11 @@ describe("useCalendarStore", () => {
     await useCalendarStore
       .getState()
       .addBill("Netflix", "35000", "monthly", "services" as CategoryId, testDate);
-    const billId = useCalendarStore.getState().bills[0].id as BillId;
+    const billId = useCalendarStore.getState().bills[0]?.id as BillId;
 
     await useCalendarStore.getState().updateBill(billId, { name: "Hulu" });
 
-    const updated = useCalendarStore.getState().bills[0];
+    const updated = useCalendarStore.getState().bills[0]!;
     expect(updated.name).toBe("Hulu");
   });
 
@@ -242,7 +245,7 @@ describe("useCalendarStore", () => {
     await useCalendarStore
       .getState()
       .addBill("Netflix", "35000", "monthly", "services" as CategoryId, testDate);
-    const billId = useCalendarStore.getState().bills[0].id as BillId;
+    const billId = useCalendarStore.getState().bills[0]?.id as BillId;
     const newDate = new Date("2026-06-01T00:00:00.000Z");
 
     await useCalendarStore.getState().updateBill(billId, { startDate: newDate });
@@ -271,7 +274,7 @@ describe("useCalendarStore", () => {
     await useCalendarStore
       .getState()
       .addBill("Netflix", "35000", "monthly", "services" as CategoryId, testDate);
-    const billId = useCalendarStore.getState().bills[0].id as BillId;
+    const billId = useCalendarStore.getState().bills[0]?.id as BillId;
 
     // Manually add a payment for this bill
     useCalendarStore.setState((s) => ({
@@ -301,7 +304,7 @@ describe("useCalendarStore", () => {
     await useCalendarStore
       .getState()
       .addBill("Netflix", "35000", "monthly", "services" as CategoryId, testDate);
-    const billId = useCalendarStore.getState().bills[0].id as BillId;
+    const billId = useCalendarStore.getState().bills[0]?.id as BillId;
 
     // Seed payment with a linked transaction
     useTransactionStore.setState({
@@ -361,15 +364,15 @@ describe("useCalendarStore", () => {
     await useCalendarStore
       .getState()
       .addBill("Netflix", "35000", "monthly", "services" as CategoryId, testDate);
-    const billId = useCalendarStore.getState().bills[0].id as BillId;
+    const billId = useCalendarStore.getState().bills[0]?.id as BillId;
 
     await useCalendarStore.getState().markBillPaid(billId, "2026-03-15" as IsoDate);
 
     const { payments } = useCalendarStore.getState();
     expect(payments).toHaveLength(1);
-    expect(payments[0].billId).toBe(billId);
-    expect(payments[0].dueDate).toBe("2026-03-15");
-    expect(payments[0].paidAt).toBeDefined();
+    expect(payments[0]?.billId).toBe(billId);
+    expect(payments[0]?.dueDate).toBe("2026-03-15");
+    expect(payments[0]?.paidAt).toBeDefined();
     expect(insertBillPayment).toHaveBeenCalledTimes(1);
   });
 
@@ -380,12 +383,12 @@ describe("useCalendarStore", () => {
     await useCalendarStore
       .getState()
       .addBill("Netflix", "35000", "monthly", "services" as CategoryId, testDate);
-    const billId = useCalendarStore.getState().bills[0].id as BillId;
+    const billId = useCalendarStore.getState().bills[0]?.id as BillId;
 
     await useCalendarStore.getState().markBillPaid(billId, "2026-03-15" as IsoDate);
 
     expect(insertTransaction).toHaveBeenCalledTimes(1);
-    const txRow = vi.mocked(insertTransaction).mock.calls[0][1];
+    const txRow = vi.mocked(insertTransaction).mock.calls[0]![1];
     expect(txRow.type).toBe("expense");
     expect(txRow.amount).toBe(35000);
     expect(txRow.categoryId).toBe("services");
@@ -396,13 +399,13 @@ describe("useCalendarStore", () => {
     await useCalendarStore
       .getState()
       .addBill("Netflix", "35000", "monthly", "services" as CategoryId, testDate);
-    const billId = useCalendarStore.getState().bills[0].id as BillId;
+    const billId = useCalendarStore.getState().bills[0]?.id as BillId;
 
     await useCalendarStore.getState().markBillPaid(billId, "2026-03-15" as IsoDate);
 
     const { payments } = useCalendarStore.getState();
-    expect(payments[0].transactionId).toBeDefined();
-    expect(payments[0].transactionId).toMatch(/^txn-/);
+    expect(payments[0]?.transactionId).toBeDefined();
+    expect(payments[0]?.transactionId).toMatch(/^txn-/);
   });
 
   test("markBillPaid updates transaction store state", async () => {
@@ -411,15 +414,15 @@ describe("useCalendarStore", () => {
     await useCalendarStore
       .getState()
       .addBill("Netflix", "35000", "monthly", "services" as CategoryId, testDate);
-    const billId = useCalendarStore.getState().bills[0].id as BillId;
+    const billId = useCalendarStore.getState().bills[0]?.id as BillId;
 
     await useCalendarStore.getState().markBillPaid(billId, "2026-03-15" as IsoDate);
 
     const txs = useTransactionStore.getState().pages;
     expect(txs).toHaveLength(1);
-    expect(txs[0].type).toBe("expense");
-    expect(txs[0].amount).toBe(35000);
-    expect(txs[0].description).toBe("Netflix");
+    expect(txs[0]?.type).toBe("expense");
+    expect(txs[0]?.amount).toBe(35000);
+    expect(txs[0]?.description).toBe("Netflix");
   });
 
   test("markBillPaid enqueues sync for the transaction", async () => {
@@ -429,7 +432,7 @@ describe("useCalendarStore", () => {
     await useCalendarStore
       .getState()
       .addBill("Netflix", "35000", "monthly", "services" as CategoryId, testDate);
-    const billId = useCalendarStore.getState().bills[0].id as BillId;
+    const billId = useCalendarStore.getState().bills[0]?.id as BillId;
 
     await useCalendarStore.getState().markBillPaid(billId, "2026-03-15" as IsoDate);
 
@@ -555,7 +558,7 @@ describe("useCalendarStore", () => {
 
   test("loadPaymentsForMonth populates payments from DB", async () => {
     const { getBillPaymentsForMonth } = await import("@/features/calendar/lib/repository");
-    vi.mocked(getBillPaymentsForMonth).mockResolvedValueOnce([
+    vi.mocked(getBillPaymentsForMonth).mockReturnValueOnce([
       {
         id: "pay-1" as BillPaymentId,
         billId: "bill-1" as BillId,
@@ -570,7 +573,7 @@ describe("useCalendarStore", () => {
 
     const { payments } = useCalendarStore.getState();
     expect(payments).toHaveLength(1);
-    expect(payments[0].billId).toBe("bill-1");
+    expect(payments[0]?.billId).toBe("bill-1");
   });
 
   test("loadPaymentsForMonth preserves existing payments on error", async () => {
@@ -590,12 +593,14 @@ describe("useCalendarStore", () => {
       ],
     });
 
-    vi.mocked(getBillPaymentsForMonth).mockRejectedValueOnce(new Error("DB error"));
+    vi.mocked(getBillPaymentsForMonth).mockImplementationOnce(() => {
+      throw new Error("DB error");
+    });
 
     await expect(useCalendarStore.getState().loadPaymentsForMonth()).rejects.toThrow("DB error");
 
     const { payments } = useCalendarStore.getState();
     expect(payments).toHaveLength(1);
-    expect(payments[0].id).toBe("pay-existing");
+    expect(payments[0]?.id).toBe("pay-existing");
   });
 });

--- a/apps/mobile/__tests__/capture-sources/apple-pay-pipeline.test.ts
+++ b/apps/mobile/__tests__/capture-sources/apple-pay-pipeline.test.ts
@@ -1,6 +1,9 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: mock db needs flexible typing
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { ApplePayIntentData } from "@/features/capture-sources/schema";
+import { processApplePayIntent } from "@/features/capture-sources/services/apple-pay-pipeline";
+
 const mockInsertTransaction = vi.fn();
 const mockEnqueueSync = vi.fn();
 const mockLookupMerchantRule = vi.fn().mockResolvedValue(null);
@@ -45,9 +48,6 @@ vi.mock("@/shared/lib/generate-id", () => ({
   generateProcessedCaptureId: () => mockGenerateId("pc"),
   generateSyncQueueId: () => mockGenerateId("sq"),
 }));
-
-import type { ApplePayIntentData } from "@/features/capture-sources/schema";
-import { processApplePayIntent } from "@/features/capture-sources/services/apple-pay-pipeline";
 
 const mockDb = {} as any;
 const USER_ID = "user-1";

--- a/apps/mobile/__tests__/capture-sources/expo-app-intents.test.ts
+++ b/apps/mobile/__tests__/capture-sources/expo-app-intents.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  addDetectBankSmsListener,
+  addLogTransactionListener,
+  isAvailable,
+} from "@/modules/expo-app-intents";
+
 const { mockAddListener, mockIsAvailable } = vi.hoisted(() => ({
   mockAddListener: vi.fn(() => ({ remove: vi.fn() })),
   mockIsAvailable: vi.fn(() => true),
@@ -16,12 +22,6 @@ vi.mock("react-native", () => ({
   // biome-ignore lint/style/useNamingConvention: matches React Native API
   Platform: { OS: "ios" },
 }));
-
-import {
-  addDetectBankSmsListener,
-  addLogTransactionListener,
-  isAvailable,
-} from "@/modules/expo-app-intents";
 
 describe("expo-app-intents JS API", () => {
   beforeEach(() => {

--- a/apps/mobile/__tests__/capture-sources/hooks.test.ts
+++ b/apps/mobile/__tests__/capture-sources/hooks.test.ts
@@ -1,6 +1,12 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: mock db needs flexible typing
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  setupApplePayCapture,
+  setupNotificationCapture,
+  setupSmsDetection,
+} from "@/features/capture-sources/hooks/setup";
+
 const mockAddLogTransactionListener = vi.fn().mockReturnValue({ remove: vi.fn() });
 const mockAddDetectBankSmsListener = vi.fn().mockReturnValue({ remove: vi.fn() });
 const mockIsAvailable = vi.fn().mockReturnValue(true);
@@ -38,12 +44,6 @@ vi.mock("@/shared/lib/generate-id", () => ({
   generateId: (prefix: string) => `${prefix}-1`,
   generateDetectedSmsEventId: () => "sms-1",
 }));
-
-import {
-  setupApplePayCapture,
-  setupNotificationCapture,
-  setupSmsDetection,
-} from "@/features/capture-sources/hooks/setup";
 
 const mockDb = {} as any;
 const USER_ID = "user-1";

--- a/apps/mobile/__tests__/capture-sources/notification-pipeline.test.ts
+++ b/apps/mobile/__tests__/capture-sources/notification-pipeline.test.ts
@@ -1,6 +1,9 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: mock db needs flexible typing
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { NotificationData } from "@/features/capture-sources/schema";
+import { processNotification } from "@/features/capture-sources/services/notification-pipeline";
+
 const mockInsertTransaction = vi.fn();
 const mockEnqueueSync = vi.fn();
 const mockLookupMerchantRule = vi.fn().mockResolvedValue(null);
@@ -50,9 +53,6 @@ vi.mock("@/shared/lib/generate-id", () => ({
   generateProcessedCaptureId: () => mockGenerateId("pc"),
   generateSyncQueueId: () => mockGenerateId("sq"),
 }));
-
-import type { NotificationData } from "@/features/capture-sources/schema";
-import { processNotification } from "@/features/capture-sources/services/notification-pipeline";
 
 const mockDb = {} as any;
 const USER_ID = "user-1";

--- a/apps/mobile/__tests__/capture-sources/store.test.ts
+++ b/apps/mobile/__tests__/capture-sources/store.test.ts
@@ -1,6 +1,8 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: mock db needs flexible typing
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { useCaptureSourcesStore } from "@/features/capture-sources/store";
+
 const mockGetEnabledPackages = vi.fn().mockResolvedValue([]);
 const mockUpsertNotificationSource = vi.fn();
 const mockHasProcessedCaptures = vi.fn().mockResolvedValue(false);
@@ -17,8 +19,6 @@ vi.mock("@/shared/lib/generate-id", () => ({
   generateId: (prefix: string) => `${prefix}-1`,
   generateNotificationSourceId: () => "ns-1",
 }));
-
-import { useCaptureSourcesStore } from "@/features/capture-sources/store";
 
 const mockDb = {} as any;
 const USER_ID = "user-1";

--- a/apps/mobile/__tests__/categories/store.test.ts
+++ b/apps/mobile/__tests__/categories/store.test.ts
@@ -1,6 +1,11 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: mock db needs flexible typing
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { getUserCategoriesForUser, insertUserCategory } from "@/features/categories/lib/repository";
+import { CATEGORIES } from "@/features/transactions/lib/categories";
+import { enqueueSync } from "@/shared/db/enqueue-sync";
+import type { IsoDateTime, UserCategoryId, UserId } from "@/shared/types/branded";
+
 // Mock the repository
 vi.mock("@/features/categories/lib/repository", () => ({
   getUserCategoriesForUser: vi.fn().mockReturnValue([]),
@@ -9,6 +14,7 @@ vi.mock("@/features/categories/lib/repository", () => ({
 
 // Mock the icon-map
 vi.mock("@/features/categories/lib/icon-map", () => ({
+  // biome-ignore lint/style/useNamingConvention: mirrors the actual ICON_MAP export
   ICON_MAP: { Zap: () => null, PawPrint: () => null, ShoppingCart: () => null },
 }));
 
@@ -19,6 +25,7 @@ vi.mock("@/shared/db/enqueue-sync", () => ({
 
 // Mock shared/lib — the store imports from the barrel
 vi.mock("@/shared/lib", async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   const actual = await importOriginal<typeof import("@/shared/lib")>();
   return {
     ...actual,
@@ -27,11 +34,6 @@ vi.mock("@/shared/lib", async (importOriginal) => {
     toIsoDateTime: vi.fn().mockReturnValue("2026-03-21T12:00:00.000Z"),
   };
 });
-
-import { getUserCategoriesForUser, insertUserCategory } from "@/features/categories/lib/repository";
-import { CATEGORIES } from "@/features/transactions/lib/categories";
-import { enqueueSync } from "@/shared/db/enqueue-sync";
-import type { IsoDateTime, UserCategoryId, UserId } from "@/shared/types/branded";
 
 const mockDb = {
   insert: vi.fn(),
@@ -110,12 +112,12 @@ describe("useCategoriesStore", () => {
     expect(state.allCategories).toHaveLength(11);
     // Built-in first, then user categories
     expect(state.allCategories.slice(0, 10)).toEqual(CATEGORIES);
-    expect(state.allCategories[10].id).toBe("ucat-custom-1");
-    expect(state.allCategories[10].label).toEqual({
+    expect(state.allCategories[10]?.id).toBe("ucat-custom-1");
+    expect(state.allCategories[10]?.label).toEqual({
       en: "Groceries",
       es: "Groceries",
     });
-    expect(state.allCategories[10].color).toBe("#FF5722");
+    expect(state.allCategories[10]?.color).toBe("#FF5722");
   });
 
   it("isValidCategoryId returns true for user category ID after load", async () => {
@@ -157,10 +159,10 @@ describe("useCategoriesStore", () => {
     await store.getState().loadUserCategories();
 
     const state = store.getState();
-    const icon = state.allCategories[10].icon;
+    const icon = state.allCategories[10]?.icon;
     expect(icon).toBeDefined();
     // Must NOT be any of the ICON_MAP mock values — proves fallback was used
-    const mockIcons: Array<() => null> = [() => null, () => null, () => null];
+    const mockIcons: (() => null)[] = [() => null, () => null, () => null];
     expect(mockIcons).not.toContain(icon);
   });
 

--- a/apps/mobile/__tests__/dashboard/compute-arcs.test.ts
+++ b/apps/mobile/__tests__/dashboard/compute-arcs.test.ts
@@ -37,16 +37,16 @@ describe("computeArcs", () => {
   test("single 100% segment", () => {
     const arcs = computeArcs([{ percentage: 100, color: "#FF0000" }], circumference);
     expect(arcs).toHaveLength(1);
-    expect(arcs[0].dash).toBeCloseTo(circumference, 5);
-    expect(arcs[0].offset).toBeCloseTo(0, 5);
-    expect(arcs[0].rotation).toBe(-90);
+    expect(arcs[0]?.dash).toBeCloseTo(circumference, 5);
+    expect(arcs[0]?.offset).toBeCloseTo(0, 5);
+    expect(arcs[0]?.rotation).toBe(-90);
   });
 
   test("single 50% segment", () => {
     const arcs = computeArcs([{ percentage: 50, color: "#00FF00" }], circumference);
     expect(arcs).toHaveLength(1);
-    expect(arcs[0].dash).toBeCloseTo(circumference / 2, 5);
-    expect(arcs[0].offset).toBeCloseTo(circumference / 2, 5);
+    expect(arcs[0]?.dash).toBeCloseTo(circumference / 2, 5);
+    expect(arcs[0]?.offset).toBeCloseTo(circumference / 2, 5);
   });
 
   test("two equal 50% segments", () => {
@@ -58,8 +58,8 @@ describe("computeArcs", () => {
       circumference
     );
     expect(arcs).toHaveLength(2);
-    expect(arcs[0].rotation).toBe(-90);
-    expect(arcs[1].rotation).toBeCloseTo(90, 5);
+    expect(arcs[0]?.rotation).toBe(-90);
+    expect(arcs[1]?.rotation).toBeCloseTo(90, 5);
   });
 
   test("three segments (35/25/40)", () => {
@@ -97,14 +97,14 @@ describe("computeArcs", () => {
       ],
       circumference
     );
-    expect(arcs[0].color).toBe("#AABBCC");
-    expect(arcs[1].color).toBe("#DDEEFF");
+    expect(arcs[0]?.color).toBe("#AABBCC");
+    expect(arcs[1]?.color).toBe("#DDEEFF");
   });
 
   test("handles 0% segment", () => {
     const arcs = computeArcs([{ percentage: 0, color: "#000000" }], circumference);
     expect(arcs).toHaveLength(1);
-    expect(arcs[0].dash).toBe(0);
-    expect(arcs[0].offset).toBeCloseTo(circumference, 5);
+    expect(arcs[0]?.dash).toBe(0);
+    expect(arcs[0]?.offset).toBeCloseTo(circumference, 5);
   });
 });

--- a/apps/mobile/__tests__/db/client.test.ts
+++ b/apps/mobile/__tests__/db/client.test.ts
@@ -1,4 +1,8 @@
+import { getRandomBytes } from "expo-crypto";
+import { deleteItemAsync, getItem, setItem } from "expo-secure-store";
+import { openDatabaseSync } from "expo-sqlite";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getDb, resetDb } from "@/shared/db/client";
 
 vi.mock("expo-sqlite", () => ({
   openDatabaseSync: vi.fn(() => ({ execSync: vi.fn(), closeSync: vi.fn() })),
@@ -23,11 +27,6 @@ vi.mock("@/shared/lib/sentry", () => ({
   capturePipelineEvent: vi.fn(),
   captureWarning: vi.fn(),
 }));
-
-import { getRandomBytes } from "expo-crypto";
-import { deleteItemAsync, getItem, setItem } from "expo-secure-store";
-import { openDatabaseSync } from "expo-sqlite";
-import { getDb, resetDb } from "@/shared/db/client";
 
 describe("getDb", () => {
   beforeEach(() => {

--- a/apps/mobile/__tests__/email-capture/bank-senders.test.ts
+++ b/apps/mobile/__tests__/email-capture/bank-senders.test.ts
@@ -9,11 +9,11 @@ import {
   resetBankSendersCache,
 } from "@/features/email-capture/services/bank-senders-cache";
 
+import { getSupabase } from "@/shared/db/supabase";
+
 vi.mock("@/shared/db/supabase", () => ({
   getSupabase: vi.fn(),
 }));
-
-import { getSupabase } from "@/shared/db/supabase";
 
 const mockFrom = vi.fn();
 const mockSelect = vi.fn();

--- a/apps/mobile/__tests__/email-capture/email-adapter.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-adapter.test.ts
@@ -1,6 +1,12 @@
 // biome-ignore-all lint/style/useNamingConvention: OAuth/API response fixtures use snake_case keys
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type {
+  EmailProviderConfig,
+  FetchEmailsFn,
+} from "@/features/email-capture/services/email-adapter";
+import { createAdapter, getAdapter } from "@/features/email-capture/services/email-adapter";
+
 const mockGetItemAsync = vi.fn();
 const mockSetItemAsync = vi.fn();
 const mockDeleteItemAsync = vi.fn();
@@ -26,12 +32,6 @@ vi.mock("expo-crypto", () => ({
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
-import type {
-  EmailProviderConfig,
-  FetchEmailsFn,
-} from "@/features/email-capture/services/email-adapter";
-import { createAdapter } from "@/features/email-capture/services/email-adapter";
-
 const testConfig: EmailProviderConfig = {
   provider: "gmail",
   tokenKey: "test-token",
@@ -41,7 +41,7 @@ const testConfig: EmailProviderConfig = {
   scope: "read",
   getRedirectUri: () => "fidy://test/callback",
   profileUrl: "https://profile.example.com/me",
-  extractEmail: (profile) => (profile.email as string) ?? null,
+  extractEmail: (profile) => (typeof profile.email === "string" ? profile.email : null),
   extraAuthParams: {},
   extraTokenExchangeParams: {},
   extraRefreshParams: {},
@@ -234,7 +234,7 @@ describe("createAdapter", () => {
       const adapter = createAdapter(configWithExtra, stubFetch);
       await adapter.connect("client-id");
 
-      const calledUrl = mockOpenAuthSession.mock.calls[0][0] as string;
+      const calledUrl = mockOpenAuthSession.mock.calls[0]?.[0] as string;
       expect(calledUrl).toContain("access_type=offline");
       expect(calledUrl).toContain("prompt=consent");
     });
@@ -255,7 +255,7 @@ describe("createAdapter", () => {
       const adapter = createAdapter(configWithExtra, stubFetch);
       await adapter.connect("client-id");
 
-      const body = mockFetch.mock.calls[0][1]?.body as string;
+      const body = mockFetch.mock.calls[0]?.[1]?.body as string;
       expect(body).toContain("scope=read+write");
     });
   });
@@ -360,13 +360,11 @@ describe("createAdapter", () => {
       const adapter = createAdapter(configWithRefresh, fetchFn);
       await adapter.fetchEmails("client-id", "2026-03-01", ["a@b.com"]);
 
-      const refreshBody = mockFetch.mock.calls[1][1]?.body as string;
+      const refreshBody = mockFetch.mock.calls[1]?.[1]?.body as string;
       expect(refreshBody).toContain("scope=read+User.Read");
     });
   });
 });
-
-import { getAdapter } from "@/features/email-capture/services/email-adapter";
 
 describe("getAdapter", () => {
   it("returns a gmail adapter with isConnected callable", async () => {

--- a/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
@@ -2,6 +2,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RawEmail } from "@/features/email-capture/schema";
 
+import { processEmails, processRetries } from "@/features/email-capture/services/email-pipeline";
+
 const mockGetProcessedExternalIds = vi.fn().mockResolvedValue(new Set<string>());
 const mockInsertProcessedEmail = vi.fn();
 const mockInsertTransaction = vi.fn();
@@ -60,8 +62,6 @@ vi.mock("@/shared/lib/generate-id", () => ({
   generateProcessedEmailId: () => mockGenerateId("pe"),
   generateSyncQueueId: () => mockGenerateId("sq"),
 }));
-
-import { processEmails, processRetries } from "@/features/email-capture/services/email-pipeline";
 
 const mockDb = {} as any;
 const USER_ID = "user-1";
@@ -302,7 +302,7 @@ describe("email processing pipeline", () => {
       })
     );
     // nextRetryAt should be set
-    const call = mockInsertProcessedEmail.mock.calls[0][1];
+    const call = mockInsertProcessedEmail.mock.calls[0]?.[1];
     expect(call.nextRetryAt).toBeTruthy();
   });
 
@@ -321,7 +321,7 @@ describe("email processing pipeline", () => {
       })
     );
     // rawBody should NOT be cached for skipped emails
-    const call = mockInsertProcessedEmail.mock.calls[0][1];
+    const call = mockInsertProcessedEmail.mock.calls[0]?.[1];
     expect(call.rawBody).toBeUndefined();
   });
 
@@ -346,13 +346,13 @@ describe("email processing pipeline", () => {
       confidence: 0.9,
     });
 
-    const progressCalls: Array<{
+    const progressCalls: {
       total: number;
       completed: number;
       saved: number;
       failed: number;
       needsReview: number;
-    }> = [];
+    }[] = [];
 
     await processEmails(mockDb, USER_ID, emails, (p) => progressCalls.push(p));
 
@@ -363,11 +363,11 @@ describe("email processing pipeline", () => {
       expect.objectContaining({ total: 2, completed: 0, saved: 0, failed: 0, needsReview: 0 })
     );
     // After first email (needs_review): needsReview = 1
-    const afterFirst = progressCalls[1];
+    const afterFirst = progressCalls[1]!;
     expect(afterFirst.needsReview).toBe(1);
     expect(afterFirst.saved).toBe(0);
     // After second email (saved): saved = 1
-    const last = progressCalls[progressCalls.length - 1];
+    const last = progressCalls[progressCalls.length - 1]!;
     expect(last.needsReview).toBe(1);
     expect(last.saved).toBe(1);
   });
@@ -612,7 +612,9 @@ describe("processRetries", () => {
       date: "2026-03-05",
       confidence: 0.9,
     });
-    mockInsertTransaction.mockRejectedValueOnce(new Error("DB constraint error"));
+    mockInsertTransaction.mockImplementationOnce(() => {
+      throw new Error("DB constraint error");
+    });
 
     const result = await processRetries(mockDb, USER_ID);
 
@@ -632,7 +634,9 @@ describe("processRetries", () => {
       date: "2026-03-05",
       confidence: 0.9,
     });
-    mockInsertTransaction.mockRejectedValueOnce(new Error("DB constraint error"));
+    mockInsertTransaction.mockImplementationOnce(() => {
+      throw new Error("DB constraint error");
+    });
 
     const result = await processRetries(mockDb, USER_ID);
 

--- a/apps/mobile/__tests__/email-capture/gmail-adapter.test.ts
+++ b/apps/mobile/__tests__/email-capture/gmail-adapter.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { fetchGmailEmailsWithToken } from "@/features/email-capture/services/gmail-adapter";
+
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
-
-import { fetchGmailEmailsWithToken } from "@/features/email-capture/services/gmail-adapter";
 
 describe("gmail adapter", () => {
   beforeEach(() => {
@@ -80,7 +80,7 @@ describe("gmail adapter", () => {
         "bank@example.com",
       ]);
 
-      expect(emails[0].body).toBe(utf8Text);
+      expect(emails[0]?.body).toBe(utf8Text);
     });
 
     it("handles invalid date header gracefully", async () => {
@@ -110,8 +110,8 @@ describe("gmail adapter", () => {
       ]);
 
       expect(emails).toHaveLength(1);
-      expect(emails[0].receivedAt).toBeDefined();
-      expect(() => new Date(emails[0].receivedAt)).not.toThrow();
+      expect(emails[0]?.receivedAt).toBeDefined();
+      expect(() => new Date(emails[0]!.receivedAt)).not.toThrow();
     });
 
     it("returns empty array when no messages found", async () => {

--- a/apps/mobile/__tests__/email-capture/merchant-rules.test.ts
+++ b/apps/mobile/__tests__/email-capture/merchant-rules.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  insertMerchantRule,
+  lookupMerchantRule,
+} from "../../features/email-capture/lib/merchant-rules";
+
 vi.mock("drizzle-orm", () => ({
   and: vi.fn((...args: unknown[]) => args),
   eq: vi.fn((col: unknown, val: unknown) => ({ col, val })),
@@ -29,11 +34,6 @@ const mockDb = {
   })),
   // biome-ignore lint/suspicious/noExplicitAny: mock DB object for testing
 } as any;
-
-import {
-  insertMerchantRule,
-  lookupMerchantRule,
-} from "../../features/email-capture/lib/merchant-rules";
 
 describe("merchant-rules", () => {
   beforeEach(() => vi.clearAllMocks());

--- a/apps/mobile/__tests__/email-capture/outlook-adapter.test.ts
+++ b/apps/mobile/__tests__/email-capture/outlook-adapter.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { fetchOutlookEmailsWithToken } from "@/features/email-capture/services/outlook-adapter";
+
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
-
-import { fetchOutlookEmailsWithToken } from "@/features/email-capture/services/outlook-adapter";
 
 describe("outlook adapter", () => {
   beforeEach(() => {

--- a/apps/mobile/__tests__/email-capture/parse-email-api.test.ts
+++ b/apps/mobile/__tests__/email-capture/parse-email-api.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  classifyMerchantApi,
+  parseEmailApi,
+  stripPii,
+} from "@/features/email-capture/services/parse-email-api";
+
 const mockInvoke = vi.fn();
 
 vi.mock("@/shared/db/supabase", () => ({
@@ -7,12 +13,6 @@ vi.mock("@/shared/db/supabase", () => ({
     functions: { invoke: mockInvoke },
   }),
 }));
-
-import {
-  classifyMerchantApi,
-  parseEmailApi,
-  stripPii,
-} from "@/features/email-capture/services/parse-email-api";
 
 describe("stripPii", () => {
   it("removes email addresses", () => {

--- a/apps/mobile/__tests__/email-capture/retry-integration.test.ts
+++ b/apps/mobile/__tests__/email-capture/retry-integration.test.ts
@@ -11,9 +11,19 @@
 
 import { resolve } from "node:path";
 import Database from "better-sqlite3";
+import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getPendingRetryEmails,
+  markForRetry,
+  markPermanentlyFailed,
+  markRetrySuccess,
+} from "@/features/email-capture/lib/repository";
+import { processRetries } from "@/features/email-capture/services/email-pipeline";
+import { processedEmails, syncQueue, transactions } from "@/shared/db/schema";
+import type { IsoDateTime, ProcessedEmailId, TransactionId } from "@/shared/types/branded";
 
 const mockParseEmailApi = vi.fn();
 vi.mock("@/features/email-capture/services/parse-email-api", () => ({
@@ -30,17 +40,6 @@ const mockFindDuplicateTransaction = vi.fn().mockResolvedValue(null);
 vi.mock("@/features/capture-sources/lib/dedup", () => ({
   findDuplicateTransaction: (...args: unknown[]) => mockFindDuplicateTransaction(...args),
 }));
-
-import { eq } from "drizzle-orm";
-import {
-  getPendingRetryEmails,
-  markForRetry,
-  markPermanentlyFailed,
-  markRetrySuccess,
-} from "@/features/email-capture/lib/repository";
-import { processRetries } from "@/features/email-capture/services/email-pipeline";
-import { processedEmails, syncQueue, transactions } from "@/shared/db/schema";
-import type { IsoDateTime, ProcessedEmailId, TransactionId } from "@/shared/types/branded";
 
 let sqlite: InstanceType<typeof Database>;
 let db: ReturnType<typeof drizzle>;
@@ -99,8 +98,8 @@ describe("retry queue integration (real SQLite)", () => {
     const results = await getPendingRetryEmails(db as any);
 
     expect(results).toHaveLength(1);
-    expect(results[0].id).toBe("pe-retry-1");
-    expect(results[0].rawBody).toBe("Su compra por $50.000 fue aprobada en EXITO");
+    expect(results[0]?.id).toBe("pe-retry-1");
+    expect(results[0]?.rawBody).toBe("Su compra por $50.000 fue aprobada en EXITO");
   });
 
   it("getPendingRetryEmails excludes emails with nextRetryAt in the future", async () => {
@@ -137,10 +136,10 @@ describe("retry queue integration (real SQLite)", () => {
       .select()
       .from(processedEmails)
       .where(eq(processedEmails.id, "pe-retry-1" as ProcessedEmailId));
-    expect(row.retryCount).toBe(2);
-    expect(row.nextRetryAt).toBe(futureTime);
-    expect(row.rawBody).toBe("Su compra por $50.000 fue aprobada en EXITO");
-    expect(row.status).toBe("pending_retry");
+    expect(row?.retryCount).toBe(2);
+    expect(row?.nextRetryAt).toBe(futureTime);
+    expect(row?.rawBody).toBe("Su compra por $50.000 fue aprobada en EXITO");
+    expect(row?.status).toBe("pending_retry");
   });
 
   it("markPermanentlyFailed sets status=failed and clears rawBody", async () => {
@@ -152,8 +151,8 @@ describe("retry queue integration (real SQLite)", () => {
       .select()
       .from(processedEmails)
       .where(eq(processedEmails.id, "pe-retry-1" as ProcessedEmailId));
-    expect(row.status).toBe("failed");
-    expect(row.rawBody).toBeNull();
+    expect(row?.status).toBe("failed");
+    expect(row?.rawBody).toBeNull();
   });
 
   it("markRetrySuccess sets status/transactionId/confidence and clears rawBody", async () => {
@@ -171,10 +170,10 @@ describe("retry queue integration (real SQLite)", () => {
       .select()
       .from(processedEmails)
       .where(eq(processedEmails.id, "pe-retry-1" as ProcessedEmailId));
-    expect(row.status).toBe("success");
-    expect(row.transactionId).toBe("tx-42");
-    expect(row.confidence).toBe(0.95);
-    expect(row.rawBody).toBeNull();
+    expect(row?.status).toBe("success");
+    expect(row?.transactionId).toBe("tx-42");
+    expect(row?.confidence).toBe(0.95);
+    expect(row?.rawBody).toBeNull();
   });
 
   it("full flow: pending_retry email → successful retry → transaction created", async () => {
@@ -202,22 +201,22 @@ describe("retry queue integration (real SQLite)", () => {
     // Verify transaction was created in DB
     const txRows = await db.select().from(transactions);
     expect(txRows).toHaveLength(1);
-    expect(txRows[0].amount).toBe(50000);
-    expect(txRows[0].source).toBe("email_gmail");
+    expect(txRows[0]?.amount).toBe(50000);
+    expect(txRows[0]?.source).toBe("email_gmail");
 
     // Verify sync queue entry
     const syncRows = await db.select().from(syncQueue);
     expect(syncRows).toHaveLength(1);
-    expect(syncRows[0].tableName).toBe("transactions");
+    expect(syncRows[0]?.tableName).toBe("transactions");
 
     // Verify processed email was updated
     const [pe] = await db
       .select()
       .from(processedEmails)
       .where(eq(processedEmails.id, "pe-retry-1" as ProcessedEmailId));
-    expect(pe.status).toBe("success");
-    expect(pe.rawBody).toBeNull();
-    expect(pe.transactionId).toBe(txRows[0].id);
+    expect(pe?.status).toBe("success");
+    expect(pe?.rawBody).toBeNull();
+    expect(pe?.transactionId).toBe(txRows[0]?.id);
   });
 
   it("full flow: pending_retry email → parse fails again → rescheduled with backoff", async () => {
@@ -236,12 +235,12 @@ describe("retry queue integration (real SQLite)", () => {
       .select()
       .from(processedEmails)
       .where(eq(processedEmails.id, "pe-retry-1" as ProcessedEmailId));
-    expect(pe.retryCount).toBe(3);
-    expect(pe.status).toBe("pending_retry");
-    expect(pe.rawBody).toBe("Su compra por $50.000 fue aprobada en EXITO");
+    expect(pe?.retryCount).toBe(3);
+    expect(pe?.status).toBe("pending_retry");
+    expect(pe?.rawBody).toBe("Su compra por $50.000 fue aprobada en EXITO");
 
     // nextRetryAt should be in the future
-    const nextRetry = new Date(pe.nextRetryAt ?? "");
+    const nextRetry = new Date(pe?.nextRetryAt ?? "");
     expect(nextRetry.getTime()).toBeGreaterThan(Date.now());
   });
 
@@ -259,8 +258,8 @@ describe("retry queue integration (real SQLite)", () => {
       .select()
       .from(processedEmails)
       .where(eq(processedEmails.id, "pe-retry-1" as ProcessedEmailId));
-    expect(pe.status).toBe("failed");
-    expect(pe.rawBody).toBeNull();
+    expect(pe?.status).toBe("failed");
+    expect(pe?.rawBody).toBeNull();
   });
 
   it("ISO timestamp comparison is correct in SQLite", () => {
@@ -272,27 +271,27 @@ describe("retry queue integration (real SQLite)", () => {
         "SELECT strftime('%Y-%m-%dT%H:%M:%fZ', 'now') as now_iso, datetime('now') as now_plain"
       )
       // biome-ignore lint/style/useNamingConvention: SQL column aliases
-      .all() as Array<{ now_iso: string; now_plain: string }>;
+      .all() as { now_iso: string; now_plain: string }[];
 
     // ISO format should have T separator and Z suffix
-    expect(row.now_iso).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    expect(row?.now_iso).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
     // Plain datetime should NOT have T or Z
-    expect(row.now_plain).not.toContain("T");
+    expect(row?.now_plain).not.toContain("T");
 
     // An ISO timestamp should correctly compare against strftime ISO output
     const pastIso = new Date(Date.now() - 60_000).toISOString();
     const [cmp] = sqlite
       .prepare("SELECT ? <= strftime('%Y-%m-%dT%H:%M:%fZ', 'now') as is_due")
       // biome-ignore lint/style/useNamingConvention: SQL column alias
-      .all(pastIso) as Array<{ is_due: number }>;
-    expect(cmp.is_due).toBe(1);
+      .all(pastIso) as { is_due: number }[];
+    expect(cmp?.is_due).toBe(1);
 
     // A future ISO timestamp should NOT be due
     const futureIso = new Date(Date.now() + 600_000).toISOString();
     const [cmp2] = sqlite
       .prepare("SELECT ? <= strftime('%Y-%m-%dT%H:%M:%fZ', 'now') as is_due")
       // biome-ignore lint/style/useNamingConvention: SQL column alias
-      .all(futureIso) as Array<{ is_due: number }>;
-    expect(cmp2.is_due).toBe(0);
+      .all(futureIso) as { is_due: number }[];
+    expect(cmp2?.is_due).toBe(0);
   });
 });

--- a/apps/mobile/__tests__/email-capture/schema-compat.test.ts
+++ b/apps/mobile/__tests__/email-capture/schema-compat.test.ts
@@ -27,24 +27,26 @@ function extractPropertyKeys(source: string): string[] {
     /FULL_PARSE_SCHEMA\s*=\s*\{[\s\S]*?properties:\s*\{([\s\S]*?)\},\s*\n\s*required:/
   );
   if (!propsMatch) return [];
-  const propsBlock = propsMatch[1];
+  const propsBlock = propsMatch[1] ?? "";
   // Match only top-level property keys: `keyName: { type:` pattern
   const keyMatches = propsBlock.matchAll(/(\w+)\s*:\s*\{/g);
-  return [...keyMatches].map((m) => m[1]);
+  return [...keyMatches].map((m) => m[1] ?? "").filter(Boolean);
 }
 
 /** Extract required field names from FULL_PARSE_SCHEMA */
 function extractRequired(source: string): string[] {
   const reqMatch = source.match(/FULL_PARSE_SCHEMA[\s\S]*?required:\s*\[([\s\S]*?)\]/);
   if (!reqMatch) return [];
-  return [...reqMatch[1].matchAll(/"(\w+)"/g)].map((m) => m[1]);
+  const reqBlock = reqMatch[1] ?? "";
+  return [...reqBlock.matchAll(/"(\w+)"/g)].map((m) => m[1] ?? "").filter(Boolean);
 }
 
 /** Extract CATEGORY_IDS array values from the Edge Function source */
 function extractCategoryIds(source: string): string[] {
   const catMatch = source.match(/const CATEGORY_IDS\s*=\s*\[([\s\S]*?)\]\s*as const/);
   if (!catMatch) return [];
-  return [...catMatch[1].matchAll(/"(\w+)"/g)].map((m) => m[1]);
+  const catBlock = catMatch[1] ?? "";
+  return [...catBlock.matchAll(/"(\w+)"/g)].map((m) => m[1] ?? "").filter(Boolean);
 }
 
 /** Extract type enum values from FULL_PARSE_SCHEMA */
@@ -53,7 +55,8 @@ function extractTypeEnum(source: string): string[] {
     /FULL_PARSE_SCHEMA[\s\S]*?type:\s*\{\s*type:\s*"string",\s*enum:\s*\[([\s\S]*?)\]/
   );
   if (!typeMatch) return [];
-  return [...typeMatch[1].matchAll(/"(\w+)"/g)].map((m) => m[1]);
+  const typeBlock = typeMatch[1] ?? "";
+  return [...typeBlock.matchAll(/"(\w+)"/g)].map((m) => m[1] ?? "").filter(Boolean);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -1,4 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { insertMerchantRule } from "@/features/email-capture/lib/merchant-rules";
+import {
+  deleteEmailAccount,
+  dismissProcessedEmail,
+  getEmailAccounts,
+  getFailedEmails,
+  getNeedsReviewEmails,
+  insertEmailAccount,
+  updateLastFetchedAt,
+  updateProcessedEmailStatus,
+} from "@/features/email-capture/lib/repository";
+import { getAdapter } from "@/features/email-capture/services/email-adapter";
+import { processEmails } from "@/features/email-capture/services/email-pipeline";
+import { useEmailCaptureStore } from "@/features/email-capture/store";
 import type {
   EmailAccountId,
   IsoDateTime,
@@ -53,7 +67,7 @@ vi.mock("@/shared/lib/normalize-merchant", () => ({
 }));
 
 // Mock passes through real implementations for progress-phases
-const mockIsFirstFetchForAny = vi.fn((accounts: Array<{ lastFetchedAt: string | null }>) =>
+const mockIsFirstFetchForAny = vi.fn((accounts: { lastFetchedAt: string | null }[]) =>
   accounts.some((a) => a.lastFetchedAt === null)
 );
 const mockShouldShowProgress = vi.fn(
@@ -61,12 +75,13 @@ const mockShouldShowProgress = vi.fn(
 );
 vi.mock("@/features/email-capture/lib/progress-phases", () => ({
   isFirstFetchForAny: (...args: unknown[]) =>
-    mockIsFirstFetchForAny(...(args as [Array<{ lastFetchedAt: string | null }>])),
+    mockIsFirstFetchForAny(...(args as [{ lastFetchedAt: string | null }[]])),
   shouldShowProgress: (...args: unknown[]) =>
     mockShouldShowProgress(...(args as [number, boolean, number])),
 }));
 
 vi.mock("@/features/email-capture/lib/bank-senders", async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   const actual = await importOriginal<typeof import("@/features/email-capture/lib/bank-senders")>();
   return {
     ...actual,
@@ -98,21 +113,6 @@ vi.mock("@/shared/lib/generate-id", () => ({
   generateEmailAccountId: () => "ea-generated",
   generateSyncQueueId: () => "sq-generated",
 }));
-
-import { insertMerchantRule } from "@/features/email-capture/lib/merchant-rules";
-import {
-  deleteEmailAccount,
-  dismissProcessedEmail,
-  getEmailAccounts,
-  getFailedEmails,
-  getNeedsReviewEmails,
-  insertEmailAccount,
-  updateLastFetchedAt,
-  updateProcessedEmailStatus,
-} from "@/features/email-capture/lib/repository";
-import { getAdapter } from "@/features/email-capture/services/email-adapter";
-import { processEmails } from "@/features/email-capture/services/email-pipeline";
-import { useEmailCaptureStore } from "@/features/email-capture/store";
 
 const mockSelectWhere = vi.fn().mockResolvedValue([{ description: "Compra en Exito" }]);
 const mockDb = {
@@ -482,7 +482,7 @@ describe("useEmailCaptureStore", () => {
       ];
       mockAdapter.fetchEmails.mockResolvedValueOnce(mockRawEmails);
 
-      const phases: Array<string | null> = [];
+      const phases: (string | null)[] = [];
       vi.mocked(processEmails).mockImplementationOnce(async (_db, _uid, _emails, onProgress) => {
         phases.push(useEmailCaptureStore.getState().phase);
         onProgress?.({ total: 1, completed: 1, saved: 1, failed: 0, needsReview: 0 });
@@ -554,7 +554,7 @@ describe("useEmailCaptureStore", () => {
 
       await useEmailCaptureStore.getState().fetchAndProcess("g", "o");
 
-      const updatedAccount = useEmailCaptureStore.getState().accounts[0];
+      const updatedAccount = useEmailCaptureStore.getState().accounts[0]!;
       expect(updatedAccount.lastFetchedAt).not.toBeNull();
     });
 
@@ -649,7 +649,7 @@ describe("useEmailCaptureStore", () => {
         },
       ]);
 
-      const phases: Array<string | null> = [];
+      const phases: (string | null)[] = [];
       vi.mocked(processEmails).mockImplementationOnce(async (_db, _uid, _emails, onProgress) => {
         phases.push(useEmailCaptureStore.getState().phase);
         onProgress?.({ total: 1, completed: 1, saved: 0, failed: 0, needsReview: 0 });

--- a/apps/mobile/__tests__/error-handling/db-client-error.test.ts
+++ b/apps/mobile/__tests__/error-handling/db-client-error.test.ts
@@ -1,4 +1,6 @@
+import { openDatabaseSync } from "expo-sqlite";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getDb, resetDb } from "@/shared/db/client";
 
 const mockCaptureError = vi.fn();
 
@@ -22,9 +24,6 @@ vi.mock("expo-secure-store", () => ({
 vi.mock("expo-crypto", () => ({
   getRandomBytes: vi.fn(() => new Uint8Array(32)),
 }));
-
-import { openDatabaseSync } from "expo-sqlite";
-import { getDb, resetDb } from "@/shared/db/client";
 
 describe("getDb error path", () => {
   beforeEach(() => {

--- a/apps/mobile/__tests__/error-handling/pipeline-save-error.test.ts
+++ b/apps/mobile/__tests__/error-handling/pipeline-save-error.test.ts
@@ -2,6 +2,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RawEmail } from "@/features/email-capture/schema";
 
+import { processEmails } from "@/features/email-capture/services/email-pipeline";
+
 const mockCaptureError = vi.fn();
 
 vi.mock("@/shared/lib/sentry", () => ({
@@ -53,8 +55,6 @@ vi.mock("@/shared/lib/generate-id", () => ({
   generateSyncQueueId: () => mockGenerateId("sq"),
 }));
 
-import { processEmails } from "@/features/email-capture/services/email-pipeline";
-
 const mockDb = {} as any;
 const USER_ID = "user-1";
 
@@ -104,7 +104,9 @@ describe("pipeline worker save error path", () => {
       date: "2026-03-05",
       confidence: 0.9,
     });
-    mockInsertTransaction.mockRejectedValueOnce(saveError);
+    mockInsertTransaction.mockImplementationOnce(() => {
+      throw saveError;
+    });
 
     // Second email: LLM returns valid result, save succeeds
     mockParseEmailApi.mockResolvedValueOnce({

--- a/apps/mobile/__tests__/goals/derive.test.ts
+++ b/apps/mobile/__tests__/goals/derive.test.ts
@@ -1,15 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
 
-// Restore real date-fns (global setup mocks it without addMonths)
-vi.mock("date-fns", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("date-fns")>();
-  return { ...actual };
-});
-
-// Freeze "today" so projected dates are deterministic
-const FIXED_NOW = new Date("2026-03-19T12:00:00.000Z");
-vi.useFakeTimers({ now: FIXED_NOW });
-
 import {
   computeMedian,
   deriveBudgetNudges,
@@ -23,6 +13,17 @@ import {
   deriveMonthlyMilestones,
 } from "@/features/goals/lib/derive";
 import type { CopAmount } from "@/shared/types/branded";
+
+// Restore real date-fns (global setup mocks it without addMonths)
+vi.mock("date-fns", async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const actual = await importOriginal<typeof import("date-fns")>();
+  return { ...actual };
+});
+
+// Freeze "today" so projected dates are deterministic
+const FIXED_NOW = new Date("2026-03-19T12:00:00.000Z");
+vi.useFakeTimers({ now: FIXED_NOW });
 
 // ---------------------------------------------------------------------------
 // deriveGoalProgress
@@ -366,9 +367,9 @@ describe("deriveMonthlyMilestones", () => {
 
   it("generates correct cumulative targets", () => {
     const result = deriveMonthlyMilestones(500_000, 100_000, 3);
-    expect(result[0].cumulativeTarget).toBe(600_000);
-    expect(result[1].cumulativeTarget).toBe(700_000);
-    expect(result[2].cumulativeTarget).toBe(800_000);
+    expect(result[0]?.cumulativeTarget).toBe(600_000);
+    expect(result[1]?.cumulativeTarget).toBe(700_000);
+    expect(result[2]?.cumulativeTarget).toBe(800_000);
   });
 
   it("returns empty array when monthsToGo is 0", () => {
@@ -386,9 +387,9 @@ describe("deriveMonthlyMilestones", () => {
   it("generates sequential month dates", () => {
     const result = deriveMonthlyMilestones(0, 100_000, 3);
     // From FIXED_NOW (2026-03-19), months should be Apr, May, Jun 2026
-    expect(result[0].month.getMonth()).toBe(3); // April (0-indexed)
-    expect(result[1].month.getMonth()).toBe(4); // May
-    expect(result[2].month.getMonth()).toBe(5); // June
+    expect(result[0]?.month.getMonth()).toBe(3); // April (0-indexed)
+    expect(result[1]?.month.getMonth()).toBe(4); // May
+    expect(result[2]?.month.getMonth()).toBe(5); // June
   });
 });
 
@@ -437,7 +438,7 @@ describe("deriveBudgetNudges", () => {
   it("returns top 3 categories by total spending", () => {
     const result = deriveBudgetNudges(0, 5_000_000, 500_000, spending);
     expect(result).toHaveLength(3);
-    expect(result[0].categoryId).toBe("food");
+    expect(result[0]?.categoryId).toBe("food");
   });
 
   it("calculates 15% reduction for each category", () => {
@@ -492,9 +493,9 @@ describe("deriveGoalAlerts", () => {
     const previous = new Map([["g1", 6]]);
     const result = deriveGoalAlerts(goals, previous);
     expect(result).toHaveLength(1);
-    expect(result[0].goalId).toBe("g1");
-    expect(result[0].goalName).toBe("Trip");
-    expect(result[0].shiftMonths).toBe(2); // delayed by 2 months
+    expect(result[0]?.goalId).toBe("g1");
+    expect(result[0]?.goalName).toBe("Trip");
+    expect(result[0]?.shiftMonths).toBe(2); // delayed by 2 months
   });
 
   it("generates alert when shift >= 1 month (ahead of schedule)", () => {
@@ -502,7 +503,7 @@ describe("deriveGoalAlerts", () => {
     const previous = new Map([["g1", 6]]);
     const result = deriveGoalAlerts(goals, previous);
     expect(result).toHaveLength(1);
-    expect(result[0].shiftMonths).toBe(-2); // 2 months ahead
+    expect(result[0]?.shiftMonths).toBe(-2); // 2 months ahead
   });
 
   it("does not generate alert when shift < 1 month", () => {

--- a/apps/mobile/__tests__/lib/supabase.test.ts
+++ b/apps/mobile/__tests__/lib/supabase.test.ts
@@ -1,4 +1,6 @@
+import { createClient } from "@supabase/supabase-js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getSupabase, resetSupabase } from "@/shared/db/supabase";
 
 process.env.EXPO_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
 process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY = "test-anon-key";
@@ -12,9 +14,6 @@ vi.mock("expo-secure-store", () => ({
   setItemAsync: vi.fn(),
   deleteItemAsync: vi.fn(),
 }));
-
-import { createClient } from "@supabase/supabase-js";
-import { getSupabase, resetSupabase } from "@/shared/db/supabase";
 
 describe("getSupabase", () => {
   beforeEach(() => {

--- a/apps/mobile/__tests__/navigation/tab-config.test.ts
+++ b/apps/mobile/__tests__/navigation/tab-config.test.ts
@@ -19,10 +19,10 @@ describe("TAB_CONFIG", () => {
   });
 
   test("has correct labels", () => {
-    expect(TAB_CONFIG.index.label).toBe("HOME");
-    expect(TAB_CONFIG.ai.label).toBe("AI");
-    expect(TAB_CONFIG.budgets.label).toBe("BUDGETS");
-    expect(TAB_CONFIG.menu.label).toBe("MORE");
+    expect(TAB_CONFIG.index?.label).toBe("HOME");
+    expect(TAB_CONFIG.ai?.label).toBe("AI");
+    expect(TAB_CONFIG.budgets?.label).toBe("BUDGETS");
+    expect(TAB_CONFIG.menu?.label).toBe("MORE");
   });
 
   test("every entry has icon property", () => {

--- a/apps/mobile/__tests__/navigation/tab-layout.test.ts
+++ b/apps/mobile/__tests__/navigation/tab-layout.test.ts
@@ -14,13 +14,11 @@ describe("Tab layout", () => {
 
     const iosMatch = layoutSource.match(/function\s+IosTabs\b[\s\S]*?^}/m);
     expect(iosMatch).not.toBeNull();
-    // biome-ignore lint/style/noNonNullAssertion: guarded by expect above
     const iosNames = Array.from(iosMatch![0].matchAll(/name="([^"]+)"/g), (m) => m[1]);
     expect(iosNames).toEqual(expectedTabs);
 
     const androidMatch = layoutSource.match(/function\s+AndroidTabs\b[\s\S]*?^}/m);
     expect(androidMatch).not.toBeNull();
-    // biome-ignore lint/style/noNonNullAssertion: guarded by expect above
     const androidNames = Array.from(androidMatch![0].matchAll(/name="([^"]+)"/g), (m) => m[1]);
     expect(androidNames).toEqual(expectedTabs);
   });

--- a/apps/mobile/__tests__/notifications/derive.test.ts
+++ b/apps/mobile/__tests__/notifications/derive.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { BudgetProgress } from "@/features/budget/lib/derive";
+import type { WeeklyMove } from "@/features/notifications/lib/derive";
 import { deriveWeeklyMoves } from "@/features/notifications/lib/derive";
 import type { StoredTransaction } from "@/features/transactions/schema";
 import type {
@@ -9,6 +10,15 @@ import type {
   TransactionId,
   UserId,
 } from "@/shared/types/branded";
+
+// ---------------------------------------------------------------------------
+// Type predicates for discriminated union narrowing in filter()
+// ---------------------------------------------------------------------------
+
+const isAnomaly = (m: WeeklyMove): m is Extract<WeeklyMove, { type: "anomaly" }> =>
+  m.type === "anomaly";
+const isBudgetPace = (m: WeeklyMove): m is Extract<WeeklyMove, { type: "budget_pace" }> =>
+  m.type === "budget_pace";
 
 // ---------------------------------------------------------------------------
 // Factories
@@ -113,16 +123,14 @@ describe("deriveWeeklyMoves", () => {
       amount: 200_000 as CopAmount,
     });
     const result = deriveWeeklyMoves([...prior, currentWeekTx], [], WEEK_START);
-    const anomalies = result.filter((m) => m.type === "anomaly");
+    const anomalies = result.filter(isAnomaly);
     expect(anomalies).toHaveLength(1);
-    const anomaly = anomalies[0];
+    const anomaly = anomalies[0]!;
     expect(anomaly.type).toBe("anomaly");
-    if (anomaly.type === "anomaly") {
-      expect(anomaly.categoryId).toBe("food");
-      expect(anomaly.weeklySpend).toBe(200_000);
-      expect(anomaly.medianWeeklySpend).toBe(100_000);
-      expect(anomaly.impact).toBe(100_000); // 200_000 − 100_000
-    }
+    expect(anomaly.categoryId).toBe("food");
+    expect(anomaly.weeklySpend).toBe(200_000);
+    expect(anomaly.medianWeeklySpend).toBe(100_000);
+    expect(anomaly.impact).toBe(100_000); // 200_000 − 100_000
   });
 
   // Test 5 — no budget progresses → no pace moves
@@ -159,19 +167,17 @@ describe("deriveWeeklyMoves", () => {
       spent: 0 as CopAmount,
     });
     const result = deriveWeeklyMoves([currentWeekTx], [progress], WEEK_START);
-    const paces = result.filter((m) => m.type === "budget_pace");
+    const paces = result.filter(isBudgetPace);
     expect(paces).toHaveLength(1);
-    const pace = paces[0];
+    const pace = paces[0]!;
     expect(pace.type).toBe("budget_pace");
-    if (pace.type === "budget_pace") {
-      expect(pace.budgetId).toBe("b1");
-      expect(pace.categoryId).toBe("food");
-      expect(pace.budgetAmount).toBe(500_000);
-      // projected = 0 + (700_000/7) × 16 = 1_600_000
-      expect(pace.projectedSpend).toBe(1_600_000);
-      // impact = 1_600_000 − 500_000 = 1_100_000
-      expect(pace.impact).toBe(1_100_000);
-    }
+    expect(pace.budgetId).toBe("b1");
+    expect(pace.categoryId).toBe("food");
+    expect(pace.budgetAmount).toBe(500_000);
+    // projected = 0 + (700_000/7) × 16 = 1_600_000
+    expect(pace.projectedSpend).toBe(1_600_000);
+    // impact = 1_600_000 − 500_000 = 1_100_000
+    expect(pace.impact).toBe(1_100_000);
   });
 
   // Test 8 — thisWeekSpend = 0 → weekDailyRate = 0, projected = spent, no alert if under budget
@@ -303,16 +309,14 @@ describe("deriveWeeklyMoves", () => {
 
     const result = deriveWeeklyMoves([...prior, currentWeekTx], [progress], WEEK_START);
 
-    const anomalies = result.filter((m) => m.type === "anomaly");
-    const paces = result.filter((m) => m.type === "budget_pace");
+    const anomalies = result.filter(isAnomaly);
+    const paces = result.filter(isBudgetPace);
 
     expect(anomalies).toHaveLength(1);
     expect(paces).toHaveLength(1);
 
     // Verify they both refer to "food"
-    expect(anomalies[0].categoryId).toBe("food");
-    if (paces[0].type === "budget_pace") {
-      expect(paces[0].categoryId).toBe("food");
-    }
+    expect(anomalies[0]?.categoryId).toBe("food");
+    expect(paces[0]?.categoryId).toBe("food");
   });
 });

--- a/apps/mobile/__tests__/notifications/display.test.ts
+++ b/apps/mobile/__tests__/notifications/display.test.ts
@@ -196,8 +196,8 @@ describe("groupNotificationsBySection", () => {
     });
     const result = groupNotificationsBySection([display], Today, mockT);
     expect(result).toHaveLength(1);
-    expect(result[0].label).toBe("notifications.weeklyMovesHeader");
-    expect(result[0].notifications).toHaveLength(1);
+    expect(result[0]?.label).toBe("notifications.weeklyMovesHeader");
+    expect(result[0]?.notifications).toHaveLength(1);
   });
 
   it("groups budget_pace from current week into weekly moves section", () => {
@@ -207,7 +207,7 @@ describe("groupNotificationsBySection", () => {
     });
     const result = groupNotificationsBySection([display], Today, mockT);
     expect(result).toHaveLength(1);
-    expect(result[0].label).toBe("notifications.weeklyMovesHeader");
+    expect(result[0]?.label).toBe("notifications.weeklyMovesHeader");
   });
 
   it("groups budget_alert into EARLIER section", () => {
@@ -217,7 +217,7 @@ describe("groupNotificationsBySection", () => {
     });
     const result = groupNotificationsBySection([display], Today, mockT);
     expect(result).toHaveLength(1);
-    expect(result[0].label).toBe("notifications.earlierHeader");
+    expect(result[0]?.label).toBe("notifications.earlierHeader");
   });
 
   it("groups goal_milestone into EARLIER section", () => {
@@ -227,7 +227,7 @@ describe("groupNotificationsBySection", () => {
     });
     const result = groupNotificationsBySection([display], Today, mockT);
     expect(result).toHaveLength(1);
-    expect(result[0].label).toBe("notifications.earlierHeader");
+    expect(result[0]?.label).toBe("notifications.earlierHeader");
   });
 
   it("groups spending_anomaly from prior week into EARLIER section", () => {
@@ -237,7 +237,7 @@ describe("groupNotificationsBySection", () => {
     });
     const result = groupNotificationsBySection([display], Today, mockT);
     expect(result).toHaveLength(1);
-    expect(result[0].label).toBe("notifications.earlierHeader");
+    expect(result[0]?.label).toBe("notifications.earlierHeader");
   });
 
   it("creates both sections when applicable, weekly moves first", () => {
@@ -253,8 +253,8 @@ describe("groupNotificationsBySection", () => {
     });
     const result = groupNotificationsBySection([weeklyMove, earlier], Today, mockT);
     expect(result).toHaveLength(2);
-    expect(result[0].label).toBe("notifications.weeklyMovesHeader");
-    expect(result[1].label).toBe("notifications.earlierHeader");
+    expect(result[0]?.label).toBe("notifications.weeklyMovesHeader");
+    expect(result[1]?.label).toBe("notifications.earlierHeader");
   });
 
   it("sorts notifications within each section by createdAt DESC", () => {
@@ -269,8 +269,8 @@ describe("groupNotificationsBySection", () => {
       createdAt: "2026-03-18T14:00:00.000Z" as IsoDateTime,
     });
     const result = groupNotificationsBySection([older, newer], Today, mockT);
-    expect(result[0].notifications[0].id).toBe("nf-2");
-    expect(result[0].notifications[1].id).toBe("nf-1");
+    expect(result[0]?.notifications[0]?.id).toBe("nf-2");
+    expect(result[0]?.notifications[1]?.id).toBe("nf-1");
   });
 
   it("omits weekly moves section when no qualifying notifications exist", () => {
@@ -280,7 +280,7 @@ describe("groupNotificationsBySection", () => {
     });
     const result = groupNotificationsBySection([display], Today, mockT);
     expect(result).toHaveLength(1);
-    expect(result[0].label).toBe("notifications.earlierHeader");
+    expect(result[0]?.label).toBe("notifications.earlierHeader");
   });
 
   it("formats week range as 'Mar 16–22' for the week of March 16-22", () => {

--- a/apps/mobile/__tests__/sync/sync-pull-integration.test.ts
+++ b/apps/mobile/__tests__/sync/sync-pull-integration.test.ts
@@ -17,12 +17,6 @@ import { drizzle } from "drizzle-orm/better-sqlite3";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@/shared/lib/sentry", () => ({
-  captureError: vi.fn(),
-  capturePipelineEvent: vi.fn(),
-  captureWarning: vi.fn(),
-}));
-
 import { getUnresolvedConflicts } from "@/features/sync/lib/conflict-repository";
 import { syncPull } from "@/features/sync/services/syncEngine";
 import {
@@ -38,6 +32,12 @@ import type {
   TransactionId,
   UserId,
 } from "@/shared/types/branded";
+
+vi.mock("@/shared/lib/sentry", () => ({
+  captureError: vi.fn(),
+  capturePipelineEvent: vi.fn(),
+  captureWarning: vi.fn(),
+}));
 
 let sqlite: InstanceType<typeof Database>;
 let db: ReturnType<typeof drizzle>;
@@ -132,15 +132,15 @@ describe("syncPull integration (real SQLite)", () => {
     // Local row should now have the server's amount
     const tx = getTransactionById(db as any, "tx-1" as TransactionId);
     expect(tx).not.toBeNull();
-    expect(tx!.amount).toBe(2000);
+    expect(tx?.amount).toBe(2000);
 
     // A conflict should be logged
     const conflicts = getUnresolvedConflicts(db as any);
     expect(conflicts).toHaveLength(1);
-    expect(conflicts[0].transactionId).toBe("tx-1");
+    expect(conflicts[0]?.transactionId).toBe("tx-1");
 
-    const localData = JSON.parse(conflicts[0].localData);
-    const serverData = JSON.parse(conflicts[0].serverData);
+    const localData = JSON.parse(conflicts[0]?.localData ?? "{}");
+    const serverData = JSON.parse(conflicts[0]?.serverData ?? "{}");
     expect(localData.amount).toBe(1000);
     expect(serverData.amount).toBe(2000);
   });
@@ -157,8 +157,8 @@ describe("syncPull integration (real SQLite)", () => {
 
     // Local data should be unchanged
     const tx = getTransactionById(db as any, "tx-1" as TransactionId);
-    expect(tx!.amount).toBe(1000);
-    expect(tx!.description).toBe("Local merchant");
+    expect(tx?.amount).toBe(1000);
+    expect(tx?.description).toBe("Local merchant");
 
     // No conflicts
     const conflicts = getUnresolvedConflicts(db as any);
@@ -173,8 +173,8 @@ describe("syncPull integration (real SQLite)", () => {
 
     const tx = getTransactionById(db as any, "tx-new" as TransactionId);
     expect(tx).not.toBeNull();
-    expect(tx!.description).toBe("Cloud-only");
-    expect(tx!.amount).toBe(2000);
+    expect(tx?.description).toBe("Cloud-only");
+    expect(tx?.amount).toBe(2000);
 
     const conflicts = getUnresolvedConflicts(db as any);
     expect(conflicts).toHaveLength(0);
@@ -208,7 +208,7 @@ describe("syncPull integration (real SQLite)", () => {
 
     // Timestamp should be updated
     const tx = getTransactionById(db as any, "tx-1" as TransactionId);
-    expect(tx!.updatedAt).toBe("2026-03-10T14:00:00.000Z");
+    expect(tx?.updatedAt).toBe("2026-03-10T14:00:00.000Z");
 
     // No conflict since data is identical
     const conflicts = getUnresolvedConflicts(db as any);

--- a/apps/mobile/__tests__/sync/syncEngine.test.ts
+++ b/apps/mobile/__tests__/sync/syncEngine.test.ts
@@ -2,10 +2,10 @@
 // biome-ignore-all lint/style/useNamingConvention: snake_case matches Supabase API column names
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockGetQueuedSyncEntries = vi.fn().mockResolvedValue([]);
+const mockGetQueuedSyncEntries = vi.fn().mockReturnValue([]);
 const mockClearSyncEntries = vi.fn();
-const mockGetTransactionById = vi.fn().mockResolvedValue(null);
-const mockGetSyncMeta = vi.fn().mockResolvedValue(null);
+const mockGetTransactionById = vi.fn().mockReturnValue(null);
+const mockGetSyncMeta = vi.fn().mockReturnValue(null);
 const mockSetSyncMeta = vi.fn();
 const mockUpsertTransaction = vi.fn();
 
@@ -55,7 +55,7 @@ describe("syncEngine", () => {
 
   describe("syncPush", () => {
     it("does nothing when sync queue is empty", async () => {
-      mockGetQueuedSyncEntries.mockResolvedValueOnce([]);
+      mockGetQueuedSyncEntries.mockReturnValueOnce([]);
       const mockSupabase = createMockSupabase();
 
       const { syncPush } = await import("@/features/sync/services/syncEngine");
@@ -66,7 +66,7 @@ describe("syncEngine", () => {
     });
 
     it("upserts transaction row to supabase and clears queue on success", async () => {
-      mockGetQueuedSyncEntries.mockResolvedValueOnce([
+      mockGetQueuedSyncEntries.mockReturnValueOnce([
         {
           id: "sq-1",
           tableName: "transactions",
@@ -75,7 +75,7 @@ describe("syncEngine", () => {
           createdAt: "2026-03-04T10:00:00.000Z",
         },
       ]);
-      mockGetTransactionById.mockResolvedValueOnce({
+      mockGetTransactionById.mockReturnValueOnce({
         id: "tx-1",
         userId: "user-1",
         type: "expense",
@@ -105,7 +105,7 @@ describe("syncEngine", () => {
     });
 
     it("keeps entry in queue when supabase returns error", async () => {
-      mockGetQueuedSyncEntries.mockResolvedValueOnce([
+      mockGetQueuedSyncEntries.mockReturnValueOnce([
         {
           id: "sq-1",
           tableName: "transactions",
@@ -114,7 +114,7 @@ describe("syncEngine", () => {
           createdAt: "2026-03-04T10:00:00.000Z",
         },
       ]);
-      mockGetTransactionById.mockResolvedValueOnce({
+      mockGetTransactionById.mockReturnValueOnce({
         id: "tx-1",
         userId: "user-1",
         type: "expense",
@@ -136,7 +136,7 @@ describe("syncEngine", () => {
     });
 
     it("clears queue entry when local row is missing", async () => {
-      mockGetQueuedSyncEntries.mockResolvedValueOnce([
+      mockGetQueuedSyncEntries.mockReturnValueOnce([
         {
           id: "sq-1",
           tableName: "transactions",
@@ -145,7 +145,7 @@ describe("syncEngine", () => {
           createdAt: "2026-03-04T10:00:00.000Z",
         },
       ]);
-      mockGetTransactionById.mockResolvedValueOnce(null);
+      mockGetTransactionById.mockReturnValueOnce(null);
       const mockSupabase = createMockSupabase();
 
       const { syncPush } = await import("@/features/sync/services/syncEngine");
@@ -157,7 +157,7 @@ describe("syncEngine", () => {
 
   describe("syncPull", () => {
     it("fetches all rows on first sync and sets last_sync_at to max updated_at", async () => {
-      mockGetSyncMeta.mockResolvedValueOnce(null);
+      mockGetSyncMeta.mockReturnValueOnce(null);
       const serverRows = [
         {
           id: "tx-remote-1",
@@ -173,7 +173,7 @@ describe("syncEngine", () => {
         },
       ];
       const mockSupabase = createMockSupabase({ data: serverRows, error: null });
-      mockGetTransactionById.mockResolvedValueOnce(null);
+      mockGetTransactionById.mockReturnValueOnce(null);
 
       const { syncPull } = await import("@/features/sync/services/syncEngine");
       const result = await syncPull(mockDb, mockSupabase, "user-1");
@@ -191,7 +191,7 @@ describe("syncEngine", () => {
     });
 
     it("uses last_sync_at for incremental pull and skips setSyncMeta when no rows", async () => {
-      mockGetSyncMeta.mockResolvedValueOnce("2026-03-04T10:00:00.000Z");
+      mockGetSyncMeta.mockReturnValueOnce("2026-03-04T10:00:00.000Z");
       const mockSupabase = createMockSupabase({ data: [], error: null });
 
       const { syncPull } = await import("@/features/sync/services/syncEngine");
@@ -202,7 +202,7 @@ describe("syncEngine", () => {
     });
 
     it("skips upsert when local row is newer (LWW)", async () => {
-      mockGetSyncMeta.mockResolvedValueOnce(null);
+      mockGetSyncMeta.mockReturnValueOnce(null);
       const serverRows = [
         {
           id: "tx-1",
@@ -218,7 +218,7 @@ describe("syncEngine", () => {
         },
       ];
       const mockSupabase = createMockSupabase({ data: serverRows, error: null });
-      mockGetTransactionById.mockResolvedValueOnce({
+      mockGetTransactionById.mockReturnValueOnce({
         id: "tx-1",
         userId: "user-1",
         type: "expense",
@@ -238,7 +238,7 @@ describe("syncEngine", () => {
     });
 
     it("upserts when server row is newer", async () => {
-      mockGetSyncMeta.mockResolvedValueOnce(null);
+      mockGetSyncMeta.mockReturnValueOnce(null);
       const serverRows = [
         {
           id: "tx-1",
@@ -254,7 +254,7 @@ describe("syncEngine", () => {
         },
       ];
       const mockSupabase = createMockSupabase({ data: serverRows, error: null });
-      mockGetTransactionById.mockResolvedValueOnce({
+      mockGetTransactionById.mockReturnValueOnce({
         id: "tx-1",
         userId: "user-1",
         type: "expense",
@@ -277,7 +277,7 @@ describe("syncEngine", () => {
     });
 
     it("returns false on supabase error and skips upsert", async () => {
-      mockGetSyncMeta.mockResolvedValueOnce(null);
+      mockGetSyncMeta.mockReturnValueOnce(null);
       const mockSupabase = createMockSupabase({ data: null, error: { message: "fail" } });
 
       const { syncPull } = await import("@/features/sync/services/syncEngine");
@@ -291,8 +291,8 @@ describe("syncEngine", () => {
 
   describe("fullSync", () => {
     it("calls syncPull then syncPush when pull succeeds", async () => {
-      mockGetSyncMeta.mockResolvedValueOnce(null);
-      mockGetQueuedSyncEntries.mockResolvedValueOnce([]);
+      mockGetSyncMeta.mockReturnValueOnce(null);
+      mockGetQueuedSyncEntries.mockReturnValueOnce([]);
       const mockSupabase = createMockSupabase({ data: [], error: null });
 
       const { fullSync } = await import("@/features/sync/services/syncEngine");
@@ -305,7 +305,7 @@ describe("syncEngine", () => {
     });
 
     it("skips push when pull fails and returns false", async () => {
-      mockGetSyncMeta.mockResolvedValueOnce(null);
+      mockGetSyncMeta.mockReturnValueOnce(null);
       const mockSupabase = createMockSupabase({ data: null, error: { message: "fail" } });
 
       const { fullSync } = await import("@/features/sync/services/syncEngine");
@@ -319,7 +319,7 @@ describe("syncEngine", () => {
 
   describe("conflict logging", () => {
     it("logs conflict when server overwrites local with different data", async () => {
-      mockGetSyncMeta.mockResolvedValueOnce(null);
+      mockGetSyncMeta.mockReturnValueOnce(null);
       const serverRows = [
         {
           id: "tx-1",
@@ -335,7 +335,7 @@ describe("syncEngine", () => {
         },
       ];
       const mockSupabase = createMockSupabase({ data: serverRows, error: null });
-      mockGetTransactionById.mockResolvedValueOnce({
+      mockGetTransactionById.mockReturnValueOnce({
         id: "tx-1",
         userId: "user-1",
         type: "expense",
@@ -362,7 +362,7 @@ describe("syncEngine", () => {
     });
 
     it("does not log conflict when data matches (only timestamp differs)", async () => {
-      mockGetSyncMeta.mockResolvedValueOnce(null);
+      mockGetSyncMeta.mockReturnValueOnce(null);
       const serverRows = [
         {
           id: "tx-1",
@@ -378,7 +378,7 @@ describe("syncEngine", () => {
         },
       ];
       const mockSupabase = createMockSupabase({ data: serverRows, error: null });
-      mockGetTransactionById.mockResolvedValueOnce({
+      mockGetTransactionById.mockReturnValueOnce({
         id: "tx-1",
         userId: "user-1",
         type: "expense",
@@ -400,7 +400,7 @@ describe("syncEngine", () => {
     });
 
     it("does not log conflict for new server-only transactions", async () => {
-      mockGetSyncMeta.mockResolvedValueOnce(null);
+      mockGetSyncMeta.mockReturnValueOnce(null);
       const serverRows = [
         {
           id: "tx-new",
@@ -416,7 +416,7 @@ describe("syncEngine", () => {
         },
       ];
       const mockSupabase = createMockSupabase({ data: serverRows, error: null });
-      mockGetTransactionById.mockResolvedValueOnce(null);
+      mockGetTransactionById.mockReturnValueOnce(null);
 
       const { syncPull } = await import("@/features/sync/services/syncEngine");
       await syncPull(mockDb, mockSupabase, "user-1");

--- a/apps/mobile/__tests__/transactions/store.test.ts
+++ b/apps/mobile/__tests__/transactions/store.test.ts
@@ -1,4 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getBalanceAggregate,
+  getSpendingByCategoryAggregate,
+  getTransactionsPaginated,
+  insertTransaction,
+  softDeleteTransaction,
+} from "@/features/transactions/lib/repository";
+import { useTransactionStore } from "@/features/transactions/store";
+import { enqueueSync } from "@/shared/db/enqueue-sync";
 import type {
   CategoryId,
   CopAmount,
@@ -22,16 +31,6 @@ vi.mock("@/features/transactions/lib/repository", () => ({
 vi.mock("@/shared/db/enqueue-sync", () => ({
   enqueueSync: vi.fn(),
 }));
-
-import {
-  getBalanceAggregate,
-  getSpendingByCategoryAggregate,
-  getTransactionsPaginated,
-  insertTransaction,
-  softDeleteTransaction,
-} from "@/features/transactions/lib/repository";
-import { useTransactionStore } from "@/features/transactions/store";
-import { enqueueSync } from "@/shared/db/enqueue-sync";
 
 // biome-ignore lint/suspicious/noExplicitAny: mock db needs flexible typing
 const mockDb = {} as any;
@@ -232,8 +231,8 @@ describe("useTransactionStore", () => {
 
     const state = useTransactionStore.getState();
     expect(state.pages).toHaveLength(1);
-    expect(state.pages[0].id).toBe("tx-1");
-    expect(state.pages[0].date).toBeInstanceOf(Date);
+    expect(state.pages[0]?.id).toBe("tx-1");
+    expect(state.pages[0]?.date).toBeInstanceOf(Date);
     expect(state.hasMore).toBe(false);
     expect(state.offset).toBe(1);
     expect(getTransactionsPaginated).toHaveBeenCalledWith(mockDb, mockUserId, 30, 0);
@@ -305,7 +304,7 @@ describe("useTransactionStore", () => {
 
     const state = useTransactionStore.getState();
     expect(state.pages).toHaveLength(2);
-    expect(state.pages[1].id).toBe("tx-1");
+    expect(state.pages[1]?.id).toBe("tx-1");
     expect(state.hasMore).toBe(false);
   });
 
@@ -351,7 +350,9 @@ describe("useTransactionStore", () => {
   });
 
   it("saveTransaction returns error when DB insert fails", async () => {
-    vi.mocked(insertTransaction).mockRejectedValueOnce(new Error("disk full"));
+    vi.mocked(insertTransaction).mockImplementationOnce(() => {
+      throw new Error("disk full");
+    });
 
     const store = useTransactionStore.getState();
     store.setDigits("500");
@@ -382,10 +383,10 @@ describe("useTransactionStore", () => {
       ],
     });
 
-    vi.mocked(softDeleteTransaction).mockRejectedValueOnce(new Error("db error"));
-    await expect(
-      useTransactionStore.getState().removeTransaction("tx-1" as TransactionId)
-    ).rejects.toThrow("db error");
+    vi.mocked(softDeleteTransaction).mockImplementationOnce(() => {
+      throw new Error("db error");
+    });
+    await useTransactionStore.getState().removeTransaction("tx-1" as TransactionId);
 
     expect(useTransactionStore.getState().pages).toHaveLength(1);
   });
@@ -406,7 +407,7 @@ describe("useTransactionStore", () => {
 
     useTransactionStore.getState().addToCache(tx);
 
-    expect(useTransactionStore.getState().pages[0].id).toBe("tx-new");
+    expect(useTransactionStore.getState().pages[0]?.id).toBe("tx-new");
   });
 
   it("removeFromCache filters from pages", () => {

--- a/apps/mobile/__tests__/transactions/store.test.ts
+++ b/apps/mobile/__tests__/transactions/store.test.ts
@@ -383,10 +383,10 @@ describe("useTransactionStore", () => {
       ],
     });
 
-    vi.mocked(softDeleteTransaction).mockImplementationOnce(() => {
-      throw new Error("db error");
-    });
-    await useTransactionStore.getState().removeTransaction("tx-1" as TransactionId);
+    vi.mocked(softDeleteTransaction).mockRejectedValueOnce(new Error("db error"));
+    await expect(
+      useTransactionStore.getState().removeTransaction("tx-1" as TransactionId)
+    ).rejects.toThrow("db error");
 
     expect(useTransactionStore.getState().pages).toHaveLength(1);
   });

--- a/biome.json
+++ b/biome.json
@@ -74,6 +74,21 @@
           }
         }
       }
+    },
+    {
+      "includes": [
+        "**/__tests__/**/*.ts",
+        "**/__tests__/**/*.tsx",
+        "**/*.test.ts",
+        "**/*.test.tsx"
+      ],
+      "linter": {
+        "rules": {
+          "style": {
+            "noNonNullAssertion": "off"
+          }
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add null guards (`!`, `?.`) in test files for future `noUncheckedIndexedAccess` TS flag
- Add biome override to allow `!` assertions in test files
- Strengthen assertion per review: add `toHaveLength(1)` before accessing `result[0]`

## Test plan
- [ ] `npx vitest run` — all tests pass