### PR TITLE
chore(mobile): upgrade lint rules to error and enable strict TS flags

### DIFF
--- a/apps/mobile/eslint.config.js
+++ b/apps/mobile/eslint.config.js
@@ -48,42 +48,40 @@ module.exports = defineConfig([
   },
 
   // ── Strict rules (all TS files) ─────────────────────────────────────
-  // Rules start as "warn" so this PR can land before auto-fixes.
-  // A follow-up PR upgrades all "warn" → "error" after fixes are merged.
   {
     files: ["**/*.ts", "**/*.tsx"],
     rules: {
       // — Type-aware rules (highest value) —
-      "@typescript-eslint/no-floating-promises": "warn",
-      "@typescript-eslint/no-misused-promises": "warn",
-      "@typescript-eslint/await-thenable": "warn",
-      "@typescript-eslint/no-unnecessary-condition": "warn",
-      "@typescript-eslint/switch-exhaustiveness-check": "warn",
-      "@typescript-eslint/no-unsafe-assignment": "warn",
-      "@typescript-eslint/no-unsafe-call": "warn",
-      "@typescript-eslint/no-unsafe-member-access": "warn",
-      "@typescript-eslint/no-unsafe-return": "warn",
-      "@typescript-eslint/no-unsafe-argument": "warn",
-      "@typescript-eslint/restrict-template-expressions": "warn",
-      "@typescript-eslint/prefer-nullish-coalescing": "warn",
-      "@typescript-eslint/no-unnecessary-type-assertion": "warn",
+      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-misused-promises": "error",
+      "@typescript-eslint/await-thenable": "error",
+      "@typescript-eslint/no-unnecessary-condition": "error",
+      "@typescript-eslint/switch-exhaustiveness-check": "error",
+      "@typescript-eslint/no-unsafe-assignment": "error",
+      "@typescript-eslint/no-unsafe-call": "error",
+      "@typescript-eslint/no-unsafe-member-access": "error",
+      "@typescript-eslint/no-unsafe-return": "error",
+      "@typescript-eslint/no-unsafe-argument": "error",
+      "@typescript-eslint/restrict-template-expressions": "error",
+      "@typescript-eslint/prefer-nullish-coalescing": "error",
+      "@typescript-eslint/no-unnecessary-type-assertion": "error",
 
       // — Syntax-only rules —
-      "@typescript-eslint/no-explicit-any": "warn",
-      "@typescript-eslint/no-non-null-assertion": "warn",
-      "@typescript-eslint/prefer-optional-chain": "warn",
+      "@typescript-eslint/no-explicit-any": "error",
+      "@typescript-eslint/no-non-null-assertion": "error",
+      "@typescript-eslint/prefer-optional-chain": "error",
       "@typescript-eslint/consistent-type-imports": [
-        "warn",
+        "error",
         { prefer: "type-imports", fixStyle: "inline-type-imports" },
       ],
 
       // — FP-mandate rules (align with CLAUDE.md) —
-      "no-param-reassign": "warn",
-      "prefer-const": "warn",
+      "no-param-reassign": "error",
+      "prefer-const": "error",
       "no-var": "error",
 
       // — React rules —
-      "react-hooks/exhaustive-deps": "warn",
+      "react-hooks/exhaustive-deps": "error",
     },
   },
 
@@ -94,7 +92,7 @@ module.exports = defineConfig([
     ignores: ["shared/hooks/**", "__tests__/**"],
     rules: {
       "no-restricted-imports": [
-        "warn",
+        "error",
         {
           paths: [
             {
@@ -121,7 +119,7 @@ module.exports = defineConfig([
   {
     files: ["shared/hooks/**/*.ts", "shared/hooks/**/*.tsx"],
     rules: {
-      "no-restricted-imports": ["warn", { patterns: BARREL_PATTERNS }],
+      "no-restricted-imports": ["error", { patterns: BARREL_PATTERNS }],
     },
   },
 

--- a/apps/mobile/features/budget/components/ProgressBar.tsx
+++ b/apps/mobile/features/budget/components/ProgressBar.tsx
@@ -1,4 +1,5 @@
-import Animated from "react-native-reanimated";
+import type { ViewStyle } from "react-native";
+import Animated, { type AnimatedStyle } from "react-native-reanimated";
 import { StyleSheet, View } from "@/shared/components/rn";
 import { useAnimatedProgress, useThemeColor } from "@/shared/hooks";
 
@@ -18,7 +19,13 @@ export function ProgressBar({ percent, height = 8 }: Props) {
 
   return (
     <View style={[styles.track, { height, backgroundColor: borderColor }]}>
-      <Animated.View style={[styles.fill, { height, backgroundColor: barColor }, animatedStyle]} />
+      <Animated.View
+        style={[
+          styles.fill,
+          { height, backgroundColor: barColor },
+          animatedStyle as AnimatedStyle<ViewStyle>,
+        ]}
+      />
     </View>
   );
 }

--- a/apps/mobile/features/email-capture/components/EmailProgressCard.tsx
+++ b/apps/mobile/features/email-capture/components/EmailProgressCard.tsx
@@ -1,5 +1,7 @@
 import { useRef } from "react";
+import type { ViewStyle } from "react-native";
 import Animated, {
+  type AnimatedStyle,
   FadeIn,
   FadeOut,
   useAnimatedStyle,
@@ -94,7 +96,7 @@ export const EmailProgressCard = ({ phase, display, onComplete }: EmailProgressC
           >
             <Animated.View
               style={[
-                barAnimatedStyle,
+                barAnimatedStyle as AnimatedStyle<ViewStyle>,
                 {
                   backgroundColor: accentGreen,
                   height: "100%",

--- a/apps/mobile/features/sync/services/syncEngine.ts
+++ b/apps/mobile/features/sync/services/syncEngine.ts
@@ -295,9 +295,11 @@ export async function syncPull(
     }
     // else: earliest row failed — don't advance cursor
   } else if (rows.length > 0) {
+    const firstRow = rows[0];
+    if (!firstRow) return false;
     const maxUpdatedAt = rows.reduce(
       (max, r) => (r.updated_at > max ? r.updated_at : max),
-      rows[0].updated_at
+      firstRow.updated_at
     );
     await setSyncMeta(db, LAST_SYNC_AT, maxUpdatedAt);
   } else if (!lastSyncAt) {

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -2,6 +2,10 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitReturns": true,
     "types": [],
     "paths": {
       "@/*": ["./*"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,11 @@
     "moduleResolution": "bundler",
     "target": "ESNext",
     "module": "ESNext",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "noUncheckedIndexedAccess": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitReturns": true
   },
   "references": [
     { "path": "./packages/assets" },


### PR DESCRIPTION
## Summary
- Upgrade all ESLint strict rules from `warn` → `error`
- Add `noUncheckedIndexedAccess`, `noFallthroughCasesInSwitch`, `forceConsistentCasingInFileNames`, `noImplicitReturns` to tsconfig
- Add per-feature barrel enforcement with self-import exemptions

## Test plan
- [x] `npx eslint .` — 0 errors
- [x] `npx tsc --noEmit` — 0 errors  
- [x] `npx vitest run` — all tests pass (1213 tests)