### PR TITLE
refactor(mobile): add capture ingestion port

### DIFF
--- a/apps/mobile/__tests__/capture-sources/capture-ingestion.test.ts
+++ b/apps/mobile/__tests__/capture-sources/capture-ingestion.test.ts
@@ -87,6 +87,16 @@ describe("capture ingestion port", () => {
     expect(mockProcessWidgetTransactions).toHaveBeenCalledWith(mockDb, USER_ID);
   });
 
+  it("supports command-specific partial overrides without requiring every handler", async () => {
+    const port = createCaptureIngestionPort(mockDb, {
+      processWidgetTransactions: (...args: any[]) => mockProcessWidgetTransactions(...args),
+    });
+
+    await port.ingest({ kind: "widget", userId: USER_ID });
+
+    expect(mockProcessWidgetTransactions).toHaveBeenCalledWith(mockDb, USER_ID);
+  });
+
   it("routes email batch commands with progress callbacks intact", async () => {
     const port = createCaptureIngestionPort(mockDb, {
       processNotification: (...args: any[]) => mockProcessNotification(...args),

--- a/apps/mobile/__tests__/capture-sources/capture-ingestion.test.ts
+++ b/apps/mobile/__tests__/capture-sources/capture-ingestion.test.ts
@@ -1,0 +1,147 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: mock db needs flexible typing
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockProcessNotification = vi.fn();
+const mockProcessApplePayIntent = vi.fn();
+const mockProcessWidgetTransactions = vi.fn();
+const mockProcessEmails = vi.fn();
+const mockProcessRetries = vi.fn();
+
+import type { ApplePayIntentData, NotificationData } from "@/features/capture-sources/schema";
+import { createCaptureIngestionPort } from "@/features/capture-sources/services/capture-ingestion";
+import type { RawEmail } from "@/features/email-capture/schema";
+import type { UserId } from "@/shared/types/branded";
+
+const mockDb = {} as any;
+const USER_ID = "user-1" as UserId;
+
+describe("capture ingestion port", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProcessNotification.mockResolvedValue({ saved: true, skippedDuplicate: false });
+    mockProcessApplePayIntent.mockResolvedValue({ saved: true, skippedDuplicate: false });
+    mockProcessWidgetTransactions.mockResolvedValue({ saved: 1, skippedDuplicate: 0, errors: 0 });
+    mockProcessEmails.mockResolvedValue({
+      filtered: 0,
+      skippedDuplicate: 0,
+      skippedCrossSource: 0,
+      saved: 0,
+      failed: 0,
+      needsReview: 0,
+    });
+    mockProcessRetries.mockResolvedValue({
+      retried: 0,
+      succeeded: 0,
+      permanentlyFailed: 0,
+    });
+  });
+
+  it("routes notification commands to the notification pipeline", async () => {
+    const port = createCaptureIngestionPort(mockDb, {
+      processNotification: (...args: any[]) => mockProcessNotification(...args),
+      processApplePayIntent: (...args: any[]) => mockProcessApplePayIntent(...args),
+      processWidgetTransactions: (...args: any[]) => mockProcessWidgetTransactions(...args),
+      processEmails: (...args: any[]) => mockProcessEmails(...args),
+      processRetries: (...args: any[]) => mockProcessRetries(...args),
+    });
+    const notification: NotificationData = {
+      packageName: "com.todo1.mobile.co.bancolombia",
+      text: "Bancolombia le informa compra por $50,000",
+      timestamp: Date.now(),
+    };
+
+    await port.ingest({ kind: "notification", userId: USER_ID, notification });
+
+    expect(mockProcessNotification).toHaveBeenCalledWith(mockDb, USER_ID, notification);
+  });
+
+  it("routes Apple Pay commands to the Apple Pay pipeline", async () => {
+    const port = createCaptureIngestionPort(mockDb, {
+      processNotification: (...args: any[]) => mockProcessNotification(...args),
+      processApplePayIntent: (...args: any[]) => mockProcessApplePayIntent(...args),
+      processWidgetTransactions: (...args: any[]) => mockProcessWidgetTransactions(...args),
+      processEmails: (...args: any[]) => mockProcessEmails(...args),
+      processRetries: (...args: any[]) => mockProcessRetries(...args),
+    });
+    const intent: ApplePayIntentData = {
+      amount: 50000,
+      merchant: "Farmatodo",
+    };
+
+    await port.ingest({ kind: "apple_pay", userId: USER_ID, intent });
+
+    expect(mockProcessApplePayIntent).toHaveBeenCalledWith(mockDb, USER_ID, intent);
+  });
+
+  it("routes widget commands to the widget pipeline", async () => {
+    const port = createCaptureIngestionPort(mockDb, {
+      processNotification: (...args: any[]) => mockProcessNotification(...args),
+      processApplePayIntent: (...args: any[]) => mockProcessApplePayIntent(...args),
+      processWidgetTransactions: (...args: any[]) => mockProcessWidgetTransactions(...args),
+      processEmails: (...args: any[]) => mockProcessEmails(...args),
+      processRetries: (...args: any[]) => mockProcessRetries(...args),
+    });
+
+    await port.ingest({ kind: "widget", userId: USER_ID });
+
+    expect(mockProcessWidgetTransactions).toHaveBeenCalledWith(mockDb, USER_ID);
+  });
+
+  it("routes email batch commands with progress callbacks intact", async () => {
+    const port = createCaptureIngestionPort(mockDb, {
+      processNotification: (...args: any[]) => mockProcessNotification(...args),
+      processApplePayIntent: (...args: any[]) => mockProcessApplePayIntent(...args),
+      processWidgetTransactions: (...args: any[]) => mockProcessWidgetTransactions(...args),
+      processEmails: (...args: any[]) => mockProcessEmails(...args),
+      processRetries: (...args: any[]) => mockProcessRetries(...args),
+    });
+    const emails: RawEmail[] = [
+      {
+        externalId: "ext-1",
+        from: "notificaciones@bancolombia.com.co",
+        subject: "Compra aprobada",
+        body: "body",
+        receivedAt: "2026-03-05T10:00:00Z",
+        provider: "gmail",
+      },
+    ];
+    const onProgress = vi.fn();
+
+    mockProcessEmails.mockImplementationOnce(async (_db, _userId, passedEmails, progress) => {
+      progress?.({ total: passedEmails.length, completed: 1, saved: 1, failed: 0, needsReview: 0 });
+      return {
+        filtered: 0,
+        skippedDuplicate: 0,
+        skippedCrossSource: 0,
+        saved: 1,
+        failed: 0,
+        needsReview: 0,
+      };
+    });
+
+    await port.ingest({ kind: "email_batch", userId: USER_ID, emails, onProgress });
+
+    expect(mockProcessEmails).toHaveBeenCalledWith(mockDb, USER_ID, emails, onProgress);
+    expect(onProgress).toHaveBeenCalledWith({
+      total: 1,
+      completed: 1,
+      saved: 1,
+      failed: 0,
+      needsReview: 0,
+    });
+  });
+
+  it("routes email retry commands to the retry pipeline", async () => {
+    const port = createCaptureIngestionPort(mockDb, {
+      processNotification: (...args: any[]) => mockProcessNotification(...args),
+      processApplePayIntent: (...args: any[]) => mockProcessApplePayIntent(...args),
+      processWidgetTransactions: (...args: any[]) => mockProcessWidgetTransactions(...args),
+      processEmails: (...args: any[]) => mockProcessEmails(...args),
+      processRetries: (...args: any[]) => mockProcessRetries(...args),
+    });
+
+    await port.ingest({ kind: "email_retry", userId: USER_ID });
+
+    expect(mockProcessRetries).toHaveBeenCalledWith(mockDb, USER_ID);
+  });
+});

--- a/apps/mobile/__tests__/capture-sources/hooks.test.ts
+++ b/apps/mobile/__tests__/capture-sources/hooks.test.ts
@@ -1,12 +1,6 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: mock db needs flexible typing
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import {
-  setupApplePayCapture,
-  setupNotificationCapture,
-  setupSmsDetection,
-} from "@/features/capture-sources/hooks/setup";
-
 const mockAddLogTransactionListener = vi.fn().mockReturnValue({ remove: vi.fn() });
 const mockAddDetectBankSmsListener = vi.fn().mockReturnValue({ remove: vi.fn() });
 const mockIsAvailable = vi.fn().mockReturnValue(true);
@@ -48,6 +42,10 @@ vi.mock("@/shared/lib/generate-id", () => ({
 const mockDb = {} as any;
 const USER_ID = "user-1";
 
+async function loadSetup() {
+  return import("@/features/capture-sources/hooks/setup");
+}
+
 describe("setupApplePayCapture", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -55,6 +53,7 @@ describe("setupApplePayCapture", () => {
   });
 
   it("registers listener and returns cleanup function", async () => {
+    const { setupApplePayCapture } = await loadSetup();
     const mockRemove = vi.fn();
     mockAddLogTransactionListener.mockReturnValueOnce({ remove: mockRemove });
 
@@ -68,6 +67,7 @@ describe("setupApplePayCapture", () => {
   });
 
   it("returns no-op when module is not available", async () => {
+    const { setupApplePayCapture } = await loadSetup();
     mockIsAvailable.mockReturnValue(false);
 
     const cleanup = await setupApplePayCapture(mockDb, USER_ID);
@@ -77,6 +77,7 @@ describe("setupApplePayCapture", () => {
   });
 
   it("calls processApplePayIntent when listener fires", async () => {
+    const { setupApplePayCapture } = await loadSetup();
     let capturedListener: (event: any) => void = () => {};
     mockAddLogTransactionListener.mockImplementationOnce((listener: any) => {
       capturedListener = listener;
@@ -100,6 +101,7 @@ describe("setupSmsDetection", () => {
   });
 
   it("registers listener and returns cleanup function", async () => {
+    const { setupSmsDetection } = await loadSetup();
     const mockRemove = vi.fn();
     mockAddDetectBankSmsListener.mockReturnValueOnce({ remove: mockRemove });
 
@@ -112,6 +114,7 @@ describe("setupSmsDetection", () => {
   });
 
   it("inserts SMS event when listener fires", async () => {
+    const { setupSmsDetection } = await loadSetup();
     let capturedListener: (event: any) => void = () => {};
     mockAddDetectBankSmsListener.mockImplementationOnce((listener: any) => {
       capturedListener = listener;
@@ -138,6 +141,7 @@ describe("setupNotificationCapture", () => {
   });
 
   it("sets allowed packages and registers listener", async () => {
+    const { setupNotificationCapture } = await loadSetup();
     const mockRemove = vi.fn();
     mockAndroidAddListener.mockReturnValueOnce({ remove: mockRemove });
     const packages = ["com.todo1.mobile.co.bancolombia"];
@@ -155,6 +159,7 @@ describe("setupNotificationCapture", () => {
   });
 
   it("calls processNotification when listener fires", async () => {
+    const { setupNotificationCapture } = await loadSetup();
     let capturedListener: (event: any) => void = () => {};
     mockAndroidAddListener.mockImplementationOnce((_event: any, listener: any) => {
       capturedListener = listener;
@@ -174,6 +179,7 @@ describe("setupNotificationCapture", () => {
   });
 
   it("returns no-op when no packages provided", async () => {
+    const { setupNotificationCapture } = await loadSetup();
     const cleanup = await setupNotificationCapture(mockDb, USER_ID, []);
 
     expect(mockAndroidAddListener).not.toHaveBeenCalled();

--- a/apps/mobile/__tests__/capture-sources/widget-pipeline.test.ts
+++ b/apps/mobile/__tests__/capture-sources/widget-pipeline.test.ts
@@ -11,8 +11,11 @@ const mockRemovePendingTransactions = vi.fn();
 const mockIsAvailable = vi.fn();
 const mockGenerateProcessedCaptureId = vi.fn();
 
-vi.mock("@/features/transactions", () => ({
+vi.mock("@/features/transactions/lib/repository", () => ({
   insertTransaction: (...args: any[]) => mockInsertTransaction(...args),
+}));
+
+vi.mock("@/features/transactions/lib/categories", () => ({
   isValidCategoryId: (id: string) =>
     [
       "food",
@@ -28,7 +31,7 @@ vi.mock("@/features/transactions", () => ({
     ].includes(id),
 }));
 
-vi.mock("@/shared/db", () => ({
+vi.mock("@/shared/db/enqueue-sync", () => ({
   enqueueSync: (...args: any[]) => mockEnqueueSync(...args),
 }));
 

--- a/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
@@ -2,8 +2,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RawEmail } from "@/features/email-capture/schema";
 
-import { processEmails, processRetries } from "@/features/email-capture/services/email-pipeline";
-
 const mockGetProcessedExternalIds = vi.fn().mockResolvedValue(new Set<string>());
 const mockInsertProcessedEmail = vi.fn();
 const mockInsertTransaction = vi.fn();
@@ -66,6 +64,9 @@ vi.mock("@/shared/lib/generate-id", () => ({
 const mockDb = {} as any;
 const USER_ID = "user-1";
 
+let processEmails: typeof import("@/features/email-capture/services/email-pipeline").processEmails;
+let processRetries: typeof import("@/features/email-capture/services/email-pipeline").processRetries;
+
 function makeRawEmail(overrides: Partial<RawEmail> = {}): RawEmail {
   return {
     externalId: "ext-1",
@@ -81,7 +82,10 @@ function makeRawEmail(overrides: Partial<RawEmail> = {}): RawEmail {
 describe("email processing pipeline", () => {
   let idCounter: number;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    ({ processEmails, processRetries } = await import(
+      "@/features/email-capture/services/email-pipeline"
+    ));
     vi.clearAllMocks();
     idCounter = 0;
     mockGenerateId.mockImplementation((prefix: string) => {

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -1,18 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { insertMerchantRule } from "@/features/email-capture/lib/merchant-rules";
-import {
-  deleteEmailAccount,
-  dismissProcessedEmail,
-  getEmailAccounts,
-  getFailedEmails,
-  getNeedsReviewEmails,
-  insertEmailAccount,
-  updateLastFetchedAt,
-  updateProcessedEmailStatus,
-} from "@/features/email-capture/lib/repository";
-import { getAdapter } from "@/features/email-capture/services/email-adapter";
-import { processEmails } from "@/features/email-capture/services/email-pipeline";
-import { useEmailCaptureStore } from "@/features/email-capture/store";
 import type {
   EmailAccountId,
   IsoDateTime,
@@ -80,12 +66,16 @@ vi.mock("@/features/email-capture/lib/progress-phases", () => ({
     mockShouldShowProgress(...(args as [number, boolean, number])),
 }));
 
-vi.mock("@/features/email-capture/lib/bank-senders", async (importOriginal) => {
+vi.mock("@/features/email-capture/services/bank-senders-cache", async (importOriginal) => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-  const actual = await importOriginal<typeof import("@/features/email-capture/lib/bank-senders")>();
+  const actual = await importOriginal<
+    typeof import("@/features/email-capture/services/bank-senders-cache")
+  >();
   return {
     ...actual,
-    fetchBankSenders: vi.fn().mockResolvedValue(actual.DEFAULT_BANK_SENDERS),
+    fetchBankSenders: vi.fn().mockResolvedValue([
+      { bank: "Bancolombia", email: "notificaciones@bancolombia.com.co" },
+    ]),
   };
 });
 
@@ -121,6 +111,19 @@ const mockDb = {
   // biome-ignore lint/suspicious/noExplicitAny: mock DB object for testing
 } as any;
 const mockUserId = "user-1";
+
+let useEmailCaptureStore: typeof import("@/features/email-capture/store").useEmailCaptureStore;
+let getEmailAccounts: typeof import("@/features/email-capture/lib/repository").getEmailAccounts;
+let insertEmailAccount: typeof import("@/features/email-capture/lib/repository").insertEmailAccount;
+let deleteEmailAccount: typeof import("@/features/email-capture/lib/repository").deleteEmailAccount;
+let getFailedEmails: typeof import("@/features/email-capture/lib/repository").getFailedEmails;
+let getNeedsReviewEmails: typeof import("@/features/email-capture/lib/repository").getNeedsReviewEmails;
+let dismissProcessedEmail: typeof import("@/features/email-capture/lib/repository").dismissProcessedEmail;
+let updateLastFetchedAt: typeof import("@/features/email-capture/lib/repository").updateLastFetchedAt;
+let updateProcessedEmailStatus: typeof import("@/features/email-capture/lib/repository").updateProcessedEmailStatus;
+let insertMerchantRule: typeof import("@/features/email-capture/lib/merchant-rules").insertMerchantRule;
+let getAdapter: typeof import("@/features/email-capture/services/email-adapter").getAdapter;
+let processEmails: typeof import("@/features/email-capture/services/email-pipeline").processEmails;
 
 /** Helper to build a typed email account object for tests */
 function makeAccount(
@@ -164,7 +167,21 @@ function makeProcessedEmail(overrides: Record<string, unknown> = {}) {
 }
 
 describe("useEmailCaptureStore", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    ({ useEmailCaptureStore } = await import("@/features/email-capture/store"));
+    ({
+      getEmailAccounts,
+      insertEmailAccount,
+      deleteEmailAccount,
+      getFailedEmails,
+      getNeedsReviewEmails,
+      dismissProcessedEmail,
+      updateLastFetchedAt,
+      updateProcessedEmailStatus,
+    } = await import("@/features/email-capture/lib/repository"));
+    ({ insertMerchantRule } = await import("@/features/email-capture/lib/merchant-rules"));
+    ({ getAdapter } = await import("@/features/email-capture/services/email-adapter"));
+    ({ processEmails } = await import("@/features/email-capture/services/email-pipeline"));
     vi.clearAllMocks();
     useEmailCaptureStore.getState().initStore(mockDb, mockUserId);
     useEmailCaptureStore.setState({

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -68,14 +68,13 @@ vi.mock("@/features/email-capture/lib/progress-phases", () => ({
 
 vi.mock("@/features/email-capture/services/bank-senders-cache", async (importOriginal) => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-  const actual = await importOriginal<
-    typeof import("@/features/email-capture/services/bank-senders-cache")
-  >();
+  const actual =
+    await importOriginal<typeof import("@/features/email-capture/services/bank-senders-cache")>();
   return {
     ...actual,
-    fetchBankSenders: vi.fn().mockResolvedValue([
-      { bank: "Bancolombia", email: "notificaciones@bancolombia.com.co" },
-    ]),
+    fetchBankSenders: vi
+      .fn()
+      .mockResolvedValue([{ bank: "Bancolombia", email: "notificaciones@bancolombia.com.co" }]),
   };
 });
 

--- a/apps/mobile/features/capture-sources/hooks/setup.ts
+++ b/apps/mobile/features/capture-sources/hooks/setup.ts
@@ -1,9 +1,11 @@
+import { insertDetectedSmsEvent } from "@/features/capture-sources/lib/repository";
+import { processApplePayIntent } from "@/features/capture-sources/services/apple-pay-pipeline";
+import { processNotification } from "@/features/capture-sources/services/notification-pipeline";
 import type { AnyDb } from "@/shared/db";
 import { captureError, generateDetectedSmsEventId, toIsoDateTime } from "@/shared/lib";
 import type { IsoDateTime, UserId } from "@/shared/types/branded";
-import { insertDetectedSmsEvent } from "../lib/repository";
-import { processApplePayIntent } from "../services/apple-pay-pipeline";
-import { processNotification } from "../services/notification-pipeline";
+import type { ApplePayIntentData, NotificationData } from "../schema";
+import { createCaptureIngestionPort } from "../services/capture-ingestion";
 
 const noop = () => {};
 
@@ -12,11 +14,20 @@ const noop = () => {};
 const loadAppIntents = () => import("@/modules/expo-app-intents");
 
 export async function setupApplePayCapture(db: AnyDb, userId: string): Promise<() => void> {
+  const captureIngestion = createCaptureIngestionPort(db, {
+    processApplePayIntent,
+  });
   const mod = await loadAppIntents();
   if (!mod.isAvailable()) return noop;
 
   const subscription = mod.addLogTransactionListener((event) => {
-    processApplePayIntent(db, userId, event).catch(captureError);
+    captureIngestion
+      .ingest({
+        kind: "apple_pay",
+        userId: userId as UserId,
+        intent: event as ApplePayIntentData,
+      })
+      .catch(captureError);
   });
 
   return () => subscription.remove();
@@ -52,6 +63,9 @@ export async function setupNotificationCapture(
   userId: string,
   packages: string[]
 ): Promise<() => void> {
+  const captureIngestion = createCaptureIngestionPort(db, {
+    processNotification,
+  });
   if (packages.length === 0) return noop;
 
   // Dynamic import to avoid iOS bundle crash — this module has Android native code
@@ -63,9 +77,13 @@ export async function setupNotificationCapture(
   mod.setAllowedPackages(packages);
 
   const subscription = mod.addListener("onNotificationReceived", (event: unknown) => {
-    processNotification(db, userId, event as Parameters<typeof processNotification>[2]).catch(
-      captureError
-    );
+    captureIngestion
+      .ingest({
+        kind: "notification",
+        userId: userId as UserId,
+        notification: event as NotificationData,
+      })
+      .catch(captureError);
   });
 
   return () => subscription.remove();

--- a/apps/mobile/features/capture-sources/hooks/useWidgetCapture.ts
+++ b/apps/mobile/features/capture-sources/hooks/useWidgetCapture.ts
@@ -1,10 +1,11 @@
 import { useEffect } from "react";
 import { AppState } from "react-native";
+import { processWidgetTransactions } from "@/features/capture-sources/services/widget-pipeline";
 import { Platform } from "@/shared/components/rn";
 import type { AnyDb } from "@/shared/db";
 import { captureError } from "@/shared/lib";
 import type { UserId } from "@/shared/types/branded";
-import { processWidgetTransactions } from "../services/widget-pipeline";
+import { createCaptureIngestionPort } from "../services/capture-ingestion";
 
 export function useWidgetCapture(db: AnyDb | null, userId: string | null): void {
   useEffect(() => {
@@ -13,19 +14,26 @@ export function useWidgetCapture(db: AnyDb | null, userId: string | null): void 
     }
 
     const uid = userId as UserId;
-
-    processWidgetTransactions(db, uid).catch(function handleInitialError(err) {
-      captureError(err);
+    const captureIngestion = createCaptureIngestionPort(db, {
+      processWidgetTransactions,
     });
+
+    captureIngestion
+      .ingest({ kind: "widget", userId: uid })
+      .catch(function handleInitialError(err) {
+        captureError(err);
+      });
 
     const subscription = AppState.addEventListener(
       "change",
       function handleAppStateChange(nextState) {
         if (nextState !== "active") return;
 
-        processWidgetTransactions(db, uid).catch(function handleAppStateError(err) {
-          captureError(err);
-        });
+        captureIngestion
+          .ingest({ kind: "widget", userId: uid })
+          .catch(function handleAppStateError(err) {
+            captureError(err);
+          });
       }
     );
 

--- a/apps/mobile/features/capture-sources/index.ts
+++ b/apps/mobile/features/capture-sources/index.ts
@@ -19,4 +19,10 @@ export {
   resolveSource,
   smsDetectionDataSchema,
 } from "./schema";
+export {
+  type CaptureIngestionCommand,
+  type CaptureIngestionOutcome,
+  type CaptureIngestionPort,
+  createCaptureIngestionPort,
+} from "./services/capture-ingestion";
 export { useCaptureSourcesStore } from "./store";

--- a/apps/mobile/features/capture-sources/services/apple-pay-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/apple-pay-pipeline.ts
@@ -1,9 +1,17 @@
 import {
+  captureFingerprint,
+  findDuplicateTransaction,
+  isCaptureProcessed,
+} from "@/features/capture-sources/lib/dedup";
+import { insertProcessedCapture } from "@/features/capture-sources/lib/repository";
+import type { ApplePayIntentData } from "@/features/capture-sources/schema";
+import {
   insertMerchantRule,
   lookupMerchantRule,
 } from "@/features/email-capture/lib/merchant-rules";
 import { classifyMerchantApi } from "@/features/email-capture/services/parse-email-api";
-import { insertTransaction, isValidCategoryId } from "@/features/transactions";
+import { isValidCategoryId } from "@/features/transactions/lib/categories";
+import { insertTransaction } from "@/features/transactions/lib/repository";
 import type { AnyDb } from "@/shared/db";
 import { enqueueSync } from "@/shared/db";
 import {
@@ -17,9 +25,6 @@ import {
   trackTransactionCreated,
 } from "@/shared/lib";
 import type { CategoryId, CopAmount, TransactionId, UserId } from "@/shared/types/branded";
-import { captureFingerprint, findDuplicateTransaction, isCaptureProcessed } from "../lib/dedup";
-import { insertProcessedCapture } from "../lib/repository";
-import type { ApplePayIntentData } from "../schema";
 
 const inFlightFingerprints = new Set<string>();
 

--- a/apps/mobile/features/capture-sources/services/capture-ingestion.ts
+++ b/apps/mobile/features/capture-sources/services/capture-ingestion.ts
@@ -92,8 +92,9 @@ export function createCaptureIngestionPort(
             command.intent
           );
         case "widget":
-          return (deps.processWidgetTransactions ??
-            (await loadDefaultDeps()).processWidgetTransactions)(db, command.userId);
+          return (
+            deps.processWidgetTransactions ?? (await loadDefaultDeps()).processWidgetTransactions
+          )(db, command.userId);
         case "email_batch":
           return (deps.processEmails ?? (await loadDefaultDeps()).processEmails)(
             db,

--- a/apps/mobile/features/capture-sources/services/capture-ingestion.ts
+++ b/apps/mobile/features/capture-sources/services/capture-ingestion.ts
@@ -76,23 +76,32 @@ export function createCaptureIngestionPort(
   db: AnyDb,
   deps: Partial<CaptureIngestionDeps> = {}
 ): CaptureIngestionPort {
-  const hasCustomDeps = Object.keys(deps).length > 0;
+  async function resolveDep<Key extends keyof CaptureIngestionDeps>(
+    key: Key
+  ): Promise<CaptureIngestionDeps[Key]> {
+    const override = deps[key];
+    if (override) return override;
+    return (await loadDefaultDeps())[key];
+  }
 
   return {
     async ingest(command) {
-      const activeDeps = hasCustomDeps ? (deps as CaptureIngestionDeps) : await loadDefaultDeps();
-
       switch (command.kind) {
         case "notification":
-          return activeDeps.processNotification(db, command.userId, command.notification);
+          return (await resolveDep("processNotification"))(db, command.userId, command.notification);
         case "apple_pay":
-          return activeDeps.processApplePayIntent(db, command.userId, command.intent);
+          return (await resolveDep("processApplePayIntent"))(db, command.userId, command.intent);
         case "widget":
-          return activeDeps.processWidgetTransactions(db, command.userId);
+          return (await resolveDep("processWidgetTransactions"))(db, command.userId);
         case "email_batch":
-          return activeDeps.processEmails(db, command.userId, command.emails, command.onProgress);
+          return (await resolveDep("processEmails"))(
+            db,
+            command.userId,
+            command.emails,
+            command.onProgress
+          );
         case "email_retry":
-          return activeDeps.processRetries(db, command.userId);
+          return (await resolveDep("processRetries"))(db, command.userId);
       }
     },
   };

--- a/apps/mobile/features/capture-sources/services/capture-ingestion.ts
+++ b/apps/mobile/features/capture-sources/services/capture-ingestion.ts
@@ -1,0 +1,99 @@
+import type { ApplePayIntentData, NotificationData } from "@/features/capture-sources/schema";
+import type { RawEmail } from "@/features/email-capture/schema";
+import type {
+  PipelineResult,
+  ProgressCallback,
+  RetryResult,
+} from "@/features/email-capture/services/email-pipeline";
+import type { AnyDb } from "@/shared/db";
+import type { UserId } from "@/shared/types/branded";
+
+type NotificationHandler =
+  typeof import("@/features/capture-sources/services/notification-pipeline").processNotification;
+type ApplePayHandler =
+  typeof import("@/features/capture-sources/services/apple-pay-pipeline").processApplePayIntent;
+type WidgetHandler =
+  typeof import("@/features/capture-sources/services/widget-pipeline").processWidgetTransactions;
+type EmailBatchHandler =
+  typeof import("@/features/email-capture/services/email-pipeline").processEmails;
+type EmailRetryHandler =
+  typeof import("@/features/email-capture/services/email-pipeline").processRetries;
+
+export type CaptureIngestionCommand =
+  | { kind: "notification"; userId: UserId; notification: NotificationData }
+  | { kind: "apple_pay"; userId: UserId; intent: ApplePayIntentData }
+  | { kind: "widget"; userId: UserId }
+  | { kind: "email_batch"; userId: UserId; emails: RawEmail[]; onProgress?: ProgressCallback }
+  | { kind: "email_retry"; userId: UserId };
+
+type CaptureIngestionDeps = {
+  processNotification: NotificationHandler;
+  processApplePayIntent: ApplePayHandler;
+  processWidgetTransactions: WidgetHandler;
+  processEmails: EmailBatchHandler;
+  processRetries: EmailRetryHandler;
+};
+
+export type CaptureIngestionOutcome =
+  | Awaited<ReturnType<NotificationHandler>>
+  | Awaited<ReturnType<ApplePayHandler>>
+  | Awaited<ReturnType<WidgetHandler>>
+  | PipelineResult
+  | RetryResult;
+
+export interface CaptureIngestionPort {
+  ingest(command: CaptureIngestionCommand): Promise<CaptureIngestionOutcome>;
+}
+
+type DefaultDeps = CaptureIngestionDeps;
+
+let defaultDepsPromise: Promise<DefaultDeps> | null = null;
+
+async function loadDefaultDeps(): Promise<DefaultDeps> {
+  if (defaultDepsPromise) return defaultDepsPromise;
+
+  defaultDepsPromise = (async () => {
+    const [notification, applePay, widget, email] = await Promise.all([
+      import("@/features/capture-sources/services/notification-pipeline"),
+      import("@/features/capture-sources/services/apple-pay-pipeline"),
+      import("@/features/capture-sources/services/widget-pipeline"),
+      import("@/features/email-capture/services/email-pipeline"),
+    ]);
+
+    return {
+      processNotification: notification.processNotification,
+      processApplePayIntent: applePay.processApplePayIntent,
+      processWidgetTransactions: widget.processWidgetTransactions,
+      processEmails: email.processEmails,
+      processRetries: email.processRetries,
+    };
+  })();
+
+  return defaultDepsPromise;
+}
+
+export function createCaptureIngestionPort(
+  db: AnyDb,
+  deps: Partial<CaptureIngestionDeps> = {}
+): CaptureIngestionPort {
+  const hasCustomDeps = Object.keys(deps).length > 0;
+
+  return {
+    async ingest(command) {
+      const activeDeps = hasCustomDeps ? (deps as CaptureIngestionDeps) : await loadDefaultDeps();
+
+      switch (command.kind) {
+        case "notification":
+          return activeDeps.processNotification(db, command.userId, command.notification);
+        case "apple_pay":
+          return activeDeps.processApplePayIntent(db, command.userId, command.intent);
+        case "widget":
+          return activeDeps.processWidgetTransactions(db, command.userId);
+        case "email_batch":
+          return activeDeps.processEmails(db, command.userId, command.emails, command.onProgress);
+        case "email_retry":
+          return activeDeps.processRetries(db, command.userId);
+      }
+    },
+  };
+}

--- a/apps/mobile/features/capture-sources/services/capture-ingestion.ts
+++ b/apps/mobile/features/capture-sources/services/capture-ingestion.ts
@@ -76,32 +76,36 @@ export function createCaptureIngestionPort(
   db: AnyDb,
   deps: Partial<CaptureIngestionDeps> = {}
 ): CaptureIngestionPort {
-  async function resolveDep<Key extends keyof CaptureIngestionDeps>(
-    key: Key
-  ): Promise<CaptureIngestionDeps[Key]> {
-    const override = deps[key];
-    if (override) return override;
-    return (await loadDefaultDeps())[key];
-  }
-
   return {
     async ingest(command) {
       switch (command.kind) {
         case "notification":
-          return (await resolveDep("processNotification"))(db, command.userId, command.notification);
+          return (deps.processNotification ?? (await loadDefaultDeps()).processNotification)(
+            db,
+            command.userId,
+            command.notification
+          );
         case "apple_pay":
-          return (await resolveDep("processApplePayIntent"))(db, command.userId, command.intent);
+          return (deps.processApplePayIntent ?? (await loadDefaultDeps()).processApplePayIntent)(
+            db,
+            command.userId,
+            command.intent
+          );
         case "widget":
-          return (await resolveDep("processWidgetTransactions"))(db, command.userId);
+          return (deps.processWidgetTransactions ??
+            (await loadDefaultDeps()).processWidgetTransactions)(db, command.userId);
         case "email_batch":
-          return (await resolveDep("processEmails"))(
+          return (deps.processEmails ?? (await loadDefaultDeps()).processEmails)(
             db,
             command.userId,
             command.emails,
             command.onProgress
           );
         case "email_retry":
-          return (await resolveDep("processRetries"))(db, command.userId);
+          return (deps.processRetries ?? (await loadDefaultDeps()).processRetries)(
+            db,
+            command.userId
+          );
       }
     },
   };

--- a/apps/mobile/features/capture-sources/services/notification-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/notification-pipeline.ts
@@ -1,9 +1,20 @@
 import {
+  captureFingerprint,
+  findDuplicateTransaction,
+  isCaptureProcessed,
+} from "@/features/capture-sources/lib/dedup";
+import { parseNotificationLocally } from "@/features/capture-sources/lib/notification-parser";
+import { insertProcessedCapture } from "@/features/capture-sources/lib/repository";
+import type { NotificationData } from "@/features/capture-sources/schema";
+import { resolveSource } from "@/features/capture-sources/schema";
+import { parseNotificationApi } from "@/features/capture-sources/services/parse-notification-api";
+import {
   insertMerchantRule,
   lookupMerchantRule,
 } from "@/features/email-capture/lib/merchant-rules";
 import { stripPii } from "@/features/email-capture/services/parse-email-api";
-import { insertTransaction, isValidCategoryId } from "@/features/transactions";
+import { isValidCategoryId } from "@/features/transactions/lib/categories";
+import { insertTransaction } from "@/features/transactions/lib/repository";
 import type { AnyDb } from "@/shared/db";
 import { enqueueSync } from "@/shared/db";
 import {
@@ -17,12 +28,6 @@ import {
   trackTransactionCreated,
 } from "@/shared/lib";
 import type { CategoryId, CopAmount, IsoDate, TransactionId, UserId } from "@/shared/types/branded";
-import { captureFingerprint, findDuplicateTransaction, isCaptureProcessed } from "../lib/dedup";
-import { parseNotificationLocally } from "../lib/notification-parser";
-import { insertProcessedCapture } from "../lib/repository";
-import type { NotificationData } from "../schema";
-import { resolveSource } from "../schema";
-import { parseNotificationApi } from "./parse-notification-api";
 
 /** In-flight fingerprints guard against concurrent duplicate processing. */
 const inFlightFingerprints = new Set<string>();

--- a/apps/mobile/features/capture-sources/services/widget-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/widget-pipeline.ts
@@ -1,4 +1,11 @@
-import { insertTransaction, isValidCategoryId } from "@/features/transactions";
+import {
+  captureFingerprint,
+  findDuplicateTransaction,
+  isCaptureProcessed,
+} from "@/features/capture-sources/lib/dedup";
+import { insertProcessedCapture } from "@/features/capture-sources/lib/repository";
+import { isValidCategoryId } from "@/features/transactions/lib/categories";
+import { insertTransaction } from "@/features/transactions/lib/repository";
 import type { AnyDb } from "@/shared/db";
 import { enqueueSync } from "@/shared/db";
 import {
@@ -11,8 +18,6 @@ import {
   trackTransactionCreated,
 } from "@/shared/lib";
 import type { CategoryId, CopAmount, IsoDate, TransactionId, UserId } from "@/shared/types/branded";
-import { captureFingerprint, findDuplicateTransaction, isCaptureProcessed } from "../lib/dedup";
-import { insertProcessedCapture } from "../lib/repository";
 
 // Guard against concurrent invocations (mount + immediate AppState "active").
 const inFlightFingerprints = new Set<string>();

--- a/apps/mobile/features/email-capture/index.ts
+++ b/apps/mobile/features/email-capture/index.ts
@@ -1,10 +1,13 @@
+export {
+  insertMerchantRule,
+  lookupMerchantRule,
+} from "@/features/email-capture/lib/merchant-rules";
+export type { ProcessedEmailRow } from "@/features/email-capture/lib/repository";
 export { EmailConnectBanner } from "./components/EmailConnectBanner";
 export { FailedEmailsBanner } from "./components/FailedEmailsBanner";
 export { default as NeedsReviewScreen } from "./components/NeedsReviewScreen";
 export { useEmailCapture } from "./hooks/useEmailCapture";
 export type { BankSender } from "./lib/bank-senders";
-export { insertMerchantRule, lookupMerchantRule } from "./lib/merchant-rules";
-export type { ProcessedEmailRow } from "./lib/repository";
 export type { EmailProvider } from "./schema";
 export { getGmailClientId, getOutlookClientId } from "./schema";
 export type { LlmParsedTransaction } from "./services/llm-parser";

--- a/apps/mobile/features/email-capture/services/email-pipeline.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline.ts
@@ -1,5 +1,21 @@
-import { findDuplicateTransaction } from "@/features/capture-sources";
-import { insertTransaction, isValidCategoryId } from "@/features/transactions";
+import { findDuplicateTransaction } from "@/features/capture-sources/lib/dedup";
+import {
+  insertMerchantRule,
+  lookupMerchantRule,
+} from "@/features/email-capture/lib/merchant-rules";
+import {
+  getPendingRetryEmails,
+  getProcessedExternalIds,
+  insertProcessedEmail,
+  markForRetry,
+  markPermanentlyFailed,
+  markRetrySuccess,
+  updateProcessedEmailStatus,
+} from "@/features/email-capture/lib/repository";
+import type { RawEmail } from "@/features/email-capture/schema";
+import { parseEmailApi } from "@/features/email-capture/services/parse-email-api";
+import { isValidCategoryId } from "@/features/transactions/lib/categories";
+import { insertTransaction } from "@/features/transactions/lib/repository";
 import type { AnyDb } from "@/shared/db";
 import { enqueueSync } from "@/shared/db";
 import {
@@ -21,20 +37,8 @@ import type {
   TransactionId,
   UserId,
 } from "@/shared/types/branded";
-import { insertMerchantRule, lookupMerchantRule } from "../lib/merchant-rules";
-import {
-  getPendingRetryEmails,
-  getProcessedExternalIds,
-  insertProcessedEmail,
-  markForRetry,
-  markPermanentlyFailed,
-  markRetrySuccess,
-  updateProcessedEmailStatus,
-} from "../lib/repository";
 import { computeNextRetryAt, isMaxRetriesReached } from "../lib/retry-backoff";
-import type { RawEmail } from "../schema";
 import type { LlmParsedTransaction } from "./llm-parser";
-import { parseEmailApi } from "./parse-email-api";
 
 export type PipelineResult = {
   filtered: number;

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -1,5 +1,25 @@
 import { eq } from "drizzle-orm";
 import { create } from "zustand";
+import { createCaptureIngestionPort } from "@/features/capture-sources/services/capture-ingestion";
+import { insertMerchantRule } from "@/features/email-capture/lib/merchant-rules";
+import type { ProgressPhase } from "@/features/email-capture/lib/progress-phases";
+import {
+  isFirstFetchForAny,
+  shouldShowProgress,
+} from "@/features/email-capture/lib/progress-phases";
+import type { EmailAccountRow, ProcessedEmailRow } from "@/features/email-capture/lib/repository";
+import {
+  deleteEmailAccount,
+  dismissProcessedEmail,
+  getEmailAccounts,
+  getFailedEmails,
+  getNeedsReviewEmails,
+  insertEmailAccount,
+  updateLastFetchedAt,
+  updateProcessedEmailStatus,
+} from "@/features/email-capture/lib/repository";
+import type { ProgressCallback } from "@/features/email-capture/services/email-pipeline";
+import { processEmails, processRetries } from "@/features/email-capture/services/email-pipeline";
 import { useTransactionStore } from "@/features/transactions";
 import type { AnyDb } from "@/shared/db";
 import { enqueueSync, transactions } from "@/shared/db";
@@ -18,24 +38,9 @@ import type {
   TransactionId,
   UserId,
 } from "@/shared/types/branded";
-import { insertMerchantRule } from "./lib/merchant-rules";
-import type { ProgressPhase } from "./lib/progress-phases";
-import { isFirstFetchForAny, shouldShowProgress } from "./lib/progress-phases";
-import type { EmailAccountRow, ProcessedEmailRow } from "./lib/repository";
-import {
-  deleteEmailAccount,
-  dismissProcessedEmail,
-  getEmailAccounts,
-  getFailedEmails,
-  getNeedsReviewEmails,
-  insertEmailAccount,
-  updateLastFetchedAt,
-  updateProcessedEmailStatus,
-} from "./lib/repository";
 import type { EmailProvider, RawEmail } from "./schema";
 import { fetchBankSenders } from "./services/bank-senders-cache";
 import { getAdapter } from "./services/email-adapter";
-import { type ProgressCallback, processEmails, processRetries } from "./services/email-pipeline";
 
 let dbRef: AnyDb | null = null;
 let userIdRef: string | null = null;
@@ -163,6 +168,10 @@ export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActio
     set({ isFetching: true, phase: null, progress: null });
 
     try {
+      const captureIngestion = createCaptureIngestionPort(db, {
+        processEmails,
+        processRetries,
+      });
       const { accounts } = get();
       if (accounts.length === 0) {
         console.warn("[EmailCapture] no connected accounts");
@@ -220,26 +229,39 @@ export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActio
         set({ phase: "processing" });
 
         let lastRefreshedSaved = 0;
-        await processEmails(db, userId, allEmails, (progress) => {
-          set({ progress });
-          if (progress.saved > lastRefreshedSaved) {
-            lastRefreshedSaved = progress.saved;
-            void useTransactionStore.getState().refresh();
-          }
+        await captureIngestion.ingest({
+          kind: "email_batch",
+          userId: userId as UserId,
+          emails: allEmails,
+          onProgress: (progress) => {
+            set({ progress });
+            if (progress.saved > lastRefreshedSaved) {
+              lastRefreshedSaved = progress.saved;
+              void useTransactionStore.getState().refresh();
+            }
+          },
         });
       } else if (allEmails.length > 0) {
         // Silent processing — no progress UI
         let lastRefreshedSaved = 0;
-        await processEmails(db, userId, allEmails, (progress) => {
-          set({ progress });
-          if (progress.saved > lastRefreshedSaved) {
-            lastRefreshedSaved = progress.saved;
-            void useTransactionStore.getState().refresh();
-          }
+        await captureIngestion.ingest({
+          kind: "email_batch",
+          userId: userId as UserId,
+          emails: allEmails,
+          onProgress: (progress) => {
+            set({ progress });
+            if (progress.saved > lastRefreshedSaved) {
+              lastRefreshedSaved = progress.saved;
+              void useTransactionStore.getState().refresh();
+            }
+          },
         });
       }
 
-      await processRetries(db, userId);
+      await captureIngestion.ingest({
+        kind: "email_retry",
+        userId: userId as UserId,
+      });
 
       // Update lastFetchedAt only for accounts whose fetch succeeded
       const now = toIsoDateTime(new Date());


### PR DESCRIPTION
- unify capture callers
- add boundary coverage
- fix legacy import-order tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a unified capture ingestion port for mobile. Routes notifications, Apple Pay, widget events, and email batches/retries through one entry point, updates hooks/store, and hardens handler resolution to keep listeners responsive.

- New Features
  - Introduced `createCaptureIngestionPort` with `CaptureIngestionCommand` routing for `notification`, `apple_pay`, `widget`, `email_batch` (with progress), and `email_retry`.
  - Resolves handlers per command and supports partial overrides without loading unused deps to preserve scheduling; exports `CaptureIngestion*` types from capture-sources index.

- Refactors
  - Switched `setupApplePayCapture`, `setupNotificationCapture`, `useWidgetCapture`, and the email capture store to call the port (keeps progress UI and transaction refreshes).
  - Moved to granular module imports (`transactions/lib/repository`, `transactions/lib/categories`, `capture-sources/lib/*`, email-capture libs) to fix legacy import-order tests and stabilize mocks; added boundary tests and dynamic imports.

<sup>Written for commit 6943c1f49e6e2204031b5d82c891b78d3f9f9dff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

