### PR TITLE
refactor(mobile): add category registry

### DIFF
--- a/apps/mobile/__tests__/categories/registry.test.ts
+++ b/apps/mobile/__tests__/categories/registry.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  createCategoryRegistrySnapshot,
+  isCategoryIdValid,
+} from "@/features/categories/lib/registry";
+import { CATEGORIES } from "@/features/transactions/lib/categories";
+import type { UserCategoryId } from "@/shared/types/branded";
+
+describe("createCategoryRegistrySnapshot", () => {
+  it("keeps built-in categories separate from merged custom categories", () => {
+    const snapshot = createCategoryRegistrySnapshot([]);
+
+    expect(snapshot.builtIn).toEqual(CATEGORIES);
+    expect(snapshot.custom).toEqual([]);
+    expect(snapshot.merged).toEqual(CATEGORIES);
+    expect(snapshot.builtInRows).toHaveLength(2);
+    expect(snapshot.byId.get("food")).toEqual(CATEGORIES[0]);
+  });
+
+  it("indexes custom categories in the merged registry only", () => {
+    const customRow = {
+      id: "ucat-custom-1" as UserCategoryId,
+      name: "Groceries",
+      iconName: "NonExistentIcon",
+      colorHex: "#FF5722",
+    };
+
+    const snapshot = createCategoryRegistrySnapshot([customRow]);
+
+    expect(snapshot.custom).toHaveLength(1);
+    expect(snapshot.merged).toHaveLength(CATEGORIES.length + 1);
+    expect(snapshot.builtInRows).toHaveLength(2);
+    expect(snapshot.byId.get("ucat-custom-1")).toMatchObject({
+      label: { en: "Groceries", es: "Groceries" },
+      color: "#FF5722",
+    });
+  });
+});
+
+describe("isCategoryIdValid", () => {
+  it("respects the requested scope", () => {
+    const builtInOnly = createCategoryRegistrySnapshot([]);
+    const merged = createCategoryRegistrySnapshot([
+      {
+        id: "ucat-custom-1" as UserCategoryId,
+        name: "Groceries",
+        iconName: "Zap",
+        colorHex: "#FF5722",
+      },
+    ]);
+
+    expect(isCategoryIdValid(builtInOnly, "food", "built_in")).toBe(true);
+    expect(isCategoryIdValid(builtInOnly, "ucat-custom-1", "built_in")).toBe(false);
+    expect(isCategoryIdValid(merged, "ucat-custom-1", "merged")).toBe(true);
+  });
+});

--- a/apps/mobile/__tests__/categories/store.test.ts
+++ b/apps/mobile/__tests__/categories/store.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getUserCategoriesForUser, insertUserCategory } from "@/features/categories/lib/repository";
-import { CATEGORIES } from "@/features/transactions/lib/categories";
+import { CATEGORIES, CATEGORY_ROWS } from "@/features/transactions/lib/categories";
 import { enqueueSync } from "@/shared/db/enqueue-sync";
 import type { IsoDateTime, UserCategoryId, UserId } from "@/shared/types/branded";
 
