### PR TITLE
refactor(mobile): deepen sync boundary

### DIFF
--- a/apps/mobile/__tests__/sync/sync-conflict-resolution.test.ts
+++ b/apps/mobile/__tests__/sync/sync-conflict-resolution.test.ts
@@ -1,0 +1,138 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: integration test needs flexible typing
+// biome-ignore-all lint/style/useNamingConvention: snake_case matches Supabase Postgres column names
+// biome-ignore-all lint/style/noNonNullAssertion: assertions guard nullability before access
+import { resolve } from "node:path";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { getUnresolvedConflicts, insertConflict } from "@/features/sync/lib/conflict-repository";
+import { resolveConflict } from "@/features/sync/services/sync";
+import {
+  getQueuedSyncEntries,
+  getTransactionById,
+  insertTransaction,
+  useTransactionStore,
+} from "@/features/transactions";
+import type {
+  CategoryId,
+  CopAmount,
+  IsoDate,
+  IsoDateTime,
+  TransactionId,
+  UserId,
+} from "@/shared/types/branded";
+
+let sqlite: InstanceType<typeof Database>;
+let db: ReturnType<typeof drizzle>;
+
+beforeEach(() => {
+  sqlite = new Database(":memory:");
+  db = drizzle(sqlite);
+  migrate(db, { migrationsFolder: resolve(__dirname, "../../drizzle") });
+  useTransactionStore.getState().initStore(db as any, "user-1" as UserId);
+});
+
+afterEach(() => {
+  sqlite.close();
+});
+
+function insertLocalTx(overrides: Record<string, unknown> = {}) {
+  const row = {
+    id: "tx-1" as TransactionId,
+    userId: "user-1" as UserId,
+    type: "expense",
+    amount: 1000 as CopAmount,
+    categoryId: "food" as CategoryId,
+    description: "Local merchant",
+    date: "2026-03-10" as IsoDate,
+    createdAt: "2026-03-10T08:00:00.000Z" as IsoDateTime,
+    updatedAt: "2026-03-10T10:00:00.000Z" as IsoDateTime,
+    deletedAt: null,
+    source: "manual",
+    ...overrides,
+  };
+  insertTransaction(db as any, row as any);
+}
+
+function conflictRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "conflict-1",
+    transactionId: "tx-1",
+    localData: JSON.stringify({
+      id: "tx-1",
+      userId: "user-1",
+      type: "expense",
+      amount: 1000,
+      categoryId: "food",
+      description: "Local merchant",
+      date: "2026-03-10",
+      createdAt: "2026-03-10T08:00:00.000Z",
+      updatedAt: "2026-03-10T10:00:00.000Z",
+      deletedAt: null,
+      source: "manual",
+    }),
+    serverData: JSON.stringify({
+      id: "tx-1",
+      userId: "user-1",
+      type: "expense",
+      amount: 2000,
+      categoryId: "food",
+      description: "Server merchant",
+      date: "2026-03-10",
+      createdAt: "2026-03-10T08:00:00.000Z",
+      updatedAt: "2026-03-10T14:00:00.000Z",
+      deletedAt: null,
+      source: "email",
+    }),
+    detectedAt: "2026-03-15T10:00:00.000Z",
+    resolvedAt: null,
+    resolution: null,
+    ...overrides,
+  };
+}
+
+describe("sync conflict resolution boundary", () => {
+  it("keeps local data and re-enqueues sync when resolving in favor of local", async () => {
+    insertLocalTx();
+    insertConflict(db as any, conflictRow() as any);
+
+    await resolveConflict({
+      db: db as any,
+      conflictId: "conflict-1" as any,
+      resolution: "local",
+    });
+
+    const tx = getTransactionById(db as any, "tx-1" as TransactionId);
+    expect(tx?.amount).toBe(1000);
+
+    const queue = getQueuedSyncEntries(db as any);
+    expect(queue).toHaveLength(1);
+    expect(queue[0]?.tableName).toBe("transactions");
+    expect(queue[0]?.rowId).toBe("tx-1");
+
+    const conflicts = getUnresolvedConflicts(db as any);
+    expect(conflicts).toHaveLength(0);
+  });
+
+  it("marks the conflict resolved without re-enqueueing when accepting server data", async () => {
+    insertLocalTx({ amount: 1200 });
+    insertConflict(db as any, conflictRow() as any);
+
+    await resolveConflict({
+      db: db as any,
+      conflictId: "conflict-1" as any,
+      resolution: "server",
+    });
+
+    const tx = getTransactionById(db as any, "tx-1" as TransactionId);
+    expect(tx?.amount).toBe(1200);
+
+    const queue = getQueuedSyncEntries(db as any);
+    expect(queue).toHaveLength(0);
+
+    const conflicts = getUnresolvedConflicts(db as any);
+    expect(conflicts).toHaveLength(0);
+  });
+});

