### PR TITLE
chore(repo): harden codex workflow

### DIFF
--- a/.ai-security/hooks/post-tool-defender.ts
+++ b/.ai-security/hooks/post-tool-defender.ts
@@ -8,8 +8,8 @@
  * Run with: bun run post-tool-defender.ts
  */
 
-import { existsSync, readFileSync } from "fs";
-import { dirname, join } from "path";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { parse as parseYaml } from "yaml";
 
 // Types
@@ -27,10 +27,10 @@ interface Config {
 }
 
 interface HookInput {
-  tool_name: string;
-  tool_input: Record<string, unknown>;
-  tool_response?: unknown;
-  tool_result?: unknown;
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  toolResponse?: unknown;
+  toolResult?: unknown;
 }
 
 // Detection tuple: [category, reason, severity]
@@ -142,13 +142,27 @@ function scanForInjections(text: string, config: Config): Detection[] {
         if (regex.test(text)) {
           detections.push([categoryName, reason, severity]);
         }
-      } catch {
-        continue;
-      }
+      } catch {}
     }
   }
 
   return detections;
+}
+
+function normalizeHookInput(input: Record<string, unknown>): HookInput | null {
+  const toolName = input.tool_name;
+  const toolInput = input.tool_input;
+
+  if (typeof toolName !== "string" || typeof toolInput !== "object" || toolInput === null) {
+    return null;
+  }
+
+  return {
+    toolName,
+    toolInput: toolInput as Record<string, unknown>,
+    toolResponse: input.tool_response,
+    toolResult: input.tool_result,
+  };
 }
 
 /**
@@ -252,19 +266,19 @@ async function main(): Promise<void> {
   }
   inputText += decoder.decode();
 
-  let input: HookInput;
+  let input: HookInput | null;
   try {
-    input = JSON.parse(inputText);
+    const parsed = JSON.parse(inputText) as Record<string, unknown>;
+    input = normalizeHookInput(parsed);
   } catch {
     process.exit(0);
   }
 
-  const {
-    tool_name: toolName,
-    tool_input: toolInput,
-    tool_response: toolResponse,
-    tool_result: toolResultFallback,
-  } = input;
+  if (!input) {
+    process.exit(0);
+  }
+
+  const { toolName, toolInput, toolResponse, toolResult: toolResultFallback } = input;
   const toolResult = toolResponse ?? toolResultFallback;
 
   const monitoredTools = new Set(["Read", "WebFetch", "Bash", "Grep", "Glob", "Task"]);

--- a/.codex/settings.json
+++ b/.codex/settings.json
@@ -1,4 +1,19 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(git:*)",
+      "Bash(gh pr:*)",
+      "Bash(gh auth:*)",
+      "Bash(gh run:*)",
+      "Bash(bun run:*)",
+      "Bash(bunx biome:*)",
+      "Bash(find:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(grep:*)",
+      "Bash(wc:*)"
+    ]
+  },
   "hooks": {
     "PostToolUse": [
       {
@@ -23,6 +38,36 @@
       },
       {
         "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun run \"$CODEX_PROJECT_DIR\"/.ai-security/hooks/post-tool-defender.ts",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun run \"$CODEX_PROJECT_DIR\"/.ai-security/hooks/post-tool-defender.ts",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Glob",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun run \"$CODEX_PROJECT_DIR\"/.ai-security/hooks/post-tool-defender.ts",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Task",
         "hooks": [
           {
             "type": "command",

--- a/.env.local.template
+++ b/.env.local.template
@@ -1,18 +1,17 @@
-# Supabase (local development)
-SUPABASE_URL=http://localhost:54321
-SUPABASE_ANON_KEY=
-
-# OAuth (if using)
-GMAIL_CLIENT_ID=
-GMAIL_CLIENT_SECRET=
-OUTLOOK_CLIENT_ID=
-OUTLOOK_CLIENT_SECRET=
-
-# Monitoring
-SENTRY_DSN=
+# Mobile app (Expo reads EXPO_PUBLIC_* at build/runtime)
+EXPO_PUBLIC_SUPABASE_URL=http://localhost:54321
+EXPO_PUBLIC_SUPABASE_ANON_KEY=
+EXPO_PUBLIC_GMAIL_CLIENT_ID=
+EXPO_PUBLIC_OUTLOOK_CLIENT_ID=
+EXPO_PUBLIC_SENTRY_DSN=
 EXPO_PUBLIC_POSTHOG_API_KEY=
 
-# Copy this file to .env.local and fill in your values
+# Supabase Edge Functions / server-side local development
+SUPABASE_URL=http://localhost:54321
+SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+
+# Copy this file to .env.local and fill in the values you need locally
 # .env.local is git ignored
 
 # For local iOS builds, create apps/mobile/.env.sentry-build-plugin with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
           bun-version: "1.3.10"
       - name: Install dependencies
         run: bun install
-      - name: Biome check
-        run: bunx biome check .
+      - name: Root lint
+        run: bun run lint
       - name: Mobile ESLint (includes import/no-cycle)
-        run: bun run --cwd apps/mobile lint
+        run: bun run lint:mobile
 
   typecheck:
     name: Type Check
@@ -31,20 +31,8 @@ jobs:
           bun-version: "1.3.10"
       - name: Install dependencies
         run: bun install
-      - name: Build shared packages
-        run: |
-          bun run --cwd packages/assets build
-          bun run --cwd packages/types build
-          bun run --cwd packages/schemas build
-          bun run --cwd packages/utils build
-      - name: Check shared packages
-        run: |
-          bun run --cwd packages/assets typecheck
-          bun run --cwd packages/types typecheck
-          bun run --cwd packages/schemas typecheck
-          bun run --cwd packages/utils typecheck
-      - name: Check mobile app
-        run: bun run --cwd apps/mobile typecheck
+      - name: Typecheck workspace
+        run: bun run typecheck
 
   test:
     name: Test
@@ -60,7 +48,7 @@ jobs:
       - name: Install dependencies
         run: bun install
       - name: Run tests with coverage
-        run: bun run --cwd apps/mobile test:coverage
+        run: bun run test:coverage
 
   security-sca:
     name: Security (SCA)

--- a/.gitignore
+++ b/.gitignore
@@ -71,17 +71,20 @@ TODOS.md
 
 # Superpowers brainstorm artifacts
 .superpowers/
+vault/
 
 # Other AI agent skills (local-only, not used by Claude Code)
 .agents/
 skills-lock.json
+.continue/
+.kiro/
+.windsurf/
+.claude/settings.local.json
+apps/mobile/.claude/settings.local.json
 
 # Worktrees
 .worktrees/
 .claude/worktrees/
-
-# Project vault (private)
-vault/
 
 # macOS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Fidy
+
+Monorepo for the Fidy mobile app, landing site, shared packages, and Supabase functions.
+
+## Codex Quickstart
+
+1. Install dependencies with `bun install`.
+2. Copy `.env.local.template` to `.env.local` and fill the Expo public values you need.
+3. Run `bun run verify` before pushing changes.
+
+Primary commands:
+
+- `bun run mobile` starts the Expo app.
+- `bun run landing` serves the static landing site.
+- `bun run lint` runs root Biome checks.
+- `bun run lint:mobile` runs Expo ESLint for the mobile app.
+- `bun run typecheck` builds shared packages and typechecks the workspace.
+- `bun run test` runs the mobile Vitest suite.
+- `bun run test:coverage` runs the mobile tests with coverage.
+- `bun run verify` runs lint, mobile lint, typecheck, and tests in the same order used locally.
+
+## Repo Layout
+
+- `apps/mobile`: Expo / React Native app.
+- `apps/landing`: Static landing site deployed to Vercel.
+- `packages/*`: Shared workspace packages consumed by the app.
+- `supabase/functions`: Edge Functions.
+
+## Agent Guidance
+
+- Architecture and code-style constraints live in [CLAUDE.md](./CLAUDE.md).
+- Codex-specific security hooks live in `.codex/settings.json` and `.ai-security/`.
+- Local knowledge stores and editor-specific agent folders are intentionally git-ignored.

--- a/apps/mobile/.continue/skills/swiftui-expert-skill
+++ b/apps/mobile/.continue/skills/swiftui-expert-skill
@@ -1,1 +1,0 @@
-../../.agents/skills/swiftui-expert-skill

--- a/apps/mobile/.kiro/skills/swiftui-expert-skill
+++ b/apps/mobile/.kiro/skills/swiftui-expert-skill
@@ -1,1 +1,0 @@
-../../.agents/skills/swiftui-expert-skill

--- a/apps/mobile/.windsurf/skills/swiftui-expert-skill
+++ b/apps/mobile/.windsurf/skills/swiftui-expert-skill
@@ -1,1 +1,0 @@
-../../.agents/skills/swiftui-expert-skill

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -9,6 +9,7 @@
     "types": [],
     "paths": {
       "@/*": ["./*"],
+      "@fidy/assets": ["../../packages/assets/src/index.ts"],
       "@fidy/types": ["../../packages/types/src/index.ts"],
       "@fidy/schemas": ["../../packages/schemas/src/index.ts"],
       "@fidy/utils": ["../../packages/utils/src/index.ts"]

--- a/biome.json
+++ b/biome.json
@@ -16,9 +16,10 @@
       "!**/.next",
       "!.claude",
       "!**/.ocx",