@@ -56,42 +56,27 @@ describe("useCategoriesStore", () => {
     return useCategoriesStore;
   }
 
-  it("allCategories contains 10 built-in categories when no user categories loaded", async () => {
+  it("exposes built-in and merged snapshots before refresh", async () => {
     const store = await getStore();
     const state = store.getState();
 
-    expect(state.allCategories).toHaveLength(10);
-    expect(state.allCategories).toEqual(CATEGORIES);
-    expect(state.userCategories).toHaveLength(0);
+    expect(state.builtIn).toEqual(CATEGORIES);
+    expect(state.custom).toEqual([]);
+    expect(state.merged).toEqual(CATEGORIES);
+    expect(state.builtInRows).toEqual(CATEGORY_ROWS);
+    expect(state.byId.get("food")).toEqual(CATEGORIES[0]);
   });
 
-  it("isValidCategoryId returns true for built-in IDs", async () => {
+  it("isValid defaults to built-in scope", async () => {
     const store = await getStore();
     const state = store.getState();
 
-    expect(state.isValidCategoryId("food")).toBe(true);
-    expect(state.isValidCategoryId("transport")).toBe(true);
+    expect(state.isValid("food")).toBe(true);
+    expect(state.isValid("transport")).toBe(true);
+    expect(state.isValid("nonexistent")).toBe(false);
   });
 
-  it("isValidCategoryId returns false for unknown ID", async () => {
-    const store = await getStore();
-    const state = store.getState();
-
-    expect(state.isValidCategoryId("nonexistent")).toBe(false);
-    expect(state.isValidCategoryId("")).toBe(false);
-  });
-
-  it("allCategoryIds contains all built-in IDs initially", async () => {
-    const store = await getStore();
-    const state = store.getState();
-
-    expect(state.allCategoryIds.size).toBe(10);
-    for (const cat of CATEGORIES) {
-      expect(state.allCategoryIds.has(cat.id)).toBe(true);
-    }
-  });
-
-  it("after loading user categories, allCategories includes them", async () => {
+  it("refresh loads user categories into the merged registry only", async () => {
     const fakeRow = {
       id: "ucat-custom-1" as UserCategoryId,
       userId: "user-1" as UserId,
@@ -106,74 +91,28 @@ describe("useCategoriesStore", () => {
 
     const store = await getStore();
     store.getState().initStore(mockDb, "user-1" as UserId);
-    await store.getState().loadUserCategories();
+    await store.getState().refresh();
 
     const state = store.getState();
-    expect(state.allCategories).toHaveLength(11);
-    // Built-in first, then user categories
-    expect(state.allCategories.slice(0, 10)).toEqual(CATEGORIES);
-    expect(state.allCategories[10]?.id).toBe("ucat-custom-1");
-    expect(state.allCategories[10]?.label).toEqual({
-      en: "Groceries",
-      es: "Groceries",
+    expect(state.custom).toHaveLength(1);
+    expect(state.merged).toHaveLength(11);
+    expect(state.merged.slice(0, 10)).toEqual(CATEGORIES);
+    expect(state.byId.get("ucat-custom-1")).toMatchObject({
+      label: { en: "Groceries", es: "Groceries" },
+      color: "#FF5722",
     });
-    expect(state.allCategories[10]?.color).toBe("#FF5722");
+    expect(state.isValid("ucat-custom-1")).toBe(false);
+    expect(state.isValid("ucat-custom-1", "merged")).toBe(true);
   });
 
-  it("isValidCategoryId returns true for user category ID after load", async () => {
-    const fakeRow = {
-      id: "ucat-custom-1" as UserCategoryId,
-      userId: "user-1" as UserId,
-      name: "Pets",
-      iconName: "PawPrint",
-      colorHex: "#9C27B0",
-      createdAt: "2026-03-01T00:00:00.000Z" as IsoDateTime,
-      updatedAt: "2026-03-01T00:00:00.000Z" as IsoDateTime,
-      deletedAt: null,
-    };
-    vi.mocked(getUserCategoriesForUser).mockReturnValue([fakeRow]);
-
-    const store = await getStore();
-    store.getState().initStore(mockDb, "user-1" as UserId);
-    await store.getState().loadUserCategories();
-
-    const state = store.getState();
-    expect(state.isValidCategoryId("ucat-custom-1")).toBe(true);
-  });
-
-  it("uses Ellipsis fallback icon for unrecognized iconName", async () => {
-    const fakeRow = {
-      id: "ucat-custom-2" as UserCategoryId,
-      userId: "user-1" as UserId,
-      name: "Unknown Icon",
-      iconName: "NonExistentIcon",
-      colorHex: "#607D8B",
-      createdAt: "2026-03-01T00:00:00.000Z" as IsoDateTime,
-      updatedAt: "2026-03-01T00:00:00.000Z" as IsoDateTime,
-      deletedAt: null,
-    };
-    vi.mocked(getUserCategoriesForUser).mockReturnValue([fakeRow]);
-
-    const store = await getStore();
-    store.getState().initStore(mockDb, "user-1" as UserId);
-    await store.getState().loadUserCategories();
-
-    const state = store.getState();
-    const icon = state.allCategories[10]?.icon;
-    expect(icon).toBeDefined();
-    // Must NOT be any of the ICON_MAP mock values — proves fallback was used
-    const mockIcons: (() => null)[] = [() => null, () => null, () => null];
-    expect(mockIcons).not.toContain(icon);
-  });
-
-  it("createUserCategory inserts to DB and enqueues sync", async () => {
+  it("createCustom inserts to DB and enqueues sync", async () => {
     vi.mocked(getUserCategoriesForUser).mockReturnValue([]);
     vi.mocked(insertUserCategory).mockReturnValue(undefined);
 
     const store = await getStore();
     store.getState().initStore(mockDb, "user-1" as UserId);
 
-    const result = await store.getState().createUserCategory({
+    const result = await store.getState().createCustom({
       name: "Groceries",
       iconName: "ShoppingCart",
       colorHex: "#4CAF50",
@@ -184,11 +123,11 @@ describe("useCategoriesStore", () => {
     expect(enqueueSync).toHaveBeenCalledOnce();
   });
 
-  it("createUserCategory returns false when name is too short", async () => {
+  it("createCustom returns false when name is too short", async () => {
     const store = await getStore();
     store.getState().initStore(mockDb, "user-1" as UserId);
 
-    const result = await store.getState().createUserCategory({
+    const result = await store.getState().createCustom({
       name: "A",
       iconName: "Zap",
       colorHex: "#FF0000",
@@ -198,11 +137,11 @@ describe("useCategoriesStore", () => {
     expect(insertUserCategory).not.toHaveBeenCalled();
   });
 
-  it("createUserCategory returns false when name is too long", async () => {
+  it("createCustom returns false when name is too long", async () => {
     const store = await getStore();
     store.getState().initStore(mockDb, "user-1" as UserId);
 
-    const result = await store.getState().createUserCategory({
+    const result = await store.getState().createCustom({
       name: "A".repeat(33),
       iconName: "Zap",
       colorHex: "#FF0000",
@@ -212,11 +151,11 @@ describe("useCategoriesStore", () => {
     expect(insertUserCategory).not.toHaveBeenCalled();
   });
 
-  it("createUserCategory returns false when DB refs are not set", async () => {
+  it("createCustom returns false when DB refs are not set", async () => {
     const store = await getStore();
     // Don't call initStore
 
-    const result = await store.getState().createUserCategory({
+    const result = await store.getState().createCustom({
       name: "Test",
       iconName: "Zap",
       colorHex: "#FF0000",

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -103,7 +103,7 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
         .catch(handleRecoverableError("Failed to load analytics"));
       useCategoriesStore
         .getState()
-        .loadUserCategories()
+        .refresh()
         .catch(handleRecoverableError("Failed to load user categories"));
       useChatStore
         .getState()

--- a/apps/mobile/features/categories/components/CategoriesScreen.tsx
+++ b/apps/mobile/features/categories/components/CategoriesScreen.tsx
@@ -1,6 +1,5 @@
 import { useRouter } from "expo-router";
 import { useCallback } from "react";
-import { CATEGORIES } from "@/features/transactions";
 import { ScreenLayout, TAB_BAR_CLEARANCE } from "@/shared/components";
 import type { LucideIcon } from "@/shared/components/icons";
 import { Plus } from "@/shared/components/icons";
@@ -66,7 +65,8 @@ export function CategoriesScreen() {
   const accentGreen = useThemeColor("accentGreen");
   const cardBg = useThemeColor("card");
 
-  const userCategories = useCategoriesStore((s) => s.userCategories);
+  const builtInCategories = useCategoriesStore((s) => s.builtIn);
+  const customCategories = useCategoriesStore((s) => s.custom);
 
   const handleAddPress = useCallback(() => {
     router.push("/create-category");
@@ -81,20 +81,20 @@ export function CategoriesScreen() {
       >
         {/* Built-in categories */}
         <SettingsSection label={t("categories.builtInSection")}>
-          {CATEGORIES.map((category, index) => (
+          {builtInCategories.map((category, index) => (
             <CategoryRow
               key={category.id}
               icon={category.icon}
               label={getCategoryLabel(category, locale)}
               color={resolveIconColor(category.color, isDark)}
-              isLast={index === CATEGORIES.length - 1}
+              isLast={index === builtInCategories.length - 1}
             />
           ))}
         </SettingsSection>
 
         {/* Custom categories */}
         <SettingsSection label={t("categories.customSection")}>
-          {userCategories.length === 0 ? (
+          {customCategories.length === 0 ? (
             <View style={styles.emptyContainer}>
               <Text
                 className="font-poppins-medium text-sm text-tertiary dark:text-tertiary-dark"
@@ -104,13 +104,13 @@ export function CategoriesScreen() {
               </Text>
             </View>
           ) : (
-            userCategories.map((category, index) => (
+            customCategories.map((category, index) => (
               <CategoryRow
                 key={category.id}
                 icon={category.icon}
                 label={getCategoryLabel(category, locale)}
                 color={category.color}
-                isLast={index === userCategories.length - 1}
+                isLast={index === customCategories.length - 1}
               />
             ))
           )}

--- a/apps/mobile/features/categories/components/CreateCategorySheet.tsx
+++ b/apps/mobile/features/categories/components/CreateCategorySheet.tsx
@@ -125,7 +125,7 @@ export function CreateCategorySheet() {
   const handleCreate = useCallback(() => {
     if (!selectedIcon || !selectedColor) return;
     void guardedCreate(async () => {
-      const success = await useCategoriesStore.getState().createUserCategory({
+      const success = await useCategoriesStore.getState().createCustom({
         name: name.trim(),
         iconName: selectedIcon,
         colorHex: selectedColor,

--- a/apps/mobile/features/categories/index.ts
+++ b/apps/mobile/features/categories/index.ts
@@ -1,3 +1,5 @@
 export { CategoriesScreen } from "./components/CategoriesScreen";
 export { CreateCategorySheet } from "./components/CreateCategorySheet";
+export type { CategoryRegistryScope, CategoryRegistrySnapshot } from "./lib/registry";
+export { createCategoryRegistrySnapshot, isCategoryIdValid } from "./lib/registry";
 export { useCategoriesStore } from "./store";

--- a/apps/mobile/features/categories/lib/registry.ts
+++ b/apps/mobile/features/categories/lib/registry.ts
@@ -1,0 +1,58 @@
+import { CATEGORIES, CATEGORY_ROWS, type Category } from "@/features/transactions";
+import { Ellipsis } from "@/shared/components/icons";
+import type { CategoryId } from "@/shared/types/branded";
+import { ICON_MAP } from "./icon-map";
+
+export type CategoryRegistryScope = "built_in" | "merged";
+
+export type CategoryRegistryRow = {
+  readonly id: string;
+  readonly name: string;
+  readonly iconName: string;
+  readonly colorHex: string;
+};
+
+export type CategoryRegistrySnapshot = {
+  readonly builtIn: readonly Category[];
+  readonly custom: readonly Category[];
+  readonly merged: readonly Category[];
+  readonly builtInRows: readonly (readonly Category[])[];
+  readonly byId: ReadonlyMap<string, Category>;
+  readonly builtInIds: ReadonlySet<string>;
+  readonly mergedIds: ReadonlySet<string>;
+};
+
+const toCustomCategory = (row: CategoryRegistryRow): Category => ({
+  id: row.id as unknown as CategoryId,
+  label: { en: row.name, es: row.name },
+  icon: ICON_MAP[row.iconName] ?? Ellipsis,
+  color: row.colorHex,
+});
+
+const toCategoryById = (categories: readonly Category[]) =>
+  new Map(categories.map((category) => [category.id, category] as const));
+
+export function createCategoryRegistrySnapshot(
+  rows: readonly CategoryRegistryRow[]
+): CategoryRegistrySnapshot {
+  const custom = rows.map(toCustomCategory);
+  const merged = [...CATEGORIES, ...custom];
+
+  return {
+    builtIn: CATEGORIES,
+    custom,
+    merged,
+    builtInRows: CATEGORY_ROWS,
+    byId: toCategoryById(merged),
+    builtInIds: new Set(CATEGORIES.map((category) => category.id)),
+    mergedIds: new Set(merged.map((category) => category.id)),
+  };
+}
+
+export function isCategoryIdValid(
+  snapshot: CategoryRegistrySnapshot,
+  id: string,
+  scope: CategoryRegistryScope = "built_in"
+): boolean {
+  return scope === "merged" ? snapshot.mergedIds.has(id) : snapshot.builtInIds.has(id);
+}

--- a/apps/mobile/features/categories/store.ts
+++ b/apps/mobile/features/categories/store.ts
@@ -1,12 +1,17 @@
 import { create } from "zustand";
-import { CATEGORIES, type Category } from "@/features/transactions";
-import { Ellipsis } from "@/shared/components/icons";
 import type { AnyDb } from "@/shared/db";
 import { enqueueSync } from "@/shared/db";
 import { generateSyncQueueId, generateUserCategoryId, toIsoDateTime } from "@/shared/lib";
-import type { CategoryId, UserId } from "@/shared/types/branded";
+import type { UserId } from "@/shared/types/branded";
 import { MAX_NAME_LENGTH, MIN_NAME_LENGTH } from "./lib/constants";
 import { ICON_MAP } from "./lib/icon-map";
+import {
+  type CategoryRegistryRow,
+  type CategoryRegistryScope,
+  type CategoryRegistrySnapshot,
+  createCategoryRegistrySnapshot,
+  isCategoryIdValid,
+} from "./lib/registry";
 import { getUserCategoriesForUser, insertUserCategory } from "./lib/repository";
 
 // Module-level refs: Zustand doesn't serialize DB connections, so we keep them outside the store.
@@ -15,61 +20,49 @@ let userIdRef: UserId | null = null;
 
 const HEX_COLOR_REGEX = /^#[0-9A-Fa-f]{6}$/;
 
-type CategoriesState = {
-  userCategories: Category[];
-  allCategories: readonly Category[];
-  allCategoryIds: ReadonlySet<string>;
-};
+type CategoriesState = CategoryRegistrySnapshot;
 
 type CategoriesActions = {
   initStore(db: AnyDb, userId: UserId): void;
-  loadUserCategories(): Promise<void>;
-  createUserCategory(input: { name: string; iconName: string; colorHex: string }): Promise<boolean>;
-  isValidCategoryId(id: string): boolean;
+  refresh(): Promise<void>;
+  createCustom(input: { name: string; iconName: string; colorHex: string }): Promise<boolean>;
+  isValid(id: string, scope?: CategoryRegistryScope): boolean;
 };
 
-const toCategory = (row: {
+const toCustomCategoryRow = (row: {
   id: string;
   name: string;
   iconName: string;
   colorHex: string;
-}): Category => ({
-  // UserCategoryId and CategoryId are both Brand<string, _>; cast via string is safe since allCategoryIds operates on plain strings
-  id: row.id as CategoryId,
-  label: { en: row.name, es: row.name },
-  icon: ICON_MAP[row.iconName] ?? Ellipsis,
-  color: row.colorHex,
+}): CategoryRegistryRow => ({
+  id: row.id,
+  name: row.name,
+  iconName: row.iconName,
+  colorHex: row.colorHex,
 });
 
 export const useCategoriesStore = create<CategoriesState & CategoriesActions>((set, get) => ({
-  userCategories: [],
-  allCategories: CATEGORIES,
-  allCategoryIds: new Set(CATEGORIES.map((c) => c.id)),
+  ...createCategoryRegistrySnapshot([]),
 
   initStore: (db, userId) => {
     dbRef = db;
     userIdRef = userId;
   },
 
-  loadUserCategories: async () => {
+  refresh: async () => {
     const db = dbRef;
-    if (!db || !userIdRef) return;
+    const userId = userIdRef;
+    if (!db || !userId) return;
 
     try {
-      const rows = getUserCategoriesForUser(db, userIdRef);
-      const converted = rows.map(toCategory);
-      const all = [...CATEGORIES, ...converted];
-      set({
-        userCategories: converted,
-        allCategories: all,
-        allCategoryIds: new Set(all.map((c) => c.id)),
-      });
+      const rows = getUserCategoriesForUser(db, userId).map(toCustomCategoryRow);
+      set(createCategoryRegistrySnapshot(rows));
     } catch {
       // keep existing state
     }
   },
 
-  createUserCategory: async (input) => {
+  createCustom: async (input) => {
     const db = dbRef;
     const userId = userIdRef;
     if (!db || !userId) return false;
@@ -107,9 +100,9 @@ export const useCategoriesStore = create<CategoriesState & CategoriesActions>((s
       return false;
     }
 
-    await get().loadUserCategories();
+    await get().refresh();
     return true;
   },
 
-  isValidCategoryId: (id) => get().allCategoryIds.has(id),
+  isValid: (id, scope = "built_in") => isCategoryIdValid(get(), id, scope),
 }));


### PR DESCRIPTION
refactor(mobile): add category registry

- add scoped registry snapshot
- keep built-in validation explicit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce a scoped category registry for mobile. Built-in and custom categories are managed separately, with explicit validation by scope, and the store/components updated to use the new snapshot.

- **Refactors**
  - Added `createCategoryRegistrySnapshot` and `isCategoryIdValid` to manage built-in, custom, merged lists, `byId`, and ID sets.
  - Store now holds the snapshot and exposes `builtIn`, `custom`, `merged`, `builtInRows`, `byId`.
  - Renamed actions: `loadUserCategories` -> `refresh`, `createUserCategory` -> `createCustom`.
  - Validation is now `isValid(id, scope?)` and defaults to built-in scope.
  - Updated screens and layout to use `builtIn`/`custom` and `refresh`.
  - Added tests for the registry and updated store tests.

- **Migration**
  - Replace `loadUserCategories()` with `refresh()`.
  - Replace `createUserCategory()` with `createCustom()`.
  - Replace `allCategories`/`userCategories`/`allCategoryIds` with `builtIn`/`custom`/`merged` and `byId` as needed.
  - Replace `isValidCategoryId(id)` with `isValid(id, "built_in" | "merged")`.

<sup>Written for commit 4cbaacb5841dfcd18e89bf74ae1dcc06ef710555. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

