### PR TITLE
fix(opencode): remove invalid hooks configuration

### DIFF
--- a/.opencode/ocx.jsonc
+++ b/.opencode/ocx.jsonc
@@ -6,21 +6,5 @@
     }
   },
   "lockRegistries": false,
-  "skipCompatCheck": false,
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Read",
-        "command": "bun run .ai-security/hooks/post-tool-defender.ts"
-      },
-      {
-        "matcher": "WebFetch",
-        "command": "bun run .ai-security/hooks/post-tool-defender.ts"
-      },
-      {
-        "matcher": "Bash",
-        "command": "bun run .ai-security/hooks/post-tool-defender.ts"
-      }
-    ]
-  }
+  "skipCompatCheck": false
 }

--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -1,19 +1,3 @@
 {
-  "$schema": "https://opencode.ai/config.json",
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Read",
-        "command": "bun run .ai-security/hooks/post-tool-defender.ts"
-      },
-      {
-        "matcher": "WebFetch",
-        "command": "bun run .ai-security/hooks/post-tool-defender.ts"
-      },
-      {
-        "matcher": "Bash",
-        "command": "bun run .ai-security/hooks/post-tool-defender.ts"
-      }
-    ]
-  }
+  "$schema": "https://opencode.ai/config.json"
 }


### PR DESCRIPTION
Removes invalid `hooks` key from OpenCode configuration files.

## Problem
OpenCode does not support a `hooks` configuration key, causing:
```
Configuration is invalid at /Users/obarbozaa/Documents/fidy/.opencode/opencode.jsonc
↳ Unrecognized key: "hooks"
```

## Changes
- Remove `hooks` from `.opencode/opencode.jsonc`
- Remove `hooks` from `.opencode/ocx.jsonc`

## Note
The prompt injection defense still works for:
- Claude Code (via `.claude/settings.local.json`)
- Codex (via `.codex/settings.json`)

OpenCode does not have a hooks system, so this security feature cannot be enabled for it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unsupported hooks key from OpenCode config to fix validation errors. This resolves the “Unrecognized key: hooks” error when loading `.opencode` configs.

- **Bug Fixes**
  - Removed `hooks` from `.opencode/opencode.jsonc` and `.opencode/ocx.jsonc`.
  - OpenCode has no hooks system; post-tool defense remains only in `.claude/settings.local.json` and `.codex/settings.json`.

<sup>Written for commit e6bfa644efcebce81502513db10ffddc4e6a5996. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