-      "!**/apps/mobile/.continue",
-      "!**/apps/mobile/.kiro",
-      "!**/apps/mobile/.windsurf"
+      "!**/.continue",
+      "!**/.kiro",
+      "!**/.windsurf",
+      "!vault"
     ]
   },
   "formatter": {

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -33,13 +33,13 @@ commit-msg:
 pre-push:
   commands:
     root-biome:
-      run: bunx biome check .
+      run: bun run lint
       skip_output: false
     mobile-eslint:
-      run: bun run --cwd apps/mobile lint
+      run: bun run lint:mobile
       skip_output: false
     mobile-typecheck:
-      run: bun run --cwd apps/mobile typecheck
+      run: bun run typecheck
       skip_output: false
     tests:
       run: bun run test

--- a/package.json
+++ b/package.json
@@ -12,10 +12,16 @@
     "mobile:android": "bun run --cwd apps/mobile android",
     "mobile:web": "bun run --cwd apps/mobile web",
     "landing": "bun run --cwd apps/landing dev",
-    "test": "bun run --cwd apps/mobile test",
+    "build:packages": "bun run --cwd packages/assets build && bun run --cwd packages/types build && bun run --cwd packages/schemas build && bun run --cwd packages/utils build",
+    "lint:mobile": "bun run --cwd apps/mobile lint",
+    "typecheck:packages": "bun run --cwd packages/assets typecheck && bun run --cwd packages/types typecheck && bun run --cwd packages/schemas typecheck && bun run --cwd packages/utils typecheck",
+    "typecheck": "bun run build:packages && bun run typecheck:packages && bun run --cwd apps/mobile typecheck",
+    "test:mobile": "bun run --cwd apps/mobile test",
+    "test": "bun run test:mobile",
     "test:coverage": "bun run --cwd apps/mobile test:coverage",
     "lint": "bunx biome check .",
-    "format": "bunx biome format --write ."
+    "format": "bunx biome format --write .",
+    "verify": "bun run lint && bun run lint:mobile && bun run typecheck && bun run test"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.4",


### PR DESCRIPTION
- add root verify scripts
- align ci and hooks
- document codex quickstart
- ignore local agent artifacts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the Codex workflow by unifying local/CI checks, adding a Bash command allowlist, and tightening post-tool scanning. Adds a root verify flow, updates docs/env for smoother setup, and ignores local agent artifacts.

- **Refactors**
  - Added root scripts: `verify`, `lint:mobile`, `typecheck`, `test:mobile`; build/typecheck shared packages from the root.
  - CI and pre-push hooks now call the same root commands; simplified typecheck and coverage runs.
  - Aligned Codex security config: added a Bash command allowlist and PostToolUse hooks for `Grep`, `Glob`, and `Task`.
  - Updated docs/env/ignores: added Codex Quickstart; switched to `EXPO_PUBLIC_*`, added `SUPABASE_SERVICE_ROLE_KEY`; ignored local agent folders and `vault`; added `@fidy/assets` path in mobile `tsconfig`.

- **Bug Fixes**
  - Hardened `.ai-security/hooks/post-tool-defender.ts`: switched to `node:*` imports, normalized hook input to camelCase with guarded parsing/early exits, and extended monitoring to `Grep`, `Glob`, and `Task`.

<sup>Written for commit 43da385226cd46c08e75383735d0c4eeacf95d28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

