### PR TITLE
feat(vault): create fidy-vault directory structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,9 @@ skills-lock.json
 .worktrees/
 .claude/worktrees/
 
+# Project vault (private)
+vault/
+
 # macOS
 .DS_Store
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -3,4 +3,4 @@ useDefault = true
 
 [allowlist]
 description = "Supabase anon keys are public by design (role: anon, embedded in clients)"
-paths = ["apps/landing/waitlist.js"]
+paths = ["apps/landing/waitlist.js", ".claude/skills/gstack/supabase/config.sh"]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -3,4 +3,4 @@ useDefault = true
 
 [allowlist]
 description = "Supabase anon keys are public by design (role: anon, embedded in clients)"
-paths = ["apps/landing/waitlist.js", ".claude/skills/gstack/supabase/config.sh"]
+paths = ["apps/landing/waitlist.js"]

--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -1,19 +1,7 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Read",
-        "command": "bun run .ai-security/hooks/post-tool-defender.ts"
-      },
-      {
-        "matcher": "WebFetch",
-        "command": "bun run .ai-security/hooks/post-tool-defender.ts"
-      },
-      {
-        "matcher": "Bash",
-        "command": "bun run .ai-security/hooks/post-tool-defender.ts"
-      }
-    ]
-  }
+  "plugin": [
+    "./.opencode/plugins/vault-hint.js",
+    "./.opencode/plugins/prompt-injection-defender.js"
+  ]
 }

--- a/.opencode/plugins/prompt-injection-defender.js
+++ b/.opencode/plugins/prompt-injection-defender.js
@@ -1,0 +1,25 @@
+module.exports = {
+  name: "prompt-injection-defender",
+  version: "1.0.0",
+  async "tool.execute.after"(input, output) {
+    const monitoredTools = new Set(["Read", "WebFetch", "Bash", "Grep", "Glob", "Task"]);
+    if (!monitoredTools.has(input.tool)) return;
+
+    const toolResult = output?.output || output?.title || "";
+    if (!toolResult || toolResult.length < 10) return;
+
+    const lib = require("../.ai-security/hooks/post-tool-defender-lib.js");
+
+    const config = lib.loadConfig();
+    const text = typeof toolResult === "string" ? toolResult : JSON.stringify(toolResult);
+    const detections = lib.scanForInjections(text, config);
+
+    if (detections.length > 0) {
+      const sourceInfo = lib.getSourceInfo(input.tool, input.args || {});
+      const warning = lib.formatWarning(detections, input.tool, sourceInfo);
+      return {
+        feedback: warning,
+      };
+    }
+  },
+};

--- a/.opencode/plugins/vault-hint.js
+++ b/.opencode/plugins/vault-hint.js
@@ -1,0 +1,16 @@
+module.exports = {
+  name: "vault-hint",
+  version: "1.0.0",
+  executeBefore: ["tool.execute.before"],
+  handler: async (context) => {
+    const fs = require("node:fs");
+    const path = require("node:path");
+    const vaultIndex = path.join(context.cwd, "vault/wiki/index.md");
+    if (fs.existsSync(vaultIndex)) {
+      return {
+        hint: "vault: Decisions and context for this project live in ./vault/wiki/. Read vault/wiki/index.md for relevant decisions before making changes.",
+      };
+    }
+    return null;
+  },
+};

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,3 +98,16 @@ New derivation/pure functions get direct unit tests with fixture data. File-sour
 - Navigation: Expo Router — screens in `app/`, modals as top-level routes
 - Data fetching: TanStack Query for server data, Zustand for local/derived state
 - Functional programming: pure functions in `lib/`, side effects in stores/hooks only
+
+## Vault
+
+I also maintain a private project vault at `./vault/`. Read `vault/CLAUDE.md` for schema.
+
+The vault contains:
+- Decisions auto-logged from AI sessions
+- Meeting notes (Google Docs)
+- User feedback (Notion)
+- Experiments and outcomes
+- Competitive analysis
+
+Before making significant code changes, check `vault/wiki/index.md` for relevant decisions.

--- a/biome.json
+++ b/biome.json
@@ -14,7 +14,11 @@
       "!**/dist",
       "!**/build",
       "!**/.next",
-      "!.claude"
+      "!.claude",
+      "!**/.ocx",
+      "!**/apps/mobile/.continue",
+      "!**/apps/mobile/.kiro",
+      "!**/apps/mobile/.windsurf"
     ]
   },
   "formatter": {
@@ -98,6 +102,15 @@
             "useNamingConvention": "off"
           }
         }
+      }
+    },
+    {
+      "includes": [".ai-security/**", ".opencode/plugins/**"],
+      "formatter": {
+        "enabled": false
+      },
+      "linter": {
+        "enabled": false
       }
     }
   ]


### PR DESCRIPTION
- Create raw directories for meetings, decisions, feedback, experiments, competitive
- Create wiki directories for decisions, users, experiments, strategy
- Add placeholder CLAUDE.md and AGENTS.md
- Add index.md and log.md as wiki entry points

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add security and context plugins to `opencode` and formalize a private project vault to reduce prompt-injection risk and surface key decisions before code changes.

- New Features
  - Added `prompt-injection-defender` plugin to scan `Read`, `WebFetch`, `Bash`, `Grep`, `Glob`, and `Task` outputs and return warnings.
  - Added `vault-hint` plugin to show a hint when `vault/wiki/index.md` exists.

- Refactors
  - Switched `.opencode/opencode.jsonc` from PostToolUse hooks to a plugin setup.
  - Ignored `vault/` in `.gitignore` and documented the vault in `CLAUDE.md`.
  - Updated `.gitleaks.toml` allowlist.
  - Updated `biome.json` to ignore additional dev-tool dirs and disable formatter/linter for `.ai-security/**` and `.opencode/plugins/**`.

<sup>Written for commit 2eabbf5159c7d36d3efae3f708db9117778a4e1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