--- a/apps/mobile/__tests__/sync/sync-module.test.ts
+++ b/apps/mobile/__tests__/sync/sync-module.test.ts
@@ -1,0 +1,115 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: sync boundary test uses flexible mock ports
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const refreshMock = vi.fn();
+const mockGetSupabase = vi.fn();
+const mockIsOnline = vi.fn();
+const mockSyncPull = vi.fn();
+const mockSyncPush = vi.fn();
+const mockGetUnresolvedConflicts = vi.fn();
+
+vi.mock("@/shared/db", () => ({
+  getSupabase: (...args: any[]) => mockGetSupabase(...args),
+}));
+
+vi.mock("@/features/transactions", () => ({
+  useTransactionStore: {
+    getState: () => ({
+      refresh: refreshMock,
+    }),
+  },
+}));
+
+vi.mock("@/features/sync/services/networkMonitor", () => ({
+  isOnline: (...args: any[]) => mockIsOnline(...args),
+}));
+
+vi.mock("@/features/sync/services/syncEngine", () => ({
+  syncPull: (...args: any[]) => mockSyncPull(...args),
+  syncPush: (...args: any[]) => mockSyncPush(...args),
+}));
+
+vi.mock("@/features/sync/lib/conflict-repository", () => ({
+  getUnresolvedConflicts: (...args: any[]) => mockGetUnresolvedConflicts(...args),
+}));
+
+describe("sync module", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSupabase.mockReturnValue({ from: vi.fn() });
+    mockIsOnline.mockResolvedValue(true);
+    mockSyncPull.mockResolvedValue(true);
+    mockSyncPush.mockResolvedValue(undefined);
+    mockGetUnresolvedConflicts.mockReturnValue([]);
+  });
+
+  it("syncs by pulling first, then pushing queued rows when online", async () => {
+    const { sync } = await import("@/features/sync/services/sync");
+    const db = {} as any;
+
+    const result = await sync({ db, userId: "user-1", reason: "foreground" });
+
+    expect(mockIsOnline).toHaveBeenCalled();
+    expect(mockSyncPull).toHaveBeenCalledWith(db, expect.any(Object), "user-1");
+    expect(mockSyncPush).toHaveBeenCalledWith(db, expect.any(Object), "user-1");
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe("synced");
+    expect(result.unresolvedConflicts).toBe(0);
+  });
+
+  it("returns skipped_offline without touching remote sync when offline", async () => {
+    mockIsOnline.mockResolvedValue(false);
+    const { sync } = await import("@/features/sync/services/sync");
+    const db = {} as any;
+
+    const result = await sync({ db, userId: "user-1" });
+
+    expect(mockSyncPull).not.toHaveBeenCalled();
+    expect(mockSyncPush).not.toHaveBeenCalled();
+    expect(refreshMock).not.toHaveBeenCalled();
+    expect(result.status).toBe("skipped_offline");
+  });
+
+  it("lists unresolved conflicts through the boundary", async () => {
+    mockGetUnresolvedConflicts.mockReturnValueOnce([
+      {
+        id: "conflict-1",
+        transactionId: "tx-1",
+        localData: JSON.stringify({
+          id: "tx-1",
+          userId: "user-1",
+          type: "expense",
+          amount: 1000,
+          categoryId: "food",
+          description: "Local merchant",
+          date: "2026-03-10",
+          createdAt: "2026-03-10T08:00:00.000Z",
+          updatedAt: "2026-03-10T10:00:00.000Z",
+          deletedAt: null,
+          source: "manual",
+        }),
+        serverData: JSON.stringify({
+          id: "tx-1",
+          userId: "user-1",
+          type: "expense",
+          amount: 2000,
+          categoryId: "food",
+          description: "Server merchant",
+          date: "2026-03-10",
+          createdAt: "2026-03-10T08:00:00.000Z",
+          updatedAt: "2026-03-10T14:00:00.000Z",
+          deletedAt: null,
+          source: "email",
+        }),
+        detectedAt: "2026-03-15T10:00:00.000Z",
+      },
+    ]);
+
+    const { listConflicts } = await import("@/features/sync/services/sync");
+    const conflicts = await listConflicts({ db: {} as any });
+
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]?.transactionId).toBe("tx-1");
+    expect(conflicts[0]?.localData.amount).toBe(1000);
+  });
+});

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -118,7 +118,7 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
         .getState()
         .loadInitialPage()
         .catch(handleRecoverableError("Failed to load transactions"));
