### PR TITLE
feat(mobile): strict ESLint config, shared hooks, and useEffect migrations

### DIFF
--- a/apps/mobile/app/(auth)/onboarding.tsx
+++ b/apps/mobile/app/(auth)/onboarding.tsx
@@ -1,6 +1,6 @@
 import { useMigrations } from "drizzle-orm/expo-sqlite/migrator";
 import * as SplashScreen from "expo-splash-screen";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useAuthStore } from "@/features/auth";
 import { useBudgetStore } from "@/features/budget";
@@ -18,14 +18,14 @@ import {
 import { useTransactionStore } from "@/features/transactions";
 import { StyleSheet, View } from "@/shared/components/rn";
 import { getDb } from "@/shared/db";
-import { useThemeColor } from "@/shared/hooks";
+import { useSubscription, useThemeColor } from "@/shared/hooks";
 import type { UserId } from "@/shared/types/branded";
 import migrations from "../../drizzle/migrations";
 
 export default function OnboardingScreen() {
   const insets = useSafeAreaInsets();
   const session = useAuthStore((s) => s.session);
-  const userId = session?.user?.id ?? null;
+  const userId = session?.user.id ?? null;
   const step = useOnboardingStore((s) => s.step);
   const pageBg = useThemeColor("page");
 
@@ -37,8 +37,9 @@ export default function OnboardingScreen() {
   const { success: migrationsReady } = useMigrations(db ?? (undefined as never), migrations);
 
   // Initialize minimal stores needed for onboarding
-  useEffect(() => {
-    if (migrationsReady && db && userId && !storesReady) {
+  useSubscription(
+    () => {
+      if (!db || !userId) return;
       useEmailCaptureStore.getState().initStore(db, userId);
       useTransactionStore.getState().initStore(db, userId as UserId);
       useBudgetStore.getState().initStore(db, userId as UserId);
@@ -50,15 +51,19 @@ export default function OnboardingScreen() {
         .finally(() => {
           setStoresReady(true);
         });
-    }
-  }, [migrationsReady, db, userId, storesReady]);
+    },
+    [db, userId],
+    migrationsReady && db != null && userId != null && !storesReady
+  );
 
   // Hide splash once ready
-  useEffect(() => {
-    if (storesReady) {
-      SplashScreen.hideAsync();
-    }
-  }, [storesReady]);
+  useSubscription(
+    () => {
+      void SplashScreen.hideAsync();
+    },
+    [],
+    storesReady
+  );
 
   if (!storesReady) {
     return <View style={[styles.container, { backgroundColor: pageBg }]} />;

--- a/apps/mobile/app/(tabs)/add.tsx
+++ b/apps/mobile/app/(tabs)/add.tsx
@@ -1,25 +1,41 @@
 import * as Haptics from "expo-haptics";
 import { useRouter } from "expo-router";
-import { useCallback } from "react";
+import { useCallback, useMemo, useRef } from "react";
+import Animated from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useShallow } from "zustand/react/shallow";
-import { TransactionForm, useTransactionStore } from "@/features/transactions";
-import { useAsyncGuard, useTranslation } from "@/shared/hooks";
-import { trackTransactionCreated } from "@/shared/lib";
+import {
+  CATEGORIES,
+  CategoryPill,
+  getDateLabel,
+  handleNumpadPress,
+  TypeToggle,
+  useTransactionStore,
+} from "@/features/transactions";
+import { FidyNumpad } from "@/shared/components";
+import { Calendar } from "@/shared/components/icons";
+import { Platform, Pressable, Text, TextInput, View } from "@/shared/components/rn";
+import { useAsyncGuard, useBlinkingCursor, useThemeColor, useTranslation } from "@/shared/hooks";
+import { getDateFnsLocale } from "@/shared/i18n";
+import { formatInputDisplay, parseDigitsToAmount, trackTransactionCreated } from "@/shared/lib";
 
 export default function AddTransactionScreen() {
   const { navigate } = useRouter();
-  const { t } = useTranslation();
+  const { t, locale } = useTranslation();
+  const { bottom: safeBottom } = useSafeAreaInsets();
   const {
     type,
     digits,
     categoryId,
     description,
     date,
+    editingId,
     setType,
     setDigits,
     setCategoryId,
     setDescription,
     saveTransaction,
+    updateTransaction,
     resetForm,
   } = useTransactionStore(
     useShallow((s) => ({
@@ -28,49 +44,201 @@ export default function AddTransactionScreen() {
       categoryId: s.categoryId,
       description: s.description,
       date: s.date,
+      editingId: s.editingId,
       setType: s.setType,
       setDigits: s.setDigits,
       setCategoryId: s.setCategoryId,
       setDescription: s.setDescription,
       saveTransaction: s.saveTransaction,
+      updateTransaction: s.updateTransaction,
       resetForm: s.resetForm,
     }))
   );
 
+  const isEditing = editingId != null;
+
+  const accentRed = useThemeColor("accentRed");
+  const accentGreen = useThemeColor("accentGreen");
+  const secondary = useThemeColor("secondary");
+  const tertiary = useThemeColor("tertiary");
+  const primary = useThemeColor("primary");
+  const borderSubtle = useThemeColor("borderSubtle");
+
+  const amountColor = type === "expense" ? accentRed : accentGreen;
+  const displayAmount = digits.length > 0 ? formatInputDisplay(digits) : "$";
+  const canSave = parseDigitsToAmount(digits) > 0;
+  const buttonBg = canSave ? accentGreen : "#CCCCCC";
+  const dateLabel = useMemo(
+    () => getDateLabel(date, new Date(), t("dates.today"), getDateFnsLocale(locale)),
+    [date, t, locale]
+  );
+
+  const digitsRef = useRef(digits);
+  digitsRef.current = digits;
+
+  const { cursorStyle } = useBlinkingCursor();
+
   const { isBusy: isSaving, run: guardedSave } = useAsyncGuard();
 
-  const handleSave = useCallback(
-    () =>
-      guardedSave(async () => {
-        const result = await saveTransaction();
-        if (result.success) {
-          Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+  const handleSave = () => {
+    void guardedSave(async () => {
+      const result = isEditing ? await updateTransaction(editingId) : await saveTransaction();
+      if (result.success) {
+        void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+        if (!isEditing) {
           trackTransactionCreated({
             type,
             category: String(categoryId ?? ""),
             source: "manual",
           });
           resetForm();
-          navigate("/(tabs)" as never);
         }
-      }),
-    [guardedSave, saveTransaction, type, categoryId, resetForm, navigate]
+        navigate("/(tabs)" as never);
+      }
+    });
+  };
+
+  const handleKey = useCallback(
+    (key: string) => {
+      setDigits(handleNumpadPress(digitsRef.current, key));
+    },
+    [setDigits]
   );
 
+  const saveLabel = isEditing ? t("common.save") : t("transactions.saveTransaction");
+
   return (
-    <TransactionForm
-      type={type}
-      digits={digits}
-      categoryId={categoryId}
-      description={description}
-      date={date}
-      saveLabel={t("transactions.saveTransaction")}
-      isSaving={isSaving}
-      onTypeChange={setType}
-      onDigitsChange={setDigits}
-      onCategoryChange={setCategoryId}
-      onDescriptionChange={setDescription}
-      onSave={handleSave}
-    />
+    <View style={{ flex: 1 }} className="bg-page dark:bg-page-dark">
+      {/* Top zone: amount display + metadata */}
+      <View style={{ flex: 1, justifyContent: "center", paddingHorizontal: 24, gap: 12 }}>
+        {/* Type toggle + Amount */}
+        <View style={{ alignItems: "center", gap: 4 }}>
+          <TypeToggle value={type} onChange={setType} />
+          <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "center" }}>
+            <Text
+              style={{
+                fontFamily: "Poppins_700Bold",
+                fontSize: 40,
+                color: amountColor,
+              }}
+            >
+              {displayAmount}
+            </Text>
+            <Animated.View
+              style={[
+                {
+                  width: 2,
+                  height: 32,
+                  marginLeft: 2,
+                  borderRadius: 1,
+                  backgroundColor: amountColor,
+                },
+                cursorStyle,
+              ]}
+            />
+          </View>
+        </View>
+
+        {/* Categories */}
+        <View style={{ alignItems: "center", gap: 6 }}>
+          <View
+            style={{ flexDirection: "row", flexWrap: "wrap", justifyContent: "center", gap: 6 }}
+          >
+            {CATEGORIES.map((cat) => (
+              <CategoryPill
+                key={cat.id}
+                category={cat}
+                isSelected={categoryId === cat.id}
+                onPress={() => setCategoryId(cat.id)}
+              />
+            ))}
+          </View>
+        </View>
+
+        {/* Description + Date */}
+        <View style={{ flexDirection: "row", gap: 8 }}>
+          <TextInput
+            style={{
+              flex: 1,
+              height: 36,
+              borderRadius: 10,
+              paddingHorizontal: 12,
+              fontFamily: "Poppins_500Medium",
+              fontSize: 12,
+              color: primary,
+              borderWidth: 1,
+              borderColor: borderSubtle,
+            }}
+            placeholder={t("transactions.descriptionOptional")}
+            placeholderTextColor={tertiary}
+            value={description}
+            onChangeText={setDescription}
+            maxLength={200}
+          />
+          <View
+            style={{
+              height: 36,
+              borderRadius: 10,
+              flexDirection: "row",
+              alignItems: "center",
+              gap: 6,
+              paddingHorizontal: 10,
+              borderWidth: 1,
+              borderColor: borderSubtle,
+            }}
+          >
+            <Calendar size={14} color={secondary} />
+            <Text
+              style={{
+                fontFamily: "Poppins_500Medium",
+                fontSize: 12,
+                color: primary,
+              }}
+            >
+              {dateLabel}
+            </Text>
+          </View>
+        </View>
+      </View>
+
+      {/* Bottom zone: save button + numpad, pinned to bottom */}
+      <View
+        style={{
+          paddingHorizontal: 16,
+          paddingTop: 8,
+          paddingBottom: Platform.OS === "ios" ? safeBottom : 16,
+          gap: 8,
+        }}
+      >
+        {/* Save button */}
+        <Pressable
+          style={{
+            height: 48,
+            borderRadius: 12,
+            backgroundColor: buttonBg,
+            alignItems: "center",
+            justifyContent: "center",
+            opacity: isSaving ? 0.5 : 1,
+          }}
+          onPress={canSave ? handleSave : undefined}
+          disabled={!canSave || isSaving}
+          accessibilityRole="button"
+          accessibilityLabel={saveLabel}
+        >
+          <Text
+            style={{
+              fontFamily: "Poppins_600SemiBold",
+              fontSize: 15,
+              color: "#FFFFFF",
+            }}
+          >
+            {saveLabel}
+          </Text>
+        </Pressable>
+
+        {/* Custom numpad */}
+        <FidyNumpad onKeyPress={handleKey} />
+      </View>
+    </View>
   );
 }

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -13,7 +13,7 @@ import * as Notifications from "expo-notifications";
 import { type Href, Stack, useRouter, useSegments } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { useChatStore } from "@/features/ai-chat";
 import { useAnalyticsStore } from "@/features/analytics";
@@ -44,7 +44,7 @@ import { ErrorFallback } from "@/shared/components";
 import { Platform, useColorScheme } from "@/shared/components/rn";
 import { Colors } from "@/shared/constants/theme";
 import { type AnyDb, getDb } from "@/shared/db";
-import { useMountEffect } from "@/shared/hooks";
+import { useMountEffect, useSubscription } from "@/shared/hooks";
 import { useLocaleStore } from "@/shared/i18n";
 import {
   captureError,
@@ -60,9 +60,9 @@ import migrations from "../drizzle/migrations";
 const SHEET = { headerShown: false, presentation: "formSheet" } as const;
 
 // Init locale synchronously before first render
-useLocaleStore.getState().initLocale(getLocales()[0]?.languageTag ?? "es");
+useLocaleStore.getState().initLocale(getLocales()[0]?.languageTag ?? "es"); // eslint-disable-line @typescript-eslint/no-unnecessary-condition -- getLocales() CAN return empty array per Expo docs
 
-SplashScreen.preventAutoHideAsync();
+void SplashScreen.preventAutoHideAsync();
 
 const SENTRY_DSN = process.env.EXPO_PUBLIC_SENTRY_DSN ?? process.env.SENTRY_DSN ?? "";
 if (SENTRY_DSN) {
@@ -73,8 +73,8 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
   const router = useRouter();
   const { success: migrationsReady, error: migrationsError } = useMigrations(db, migrations);
 
-  useEffect(() => {
-    if (migrationsReady) {
+  useSubscription(
+    () => {
       useTransactionStore.getState().initStore(db, userId);
       useSearchStore.getState().initStore(db, userId);
       useEmailCaptureStore.getState().initStore(db, userId);
@@ -85,7 +85,7 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
       useGoalStore.getState().initStore(db, userId);
       useAnalyticsStore.getState().initStore(db, userId);
       useCategoriesStore.getState().initStore(db, userId);
-      useNotificationStore.getState().initStore(db, userId);
+      void useNotificationStore.getState().initStore(db, userId);
       useSyncConflictStore.getState().initStore(db);
       Promise.all([
         useCalendarStore.getState().loadBills(),
@@ -122,9 +122,11 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
         .getState()
         .hydrate()
         .catch(handleRecoverableError("Failed to hydrate settings"));
-      registerBackgroundTask().catch(captureError);
-    }
-  }, [migrationsReady, db, userId]);
+      void registerBackgroundTask().catch(captureError);
+    },
+    [db, userId],
+    migrationsReady
+  );
 
   const initialSyncDone = useSync(migrationsReady ? db : null, userId);
   const captureDb = initialSyncDone && migrationsReady ? db : null;
@@ -134,7 +136,7 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
   useSmsDetection(captureDb, userId);
 
   // Global notification handler + push token / response listeners
-  useEffect(() => {
+  useSubscription(() => {
     Notifications.setNotificationHandler({
       handleNotification: async () => ({
         shouldShowBanner: true,
@@ -144,10 +146,10 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
       }),
     });
 
-    registerPushToken(userId).catch(captureError);
+    void registerPushToken(userId).catch(captureError);
 
     const tokenSub = Notifications.addPushTokenListener(() => {
-      registerPushToken(userId).catch(captureError);
+      void registerPushToken(userId).catch(captureError);
     });
 
     const responseSub = Notifications.addNotificationResponseReceivedListener((response) => {
@@ -164,14 +166,14 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
     };
   }, [userId, router]);
 
-  useEffect(() => {
-    if (migrationsError) {
-      captureError(migrationsError);
-    }
-    if (migrationsReady || migrationsError) {
-      SplashScreen.hideAsync();
-    }
-  }, [migrationsReady, migrationsError]);
+  useSubscription(
+    () => {
+      if (migrationsError) captureError(migrationsError);
+      void SplashScreen.hideAsync();
+    },
+    [migrationsReady, migrationsError],
+    migrationsReady || migrationsError != null
+  );
 
   return null;
 }
@@ -179,16 +181,19 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
 function RootLayout() {
   const session = useAuthStore((s) => s.session);
   const isAuthLoading = useAuthStore((s) => s.isLoading);
-  const userId = session?.user?.id ?? null;
+  const userId = session?.user.id ?? null;
   const router = useRouter();
   const segments = useSegments();
   const colorScheme = useColorScheme();
   const theme = Colors[colorScheme === "dark" ? "dark" : "light"];
 
   // Onboarding completion: check SecureStore first, then session metadata
-  const [onboardingComplete, setOnboardingComplete] = useState(() =>
-    getOnboardingCompleteFromStore()
-  );
+  const onboardingComplete = useMemo(() => {
+    if (session) {
+      return getOnboardingCompleteFromStore() || isOnboardingComplete(session);
+    }
+    return false;
+  }, [session]);
 
   const [fontsLoaded, fontsError] = useFonts({
     Poppins_500Medium,
@@ -198,46 +203,40 @@ function RootLayout() {
   });
 
   useMountEffect(() => {
-    useAuthStore.getState().restoreSession();
+    void useAuthStore.getState().restoreSession();
   });
 
-  // Re-check onboarding status when session changes
-  useEffect(() => {
+  // Side effects when session changes: set Sentry user, clear onboarding on sign-out
+  useSubscription(() => {
     setSentryUser(userId);
-    if (session) {
-      const fromStore = getOnboardingCompleteFromStore();
-      const fromSession = isOnboardingComplete(session);
-      setOnboardingComplete(fromStore || fromSession);
-    } else {
-      // User signed out — clear local onboarding flag so a new user gets onboarding
-      clearOnboardingFromStore();
-      setOnboardingComplete(false);
-    }
+    if (!session) clearOnboardingFromStore();
   }, [session, userId]);
 
-  useEffect(() => {
-    if ((fontsLoaded || fontsError) && !isAuthLoading) {
-      if (!userId) {
-        SplashScreen.hideAsync();
-      }
-    }
-  }, [fontsLoaded, fontsError, isAuthLoading, userId]);
+  useSubscription(
+    () => {
+      if (!userId) void SplashScreen.hideAsync();
+    },
+    [fontsLoaded, fontsError, isAuthLoading, userId],
+    (fontsLoaded || fontsError != null) && !isAuthLoading
+  );
 
   // Three-state routing: no user → login, user + not onboarded → onboarding, user + onboarded → tabs
-  useEffect(() => {
-    if (isAuthLoading || (!fontsLoaded && !fontsError)) return;
+  useSubscription(
+    () => {
+      const inAuthGroup = segments[0] === "(auth)";
+      const inOnboarding = (segments as string[])[1] === "onboarding";
 
-    const inAuthGroup = segments[0] === "(auth)";
-    const inOnboarding = (segments as string[])[1] === "onboarding";
-
-    if (!userId && !inAuthGroup) {
-      router.replace("/(auth)");
-    } else if (userId && !onboardingComplete && !inOnboarding) {
-      router.replace("/(auth)/onboarding");
-    } else if (userId && onboardingComplete && inAuthGroup) {
-      router.replace("/(tabs)/(index)" as never);
-    }
-  }, [userId, segments, isAuthLoading, fontsLoaded, fontsError, router, onboardingComplete]);
+      if (!userId && !inAuthGroup) {
+        router.replace("/(auth)");
+      } else if (userId && !onboardingComplete && !inOnboarding) {
+        router.replace("/(auth)/onboarding");
+      } else if (userId && onboardingComplete && inAuthGroup) {
+        router.replace("/(tabs)/(index)" as never);
+      }
+    },
+    [userId, segments, router, onboardingComplete],
+    !isAuthLoading && (fontsLoaded || fontsError != null)
+  );
 
   if (!fontsLoaded && !fontsError) {
     return null;

--- a/apps/mobile/app/connected-accounts.tsx
+++ b/apps/mobile/app/connected-accounts.tsx
@@ -1,13 +1,6 @@
 import { formatDistanceToNow } from "date-fns";
 import { useRouter } from "expo-router";
-import { useEffect } from "react";
-import Animated, {
-  useAnimatedStyle,
-  useSharedValue,
-  withRepeat,
-  withSequence,
-  withTiming,
-} from "react-native-reanimated";
+import Animated from "react-native-reanimated";
 import { ApplePaySetupCard, NotificationSetupCard } from "@/features/capture-sources";
 import {
   getGmailClientId,
@@ -17,7 +10,7 @@ import {
 import { ScreenLayout } from "@/shared/components";
 import { Mail } from "@/shared/components/icons";
 import { Platform, Pressable, ScrollView, Text, View } from "@/shared/components/rn";
-import { useThemeColor, useTranslation } from "@/shared/hooks";
+import { usePulsingOpacity, useThemeColor, useTranslation } from "@/shared/hooks";
 import { getDateFnsLocale } from "@/shared/i18n";
 
 export default function ConnectedAccountsScreen() {
@@ -48,16 +41,24 @@ export default function ConnectedAccountsScreen() {
             provider="Gmail"
             account={gmailAccount}
             isSyncing={isFetching && !!gmailAccount}
-            onConnect={() => connectEmail("gmail", getGmailClientId())}
-            onDisconnect={() => gmailAccount && disconnectEmail(gmailAccount.id)}
+            onConnect={() => {
+              void connectEmail("gmail", getGmailClientId());
+            }}
+            onDisconnect={() => {
+              if (gmailAccount) void disconnectEmail(gmailAccount.id);
+            }}
           />
 
           <AccountCard
             provider="Outlook"
             account={outlookAccount}
             isSyncing={isFetching && !!outlookAccount}
-            onConnect={() => connectEmail("outlook", getOutlookClientId())}
-            onDisconnect={() => outlookAccount && disconnectEmail(outlookAccount.id)}
+            onConnect={() => {
+              void connectEmail("outlook", getOutlookClientId());
+            }}
+            onDisconnect={() => {
+              if (outlookAccount) void disconnectEmail(outlookAccount.id);
+            }}
           />
 
           {/* Platform-specific capture sources */}
@@ -83,22 +84,7 @@ function AccountCard({ provider, account, isSyncing, onConnect, onDisconnect }: 
   const greenColor = useThemeColor("accentGreen");
   const tertiaryColor = useThemeColor("tertiary");
 
-  const dotOpacity = useSharedValue(1);
-
-  useEffect(() => {
-    if (isSyncing) {
-      dotOpacity.value = withRepeat(
-        withSequence(withTiming(0.3, { duration: 600 }), withTiming(1, { duration: 600 })),
-        -1
-      );
-    } else {
-      dotOpacity.value = withTiming(1, { duration: 300 });
-    }
-  }, [isSyncing, dotOpacity]);
-
-  const dotAnimatedStyle = useAnimatedStyle(() => ({
-    opacity: dotOpacity.value,
-  }));
+  const { pulsingStyle: dotAnimatedStyle } = usePulsingOpacity(isSyncing);
 
   if (account) {
     return (

--- a/apps/mobile/app/create-budget.tsx
+++ b/apps/mobile/app/create-budget.tsx
@@ -1,12 +1,6 @@
 import { useLocalSearchParams, useRouter } from "expo-router";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import Animated, {
-  useAnimatedStyle,
-  useSharedValue,
-  withRepeat,
-  withSequence,
-  withTiming,
-} from "react-native-reanimated";
+import { useCallback, useMemo, useRef, useState } from "react";
+import Animated from "react-native-reanimated";
 import { type Budget, type BudgetSuggestion, useBudgetStore } from "@/features/budget";
 import {
   CATEGORIES,
@@ -17,7 +11,7 @@ import {
 } from "@/features/transactions";
 import { FidyNumpad } from "@/shared/components";
 import { Pressable, ScrollView, StyleSheet, Text, View } from "@/shared/components/rn";
-import { useAsyncGuard, useThemeColor, useTranslation } from "@/shared/hooks";
+import { useAsyncGuard, useBlinkingCursor, useThemeColor, useTranslation } from "@/shared/hooks";
 import { getCategoryLabel } from "@/shared/i18n";
 import { formatInputDisplay, formatMoney, parseDigitsToAmount } from "@/shared/lib";
 import type { BudgetId, CopAmount } from "@/shared/types/branded";
@@ -53,19 +47,7 @@ function CreateBudgetForm({
   digitsRef.current = digits;
 
   // Blinking cursor
-  const cursorOpacity = useSharedValue(1);
-  useEffect(() => {
-    cursorOpacity.value = withRepeat(
-      withSequence(
-        withTiming(1, { duration: 0 }),
-        withTiming(1, { duration: 530 }),
-        withTiming(0, { duration: 0 }),
-        withTiming(0, { duration: 530 })
-      ),
-      -1
-    );
-  }, [cursorOpacity]);
-  const cursorStyle = useAnimatedStyle(() => ({ opacity: cursorOpacity.value }));
+  const { cursorStyle } = useBlinkingCursor();
 
   const cardBg = useThemeColor("card");
   const primaryColor = useThemeColor("primary");
@@ -82,12 +64,12 @@ function CreateBudgetForm({
 
   const { isBusy: isSaving, run: guardedSave } = useAsyncGuard();
 
-  const handleSave = () =>
-    guardedSave(async () => {
-      const amount = parseDigitsToAmount(digits) as CopAmount;
+  const handleSave = () => {
+    void guardedSave(async () => {
+      const amount = parseDigitsToAmount(digits);
       if (amount <= 0) return;
 
-      if (isEdit && existingBudget) {
+      if (isEdit) {
         await onUpdateBudget(existingBudget.id, amount);
         onDone();
       } else {
@@ -96,13 +78,15 @@ function CreateBudgetForm({
         if (success) onDone();
       }
     });
+  };
 
-  const handleDelete = () =>
-    guardedSave(async () => {
+  const handleDelete = () => {
+    void guardedSave(async () => {
       if (!existingBudget) return;
       await onDeleteBudget(existingBudget.id);
       onDone();
     });
+  };
 
   const handleKey = useCallback((key: string) => {
     setDigits(handleNumpadPress(digitsRef.current, key));

--- a/apps/mobile/app/edit-transaction.tsx
+++ b/apps/mobile/app/edit-transaction.tsx
@@ -1,10 +1,10 @@
 import * as Haptics from "expo-haptics";
 import { useLocalSearchParams, useRouter } from "expo-router";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import type { TransactionType } from "@/features/transactions";
 import { TransactionForm, useTransactionStore } from "@/features/transactions";
 import { InteractionManager } from "@/shared/components/rn";
-import { useAsyncGuard, useTranslation } from "@/shared/hooks";
+import { useAsyncGuard, useMountEffect, useTranslation } from "@/shared/hooks";
 import { showErrorToast } from "@/shared/lib";
 import type { CategoryId, TransactionId } from "@/shared/types/branded";
 
@@ -29,8 +29,7 @@ export default function EditTransactionScreen() {
   const [date, setDate] = useState(new Date());
   const [loaded, setLoaded] = useState(false);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: router and getTransactionById are stable refs
-  useEffect(() => {
+  useMountEffect(() => {
     const tx = getTransactionById(transactionId as TransactionId);
     if (tx) {
       setType(tx.type);
@@ -42,13 +41,13 @@ export default function EditTransactionScreen() {
     } else {
       router.back();
     }
-  }, [transactionId]);
+  });
 
   const { isBusy: isSaving, run: guardedSave } = useAsyncGuard();
 
-  const handleSave = () =>
-    guardedSave(async () => {
-      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+  const handleSave = () => {
+    void guardedSave(async () => {
+      void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       router.back();
       await afterDismiss();
       try {
@@ -66,10 +65,11 @@ export default function EditTransactionScreen() {
         showErrorToast(t("transactions.updateFailed"));
       }
     });
+  };
 
-  const handleDelete = () =>
-    guardedSave(async () => {
-      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+  const handleDelete = () => {
+    void guardedSave(async () => {
+      void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       router.back();
       await afterDismiss();
       try {
@@ -78,6 +78,7 @@ export default function EditTransactionScreen() {
         showErrorToast(t("transactions.deleteFailed"));
       }
     });
+  };
 
   if (!loaded) return null;
 

--- a/apps/mobile/eslint.config.js
+++ b/apps/mobile/eslint.config.js
@@ -1,82 +1,151 @@
 // https://docs.expo.dev/guides/using-eslint/
 const { defineConfig } = require("eslint/config");
 const expoConfig = require("eslint-config-expo/flat");
+const tseslint = require("typescript-eslint");
+
+// __dirname is available here because this file is CommonJS (require/module.exports)
+// eslint-disable-next-line no-undef
+const rootDir = __dirname;
+
+// Shared barrel-import restriction patterns used across multiple config layers
+const BARREL_PATTERNS = [
+  { group: ["@/features/*/lib/*"], message: "Import from @/features/<name> barrel instead" },
+  { group: ["@/features/*/components/*"], message: "Import from @/features/<name> barrel instead" },
+  { group: ["@/features/*/hooks/*"], message: "Import from @/features/<name> barrel instead" },
+  { group: ["@/features/*/store"], message: "Import from @/features/<name> barrel instead" },
+  { group: ["@/features/*/schema"], message: "Import from @/features/<name> barrel instead" },
+  { group: ["@/features/*/services/*"], message: "Import from @/features/<name> barrel instead" },
+  { group: ["@/shared/lib/*"], message: "Import from @/shared/lib barrel instead" },
+  { group: ["@/shared/db/*"], message: "Import from @/shared/db barrel instead" },
+  {
+    group: ["@/shared/components/*", "!@/shared/components/rn", "!@/shared/components/icons"],
+    message:
+      "Import from @/shared/components barrel, @/shared/components/rn, or @/shared/components/icons instead",
+  },
+  // "react-native" pattern also matches @sentry/react-native — exclude it
+  { group: ["react-native", "!@sentry/*"], message: "Import from @/shared/components/rn instead" },
+  { group: ["lucide-react-native"], message: "Import from @/shared/components/icons instead" },
+];
 
 module.exports = defineConfig([
   expoConfig,
   {
     ignores: ["dist/*"],
   },
+
+  // ── Type-aware parser setup ──────────────────────────────────────────
+  // Note: @typescript-eslint plugin is already registered by eslint-config-expo.
+  // We only need to configure the parser and parserOptions here.
   {
     files: ["**/*.ts", "**/*.tsx"],
-    ignores: [
-      "__tests__/**",
-      "shared/components/rn.ts",
-      "shared/components/icons.ts",
-      "modules/**",
-    ],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: rootDir,
+      },
+    },
+  },
+
+  // ── Strict rules (all TS files) ─────────────────────────────────────
+  // Rules start as "warn" so this PR can land before auto-fixes.
+  // A follow-up PR upgrades all "warn" → "error" after fixes are merged.
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    rules: {
+      // — Type-aware rules (highest value) —
+      "@typescript-eslint/no-floating-promises": "warn",
+      "@typescript-eslint/no-misused-promises": "warn",
+      "@typescript-eslint/await-thenable": "warn",
+      "@typescript-eslint/no-unnecessary-condition": "warn",
+      "@typescript-eslint/switch-exhaustiveness-check": "warn",
+      "@typescript-eslint/no-unsafe-assignment": "warn",
+      "@typescript-eslint/no-unsafe-call": "warn",
+      "@typescript-eslint/no-unsafe-member-access": "warn",
+      "@typescript-eslint/no-unsafe-return": "warn",
+      "@typescript-eslint/no-unsafe-argument": "warn",
+      "@typescript-eslint/restrict-template-expressions": "warn",
+      "@typescript-eslint/prefer-nullish-coalescing": "warn",
+      "@typescript-eslint/no-unnecessary-type-assertion": "warn",
+
+      // — Syntax-only rules —
+      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/no-non-null-assertion": "warn",
+      "@typescript-eslint/prefer-optional-chain": "warn",
+      "@typescript-eslint/consistent-type-imports": [
+        "warn",
+        { prefer: "type-imports", fixStyle: "inline-type-imports" },
+      ],
+
+      // — FP-mandate rules (align with CLAUDE.md) —
+      "no-param-reassign": "warn",
+      "prefer-const": "warn",
+      "no-var": "error",
+
+      // — React rules —
+      "react-hooks/exhaustive-deps": "warn",
+    },
+  },
+
+  // ── useEffect / useLayoutEffect ban (feature code only) ─────────────
+  // Allowed ONLY in shared/hooks/** (where approved wrappers live)
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    ignores: ["shared/hooks/**", "__tests__/**"],
     rules: {
       "no-restricted-imports": [
-        "error",
+        "warn",
         {
+          paths: [
+            {
+              name: "react",
+              importNames: ["useEffect", "useLayoutEffect"],
+              message:
+                "useEffect/useLayoutEffect are banned. Use approved hooks from @/shared/hooks instead (useMountEffect, useSubscription, useBlinkingCursor, useAnimatedProgress).",
+            },
+          ],
           patterns: [
-            {
-              group: ["@/features/*/lib/*"],
-              message: "Import from @/features/<name> barrel instead",
-            },
-            {
-              group: ["@/features/*/components/*"],
-              message: "Import from @/features/<name> barrel instead",
-            },
-            {
-              group: ["@/features/*/hooks/*"],
-              message: "Import from @/features/<name> barrel instead",
-            },
-            {
-              group: ["@/features/*/store"],
-              message: "Import from @/features/<name> barrel instead",
-            },
-            {
-              group: ["@/features/*/schema"],
-              message: "Import from @/features/<name> barrel instead",
-            },
-            {
-              group: ["@/features/*/services/*"],
-              message: "Import from @/features/<name> barrel instead",
-            },
-            {
-              group: ["@/shared/lib/*"],
-              message: "Import from @/shared/lib barrel instead",
-            },
+            ...BARREL_PATTERNS,
             {
               group: ["@/shared/hooks/*"],
               message: "Import from @/shared/hooks barrel instead",
             },
-            {
-              group: ["@/shared/db/*"],
-              message: "Import from @/shared/db barrel instead",
-            },
-            {
-              group: [
-                "@/shared/components/*",
-                "!@/shared/components/rn",
-                "!@/shared/components/icons",
-              ],
-              message:
-                "Import from @/shared/components barrel, @/shared/components/rn, or @/shared/components/icons instead",
-            },
-            {
-              // "react-native" pattern also matches @sentry/react-native — exclude it
-              group: ["react-native", "!@sentry/*"],
-              message: "Import from @/shared/components/rn instead",
-            },
-            {
-              group: ["lucide-react-native"],
-              message: "Import from @/shared/components/icons instead",
-            },
           ],
         },
       ],
+    },
+  },
+
+  // ── Barrel import restrictions for shared/hooks/** ──────────────────
+  // Exempt from the useEffect ban but still need barrel restrictions
+  {
+    files: ["shared/hooks/**/*.ts", "shared/hooks/**/*.tsx"],
+    rules: {
+      "no-restricted-imports": ["warn", { patterns: BARREL_PATTERNS }],
+    },
+  },
+
+  // ── Exemptions for rn.ts, icons.ts, and native modules ──────────────
+  {
+    files: ["shared/components/rn.ts", "shared/components/icons.ts", "modules/**"],
+    rules: {
+      "no-restricted-imports": "off",
+    },
+  },
+
+  // ── Test file overrides ─────────────────────────────────────────────
+  {
+    files: ["__tests__/**/*.ts", "__tests__/**/*.tsx"],
+    rules: {
+      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
+      "@typescript-eslint/no-unsafe-argument": "off",
+      "@typescript-eslint/no-non-null-assertion": "off",
+      "@typescript-eslint/restrict-template-expressions": "off",
+      "no-restricted-imports": "off",
     },
   },
 ]);

--- a/apps/mobile/features/ai-chat/components/ChatInput.tsx
+++ b/apps/mobile/features/ai-chat/components/ChatInput.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { SendHorizonal } from "@/shared/components/icons";
 import { Keyboard, Platform, Pressable, TextInput, View } from "@/shared/components/rn";
-import { useThemeColor, useTranslation } from "@/shared/hooks";
+import { useSubscription, useThemeColor, useTranslation } from "@/shared/hooks";
 
 type ChatInputProps = {
   readonly onSend: (text: string) => void;
@@ -18,7 +18,7 @@ export function ChatInput({ onSend, disabled = false }: ChatInputProps) {
   const tertiary = useThemeColor("tertiary");
   const accentGreen = useThemeColor("accentGreen");
 
-  useEffect(() => {
+  useSubscription(() => {
     const showEvent = Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow";
     const hideEvent = Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide";
     const showSub = Keyboard.addListener(showEvent, () => setKeyboardVisible(true));

--- a/apps/mobile/features/budget/components/BudgetListScreen.tsx
+++ b/apps/mobile/features/budget/components/BudgetListScreen.tsx
@@ -1,10 +1,10 @@
 import { useRouter } from "expo-router";
-import { useCallback, useEffect } from "react";
-import { MonthNavigator } from "@/features/calendar/components/MonthNavigator";
+import { useCallback } from "react";
+import { MonthNavigator } from "@/features/calendar";
 import { ScreenLayout, TAB_BAR_CLEARANCE } from "@/shared/components";
 import { Plus, Wallet } from "@/shared/components/icons";
 import { Platform, Pressable, ScrollView, StyleSheet, Text, View } from "@/shared/components/rn";
-import { useThemeColor, useTranslation } from "@/shared/hooks";
+import { useSubscription, useThemeColor, useTranslation } from "@/shared/hooks";
 import { useBudgetStore } from "../store";
 import { BudgetCard } from "./BudgetCard";
 import { BudgetSummaryCard } from "./BudgetSummaryCard";
@@ -34,14 +34,16 @@ export function BudgetListScreen() {
   const clearPendingPermissionRequest = useBudgetStore((s) => s.clearPendingPermissionRequest);
 
   // Navigate to pre-permission screen when store signals it.
-  // Uses useEffect because the store's refreshProgress() is async/deep in the derivation
+  // Uses useSubscription because the store's refreshProgress() is async/deep in the derivation
   // chain and cannot call router.push() directly — this is a Zustand subscription pattern.
-  useEffect(() => {
-    if (pendingPermissionRequest) {
+  useSubscription(
+    () => {
       clearPendingPermissionRequest();
       router.push("/enable-notifications");
-    }
-  }, [pendingPermissionRequest, clearPendingPermissionRequest, router]);
+    },
+    [pendingPermissionRequest, clearPendingPermissionRequest, router],
+    pendingPermissionRequest
+  );
 
   const primaryColor = useThemeColor("primary");
   const secondaryColor = useThemeColor("secondary");

--- a/apps/mobile/features/budget/components/ProgressBar.tsx
+++ b/apps/mobile/features/budget/components/ProgressBar.tsx
@@ -1,7 +1,6 @@
-import { useEffect } from "react";
-import Animated, { useAnimatedStyle, useSharedValue, withTiming } from "react-native-reanimated";
+import Animated from "react-native-reanimated";
 import { StyleSheet, View } from "@/shared/components/rn";
-import { useThemeColor } from "@/shared/hooks";
+import { useAnimatedProgress, useThemeColor } from "@/shared/hooks";
 
 type Props = {
   readonly percent: number; // 0-100+
@@ -13,18 +12,9 @@ export function ProgressBar({ percent, height = 8 }: Props) {
   const accentRed = useThemeColor("accentRed");
   const borderColor = useThemeColor("borderSubtle");
 
-  const progress = useSharedValue(0);
+  const { animatedStyle } = useAnimatedProgress(Math.min(percent, 100) / 100, 600);
 
-  useEffect(() => {
-    progress.value = withTiming(Math.min(percent, 100) / 100, { duration: 600 });
-  }, [percent, progress]);
-
-  // Determine bar color outside the worklet — it depends on React props, not shared values
   const barColor = percent >= 100 ? accentRed : accentGreen;
-
-  const animatedStyle = useAnimatedStyle(() => ({
-    width: `${progress.value * 100}%`,
-  }));
 
   return (
     <View style={[styles.track, { height, backgroundColor: borderColor }]}>

--- a/apps/mobile/features/capture-sources/hooks/useApplePayCapture.ts
+++ b/apps/mobile/features/capture-sources/hooks/useApplePayCapture.ts
@@ -1,26 +1,15 @@
-import { useEffect } from "react";
 import { Platform } from "@/shared/components/rn";
 import type { AnyDb } from "@/shared/db";
+import { useSubscription } from "@/shared/hooks";
 import { setupApplePayCapture } from "./setup";
 
 export function useApplePayCapture(db: AnyDb | null, userId: string | null) {
-  useEffect(() => {
-    if (Platform.OS !== "ios" || !db || !userId) return;
-
-    let cleanup: (() => void) | undefined;
-    let cancelled = false;
-
-    setupApplePayCapture(db, userId).then((teardown) => {
-      if (cancelled) {
-        teardown();
-      } else {
-        cleanup = teardown;
-      }
-    });
-
-    return () => {
-      cancelled = true;
-      cleanup?.();
-    };
-  }, [db, userId]);
+  useSubscription(
+    () => {
+      if (!db || !userId) return;
+      return setupApplePayCapture(db, userId);
+    },
+    [db, userId],
+    Platform.OS === "ios" && db != null && userId != null
+  );
 }

--- a/apps/mobile/features/capture-sources/hooks/useNotificationCapture.ts
+++ b/apps/mobile/features/capture-sources/hooks/useNotificationCapture.ts
@@ -1,6 +1,6 @@
-import { useEffect } from "react";
 import { Platform } from "@/shared/components/rn";
 import type { AnyDb } from "@/shared/db";
+import { useSubscription } from "@/shared/hooks";
 import { captureError } from "@/shared/lib";
 import { useCaptureSourcesStore } from "../store";
 import { setupNotificationCapture } from "./setup";
@@ -8,22 +8,15 @@ import { setupNotificationCapture } from "./setup";
 export function useNotificationCapture(db: AnyDb | null, userId: string | null) {
   const enabledPackages = useCaptureSourcesStore((s) => s.enabledPackages);
 
-  useEffect(() => {
-    if (Platform.OS !== "android" || !db || !userId || enabledPackages.length === 0) return;
-    let cancelled = false;
-    let cleanup: (() => void) | undefined;
-    setupNotificationCapture(db, userId, enabledPackages)
-      .then((c) => {
-        if (cancelled) {
-          c();
-        } else {
-          cleanup = c;
-        }
-      })
-      .catch(captureError);
-    return () => {
-      cancelled = true;
-      cleanup?.();
-    };
-  }, [db, userId, enabledPackages]);
+  useSubscription(
+    () => {
+      if (!db || !userId) return;
+      return setupNotificationCapture(db, userId, enabledPackages).catch((error) => {
+        captureError(error);
+        return () => {};
+      });
+    },
+    [db, userId, enabledPackages],
+    Platform.OS === "android" && db != null && userId != null && enabledPackages.length > 0
+  );
 }

--- a/apps/mobile/features/capture-sources/hooks/useSmsDetection.ts
+++ b/apps/mobile/features/capture-sources/hooks/useSmsDetection.ts
@@ -1,6 +1,6 @@
-import { useEffect } from "react";
 import { Platform } from "@/shared/components/rn";
 import type { AnyDb } from "@/shared/db";
+import { useSubscription } from "@/shared/hooks";
 import { captureError } from "@/shared/lib";
 import { useCaptureSourcesStore } from "../store";
 import { setupSmsDetection } from "./setup";
@@ -8,25 +8,18 @@ import { setupSmsDetection } from "./setup";
 export function useSmsDetection(db: AnyDb | null, userId: string | null) {
   const refreshDetectedSms = useCaptureSourcesStore((s) => s.refreshDetectedSms);
 
-  useEffect(() => {
-    if (Platform.OS !== "ios" || !db || !userId) return;
-
-    let cleanup: (() => void) | undefined;
-    let cancelled = false;
-
-    setupSmsDetection(db, userId, refreshDetectedSms)
-      .then((teardown) => {
-        if (cancelled) {
-          teardown();
-        } else {
-          cleanup = teardown;
-        }
-      })
-      .catch(captureError);
-
-    return () => {
-      cancelled = true;
-      cleanup?.();
-    };
-  }, [db, userId, refreshDetectedSms]);
+  useSubscription(
+    () => {
+      if (!db || !userId) return;
+      const onRefresh = () => {
+        void refreshDetectedSms();
+      };
+      return setupSmsDetection(db, userId, onRefresh).catch((error: unknown) => {
+        captureError(error);
+        return () => {};
+      });
+    },
+    [db, userId, refreshDetectedSms],
+    Platform.OS === "ios" && db != null && userId != null
+  );
 }

--- a/apps/mobile/features/email-capture/components/EmailProgressCard.tsx
+++ b/apps/mobile/features/email-capture/components/EmailProgressCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 import Animated, {
   FadeIn,
   FadeOut,
@@ -8,7 +8,12 @@ import Animated, {
 } from "react-native-reanimated";
 import { CheckCircle, Mail, Search, TriangleAlert } from "@/shared/components/icons";
 import { Text, View } from "@/shared/components/rn";
-import { useThemeColor, useTranslation } from "@/shared/hooks";
+import {
+  useAnimatedProgress,
+  useSubscription,
+  useThemeColor,
+  useTranslation,
+} from "@/shared/hooks";
 import type { ProgressDisplay, ProgressPhase } from "../lib/progress-phases";
 import { shouldMorphToBanner } from "../lib/progress-phases";
 
@@ -26,7 +31,6 @@ const NEEDS_REVIEW_ICON = "#E65100";
 export const EmailProgressCard = ({ phase, display, onComplete }: EmailProgressCardProps) => {
   const { t } = useTranslation();
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const barWidth = useSharedValue(0);
   const morphProgress = useSharedValue(0);
 
   const cardBg = useThemeColor("card");
@@ -35,30 +39,23 @@ export const EmailProgressCard = ({ phase, display, onComplete }: EmailProgressC
   const accentGreen = useThemeColor("accentGreen");
   const borderSubtle = useThemeColor("borderSubtle");
 
-  // Animate progress bar
-  useEffect(() => {
-    barWidth.value = withTiming(display.fractionComplete, { duration: 300 });
-  }, [display.fractionComplete, barWidth]);
+  const { animatedStyle: barAnimatedStyle } = useAnimatedProgress(display.fractionComplete, 300);
 
   // Handle completion phase
-  useEffect(() => {
-    if (phase !== "complete") return;
-
-    const delay = shouldMorphToBanner(display.needsReview) ? MORPH_DELAY_MS : FADE_DELAY_MS;
-
-    if (shouldMorphToBanner(display.needsReview)) {
-      morphProgress.value = withTiming(1, { duration: 400 });
-    }
-
-    timerRef.current = setTimeout(onComplete, delay);
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-    };
-  }, [phase, display.needsReview, onComplete, morphProgress]);
-
-  const progressBarStyle = useAnimatedStyle(() => ({
-    width: `${barWidth.value * 100}%`,
-  }));
+  useSubscription(
+    () => {
+      const delay = shouldMorphToBanner(display.needsReview) ? MORPH_DELAY_MS : FADE_DELAY_MS;
+      if (shouldMorphToBanner(display.needsReview)) {
+        morphProgress.value = withTiming(1, { duration: 400 });
+      }
+      timerRef.current = setTimeout(onComplete, delay);
+      return () => {
+        if (timerRef.current) clearTimeout(timerRef.current);
+      };
+    },
+    [display.needsReview, onComplete, morphProgress],
+    phase === "complete"
+  );
 
   const containerStyle = useAnimatedStyle(() => ({
     backgroundColor: morphProgress.value > 0.5 ? NEEDS_REVIEW_BG : cardBg,
@@ -97,7 +94,7 @@ export const EmailProgressCard = ({ phase, display, onComplete }: EmailProgressC
           >
             <Animated.View
               style={[
-                progressBarStyle,
+                barAnimatedStyle,
                 {
                   backgroundColor: accentGreen,
                   height: "100%",

--- a/apps/mobile/features/email-capture/hooks/useEmailCapture.ts
+++ b/apps/mobile/features/email-capture/hooks/useEmailCapture.ts
@@ -1,35 +1,39 @@
-import { useEffect } from "react";
 import { AppState } from "@/shared/components/rn";
 import type { AnyDb } from "@/shared/db";
+import { useSubscription } from "@/shared/hooks";
 import { handleRecoverableError } from "@/shared/lib";
 import { getGmailClientId, getOutlookClientId } from "../schema";
 import { useEmailCaptureStore } from "../store";
 
 export function useEmailCapture(db: AnyDb | null, userId: string | null) {
-  useEffect(() => {
-    if (!db || !userId) return;
+  useSubscription(
+    () => {
+      if (!db || !userId) return;
 
-    useEmailCaptureStore.getState().initStore(db, userId);
+      useEmailCaptureStore.getState().initStore(db, userId);
 
-    const runFetch = () => {
+      const runFetch = () => {
+        useEmailCaptureStore
+          .getState()
+          .fetchAndProcess(getGmailClientId(), getOutlookClientId())
+          .catch(handleRecoverableError("Email sync failed"));
+      };
+
       useEmailCaptureStore
         .getState()
-        .fetchAndProcess(getGmailClientId(), getOutlookClientId())
+        .loadAccounts()
+        .then(() => runFetch())
         .catch(handleRecoverableError("Email sync failed"));
-    };
 
-    useEmailCaptureStore
-      .getState()
-      .loadAccounts()
-      .then(() => runFetch())
-      .catch(handleRecoverableError("Email sync failed"));
+      const subscription = AppState.addEventListener("change", (state) => {
+        if (state === "active") runFetch();
+      });
 
-    const subscription = AppState.addEventListener("change", (state) => {
-      if (state === "active") runFetch();
-    });
-
-    return () => {
-      subscription.remove();
-    };
-  }, [db, userId]);
+      return () => {
+        subscription.remove();
+      };
+    },
+    [db, userId],
+    db != null && userId != null
+  );
 }

--- a/apps/mobile/features/goals/components/AddPaymentSheet.tsx
+++ b/apps/mobile/features/goals/components/AddPaymentSheet.tsx
@@ -1,12 +1,6 @@
 import { useRouter } from "expo-router";
-import { useCallback, useEffect, useRef, useState } from "react";
-import Animated, {
-  useAnimatedStyle,
-  useSharedValue,
-  withRepeat,
-  withSequence,
-  withTiming,
-} from "react-native-reanimated";
+import { useCallback, useRef, useState } from "react";
+import Animated from "react-native-reanimated";
 import { handleNumpadPress } from "@/features/transactions";
 import { FidyNumpad } from "@/shared/components";
 import {
@@ -18,7 +12,7 @@ import {
   TextInput,
   View,
 } from "@/shared/components/rn";
-import { useAsyncGuard, useThemeColor, useTranslation } from "@/shared/hooks";
+import { useAsyncGuard, useBlinkingCursor, useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatInputDisplay, parseDigitsToAmount, toIsoDate } from "@/shared/lib";
 import { useGoalStore } from "../store";
 
@@ -43,19 +37,7 @@ export function AddPaymentSheet() {
   const [date, setDate] = useState<string>(toIsoDate(new Date()));
 
   // Blinking cursor
-  const cursorOpacity = useSharedValue(1);
-  useEffect(() => {
-    cursorOpacity.value = withRepeat(
-      withSequence(
-        withTiming(1, { duration: 0 }),
-        withTiming(1, { duration: 530 }),
-        withTiming(0, { duration: 0 }),
-        withTiming(0, { duration: 530 })
-      ),
-      -1
-    );
-  }, [cursorOpacity]);
-  const cursorStyle = useAnimatedStyle(() => ({ opacity: cursorOpacity.value }));
+  const { cursorStyle } = useBlinkingCursor();
 
   const { isBusy: isAdding, run: guardedAdd } = useAsyncGuard();
 
@@ -157,7 +139,9 @@ export function AddPaymentSheet() {
       {/* Add payment button */}
       <Pressable
         style={[styles.ctaButton, { backgroundColor: accentGreen, opacity: isAdding ? 0.5 : 1 }]}
-        onPress={handleAddPayment}
+        onPress={() => {
+          void handleAddPayment();
+        }}
         disabled={isAdding}
       >
         <Text style={styles.ctaButtonText}>{t("goals.payment.addPaymentCta")}</Text>

--- a/apps/mobile/features/goals/components/GoalCreateSheet.tsx
+++ b/apps/mobile/features/goals/components/GoalCreateSheet.tsx
@@ -1,13 +1,7 @@
 import DateTimePicker from "@react-native-community/datetimepicker";
 import { useRouter } from "expo-router";
-import { useCallback, useEffect, useRef, useState } from "react";
-import Animated, {
-  useAnimatedStyle,
-  useSharedValue,
-  withRepeat,
-  withSequence,
-  withTiming,
-} from "react-native-reanimated";
+import { useCallback, useRef, useState } from "react";
+import Animated from "react-native-reanimated";
 import { handleNumpadPress } from "@/features/transactions";
 import { FidyNumpad } from "@/shared/components";
 import {
@@ -20,7 +14,7 @@ import {
   TextInput,
   View,
 } from "@/shared/components/rn";
-import { useAsyncGuard, useThemeColor, useTranslation } from "@/shared/hooks";
+import { useAsyncGuard, useBlinkingCursor, useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatInputDisplay, parseDigitsToAmount, toIsoDate } from "@/shared/lib";
 import type { GoalType } from "../schema";
 import { useGoalStore } from "../store";
@@ -50,19 +44,7 @@ export function GoalCreateSheet() {
   const [showDatePicker, setShowDatePicker] = useState(false);
 
   // Blinking cursor
-  const cursorOpacity = useSharedValue(1);
-  useEffect(() => {
-    cursorOpacity.value = withRepeat(
-      withSequence(
-        withTiming(1, { duration: 0 }),
-        withTiming(1, { duration: 530 }),
-        withTiming(0, { duration: 0 }),
-        withTiming(0, { duration: 530 })
-      ),
-      -1
-    );
-  }, [cursorOpacity]);
-  const cursorStyle = useAnimatedStyle(() => ({ opacity: cursorOpacity.value }));
+  const { cursorStyle } = useBlinkingCursor();
 
   const { isBusy: isCreating, run: guardedCreate } = useAsyncGuard();
 
@@ -70,7 +52,7 @@ export function GoalCreateSheet() {
   const amount = parseDigitsToAmount(digits);
 
   // Derive projection hint
-  const projectionMonths = goals.length > 0 ? goals[0].projection.netMonthlySavings : 0;
+  const projectionMonths = goals.length > 0 ? (goals[0]?.projection.netMonthlySavings ?? 0) : 0;
   const estimatedMonths =
     projectionMonths > 0 && amount > 0 ? Math.ceil(amount / projectionMonths) : null;
 
@@ -293,7 +275,9 @@ export function GoalCreateSheet() {
           styles.createButton,
           { backgroundColor: accentGreen, opacity: isCreating ? 0.5 : 1 },
         ]}
-        onPress={handleCreate}
+        onPress={() => {
+          void handleCreate();
+        }}
         disabled={isCreating}
       >
         <Text style={styles.createButtonText}>{t("goals.create.title")}</Text>

--- a/apps/mobile/features/goals/components/GoalDetail.tsx
+++ b/apps/mobile/features/goals/components/GoalDetail.tsx
@@ -1,9 +1,9 @@
 import { format } from "date-fns";
 import { Stack, useRouter } from "expo-router";
-import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { memo, useCallback, useRef, useState } from "react";
 import Svg, { Circle as SvgCircle } from "react-native-svg";
 import { Platform, Pressable, ScrollView, StyleSheet, Text, View } from "@/shared/components/rn";
-import { useThemeColor, useTranslation } from "@/shared/hooks";
+import { useSubscription, useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatDateDisplay, formatMoney } from "@/shared/lib";
 import type { CopAmount, IsoDate } from "@/shared/types/branded";
 import type { GoalProjection, Milestone } from "../lib/derive";
@@ -36,7 +36,7 @@ const checkMilestoneCrossed = (
   const crossed = MILESTONE_THRESHOLDS.filter(
     (threshold) => prevPercent < threshold && currentPercent >= threshold
   );
-  return crossed.length > 0 ? crossed[crossed.length - 1] : null;
+  return crossed.length > 0 ? (crossed[crossed.length - 1] ?? null) : null;
 };
 
 // ---------------------------------------------------------------------------
@@ -213,7 +213,7 @@ function ContributionRowInner({
           {formatDateDisplay(contribution.date as IsoDate)}
         </Text>
         <Text style={[styles.contributionNote, { color: secondaryColor }]}>
-          {contribution.note != null ? contribution.note : t("goals.detail.manualPayment")}
+          {contribution.note ?? t("goals.detail.manualPayment")}
         </Text>
       </View>
       <Text style={[styles.contributionAmount, { color: accentGreen }]}>
@@ -308,20 +308,21 @@ export function GoalDetailScreen() {
   const goalData = goals.find((g) => g.goal.id === selectedGoalId);
 
   // Track previous progress percent to detect milestone crossings.
-  // Allowed useEffect: subscription/listener pattern detecting external store changes.
   const prevPercentRef = useRef<number | null>(null);
-  useEffect(() => {
-    if (goalData == null) return;
-    const currentPercent = goalData.progress.percentComplete;
-    const prevPercent = prevPercentRef.current;
-    if (prevPercent !== null && prevPercent !== currentPercent) {
-      const crossed = checkMilestoneCrossed(prevPercent, currentPercent);
-      if (crossed !== null) {
-        setCelebrationMilestone(crossed);
+  useSubscription(
+    () => {
+      if (goalData == null) return;
+      const currentPercent = goalData.progress.percentComplete;
+      const prevPercent = prevPercentRef.current;
+      if (prevPercent !== null && prevPercent !== currentPercent) {
+        const crossed = checkMilestoneCrossed(prevPercent, currentPercent);
+        if (crossed !== null) setCelebrationMilestone(crossed);
       }
-    }
-    prevPercentRef.current = currentPercent;
-  }, [goalData]);
+      prevPercentRef.current = currentPercent;
+    },
+    [goalData],
+    goalData != null
+  );
 
   if (goalData == null) {
     return null;
@@ -330,12 +331,12 @@ export function GoalDetailScreen() {
   const { goal, currentAmount, progress, projection } = goalData;
 
   // Compute running totals for contribution history
-  const contributionsWithRunning: Array<{ contribution: GoalContribution; runningTotal: number }> =
+  const contributionsWithRunning: { contribution: GoalContribution; runningTotal: number }[] =
     (() => {
       const reversed = [...contributions].reverse();
-      const result: Array<{ contribution: GoalContribution; runningTotal: number }> = [];
+      const result: { contribution: GoalContribution; runningTotal: number }[] = [];
       reversed.forEach((c) => {
-        const prevTotal = result.length > 0 ? result[result.length - 1].runningTotal : 0;
+        const prevTotal = result.length > 0 ? (result[result.length - 1]?.runningTotal ?? 0) : 0;
         result.push({ contribution: c, runningTotal: prevTotal + c.amount });
       });
       return result.reverse();

--- a/apps/mobile/features/goals/components/GoalEditSheet.tsx
+++ b/apps/mobile/features/goals/components/GoalEditSheet.tsx
@@ -1,13 +1,7 @@
 import DateTimePicker from "@react-native-community/datetimepicker";
 import { useRouter } from "expo-router";
-import { useCallback, useEffect, useRef, useState } from "react";
-import Animated, {
-  useAnimatedStyle,
-  useSharedValue,
-  withRepeat,
-  withSequence,
-  withTiming,
-} from "react-native-reanimated";
+import { useCallback, useRef, useState } from "react";
+import Animated from "react-native-reanimated";
 import { handleNumpadPress } from "@/features/transactions";
 import { FidyNumpad } from "@/shared/components";
 import {
@@ -21,7 +15,7 @@ import {
   TextInput,
   View,
 } from "@/shared/components/rn";
-import { useAsyncGuard, useThemeColor, useTranslation } from "@/shared/hooks";
+import { useAsyncGuard, useBlinkingCursor, useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatInputDisplay, parseDigitsToAmount, parseIsoDate, toIsoDate } from "@/shared/lib";
 import type { IsoDate } from "@/shared/types/branded";
 import { useGoalStore } from "../store";
@@ -60,19 +54,7 @@ export function GoalEditSheet() {
   const [showDatePicker, setShowDatePicker] = useState(false);
 
   // Blinking cursor
-  const cursorOpacity = useSharedValue(1);
-  useEffect(() => {
-    cursorOpacity.value = withRepeat(
-      withSequence(
-        withTiming(1, { duration: 0 }),
-        withTiming(1, { duration: 530 }),
-        withTiming(0, { duration: 0 }),
-        withTiming(0, { duration: 530 })
-      ),
-      -1
-    );
-  }, [cursorOpacity]);
-  const cursorStyle = useAnimatedStyle(() => ({ opacity: cursorOpacity.value }));
+  const { cursorStyle } = useBlinkingCursor();
 
   const { isBusy: isSaving, run: guardedSave } = useAsyncGuard();
   const { isBusy: isDeleting, run: guardedDelete } = useAsyncGuard();
@@ -132,11 +114,12 @@ export function GoalEditSheet() {
         {
           text: t("common.delete"),
           style: "destructive",
-          onPress: () =>
-            guardedDelete(async () => {
+          onPress: () => {
+            void guardedDelete(async () => {
               await deleteGoal(selectedGoalId);
               back();
-            }),
+            });
+          },
         },
       ]
     );
@@ -277,7 +260,9 @@ export function GoalEditSheet() {
       {/* Save button */}
       <Pressable
         style={[styles.saveButton, { backgroundColor: accentGreen, opacity: isSaving ? 0.5 : 1 }]}
-        onPress={handleSave}
+        onPress={() => {
+          void handleSave();
+        }}
         disabled={isSaving}
       >
         <Text style={styles.saveButtonText}>{t("goals.edit.saveChanges")}</Text>

--- a/apps/mobile/features/onboarding/components/SyncProgressStep.tsx
+++ b/apps/mobile/features/onboarding/components/SyncProgressStep.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { ProgressBar } from "@/features/budget/components/ProgressBar";
 import {
@@ -8,7 +8,7 @@ import {
 } from "@/features/email-capture";
 import { useTransactionStore } from "@/features/transactions";
 import { Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
-import { useThemeColor, useTranslation } from "@/shared/hooks";
+import { useMountEffect, useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatMoney } from "@/shared/lib";
 import { useOnboardingStore } from "../store";
 
@@ -33,12 +33,12 @@ export function SyncProgressStep() {
   const finalSavedCount = useRef(0);
 
   // Start fetch on mount if we have accounts
-  useEffect(() => {
+  useMountEffect(() => {
     if (accounts.length > 0 && !fetchStarted.current) {
       fetchStarted.current = true;
-      fetchAndProcess(getGmailClientId(), getOutlookClientId());
+      void fetchAndProcess(getGmailClientId(), getOutlookClientId());
     }
-  }, [accounts.length, fetchAndProcess]);
+  });
 
   const livePercent = progress
     ? progress.total > 0

--- a/apps/mobile/features/search/components/SearchScreen.tsx
+++ b/apps/mobile/features/search/components/SearchScreen.tsx
@@ -1,10 +1,10 @@
 import { useRouter } from "expo-router";
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useMemo, useRef, useState } from "react";
 import { CATEGORY_MAP, makeDateLabel, type StoredTransaction } from "@/features/transactions";
 import { ScreenLayout, TAB_BAR_CLEARANCE, TransactionRow } from "@/shared/components";
 import { Ellipsis } from "@/shared/components/icons";
 import { FlatList, InteractionManager, Text, TextInput, View } from "@/shared/components/rn";
-import { useThemeColor, useTranslation } from "@/shared/hooks";
+import { useMountEffect, useThemeColor, useTranslation } from "@/shared/hooks";
 import { getCategoryLabel, getDateFnsLocale } from "@/shared/i18n";
 import { formatSignedMoney, toIsoDate } from "@/shared/lib";
 import { amountDigitsToAmount } from "../lib/amount-utils";
@@ -83,23 +83,18 @@ export const SearchScreen = () => {
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const inputRef = useRef<TextInput>(null);
 
-  // Defer everything until the push transition animation finishes
-  useEffect(() => {
+  useMountEffect(() => {
     const handle = InteractionManager.runAfterInteractions(() => {
       setReady(true);
       executeSearch();
       inputRef.current?.focus();
     });
-    return () => handle.cancel();
-  }, [executeSearch]);
-
-  // Clean up on unmount
-  useEffect(() => {
     return () => {
+      handle.cancel();
       if (debounceRef.current) clearTimeout(debounceRef.current);
       reset();
     };
-  }, [reset]);
+  });
 
   const handleTextChange = useCallback(
     (text: string) => {

--- a/apps/mobile/features/sync/hooks/useSync.ts
+++ b/apps/mobile/features/sync/hooks/useSync.ts
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { useTransactionStore } from "@/features/transactions";
 import { AppState } from "@/shared/components/rn";
 import type { AnyDb } from "@/shared/db";
 import { getSupabase } from "@/shared/db";
+import { useSubscription } from "@/shared/hooks";
 import { captureWarning } from "@/shared/lib";
 import { isOnline, onConnectivityChange } from "../services/networkMonitor";
 import { fullSync } from "../services/syncEngine";
@@ -12,54 +13,58 @@ export function useSync(db: AnyDb | null, userId: string | null): boolean {
   const isSyncing = useRef(false);
   const [initialSyncDone, setInitialSyncDone] = useState(false);
 
-  useEffect(() => {
-    if (!db || !userId) return;
+  useSubscription(
+    () => {
+      if (!db || !userId) return;
 
-    setInitialSyncDone(false);
-    const supabase = getSupabase();
-    const hasCompletedInitialRun = { current: false };
+      setInitialSyncDone(false);
+      const supabase = getSupabase();
+      const hasCompletedInitialRun = { current: false };
 
-    const markInitialDone = () => {
-      if (!hasCompletedInitialRun.current) {
-        hasCompletedInitialRun.current = true;
-        setInitialSyncDone(true);
-      }
-    };
+      const markInitialDone = () => {
+        if (!hasCompletedInitialRun.current) {
+          hasCompletedInitialRun.current = true;
+          setInitialSyncDone(true);
+        }
+      };
 
-    const runSync = async () => {
-      if (isSyncing.current) return;
-      const online = await isOnline();
-      if (!online) return;
-      isSyncing.current = true;
-      try {
-        const pullOk = await fullSync(db, supabase, userId);
-        await useTransactionStore.getState().refresh();
-        useSyncConflictStore.getState().loadConflicts();
-        if (pullOk) markInitialDone();
-      } catch (error) {
-        captureWarning("background_sync_failed", {
-          errorType: error instanceof Error ? error.message : "unknown",
-        });
-      } finally {
-        isSyncing.current = false;
-      }
-    };
+      const runSync = async () => {
+        if (isSyncing.current) return;
+        const online = await isOnline();
+        if (!online) return;
+        isSyncing.current = true;
+        try {
+          const pullOk = await fullSync(db, supabase, userId);
+          await useTransactionStore.getState().refresh();
+          useSyncConflictStore.getState().loadConflicts();
+          if (pullOk) markInitialDone();
+        } catch (error) {
+          captureWarning("background_sync_failed", {
+            errorType: error instanceof Error ? error.message : "unknown",
+          });
+        } finally {
+          isSyncing.current = false;
+        }
+      };
 
-    runSync();
+      void runSync();
 
-    const appStateSubscription = AppState.addEventListener("change", (state) => {
-      if (state === "active") runSync();
-    });
+      const appStateSubscription = AppState.addEventListener("change", (state) => {
+        if (state === "active") void runSync();
+      });
 
-    const unsubscribeNet = onConnectivityChange((connected) => {
-      if (connected) runSync();
-    });
+      const unsubscribeNet = onConnectivityChange((connected) => {
+        if (connected) void runSync();
+      });
 
-    return () => {
-      appStateSubscription.remove();
-      unsubscribeNet();
-    };
-  }, [db, userId]);
+      return () => {
+        appStateSubscription.remove();
+        unsubscribeNet();
+      };
+    },
+    [db, userId],
+    db != null && userId != null
+  );
 
   return initialSyncDone;
 }

--- a/apps/mobile/features/transactions/components/TransactionForm.tsx
+++ b/apps/mobile/features/transactions/components/TransactionForm.tsx
@@ -1,17 +1,10 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import Animated, {
-  cancelAnimation,
-  useAnimatedStyle,
-  useSharedValue,
-  withRepeat,
-  withSequence,
-  withTiming,
-} from "react-native-reanimated";
+import { useCallback, useMemo, useRef, useState } from "react";
+import Animated from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { FidyNumpad } from "@/shared/components";
 import { Calendar, X } from "@/shared/components/icons";
 import { Keyboard, Platform, Pressable, Text, TextInput, View } from "@/shared/components/rn";
-import { useThemeColor, useTranslation } from "@/shared/hooks";
+import { useBlinkingCursor, useThemeColor, useTranslation } from "@/shared/hooks";
 import { getDateFnsLocale } from "@/shared/i18n";
 import { formatInputDisplay, parseDigitsToAmount } from "@/shared/lib";
 import type { CategoryId } from "@/shared/types/branded";
@@ -79,24 +72,7 @@ export function TransactionForm({
   const digitsRef = useRef(digits);
   digitsRef.current = digits;
 
-  const cursorOpacity = useSharedValue(1);
-
-  useEffect(() => {
-    cursorOpacity.value = withRepeat(
-      withSequence(
-        withTiming(1, { duration: 0 }),
-        withTiming(1, { duration: 530 }),
-        withTiming(0, { duration: 0 }),
-        withTiming(0, { duration: 530 })
-      ),
-      -1
-    );
-    return () => cancelAnimation(cursorOpacity);
-  }, [cursorOpacity]);
-
-  const cursorStyle = useAnimatedStyle(() => ({
-    opacity: cursorOpacity.value,
-  }));
+  const { cursorStyle } = useBlinkingCursor();
 
   const handleKey = useCallback(
     (key: string) => {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -90,6 +90,7 @@
     "drizzle-kit": "0.31.9",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~55.0.0",
+    "typescript-eslint": "^8.57.2",
     "vitest": "^4.0.18"
   }
 }

--- a/apps/mobile/shared/hooks/index.ts
+++ b/apps/mobile/shared/hooks/index.ts
@@ -1,5 +1,9 @@
+export { useAnimatedProgress } from "./use-animated-progress";
 export { useAsyncGuard } from "./use-async-guard";
+export { useBlinkingCursor } from "./use-blinking-cursor";
 export { useColorScheme } from "./use-color-scheme";
 export { useMountEffect } from "./use-mount-effect";
+export { usePulsingOpacity } from "./use-pulsing-opacity";
+export { useSubscription } from "./use-subscription";
 export { useThemeColor } from "./use-theme-color";
 export { useTranslation } from "./use-translation";

--- a/apps/mobile/shared/hooks/use-animated-progress.ts
+++ b/apps/mobile/shared/hooks/use-animated-progress.ts
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+import {
+  type SharedValue,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+
+/**
+ * Returns an animated style with a width percentage driven by `value` (0–1).
+ * Use for progress bars that animate smoothly on value change.
+ */
+export function useAnimatedProgress(
+  value: number,
+  duration = 600
+): {
+  progress: SharedValue<number>;
+  animatedStyle: ReturnType<typeof useAnimatedStyle>;
+} {
+  const progress = useSharedValue(0);
+
+  useEffect(() => {
+    progress.value = withTiming(value, { duration });
+  }, [value, progress, duration]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    width: `${progress.value * 100}%`,
+  }));
+
+  return { progress, animatedStyle };
+}

--- a/apps/mobile/shared/hooks/use-async-guard.ts
+++ b/apps/mobile/shared/hooks/use-async-guard.ts
@@ -8,7 +8,7 @@ import { createAsyncGuard } from "./create-async-guard";
  */
 export function useAsyncGuard() {
   const guardRef = useRef<ReturnType<typeof createAsyncGuard> | null>(null);
-  if (!guardRef.current) guardRef.current = createAsyncGuard();
+  guardRef.current ??= createAsyncGuard();
   const guard = guardRef.current;
 
   const [isBusy, setIsBusy] = useState(false);

--- a/apps/mobile/shared/hooks/use-blinking-cursor.ts
+++ b/apps/mobile/shared/hooks/use-blinking-cursor.ts
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+import {
+  type SharedValue,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from "react-native-reanimated";
+
+/**
+ * Returns a Reanimated animated style that blinks opacity on/off at ~1Hz.
+ * Use for text-cursor indicators in amount-input screens.
+ */
+export function useBlinkingCursor(): {
+  cursorOpacity: SharedValue<number>;
+  cursorStyle: { opacity: number };
+} {
+  const cursorOpacity = useSharedValue(1);
+
+  useEffect(() => {
+    cursorOpacity.value = withRepeat(
+      withSequence(
+        withTiming(1, { duration: 0 }),
+        withTiming(1, { duration: 530 }),
+        withTiming(0, { duration: 0 }),
+        withTiming(0, { duration: 530 })
+      ),
+      -1
+    );
+  }, [cursorOpacity]);
+
+  const cursorStyle = useAnimatedStyle(() => ({
+    opacity: cursorOpacity.value,
+  }));
+
+  return { cursorOpacity, cursorStyle };
+}

--- a/apps/mobile/shared/hooks/use-mount-effect.ts
+++ b/apps/mobile/shared/hooks/use-mount-effect.ts
@@ -6,5 +6,5 @@ import { type EffectCallback, useEffect } from "react";
  */
 export function useMountEffect(effect: EffectCallback) {
   // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only by design
-  useEffect(effect, []);
+  useEffect(effect, []); // eslint-disable-line react-hooks/exhaustive-deps -- mount-only by design
 }

--- a/apps/mobile/shared/hooks/use-pulsing-opacity.ts
+++ b/apps/mobile/shared/hooks/use-pulsing-opacity.ts
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+import {
+  type SharedValue,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from "react-native-reanimated";
+
+export function usePulsingOpacity(
+  active: boolean,
+  min = 0.3,
+  duration = 600
+): {
+  opacity: SharedValue<number>;
+  pulsingStyle: { opacity: number };
+} {
+  const opacity = useSharedValue(1);
+
+  useEffect(() => {
+    if (active) {
+      opacity.value = withRepeat(
+        withSequence(withTiming(min, { duration }), withTiming(1, { duration })),
+        -1
+      );
+    } else {
+      opacity.value = withTiming(1, { duration: 300 });
+    }
+  }, [active, opacity, min, duration]);
+
+  const pulsingStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+  }));
+
+  return { opacity, pulsingStyle };
+}

--- a/apps/mobile/shared/hooks/use-subscription.ts
+++ b/apps/mobile/shared/hooks/use-subscription.ts
@@ -1,0 +1,52 @@
+import { useEffect } from "react";
+
+/**
+ * Manages a subscription lifecycle — calls `subscribe` when deps are met,
+ * and runs the returned cleanup function on unmount or dep change.
+ *
+ * Handles the common async-setup pattern where setup returns a teardown
+ * function, but the component may unmount before setup completes.
+ *
+ * @param subscribe — Called when `enabled` is true. Return a cleanup function or void.
+ *   May return a Promise<cleanup> for async setup patterns.
+ * @param deps — React dependency array for re-subscribing.
+ * @param enabled — Guard condition; subscription only runs when true. Defaults to true.
+ */
+export function useSubscription(
+  subscribe: () => void | (() => void) | Promise<() => void>,
+  deps: readonly unknown[],
+  enabled = true
+): void {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: caller controls deps
+  useEffect(() => {
+    if (!enabled) return;
+
+    let cancelled = false;
+    let syncCleanup: (() => void) | undefined;
+
+    const result = subscribe();
+
+    if (result instanceof Promise) {
+      result
+        .then((teardown) => {
+          if (cancelled) {
+            teardown();
+          } else {
+            syncCleanup = teardown;
+          }
+        })
+        .catch(() => {
+          // Subscriber is responsible for its own error handling.
+          // Swallow here to prevent unhandled rejection.
+        });
+    } else if (typeof result === "function") {
+      syncCleanup = result;
+    }
+
+    return () => {
+      cancelled = true;
+      syncCleanup?.();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- subscribe is intentionally excluded; callers manage deps via spread
+  }, [enabled, ...deps]);
+}

--- a/bun.lock
+++ b/bun.lock
@@ -89,6 +89,7 @@
         "drizzle-kit": "0.31.9",
         "eslint": "^9.25.0",
         "eslint-config-expo": "~55.0.0",
+        "typescript-eslint": "^8.57.2",
         "vitest": "^4.0.18",
       },
     },
@@ -758,19 +759,19 @@
 
     "@typescript-eslint/parser": ["@typescript-eslint/parser@8.57.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.57.0", "@typescript-eslint/types": "8.57.0", "@typescript-eslint/typescript-estree": "8.57.0", "@typescript-eslint/visitor-keys": "8.57.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g=="],
 
-    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.57.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.57.0", "@typescript-eslint/types": "^8.57.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w=="],
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.57.2", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.57.2", "@typescript-eslint/types": "^8.57.2", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw=="],
 
     "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.57.0", "", { "dependencies": { "@typescript-eslint/types": "8.57.0", "@typescript-eslint/visitor-keys": "8.57.0" } }, "sha512-nvExQqAHF01lUM66MskSaZulpPL5pgy5hI5RfrxviLgzZVffB5yYzw27uK/ft8QnKXI2X0LBrHJFr1TaZtAibw=="],
 
-    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.57.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA=="],
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.57.2", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw=="],
 
     "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.57.0", "", { "dependencies": { "@typescript-eslint/types": "8.57.0", "@typescript-eslint/typescript-estree": "8.57.0", "@typescript-eslint/utils": "8.57.0", "debug": "^4.4.3", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-yjgh7gmDcJ1+TcEg8x3uWQmn8ifvSupnPfjP21twPKrDP/pTHlEQgmKcitzF/rzPSmv7QjJ90vRpN4U+zoUjwQ=="],
 
     "@typescript-eslint/types": ["@typescript-eslint/types@8.57.0", "", {}, "sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg=="],
 
-    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.57.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.57.0", "@typescript-eslint/tsconfig-utils": "8.57.0", "@typescript-eslint/types": "8.57.0", "@typescript-eslint/visitor-keys": "8.57.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q=="],
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.57.2", "", { "dependencies": { "@typescript-eslint/project-service": "8.57.2", "@typescript-eslint/tsconfig-utils": "8.57.2", "@typescript-eslint/types": "8.57.2", "@typescript-eslint/visitor-keys": "8.57.2", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA=="],
 
-    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.57.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.57.0", "@typescript-eslint/types": "8.57.0", "@typescript-eslint/typescript-estree": "8.57.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-5iIHvpD3CZe06riAsbNxxreP+MuYgVUsV0n4bwLH//VJmgtt54sQeY2GszntJ4BjYCpMzrfVh2SBnUQTtys2lQ=="],
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.57.2", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.57.2", "@typescript-eslint/types": "8.57.2", "@typescript-eslint/typescript-estree": "8.57.2" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-krRIbvPK1ju1WBKIefiX+bngPs+odIQUtR7kymzPfo1POVw3jlF+nLkmexdSSd4UCbDcQn+wMBATOOmpBbqgKg=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.57.0", "", { "dependencies": { "@typescript-eslint/types": "8.57.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-zm6xx8UT/Xy2oSr2ZXD0pZo7Jx2XsCoID2IUh9YSTFRu7z+WdwYTRk6LhUftm1crwqbuoF6I8zAFeCMw0YjwDg=="],
 
@@ -2122,6 +2123,8 @@
 
     "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
 
+    "typescript-eslint": ["typescript-eslint@8.57.2", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.57.2", "@typescript-eslint/parser": "8.57.2", "@typescript-eslint/typescript-estree": "8.57.2", "@typescript-eslint/utils": "8.57.2" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-VEPQ0iPgWO/sBaZOU1xo4nuNdODVOajPnTIbog2GKYr31nIlZ0fWPoCQgGfF3ETyBl1vn63F/p50Um9Z4J8O8A=="],
+
     "ua-parser-js": ["ua-parser-js@1.0.41", "", { "bin": { "ua-parser-js": "script/cli.js" } }, "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug=="],
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
@@ -2316,11 +2319,29 @@
 
     "@supabase/realtime-js/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
+    "@typescript-eslint/eslint-plugin/@typescript-eslint/utils": ["@typescript-eslint/utils@8.57.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.57.0", "@typescript-eslint/types": "8.57.0", "@typescript-eslint/typescript-estree": "8.57.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-5iIHvpD3CZe06riAsbNxxreP+MuYgVUsV0n4bwLH//VJmgtt54sQeY2GszntJ4BjYCpMzrfVh2SBnUQTtys2lQ=="],
+
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "@typescript-eslint/parser/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.57.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.57.0", "@typescript-eslint/tsconfig-utils": "8.57.0", "@typescript-eslint/types": "8.57.0", "@typescript-eslint/visitor-keys": "8.57.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q=="],
+
+    "@typescript-eslint/project-service/@typescript-eslint/types": ["@typescript-eslint/types@8.57.2", "", {}, "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA=="],
+
+    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.57.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.57.0", "@typescript-eslint/tsconfig-utils": "8.57.0", "@typescript-eslint/types": "8.57.0", "@typescript-eslint/visitor-keys": "8.57.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q=="],
+
+    "@typescript-eslint/type-utils/@typescript-eslint/utils": ["@typescript-eslint/utils@8.57.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.57.0", "@typescript-eslint/types": "8.57.0", "@typescript-eslint/typescript-estree": "8.57.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-5iIHvpD3CZe06riAsbNxxreP+MuYgVUsV0n4bwLH//VJmgtt54sQeY2GszntJ4BjYCpMzrfVh2SBnUQTtys2lQ=="],
+
+    "@typescript-eslint/typescript-estree/@typescript-eslint/types": ["@typescript-eslint/types@8.57.2", "", {}, "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA=="],
+
+    "@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.57.2", "", { "dependencies": { "@typescript-eslint/types": "8.57.2", "eslint-visitor-keys": "^5.0.0" } }, "sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.57.2", "", { "dependencies": { "@typescript-eslint/types": "8.57.2", "@typescript-eslint/visitor-keys": "8.57.2" } }, "sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw=="],
+
+    "@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.57.2", "", {}, "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA=="],
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
@@ -2351,6 +2372,8 @@
     "eslint-import-resolver-node/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
     "eslint-module-utils/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
+
+    "eslint-plugin-expo/@typescript-eslint/utils": ["@typescript-eslint/utils@8.57.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.57.0", "@typescript-eslint/types": "8.57.0", "@typescript-eslint/typescript-estree": "8.57.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-5iIHvpD3CZe06riAsbNxxreP+MuYgVUsV0n4bwLH//VJmgtt54sQeY2GszntJ4BjYCpMzrfVh2SBnUQTtys2lQ=="],
 
     "eslint-plugin-import/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
@@ -2494,6 +2517,10 @@
 
     "tsconfig-paths/json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
 
+    "typescript-eslint/@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.57.2", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.57.2", "@typescript-eslint/type-utils": "8.57.2", "@typescript-eslint/utils": "8.57.2", "@typescript-eslint/visitor-keys": "8.57.2", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.57.2", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w=="],
+
+    "typescript-eslint/@typescript-eslint/parser": ["@typescript-eslint/parser@8.57.2", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.57.2", "@typescript-eslint/types": "8.57.2", "@typescript-eslint/typescript-estree": "8.57.2", "@typescript-eslint/visitor-keys": "8.57.2", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA=="],
+
     "vite/lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
     "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -2620,11 +2647,35 @@
 
     "@sentry/react-native/@sentry/cli/@sentry/cli-win32-x64": ["@sentry/cli-win32-x64@2.58.4", "", { "os": "win32", "cpu": "x64" }, "sha512-cSzN4PjM1RsCZ4pxMjI0VI7yNCkxiJ5jmWncyiwHXGiXrV1eXYdQ3n1LhUYLZ91CafyprR0OhDcE+RVZ26Qb5w=="],
 
+    "@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.57.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.57.0", "@typescript-eslint/tsconfig-utils": "8.57.0", "@typescript-eslint/types": "8.57.0", "@typescript-eslint/visitor-keys": "8.57.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q=="],
+
+    "@typescript-eslint/parser/@typescript-eslint/typescript-estree/@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.57.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.57.0", "@typescript-eslint/types": "^8.57.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w=="],
+
+    "@typescript-eslint/parser/@typescript-eslint/typescript-estree/@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.57.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA=="],
+
+    "@typescript-eslint/parser/@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
+
+    "@typescript-eslint/parser/@typescript-eslint/typescript-estree/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.57.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.57.0", "@typescript-eslint/types": "^8.57.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w=="],
+
+    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.57.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA=="],
+
+    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
+
+    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
+
+    "@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.57.2", "", { "dependencies": { "@typescript-eslint/types": "8.57.2", "eslint-visitor-keys": "^5.0.0" } }, "sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw=="],
 
     "compression/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "connect/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "eslint-plugin-expo/@typescript-eslint/utils/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.57.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.57.0", "@typescript-eslint/tsconfig-utils": "8.57.0", "@typescript-eslint/types": "8.57.0", "@typescript-eslint/visitor-keys": "8.57.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q=="],
 
     "expo-constants/@expo/config/@expo/require-utils": ["@expo/require-utils@55.0.3", "", { "dependencies": { "@babel/code-frame": "^7.20.0", "@babel/core": "^7.25.2", "@babel/plugin-transform-modules-commonjs": "^7.24.8" }, "peerDependencies": { "typescript": "^5.0.0 || ^5.0.0-0" }, "optionalPeers": ["typescript"] }, "sha512-TS1m5tW45q4zoaTlt6DwmdYHxvFTIxoLrTHKOFrIirHIqIXnHCzpceg8wumiBi+ZXSaGY2gobTbfv+WVhJY6Fw=="],
 
@@ -2664,6 +2715,20 @@
 
     "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
+    "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.57.2", "", { "dependencies": { "@typescript-eslint/types": "8.57.2", "@typescript-eslint/visitor-keys": "8.57.2" } }, "sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw=="],
+
+    "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.57.2", "", { "dependencies": { "@typescript-eslint/types": "8.57.2", "@typescript-eslint/typescript-estree": "8.57.2", "@typescript-eslint/utils": "8.57.2", "debug": "^4.4.3", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-Co6ZCShm6kIbAM/s+oYVpKFfW7LBc6FXoPXjTRQ449PPNBY8U0KZXuevz5IFuuUj2H9ss40atTaf9dlGLzbWZg=="],
+
+    "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.57.2", "", { "dependencies": { "@typescript-eslint/types": "8.57.2", "eslint-visitor-keys": "^5.0.0" } }, "sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw=="],
+
+    "typescript-eslint/@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "typescript-eslint/@typescript-eslint/parser/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.57.2", "", { "dependencies": { "@typescript-eslint/types": "8.57.2", "@typescript-eslint/visitor-keys": "8.57.2" } }, "sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw=="],
+
+    "typescript-eslint/@typescript-eslint/parser/@typescript-eslint/types": ["@typescript-eslint/types@8.57.2", "", {}, "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA=="],
+
+    "typescript-eslint/@typescript-eslint/parser/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.57.2", "", { "dependencies": { "@typescript-eslint/types": "8.57.2", "eslint-visitor-keys": "^5.0.0" } }, "sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw=="],
+
     "vite/lightningcss/lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
 
     "vite/lightningcss/lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
@@ -2702,7 +2767,29 @@
 
     "@react-native/community-cli-plugin/metro/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
+    "@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.57.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.57.0", "@typescript-eslint/types": "^8.57.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w=="],
+
+    "@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.57.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA=="],
+
+    "@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
+
+    "@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "@typescript-eslint/parser/@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
+
+    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
+
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "eslint-plugin-expo/@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.57.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.57.0", "@typescript-eslint/types": "^8.57.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w=="],
+
+    "eslint-plugin-expo/@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.57.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA=="],
+
+    "eslint-plugin-expo/@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
+
+    "eslint-plugin-expo/@typescript-eslint/utils/@typescript-eslint/typescript-estree/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
@@ -2716,14 +2803,36 @@
 
     "react-native/babel-plugin-syntax-hermes-parser/hermes-parser/hermes-estree": ["hermes-estree@0.32.0", "", {}, "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ=="],
 
+    "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager/@typescript-eslint/types": ["@typescript-eslint/types@8.57.2", "", {}, "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA=="],
+
+    "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils/@typescript-eslint/types": ["@typescript-eslint/types@8.57.2", "", {}, "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA=="],
+
+    "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys/@typescript-eslint/types": ["@typescript-eslint/types@8.57.2", "", {}, "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA=="],
+
+    "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "typescript-eslint/@typescript-eslint/parser/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
     "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
     "@react-native/community-cli-plugin/metro-config/metro-cache/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "@react-native/community-cli-plugin/metro/metro-cache/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
+    "@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
+
+    "@typescript-eslint/parser/@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "eslint-plugin-expo/@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
+
     "log-symbols/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 
     "ora/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
+
+    "@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "eslint-plugin-expo/@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
   }
 }


### PR DESCRIPTION
## Summary
- Install `typescript-eslint` for type-aware linting
- Rewrite `eslint.config.js` with 17+ strict rules and per-feature barrel enforcement
- Ban `useEffect`/`useLayoutEffect` from all files except `shared/hooks/`
- Create shared hooks: `useBlinkingCursor`, `useAnimatedProgress`, `useSubscription`, `usePulsingOpacity`
- Migrate all 24 `useEffect` usages to approved hooks

## Test plan
- [ ] `npx eslint --print-config app/_layout.tsx` loads without errors
- [ ] Zero `useEffect` imports outside `shared/hooks/`
- [ ] App launches and navigates correctly
- [ ] Animations work (cursor blink, progress bars, syncing dot)