-      useSyncConflictStore.getState().loadConflicts();
+      void useSyncConflictStore.getState().loadConflicts();
       useSettingsStore
         .getState()
         .hydrate()

--- a/apps/mobile/features/sync/hooks/useSync.ts
+++ b/apps/mobile/features/sync/hooks/useSync.ts
@@ -1,12 +1,10 @@
 import { useRef, useState } from "react";
-import { useTransactionStore } from "@/features/transactions";
 import { AppState } from "@/shared/components/rn";
 import type { AnyDb } from "@/shared/db";
-import { getSupabase } from "@/shared/db";
 import { useSubscription } from "@/shared/hooks";
 import { captureWarning } from "@/shared/lib";
-import { isOnline, onConnectivityChange } from "../services/networkMonitor";
-import { fullSync } from "../services/syncEngine";
+import { onConnectivityChange } from "../services/networkMonitor";
+import { sync } from "../services/sync";
 import { useSyncConflictStore } from "../store";
 
 export function useSync(db: AnyDb | null, userId: string | null): boolean {
@@ -18,7 +16,6 @@ export function useSync(db: AnyDb | null, userId: string | null): boolean {
       if (!db || !userId) return;
 
       setInitialSyncDone(false);
-      const supabase = getSupabase();
       const hasCompletedInitialRun = { current: false };
 
       const markInitialDone = () => {
@@ -30,14 +27,11 @@ export function useSync(db: AnyDb | null, userId: string | null): boolean {
 
       const runSync = async () => {
         if (isSyncing.current) return;
-        const online = await isOnline();
-        if (!online) return;
         isSyncing.current = true;
         try {
-          const pullOk = await fullSync(db, supabase, userId);
-          await useTransactionStore.getState().refresh();
-          useSyncConflictStore.getState().loadConflicts();
-          if (pullOk) markInitialDone();
+          const result = await sync({ db, userId, reason: "foreground" });
+          await useSyncConflictStore.getState().loadConflicts();
+          if (result.status === "synced") markInitialDone();
         } catch (error) {
           captureWarning("background_sync_failed", {
             errorType: error instanceof Error ? error.message : "unknown",

--- a/apps/mobile/features/sync/index.ts
+++ b/apps/mobile/features/sync/index.ts
@@ -1,5 +1,9 @@
 export { default as ConflictResolutionScreen } from "./components/ConflictResolutionScreen";
 export { SyncConflictBanner } from "./components/SyncConflictBanner";
 export { useSync } from "./hooks/useSync";
-export { getUnresolvedConflicts } from "./lib/conflict-repository";
+export {
+  listConflicts,
+  resolveConflict,
+  sync,
+} from "./services/sync";
 export { useSyncConflictStore } from "./store";

--- a/apps/mobile/features/sync/services/sync.ts
+++ b/apps/mobile/features/sync/services/sync.ts
@@ -1,0 +1,152 @@
+// biome-ignore-all lint/style/useNamingConvention: snake_case matches Supabase Postgres column names
+import { upsertTransaction, useTransactionStore } from "@/features/transactions";
+import { type AnyDb, enqueueSync, getSupabase } from "@/shared/db";
+import { generateSyncQueueId, toIsoDateTime } from "@/shared/lib";
+import type { SyncConflictId } from "@/shared/types/branded";
+import {
+  getUnresolvedConflicts,
+  resolveConflict as resolveConflictDb,
+} from "../lib/conflict-repository";
+import { isOnline } from "./networkMonitor";
+import { syncPull, syncPush } from "./syncEngine";
+
+export type TransactionSnapshot = {
+  readonly id: string;
+  readonly userId: string;
+  readonly type: string;
+  readonly amount: number;
+  readonly categoryId: string;
+  readonly description: string | null;
+  readonly date: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly deletedAt: string | null;
+  readonly source: string;
+};
+
+export type SyncConflict = {
+  readonly id: string;
+  readonly transactionId: string;
+  readonly localData: TransactionSnapshot;
+  readonly serverData: TransactionSnapshot;
+  readonly detectedAt: string;
+};
+
+export type SyncContext = {
+  readonly db: AnyDb;
+};
+
+export type SyncReason = "startup" | "foreground" | "reconnected" | "manual";
+
+export type SyncInput = SyncContext & {
+  readonly userId: string;
+  readonly reason?: SyncReason;
+};
+
+export type SyncRunResult =
+  | {
+      readonly status: "synced";
+      readonly unresolvedConflicts: number;
+    }
+  | {
+      readonly status: "skipped_offline";
+      readonly unresolvedConflicts: number;
+    }
+  | {
+      readonly status: "failed_pull";
+      readonly unresolvedConflicts: number;
+    };
+
+export type ConflictResolution = "local" | "server";
+
+export type ResolveTransactionConflictInput = SyncContext & {
+  readonly conflictId: SyncConflictId;
+  readonly resolution: ConflictResolution;
+};
+
+export type ResolveConflictResult = {
+  readonly unresolvedConflicts: number;
+};
+
+function parseConflict(row: {
+  readonly id: string;
+  readonly transactionId: string;
+  readonly localData: string;
+  readonly serverData: string;
+  readonly detectedAt: string;
+}): SyncConflict {
+  return {
+    id: row.id,
+    transactionId: row.transactionId,
+    localData: JSON.parse(row.localData) as TransactionSnapshot,
+    serverData: JSON.parse(row.serverData) as TransactionSnapshot,
+    detectedAt: row.detectedAt,
+  };
+}
+
+export async function listConflicts({ db }: SyncContext): Promise<readonly SyncConflict[]> {
+  return getUnresolvedConflicts(db).map(parseConflict);
+}
+
+export async function sync({
+  db,
+  userId,
+  reason: _reason = "foreground",
+}: SyncInput): Promise<SyncRunResult> {
+  void _reason;
+  const online = await isOnline();
+  if (!online) {
+    return {
+      status: "skipped_offline",
+      unresolvedConflicts: (await listConflicts({ db })).length,
+    };
+  }
+
+  const supabase = getSupabase();
+  const pullOk = await syncPull(db, supabase, userId);
+  if (pullOk) {
+    await syncPush(db, supabase, userId);
+    await useTransactionStore.getState().refresh();
+  }
+
+  return {
+    status: pullOk ? "synced" : "failed_pull",
+    unresolvedConflicts: (await listConflicts({ db })).length,
+  };
+}
+
+export async function resolveConflict({
+  db,
+  conflictId,
+  resolution,
+}: ResolveTransactionConflictInput): Promise<ResolveConflictResult> {
+  const row = getUnresolvedConflicts(db).find((conflict) => conflict.id === conflictId);
+  if (!row) {
+    return {
+      unresolvedConflicts: (await listConflicts({ db })).length,
+    };
+  }
+
+  const resolvedAt = toIsoDateTime(new Date());
+
+  if (resolution === "local") {
+    const localData = JSON.parse(row.localData) as TransactionSnapshot;
+    upsertTransaction(db, { ...localData, updatedAt: resolvedAt } as Parameters<
+      typeof upsertTransaction
+    >[1]);
+    enqueueSync(db, {
+      id: generateSyncQueueId(),
+      tableName: "transactions",
+      rowId: row.transactionId,
+      operation: "update",
+      createdAt: resolvedAt,
+    });
+  }
+
+  resolveConflictDb(db, conflictId, resolution, resolvedAt);
+  await useTransactionStore.getState().refresh();
+
+  return {
+    unresolvedConflicts: (await listConflicts({ db })).length,
+  };
+}

--- a/apps/mobile/features/sync/store.ts
+++ b/apps/mobile/features/sync/store.ts
@@ -1,37 +1,14 @@
 import { create } from "zustand";
-import { upsertTransaction, useTransactionStore } from "@/features/transactions";
 import type { AnyDb } from "@/shared/db";
-import { enqueueSync } from "@/shared/db";
-import { captureError, generateSyncQueueId, toIsoDateTime } from "@/shared/lib";
+import { captureError } from "@/shared/lib";
 import type { SyncConflictId } from "@/shared/types/branded";
 import {
-  getUnresolvedConflicts,
-  resolveConflict as resolveConflictDb,
-} from "./lib/conflict-repository";
+  listConflicts,
+  resolveConflict as resolveConflictBoundary,
+  type SyncConflict,
+} from "./services/sync";
 
 let dbRef: AnyDb | null = null;
-
-type TransactionSnapshot = {
-  readonly id: string;
-  readonly userId: string;
-  readonly type: string;
-  readonly amount: number;
-  readonly categoryId: string;
-  readonly description: string | null;
-  readonly date: string;
-  readonly createdAt: string;
-  readonly updatedAt: string;
-  readonly deletedAt: string | null;
-  readonly source: string;
-};
-
-export type SyncConflict = {
-  readonly id: string;
-  readonly transactionId: string;
-  readonly localData: TransactionSnapshot;
-  readonly serverData: TransactionSnapshot;
-  readonly detectedAt: string;
-};
 
 type SyncConflictState = {
   conflicts: SyncConflict[];
@@ -40,7 +17,7 @@ type SyncConflictState = {
 
 type SyncConflictActions = {
   initStore: (db: AnyDb) => void;
-  loadConflicts: () => void;
+  loadConflicts: () => Promise<void>;
   resolveConflict: (id: string, resolution: "local" | "server") => Promise<void>;
 };
 
@@ -52,17 +29,10 @@ export const useSyncConflictStore = create<SyncConflictState & SyncConflictActio
     dbRef = db;
   },
 
-  loadConflicts: () => {
+  loadConflicts: async () => {
     if (!dbRef) return;
     try {
-      const rows = getUnresolvedConflicts(dbRef);
-      const conflicts = rows.map((row) => ({
-        id: row.id,
-        transactionId: row.transactionId,
-        localData: JSON.parse(row.localData) as TransactionSnapshot,
-        serverData: JSON.parse(row.serverData) as TransactionSnapshot,
-        detectedAt: row.detectedAt,
-      }));
+      const conflicts = [...(await listConflicts({ db: dbRef }))];
       set({ conflicts, conflictCount: conflicts.length });
     } catch (err) {
       captureError(err);
@@ -71,26 +41,13 @@ export const useSyncConflictStore = create<SyncConflictState & SyncConflictActio
 
   resolveConflict: async (id, resolution) => {
     if (!dbRef) return;
-    const conflict = get().conflicts.find((c) => c.id === id);
-    if (!conflict) return;
-
-    const now = toIsoDateTime(new Date());
-
-    if (resolution === "local") {
-      upsertTransaction(dbRef, { ...conflict.localData, updatedAt: now } as Parameters<
-        typeof upsertTransaction
-      >[1]);
-      enqueueSync(dbRef, {
-        id: generateSyncQueueId(),
-        tableName: "transactions",
-        rowId: conflict.transactionId,
-        operation: "update",
-        createdAt: now,
-      });
-    }
-
-    resolveConflictDb(dbRef, id as SyncConflictId, resolution, now);
-    get().loadConflicts();
-    await useTransactionStore.getState().refresh();
+    await resolveConflictBoundary({
+      db: dbRef,
+      conflictId: id as SyncConflictId,
+      resolution,
+    });
+    await get().loadConflicts();
   },
 }));
+
+export type { SyncConflict } from "./services/sync";


### PR DESCRIPTION
refactor(mobile): deepen sync boundary

- centralize sync orchestration
- add conflict boundary tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized mobile sync into a single boundary that orchestrates pull/push and conflict resolution. This simplifies the sync flow and removes duplicate logic, while fixing an unhandled boot-time promise.

- **Refactors**
  - Introduced `sync`, `listConflicts`, and `resolveConflict` in `@/features/sync/services/sync` to handle online checks, pull-then-push, queue writes, and store refresh.
  - Updated `useSync` to call `sync` and rely on its status; removed direct engine wiring and online checks.
  - Simplified `useSyncConflictStore` to use the boundary; `loadConflicts` is now async and reuses `listConflicts`.
  - Added tests for sync ordering/offline behavior and conflict listing/resolution.

- **Bug Fixes**
  - Silenced the background promise on app boot by prefixing `loadConflicts()` with `void` in `_layout`.

<sup>Written for commit a205cde7d317c7deb7d17e2abe304b03b018a51f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

