### PR TITLE
refactor(mobile): deepen budget monitoring

### DIFF
--- a/apps/mobile/__tests__/budget/monitoring.test.ts
+++ b/apps/mobile/__tests__/budget/monitoring.test.ts
@@ -7,7 +7,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createBudgetMonitoringModule } from "@/features/budget/lib/monitoring";
 import { insertBudget } from "@/features/budget/lib/repository";
 import { insertTransaction } from "@/features/transactions/lib/repository";
-import type { BudgetId, CategoryId, CopAmount, IsoDateTime, Month, UserId } from "@/shared/types/branded";
+import type {
+  BudgetId,
+  CategoryId,
+  CopAmount,
+  IsoDateTime,
+  Month,
+  UserId,
+} from "@/shared/types/branded";
 
 let sqlite: InstanceType<typeof Database>;
 let db: ReturnType<typeof drizzle>;

--- a/apps/mobile/__tests__/budget/monitoring.test.ts
+++ b/apps/mobile/__tests__/budget/monitoring.test.ts
@@ -233,6 +233,38 @@ describe("createBudgetMonitoringModule", () => {
     expect(mockInsertNotification).toHaveBeenCalledOnce();
   });
 
+  it("loadAutoSuggestions derives suggestions without delivering alerts", () => {
+    insertBudgetRow();
+    insertExpense({
+      id: "tx-3",
+      categoryId: "entertainment" as CategoryId,
+      amount: 43234 as CopAmount,
+      date: "2026-02-12",
+      month: "2026-02" as Month,
+    });
+
+    const module = createBudgetMonitoringModule({
+      getBudgetAlertsEnabled: () => true,
+      getLocale: () => "es",
+      resolveCategoryLabel: mockResolveCategoryLabel,
+      scheduleBudgetAlert: mockScheduleBudgetAlert,
+      insertNotification: mockInsertNotification,
+    });
+
+    const suggestions = module.loadAutoSuggestions({
+      db: db as any,
+      userId: USER_ID,
+      month: CURRENT_MONTH,
+      existingCategoryIds: new Set(["food" as CategoryId]),
+    });
+
+    expect(suggestions).toEqual([
+      { categoryId: "entertainment" as CategoryId, suggestedAmount: 44000 as CopAmount },
+    ]);
+    expect(mockScheduleBudgetAlert).not.toHaveBeenCalled();
+    expect(mockInsertNotification).not.toHaveBeenCalled();
+  });
+
   it("acknowledgeAlert removes the targeted alert from pending state", () => {
     const module = createBudgetMonitoringModule({
       getBudgetAlertsEnabled: () => true,

--- a/apps/mobile/__tests__/budget/monitoring.test.ts
+++ b/apps/mobile/__tests__/budget/monitoring.test.ts
@@ -1,0 +1,271 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: integration test uses a real SQLite DB
+import { resolve } from "node:path";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createBudgetMonitoringModule } from "@/features/budget/lib/monitoring";
+import { insertBudget } from "@/features/budget/lib/repository";
+import { insertTransaction } from "@/features/transactions/lib/repository";
+import type { BudgetId, CategoryId, CopAmount, IsoDateTime, Month, UserId } from "@/shared/types/branded";
+
+let sqlite: InstanceType<typeof Database>;
+let db: ReturnType<typeof drizzle>;
+
+const USER_ID = "user-1" as UserId;
+const CURRENT_MONTH = "2026-03" as Month;
+
+const mockScheduleBudgetAlert = vi.fn();
+const mockInsertNotification = vi.fn();
+const mockResolveCategoryLabel = vi.fn(
+  (categoryId: CategoryId, locale: string) => `${locale}:${categoryId}`
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  sqlite = new Database(":memory:");
+  db = drizzle(sqlite);
+  migrate(db, { migrationsFolder: resolve(__dirname, "../../drizzle") });
+
+  mockScheduleBudgetAlert.mockResolvedValue({ type: "scheduled", id: "notif-1" });
+});
+
+afterEach(() => {
+  sqlite.close();
+});
+
+const insertBudgetRow = (
+  overrides: Partial<{
+    id: BudgetId;
+    categoryId: CategoryId;
+    amount: CopAmount;
+    month: Month;
+  }> = {}
+) =>
+  insertBudget(db as any, {
+    id: (overrides.id ?? "budget-1") as BudgetId,
+    userId: USER_ID,
+    categoryId: (overrides.categoryId ?? "food") as CategoryId,
+    amount: (overrides.amount ?? 100000) as CopAmount,
+    month: (overrides.month ?? CURRENT_MONTH) as Month,
+    createdAt: "2026-03-01T00:00:00.000Z" as IsoDateTime,
+    updatedAt: "2026-03-01T00:00:00.000Z" as IsoDateTime,
+    deletedAt: null,
+  });
+
+const insertExpense = (
+  overrides: Partial<{
+    id: string;
+    categoryId: CategoryId;
+    amount: CopAmount;
+    date: string;
+    month: Month;
+  }> = {}
+) =>
+  insertTransaction(db as any, {
+    id: (overrides.id ?? "tx-1") as any,
+    userId: USER_ID,
+    type: "expense",
+    amount: (overrides.amount ?? 85000) as CopAmount,
+    categoryId: (overrides.categoryId ?? "food") as CategoryId,
+    description: "merchant",
+    date: (overrides.date ?? `${overrides.month ?? CURRENT_MONTH}-10`) as any,
+    createdAt: "2026-03-10T10:00:00.000Z" as IsoDateTime,
+    updatedAt: "2026-03-10T10:00:00.000Z" as IsoDateTime,
+    deletedAt: null,
+    source: "manual",
+  });
+
+describe("createBudgetMonitoringModule", () => {
+  it("refreshMonth loads budgets, derives alerts, and delivers fresh ones", async () => {
+    insertBudgetRow();
+    insertBudgetRow({
+      id: "budget-2" as BudgetId,
+      categoryId: "transport" as CategoryId,
+      amount: 50000 as CopAmount,
+    });
+
+    insertExpense({ id: "tx-1", categoryId: "food" as CategoryId, amount: 85000 as CopAmount });
+    insertExpense({
+      id: "tx-2",
+      categoryId: "transport" as CategoryId,
+      amount: 10000 as CopAmount,
+    });
+    insertExpense({
+      id: "tx-3",
+      categoryId: "entertainment" as CategoryId,
+      amount: 43234 as CopAmount,
+      date: "2026-02-12",
+      month: "2026-02" as Month,
+    });
+
+    const module = createBudgetMonitoringModule({
+      getBudgetAlertsEnabled: () => true,
+      getLocale: () => "es",
+      resolveCategoryLabel: mockResolveCategoryLabel,
+      scheduleBudgetAlert: mockScheduleBudgetAlert,
+      insertNotification: mockInsertNotification,
+    });
+
+    const result = await module.refreshMonth({
+      db: db as any,
+      userId: USER_ID,
+      month: CURRENT_MONTH,
+      previous: {
+        pendingAlerts: [],
+        acknowledgedAlerts: new Set(),
+      },
+    });
+
+    expect(result.budgets).toHaveLength(2);
+    expect(result.budgetProgress).toHaveLength(2);
+    expect(result.summary).toEqual({
+      totalBudget: 150000,
+      totalSpent: 95000,
+      percentUsed: 63,
+    });
+    expect(result.autoSuggestions).toEqual([
+      { categoryId: "entertainment" as CategoryId, suggestedAmount: 44000 as CopAmount },
+    ]);
+    expect(result.pendingAlerts).toHaveLength(1);
+    expect(result.pendingAlerts[0]?.budgetId).toBe("budget-1");
+    expect(result.pendingPermissionRequest).toBe(false);
+    expect(mockResolveCategoryLabel).toHaveBeenCalledWith("food", "es");
+    expect(mockScheduleBudgetAlert).toHaveBeenCalledOnce();
+    expect(mockInsertNotification).toHaveBeenCalledOnce();
+
+    const inserted = mockInsertNotification.mock.calls[0]?.[0] as { params: string };
+    expect(JSON.parse(inserted.params)).toMatchObject({
+      category: "es:food",
+      threshold: 80,
+      daysLeft: expect.any(Number),
+    });
+  });
+
+  it("refreshMonth skips duplicate delivery when the same alert is still pending", async () => {
+    insertBudgetRow();
+    insertExpense({
+      id: "tx-1",
+      categoryId: "food" as CategoryId,
+      amount: 85000 as CopAmount,
+    });
+
+    const module = createBudgetMonitoringModule({
+      getBudgetAlertsEnabled: () => true,
+      getLocale: () => "es",
+      resolveCategoryLabel: mockResolveCategoryLabel,
+      scheduleBudgetAlert: mockScheduleBudgetAlert,
+      insertNotification: mockInsertNotification,
+    });
+
+    const first = await module.refreshMonth({
+      db: db as any,
+      userId: USER_ID,
+      month: CURRENT_MONTH,
+      previous: {
+        pendingAlerts: [],
+        acknowledgedAlerts: new Set(),
+      },
+    });
+
+    expect(first.pendingAlerts).toHaveLength(1);
+    expect(mockScheduleBudgetAlert).toHaveBeenCalledOnce();
+    expect(mockInsertNotification).toHaveBeenCalledOnce();
+
+    mockScheduleBudgetAlert.mockClear();
+    mockInsertNotification.mockClear();
+    mockResolveCategoryLabel.mockClear();
+
+    const second = await module.refreshMonth({
+      db: db as any,
+      userId: USER_ID,
+      month: CURRENT_MONTH,
+      previous: {
+        pendingAlerts: first.pendingAlerts,
+        acknowledgedAlerts: new Set(),
+      },
+    });
+
+    expect(second.pendingAlerts).toHaveLength(1);
+    expect(mockScheduleBudgetAlert).not.toHaveBeenCalled();
+    expect(mockInsertNotification).not.toHaveBeenCalled();
+    expect(mockResolveCategoryLabel).not.toHaveBeenCalled();
+  });
+
+  it("refreshMonth requests permission when delivery needs it", async () => {
+    insertBudgetRow();
+    insertExpense({
+      id: "tx-1",
+      categoryId: "food" as CategoryId,
+      amount: 85000 as CopAmount,
+    });
+
+    mockScheduleBudgetAlert.mockResolvedValueOnce({ type: "needs_permission" });
+
+    const module = createBudgetMonitoringModule({
+      getBudgetAlertsEnabled: () => true,
+      getLocale: () => "es",
+      resolveCategoryLabel: mockResolveCategoryLabel,
+      scheduleBudgetAlert: mockScheduleBudgetAlert,
+      insertNotification: mockInsertNotification,
+    });
+
+    const result = await module.refreshMonth({
+      db: db as any,
+      userId: USER_ID,
+      month: CURRENT_MONTH,
+      previous: {
+        pendingAlerts: [],
+        acknowledgedAlerts: new Set(),
+      },
+    });
+
+    expect(result.pendingPermissionRequest).toBe(true);
+    expect(mockScheduleBudgetAlert).toHaveBeenCalledOnce();
+    expect(mockInsertNotification).toHaveBeenCalledOnce();
+  });
+
+  it("acknowledgeAlert removes the targeted alert from pending state", () => {
+    const module = createBudgetMonitoringModule({
+      getBudgetAlertsEnabled: () => true,
+      getLocale: () => "es",
+      resolveCategoryLabel: mockResolveCategoryLabel,
+      scheduleBudgetAlert: mockScheduleBudgetAlert,
+      insertNotification: mockInsertNotification,
+    });
+
+    const nextState = module.acknowledgeAlert({
+      budgetId: "budget-1" as BudgetId,
+      threshold: 80,
+      alertState: {
+        pendingAlerts: [
+          {
+            budgetId: "budget-1" as BudgetId,
+            categoryId: "food" as CategoryId,
+            threshold: 80,
+            percentUsed: 85,
+            suggestionKey: undefined,
+            daysLeft: 10,
+            remainingAmount: 15000 as CopAmount,
+          },
+          {
+            budgetId: "budget-2" as BudgetId,
+            categoryId: "transport" as CategoryId,
+            threshold: 80,
+            percentUsed: 90,
+            suggestionKey: undefined,
+            daysLeft: 10,
+            remainingAmount: 10000 as CopAmount,
+          },
+        ],
+        acknowledgedAlerts: new Set(["budget-2:80"]),
+      },
+    });
+
+    expect(nextState.pendingAlerts).toHaveLength(1);
+    expect(nextState.pendingAlerts[0]?.budgetId).toBe("budget-2");
+    expect(nextState.acknowledgedAlerts.has("budget-1:80")).toBe(true);
+    expect(nextState.acknowledgedAlerts.has("budget-2:80")).toBe(true);
+  });
+});

--- a/apps/mobile/__tests__/budget/store.test.ts
+++ b/apps/mobile/__tests__/budget/store.test.ts
@@ -1,0 +1,152 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: focused store test uses lightweight mocks
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CategoryId, CopAmount, Month, UserId } from "@/shared/types/branded";
+
+const mockRefreshMonth = vi.fn();
+const mockLoadAutoSuggestions = vi.fn();
+const mockAcknowledgeAlert = vi.fn();
+const mockSubscribe = vi.fn(() => vi.fn());
+
+vi.mock("@/features/budget/lib/monitoring", () => ({
+  createBudgetMonitoringModule: vi.fn(() => ({
+    refreshMonth: mockRefreshMonth,
+    loadAutoSuggestions: mockLoadAutoSuggestions,
+    acknowledgeAlert: mockAcknowledgeAlert,
+  })),
+}));
+
+vi.mock("@/features/notifications", () => ({
+  useNotificationStore: {
+    getState: () => ({
+      insertNotification: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock("@/features/settings", () => ({
+  useSettingsStore: {
+    getState: () => ({
+      notificationPreferences: { budgetAlerts: true },
+    }),
+  },
+}));
+
+vi.mock("@/features/transactions", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/transactions")>();
+  return {
+    ...actual,
+    CATEGORY_MAP: {},
+    useTransactionStore: {
+      subscribe: mockSubscribe,
+    },
+  };
+});
+
+vi.mock("@/shared/i18n", () => ({
+  getCategoryLabel: vi.fn((category: { id?: string }, _locale: string) => category.id ?? "unknown"),
+  useLocaleStore: {
+    getState: () => ({ locale: "es" }),
+  },
+}));
+
+vi.mock("@/features/budget/lib/notifications", () => ({
+  scheduleBudgetAlert: vi.fn(),
+}));
+
+const USER_ID = "user-1" as UserId;
+const mockDb = {} as any;
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function getStore() {
+  const { useBudgetStore } = await import("@/features/budget/store");
+  return useBudgetStore;
+}
+
+describe("useBudgetStore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it("ignores stale budget refresh results after the month changes", async () => {
+    const staleSnapshot = {
+      budgets: [{ id: "budget-march", categoryId: "food", month: "2026-03" as Month }] as any[],
+      budgetProgress: [],
+      summary: { totalBudget: 100000, totalSpent: 85000, percentUsed: 85 },
+      autoSuggestions: [],
+      pendingAlerts: [],
+      pendingPermissionRequest: false,
+    };
+    const freshSnapshot = {
+      budgets: [{ id: "budget-april", categoryId: "transport", month: "2026-04" as Month }] as any[],
+      budgetProgress: [],
+      summary: { totalBudget: 120000, totalSpent: 10000, percentUsed: 8 },
+      autoSuggestions: [],
+      pendingAlerts: [],
+      pendingPermissionRequest: false,
+    };
+    const deferredMarch = createDeferred<typeof staleSnapshot>();
+
+    mockRefreshMonth.mockImplementation(({ month }: { month: Month }) =>
+      month === ("2026-03" as Month) ? deferredMarch.promise : Promise.resolve(freshSnapshot)
+    );
+
+    const store = await getStore();
+    store.getState().initStore(mockDb, USER_ID);
+    store.setState({ currentMonth: "2026-03" as Month });
+
+    const staleLoad = store.getState().loadBudgets();
+
+    store.setState({ currentMonth: "2026-04" as Month });
+    const freshLoad = store.getState().loadBudgets();
+
+    await freshLoad;
+    deferredMarch.resolve(staleSnapshot);
+    await staleLoad;
+
+    expect(store.getState().currentMonth).toBe("2026-04");
+    expect(store.getState().budgets).toEqual(freshSnapshot.budgets);
+    expect(store.getState().summary).toEqual(freshSnapshot.summary);
+    expect(store.getState().isLoading).toBe(false);
+  });
+
+  it("loads auto suggestions without triggering the full refresh path", async () => {
+    const suggestions = [
+      {
+        categoryId: "entertainment" as CategoryId,
+        suggestedAmount: 44000 as CopAmount,
+      },
+    ];
+    mockLoadAutoSuggestions.mockReturnValue(suggestions);
+
+    const store = await getStore();
+    store.getState().initStore(mockDb, USER_ID);
+    store.setState({
+      currentMonth: "2026-03" as Month,
+      budgets: [{ id: "budget-1", categoryId: "food" as CategoryId }] as any[],
+    });
+
+    store.getState().loadAutoSuggestions();
+
+    expect(mockLoadAutoSuggestions).toHaveBeenCalledWith({
+      db: mockDb,
+      userId: USER_ID,
+      month: "2026-03",
+      existingCategoryIds: new Set(["food" as CategoryId]),
+    });
+    expect(mockRefreshMonth).not.toHaveBeenCalled();
+    expect(store.getState().autoSuggestions).toEqual(suggestions);
+  });
+});

--- a/apps/mobile/__tests__/budget/store.test.ts
+++ b/apps/mobile/__tests__/budget/store.test.ts
@@ -124,6 +124,38 @@ describe("useBudgetStore", () => {
     expect(store.getState().isLoading).toBe(false);
   });
 
+  it("clears loading when context changes without starting a newer refresh", async () => {
+    const deferredSnapshot = createDeferred<{
+      budgets: any[];
+      budgetProgress: any[];
+      summary: { totalBudget: number; totalSpent: number; percentUsed: number };
+      autoSuggestions: any[];
+      pendingAlerts: any[];
+      pendingPermissionRequest: boolean;
+    }>();
+
+    mockRefreshMonth.mockReturnValueOnce(deferredSnapshot.promise);
+
+    const store = await getStore();
+    store.getState().initStore(mockDb, USER_ID);
+    store.setState({ currentMonth: "2026-03" as Month });
+
+    const load = store.getState().loadBudgets();
+
+    store.getState().initStore(mockDb, "user-2" as UserId);
+    deferredSnapshot.resolve({
+      budgets: [],
+      budgetProgress: [],
+      summary: { totalBudget: 0, totalSpent: 0, percentUsed: 0 },
+      autoSuggestions: [],
+      pendingAlerts: [],
+      pendingPermissionRequest: false,
+    });
+    await load;
+
+    expect(store.getState().isLoading).toBe(false);
+  });
+
   it("loads auto suggestions without triggering the full refresh path", async () => {
     const suggestions = [
       {

--- a/apps/mobile/__tests__/budget/store.test.ts
+++ b/apps/mobile/__tests__/budget/store.test.ts
@@ -90,7 +90,9 @@ describe("useBudgetStore", () => {
       pendingPermissionRequest: false,
     };
     const freshSnapshot = {
-      budgets: [{ id: "budget-april", categoryId: "transport", month: "2026-04" as Month }] as any[],
+      budgets: [
+        { id: "budget-april", categoryId: "transport", month: "2026-04" as Month },
+      ] as any[],
       budgetProgress: [],
       summary: { totalBudget: 120000, totalSpent: 10000, percentUsed: 8 },
       autoSuggestions: [],

--- a/apps/mobile/features/budget/index.ts
+++ b/apps/mobile/features/budget/index.ts
@@ -8,6 +8,16 @@ export {
   deriveBudgetProgress,
   deriveBudgetSummary,
 } from "./lib/derive";
+export type {
+  AcknowledgeBudgetAlertInput,
+  BudgetAlertState,
+  BudgetMonitoringModule,
+  BudgetMonitoringPorts,
+  BudgetMonthSnapshot,
+  BudgetNotificationInput,
+  RefreshBudgetMonthInput,
+} from "./lib/monitoring";
+export { createBudgetMonitoringModule } from "./lib/monitoring";
 export type { ScheduleResult } from "./lib/notifications";
 export { scheduleBudgetAlert } from "./lib/notifications";
 export type { BudgetRow } from "./lib/repository";

--- a/apps/mobile/features/budget/lib/monitoring.ts
+++ b/apps/mobile/features/budget/lib/monitoring.ts
@@ -1,13 +1,10 @@
 import { format, subMonths } from "date-fns";
+import { getSpendingByCategoryAggregate } from "@/features/transactions/lib/repository";
 import type { AnyDb } from "@/shared/db";
 import { formatMoney } from "@/shared/lib";
-import type {
-  BudgetId,
-  CategoryId,
-  CopAmount,
-  Month,
-  UserId,
-} from "@/shared/types/branded";
+import type { BudgetId, CategoryId, CopAmount, Month, UserId } from "@/shared/types/branded";
+import type { Budget } from "../schema";
+import type { BudgetAlert, BudgetProgress, BudgetSuggestion } from "./derive";
 import {
   computeDaysLeft,
   deriveAutoSuggestBudgets,
@@ -15,14 +12,7 @@ import {
   deriveBudgetProgress,
   deriveBudgetSummary,
 } from "./derive";
-import type {
-  BudgetAlert,
-  BudgetProgress,
-  BudgetSuggestion,
-} from "./derive";
-import type { Budget } from "../schema";
 import { getBudgetsForMonth } from "./repository";
-import { getSpendingByCategoryAggregate } from "@/features/transactions/lib/repository";
 
 export type BudgetAlertState = {
   readonly pendingAlerts: readonly BudgetAlert[];
@@ -78,16 +68,11 @@ export type BudgetMonitoringPorts = {
 };
 
 export type BudgetMonitoringModule = {
-  readonly refreshMonth: (
-    input: RefreshBudgetMonthInput
-  ) => Promise<BudgetMonthSnapshot>;
-  readonly acknowledgeAlert: (
-    input: AcknowledgeBudgetAlertInput
-  ) => BudgetAlertState;
+  readonly refreshMonth: (input: RefreshBudgetMonthInput) => Promise<BudgetMonthSnapshot>;
+  readonly acknowledgeAlert: (input: AcknowledgeBudgetAlertInput) => BudgetAlertState;
 };
 
-const alertKey = (budgetId: BudgetId, threshold: 80 | 100): string =>
-  `${budgetId}:${threshold}`;
+const alertKey = (budgetId: BudgetId, threshold: 80 | 100): string => `${budgetId}:${threshold}`;
 
 const formatMonth = (date: Date): Month => format(date, "yyyy-MM") as Month;
 
@@ -113,9 +98,7 @@ const toNotificationInput = (
     titleKey:
       alert.threshold === 80 ? "notifications.budgetWarning" : "notifications.budgetExceeded",
     messageKey:
-      alert.threshold === 80
-        ? "notifications.budgetWarningMsg"
-        : "notifications.budgetExceededMsg",
+      alert.threshold === 80 ? "notifications.budgetWarningMsg" : "notifications.budgetExceededMsg",
     params: JSON.stringify({
       category: categoryName,
       remaining,
@@ -183,9 +166,7 @@ const insertFreshAlertNotifications = (
   });
 };
 
-export function createBudgetMonitoringModule(
-  ports: BudgetMonitoringPorts
-): BudgetMonitoringModule {
+export function createBudgetMonitoringModule(ports: BudgetMonitoringPorts): BudgetMonitoringModule {
   return {
     refreshMonth: async ({ db, userId, month, previous }) => {
       const budgets = getBudgetsForMonth(db, userId, month);

--- a/apps/mobile/features/budget/lib/monitoring.ts
+++ b/apps/mobile/features/budget/lib/monitoring.ts
@@ -1,0 +1,246 @@
+import { format, subMonths } from "date-fns";
+import type { AnyDb } from "@/shared/db";
+import { formatMoney } from "@/shared/lib";
+import type {
+  BudgetId,
+  CategoryId,
+  CopAmount,
+  Month,
+  UserId,
+} from "@/shared/types/branded";
+import {
+  computeDaysLeft,
+  deriveAutoSuggestBudgets,
+  deriveBudgetAlerts,
+  deriveBudgetProgress,
+  deriveBudgetSummary,
+} from "./derive";
+import type {
+  BudgetAlert,
+  BudgetProgress,
+  BudgetSuggestion,
+} from "./derive";
+import type { Budget } from "../schema";
+import { getBudgetsForMonth } from "./repository";
+import { getSpendingByCategoryAggregate } from "@/features/transactions/lib/repository";
+
+export type BudgetAlertState = {
+  readonly pendingAlerts: readonly BudgetAlert[];
+  readonly acknowledgedAlerts: ReadonlySet<string>;
+};
+
+export type BudgetMonthSnapshot = {
+  readonly budgets: readonly Budget[];
+  readonly budgetProgress: readonly BudgetProgress[];
+  readonly summary: {
+    readonly totalBudget: number;
+    readonly totalSpent: number;
+    readonly percentUsed: number;
+  };
+  readonly autoSuggestions: readonly BudgetSuggestion[];
+  readonly pendingAlerts: readonly BudgetAlert[];
+  readonly pendingPermissionRequest: boolean;
+};
+
+export type BudgetNotificationInput = {
+  readonly type: "budget_alert";
+  readonly dedupKey: string;
+  readonly categoryId: CategoryId | null;
+  readonly goalId: string | null;
+  readonly titleKey: string;
+  readonly messageKey: string;
+  readonly params: string | null;
+};
+
+export type RefreshBudgetMonthInput = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly month: Month;
+  readonly previous?: BudgetAlertState;
+};
+
+export type AcknowledgeBudgetAlertInput = {
+  readonly budgetId: BudgetId;
+  readonly threshold: 80 | 100;
+  readonly alertState: BudgetAlertState;
+};
+
+export type BudgetMonitoringPorts = {
+  readonly getBudgetAlertsEnabled: () => boolean;
+  readonly getLocale: () => string;
+  readonly resolveCategoryLabel: (categoryId: CategoryId, locale: string) => string;
+  readonly scheduleBudgetAlert: (
+    alert: BudgetAlert,
+    categoryName: string,
+    notificationsEnabled: boolean
+  ) => Promise<import("./notifications").ScheduleResult>;
+  readonly insertNotification: (input: BudgetNotificationInput) => void;
+};
+
+export type BudgetMonitoringModule = {
+  readonly refreshMonth: (
+    input: RefreshBudgetMonthInput
+  ) => Promise<BudgetMonthSnapshot>;
+  readonly acknowledgeAlert: (
+    input: AcknowledgeBudgetAlertInput
+  ) => BudgetAlertState;
+};
+
+const alertKey = (budgetId: BudgetId, threshold: 80 | 100): string =>
+  `${budgetId}:${threshold}`;
+
+const formatMonth = (date: Date): Month => format(date, "yyyy-MM") as Month;
+
+const parseMonth = (month: Month): Date => {
+  const parts = month.split("-").map(Number);
+  const year = parts[0] ?? 0;
+  const monthIndex = (parts[1] ?? 1) - 1;
+  return new Date(year, monthIndex, 1);
+};
+
+const toNotificationInput = (
+  alert: BudgetAlert,
+  categoryName: string,
+  month: Month
+): BudgetNotificationInput => {
+  const remaining = formatMoney(Math.abs(alert.remainingAmount) as CopAmount);
+
+  return {
+    type: "budget_alert",
+    dedupKey: `budget_alert:${alert.categoryId}:${alert.threshold}:${month}`,
+    categoryId: alert.categoryId,
+    goalId: null,
+    titleKey:
+      alert.threshold === 80 ? "notifications.budgetWarning" : "notifications.budgetExceeded",
+    messageKey:
+      alert.threshold === 80
+        ? "notifications.budgetWarningMsg"
+        : "notifications.budgetExceededMsg",
+    params: JSON.stringify({
+      category: categoryName,
+      remaining,
+      daysLeft: alert.daysLeft,
+      overAmount: remaining,
+      threshold: alert.threshold,
+    }),
+  };
+};
+
+const deriveFreshAlerts = (
+  pendingAlerts: readonly BudgetAlert[],
+  previousPendingAlerts: readonly BudgetAlert[]
+): readonly BudgetAlert[] => {
+  const previousKeys = new Set(
+    previousPendingAlerts.map((alert) => alertKey(alert.budgetId, alert.threshold))
+  );
+  return pendingAlerts.filter(
+    (alert) => !previousKeys.has(alertKey(alert.budgetId, alert.threshold))
+  );
+};
+
+const deliverFreshAlerts = async (
+  labeledFreshAlerts: readonly {
+    readonly alert: BudgetAlert;
+    readonly categoryName: string;
+  }[],
+  notificationsEnabled: boolean,
+  scheduleBudgetAlert: BudgetMonitoringPorts["scheduleBudgetAlert"]
+): Promise<boolean> => {
+  const firstAlert = labeledFreshAlerts[0];
+  if (firstAlert == null) return false;
+
+  const firstResult = await scheduleBudgetAlert(
+    firstAlert.alert,
+    firstAlert.categoryName,
+    notificationsEnabled
+  );
+  if (firstResult.type === "needs_permission") return true;
+  if (firstResult.type !== "scheduled") return false;
+
+  await Promise.all(
+    labeledFreshAlerts.slice(1).map(async ({ alert, categoryName }) => {
+      try {
+        await scheduleBudgetAlert(alert, categoryName, notificationsEnabled);
+      } catch {
+        // Best effort: later alerts should not block refresh.
+      }
+    })
+  );
+
+  return false;
+};
+
+const insertFreshAlertNotifications = (
+  labeledFreshAlerts: readonly {
+    readonly alert: BudgetAlert;
+    readonly categoryName: string;
+  }[],
+  month: Month,
+  insertNotification: BudgetMonitoringPorts["insertNotification"]
+): void => {
+  labeledFreshAlerts.forEach(({ alert, categoryName }) => {
+    insertNotification(toNotificationInput(alert, categoryName, month));
+  });
+};
+
+export function createBudgetMonitoringModule(
+  ports: BudgetMonitoringPorts
+): BudgetMonitoringModule {
+  return {
+    refreshMonth: async ({ db, userId, month, previous }) => {
+      const budgets = getBudgetsForMonth(db, userId, month);
+      const currentSpending = getSpendingByCategoryAggregate(db, userId, month);
+      const spendingMap = new Map(currentSpending.map((row) => [row.categoryId, row.total]));
+      const budgetProgress = budgets.map((budget) =>
+        deriveBudgetProgress(budget, spendingMap.get(budget.categoryId) ?? (0 as CopAmount))
+      );
+      const summary = deriveBudgetSummary(budgetProgress);
+      const daysLeft = computeDaysLeft(month, new Date());
+      const pendingAlerts = deriveBudgetAlerts(
+        budgetProgress,
+        previous?.acknowledgedAlerts ?? new Set<string>(),
+        daysLeft
+      );
+      const previousPendingAlerts = previous?.pendingAlerts ?? [];
+      const freshAlerts = deriveFreshAlerts(pendingAlerts, previousPendingAlerts);
+      const locale = ports.getLocale();
+      const labeledFreshAlerts = freshAlerts.map((alert) => ({
+        alert,
+        categoryName: ports.resolveCategoryLabel(alert.categoryId, locale),
+      }));
+      const notificationsEnabled = ports.getBudgetAlertsEnabled();
+      const pendingPermissionRequest = await deliverFreshAlerts(
+        labeledFreshAlerts,
+        notificationsEnabled,
+        ports.scheduleBudgetAlert
+      );
+      insertFreshAlertNotifications(labeledFreshAlerts, month, ports.insertNotification);
+
+      const previousMonth = formatMonth(subMonths(parseMonth(month), 1));
+      const previousSpending = getSpendingByCategoryAggregate(db, userId, previousMonth);
+      const autoSuggestions = deriveAutoSuggestBudgets(
+        previousSpending,
+        new Set(budgets.map((budget) => budget.categoryId))
+      );
+
+      return {
+        budgets,
+        budgetProgress,
+        summary,
+        autoSuggestions,
+        pendingAlerts,
+        pendingPermissionRequest,
+      };
+    },
+
+    acknowledgeAlert: ({ budgetId, threshold, alertState }) => {
+      const key = alertKey(budgetId, threshold);
+      return {
+        acknowledgedAlerts: new Set([...alertState.acknowledgedAlerts, key]),
+        pendingAlerts: alertState.pendingAlerts.filter(
+          (alert) => alertKey(alert.budgetId, alert.threshold) !== key
+        ),
+      };
+    },
+  };
+}

--- a/apps/mobile/features/budget/lib/monitoring.ts
+++ b/apps/mobile/features/budget/lib/monitoring.ts
@@ -55,6 +55,13 @@ export type AcknowledgeBudgetAlertInput = {
   readonly alertState: BudgetAlertState;
 };
 
+export type LoadBudgetSuggestionsInput = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly month: Month;
+  readonly existingCategoryIds: ReadonlySet<CategoryId>;
+};
+
 export type BudgetMonitoringPorts = {
   readonly getBudgetAlertsEnabled: () => boolean;
   readonly getLocale: () => string;
@@ -69,6 +76,7 @@ export type BudgetMonitoringPorts = {
 
 export type BudgetMonitoringModule = {
   readonly refreshMonth: (input: RefreshBudgetMonthInput) => Promise<BudgetMonthSnapshot>;
+  readonly loadAutoSuggestions: (input: LoadBudgetSuggestionsInput) => readonly BudgetSuggestion[];
   readonly acknowledgeAlert: (input: AcknowledgeBudgetAlertInput) => BudgetAlertState;
 };
 
@@ -81,6 +89,17 @@ const parseMonth = (month: Month): Date => {
   const year = parts[0] ?? 0;
   const monthIndex = (parts[1] ?? 1) - 1;
   return new Date(year, monthIndex, 1);
+};
+
+const deriveAutoSuggestionsForMonth = (
+  db: AnyDb,
+  userId: UserId,
+  month: Month,
+  existingCategoryIds: ReadonlySet<CategoryId>
+): readonly BudgetSuggestion[] => {
+  const previousMonth = formatMonth(subMonths(parseMonth(month), 1));
+  const previousSpending = getSpendingByCategoryAggregate(db, userId, previousMonth);
+  return deriveAutoSuggestBudgets(previousSpending, existingCategoryIds);
 };
 
 const toNotificationInput = (
@@ -197,10 +216,10 @@ export function createBudgetMonitoringModule(ports: BudgetMonitoringPorts): Budg
       );
       insertFreshAlertNotifications(labeledFreshAlerts, month, ports.insertNotification);
 
-      const previousMonth = formatMonth(subMonths(parseMonth(month), 1));
-      const previousSpending = getSpendingByCategoryAggregate(db, userId, previousMonth);
-      const autoSuggestions = deriveAutoSuggestBudgets(
-        previousSpending,
+      const autoSuggestions = deriveAutoSuggestionsForMonth(
+        db,
+        userId,
+        month,
         new Set(budgets.map((budget) => budget.categoryId))
       );
 
@@ -213,6 +232,9 @@ export function createBudgetMonitoringModule(ports: BudgetMonitoringPorts): Budg
         pendingPermissionRequest,
       };
     },
+
+    loadAutoSuggestions: ({ db, userId, month, existingCategoryIds }) =>
+      deriveAutoSuggestionsForMonth(db, userId, month, existingCategoryIds),
 
     acknowledgeAlert: ({ budgetId, threshold, alertState }) => {
       const key = alertKey(budgetId, threshold);

--- a/apps/mobile/features/budget/store.ts
+++ b/apps/mobile/features/budget/store.ts
@@ -29,6 +29,7 @@ import { createBudgetSchema } from "./schema";
 let dbRef: AnyDb | null = null;
 let userIdRef: UserId | null = null;
 let unsubscribeTxStore: (() => void) | null = null;
+let loadBudgetsRequestId = 0;
 
 const formatMonth = (date: Date): Month => format(date, "yyyy-MM") as Month;
 
@@ -123,17 +124,30 @@ export const useBudgetStore = create<BudgetState & BudgetActions>((set, get) => 
 
   loadBudgets: async () => {
     if (!dbRef || !userIdRef) return;
+    const requestId = ++loadBudgetsRequestId;
+    const requestedDb = dbRef;
+    const requestedUserId = userIdRef;
+    const requestedMonth = get().currentMonth;
+    const previous = {
+      pendingAlerts: get().pendingAlerts,
+      acknowledgedAlerts: get().acknowledgedAlerts,
+    };
     set({ isLoading: true });
     try {
       const snapshot = await budgetMonitoring.refreshMonth({
-        db: dbRef,
-        userId: userIdRef,
-        month: get().currentMonth,
-        previous: {
-          pendingAlerts: get().pendingAlerts,
-          acknowledgedAlerts: get().acknowledgedAlerts,
-        },
+        db: requestedDb,
+        userId: requestedUserId,
+        month: requestedMonth,
+        previous,
       });
+      if (
+        loadBudgetsRequestId !== requestId ||
+        dbRef !== requestedDb ||
+        userIdRef !== requestedUserId ||
+        get().currentMonth !== requestedMonth
+      ) {
+        return;
+      }
       set((state) => ({
         budgets: snapshot.budgets as Budget[],
         budgetProgress: snapshot.budgetProgress as BudgetProgress[],
@@ -145,7 +159,14 @@ export const useBudgetStore = create<BudgetState & BudgetActions>((set, get) => 
         isLoading: false,
       }));
     } catch {
-      set({ isLoading: false });
+      if (
+        loadBudgetsRequestId === requestId &&
+        dbRef === requestedDb &&
+        userIdRef === requestedUserId &&
+        get().currentMonth === requestedMonth
+      ) {
+        set({ isLoading: false });
+      }
     }
   },
 
@@ -154,7 +175,19 @@ export const useBudgetStore = create<BudgetState & BudgetActions>((set, get) => 
   },
 
   loadAutoSuggestions: () => {
-    void get().loadBudgets();
+    if (!dbRef || !userIdRef) return;
+    const { currentMonth, budgets } = get();
+    try {
+      const autoSuggestions = budgetMonitoring.loadAutoSuggestions({
+        db: dbRef,
+        userId: userIdRef,
+        month: currentMonth,
+        existingCategoryIds: new Set(budgets.map((budget) => budget.categoryId)),
+      });
+      set({ autoSuggestions: autoSuggestions as BudgetSuggestion[] });
+    } catch {
+      // Query failed — keep existing suggestions
+    }
   },
 
   createBudget: async (categoryId, amount) => {

--- a/apps/mobile/features/budget/store.ts
+++ b/apps/mobile/features/budget/store.ts
@@ -1,35 +1,18 @@
 import { addMonths, format, subMonths } from "date-fns";
 import { create } from "zustand";
+import { CATEGORY_MAP, useTransactionStore } from "@/features/transactions";
 import { useNotificationStore } from "@/features/notifications";
 import { useSettingsStore } from "@/features/settings";
-import {
-  CATEGORY_MAP,
-  getSpendingByCategoryAggregate,
-  useTransactionStore,
-} from "@/features/transactions";
 import type { AnyDb } from "@/shared/db";
 import { enqueueSync } from "@/shared/db";
 import { getCategoryLabel, useLocaleStore } from "@/shared/i18n";
-import {
-  formatMoney,
-  generateBudgetId,
-  generateSyncQueueId,
-  toIsoDateTime,
-  trackBudgetCreated,
-} from "@/shared/lib";
+import { generateBudgetId, generateSyncQueueId, toIsoDateTime, trackBudgetCreated } from "@/shared/lib";
 import type { BudgetId, CategoryId, CopAmount, Month, UserId } from "@/shared/types/branded";
 import type { BudgetAlert, BudgetProgress, BudgetSuggestion } from "./lib/derive";
-import {
-  computeDaysLeft,
-  deriveAutoSuggestBudgets,
-  deriveBudgetAlerts,
-  deriveBudgetProgress,
-  deriveBudgetSummary,
-} from "./lib/derive";
+import { createBudgetMonitoringModule } from "./lib/monitoring";
 import { scheduleBudgetAlert } from "./lib/notifications";
 import {
   copyBudgetsToMonth,
-  getBudgetsForMonth,
   insertBudget,
   softDeleteBudget,
   updateBudgetAmount,
@@ -51,6 +34,17 @@ const parseMonth = (month: Month): Date => {
   const m = parts[1] ?? 1;
   return new Date(y, m - 1, 1);
 };
+
+const budgetMonitoring = createBudgetMonitoringModule({
+  getBudgetAlertsEnabled: () => useSettingsStore.getState().notificationPreferences.budgetAlerts,
+  getLocale: () => useLocaleStore.getState().locale,
+  resolveCategoryLabel: (categoryId, locale) => {
+    const category = CATEGORY_MAP[categoryId];
+    return category ? getCategoryLabel(category, locale) : categoryId;
+  },
+  scheduleBudgetAlert,
+  insertNotification: (input) => useNotificationStore.getState().insertNotification(input),
+});
 
 type BudgetState = {
   currentMonth: Month;
@@ -98,10 +92,8 @@ export const useBudgetStore = create<BudgetState & BudgetActions>((set, get) => 
     // Subscribe to transaction store changes to auto-refresh progress
     if (unsubscribeTxStore) unsubscribeTxStore();
     unsubscribeTxStore = useTransactionStore.subscribe(() => {
-      // When transactions change, refresh budget progress
-      if (get().budgets.length > 0) {
-        get().refreshProgress();
-      }
+      // Re-run the full month refresh so transaction changes and alert policy stay in one path.
+      void get().loadBudgets();
     });
   },
 
@@ -128,90 +120,35 @@ export const useBudgetStore = create<BudgetState & BudgetActions>((set, get) => 
     if (!dbRef || !userIdRef) return;
     set({ isLoading: true });
     try {
-      const rows = getBudgetsForMonth(dbRef, userIdRef, get().currentMonth);
-      set({ budgets: rows as Budget[], isLoading: false });
-      get().refreshProgress();
-      get().loadAutoSuggestions();
+      const snapshot = await budgetMonitoring.refreshMonth({
+        db: dbRef,
+        userId: userIdRef,
+        month: get().currentMonth,
+        previous: {
+          pendingAlerts: get().pendingAlerts,
+          acknowledgedAlerts: get().acknowledgedAlerts,
+        },
+      });
+      set((state) => ({
+        budgets: snapshot.budgets as Budget[],
+        budgetProgress: snapshot.budgetProgress as BudgetProgress[],
+        summary: snapshot.summary,
+        autoSuggestions: snapshot.autoSuggestions as BudgetSuggestion[],
+        pendingAlerts: snapshot.pendingAlerts,
+        pendingPermissionRequest: state.pendingPermissionRequest || snapshot.pendingPermissionRequest,
+        isLoading: false,
+      }));
     } catch {
       set({ isLoading: false });
     }
   },
 
   refreshProgress: () => {
-    if (!dbRef || !userIdRef) return;
-    const { budgets, acknowledgedAlerts, currentMonth, pendingAlerts: previousAlerts } = get();
-    try {
-      const spending = getSpendingByCategoryAggregate(dbRef, userIdRef, currentMonth);
-      const spendingMap = new Map(spending.map((s) => [s.categoryId, s.total]));
-      const progresses = budgets.map((b) =>
-        deriveBudgetProgress(b, spendingMap.get(b.categoryId) ?? (0 as CopAmount))
-      );
-      const summary = deriveBudgetSummary(progresses);
-      const daysLeft = computeDaysLeft(currentMonth, new Date());
-      const newPendingAlerts = deriveBudgetAlerts(progresses, acknowledgedAlerts, daysLeft);
-      set({ budgetProgress: progresses, summary, pendingAlerts: newPendingAlerts });
+    void get().loadBudgets();
+  },
 
-      // Schedule push notifications for truly new alerts (best-effort, don't block)
-      const previousKeys = new Set(previousAlerts.map((a) => `${a.budgetId}:${a.threshold}`));
-      const freshAlerts = newPendingAlerts.filter(
-        (a) => !previousKeys.has(`${a.budgetId}:${a.threshold}`)
-      );
-      const locale = useLocaleStore.getState().locale;
-      // Schedule the first fresh alert to detect permission state; schedule rest only on "scheduled"
-      const firstAlert = freshAlerts[0];
-      if (freshAlerts.length > 0 && firstAlert != null) {
-        const budgetAlertsEnabled =
-          useSettingsStore.getState().notificationPreferences.budgetAlerts;
-        const firstCategory = CATEGORY_MAP[firstAlert.categoryId];
-        const firstName = firstCategory
-          ? getCategoryLabel(firstCategory, locale)
-          : firstAlert.categoryId;
-        scheduleBudgetAlert(firstAlert, firstName, budgetAlertsEnabled)
-          .then((result) => {
-            if (result.type === "needs_permission") {
-              set({ pendingPermissionRequest: true });
-              return;
-            }
-            if (result.type !== "scheduled") return;
-            // Schedule remaining alerts (permission already confirmed as granted)
-            freshAlerts.slice(1).forEach((alert) => {
-              const category = CATEGORY_MAP[alert.categoryId];
-              const name = category ? getCategoryLabel(category, locale) : alert.categoryId;
-              scheduleBudgetAlert(alert, name, budgetAlertsEnabled).catch(() => {});
-            });
-          })
-          .catch(() => {});
-      }
-
-      // Insert in-app notifications for fresh budget alerts
-      freshAlerts.forEach((alert) => {
-        const category = CATEGORY_MAP[alert.categoryId];
-        const categoryName = category ? getCategoryLabel(category, locale) : alert.categoryId;
-        const remaining = formatMoney(Math.abs(alert.remainingAmount) as CopAmount);
-
-        useNotificationStore.getState().insertNotification({
-          type: "budget_alert",
-          dedupKey: `budget_alert:${alert.categoryId}:${alert.threshold}:${get().currentMonth}`,
-          categoryId: alert.categoryId,
-          goalId: null,
-          titleKey:
-            alert.threshold === 80 ? "notifications.budgetWarning" : "notifications.budgetExceeded",
-          messageKey:
-            alert.threshold === 80
-              ? "notifications.budgetWarningMsg"
-              : "notifications.budgetExceededMsg",
-          params: JSON.stringify({
-            category: categoryName,
-            remaining,
-            daysLeft: alert.daysLeft,
-            overAmount: remaining,
-            threshold: alert.threshold,
-          }),
-        });
-      });
-    } catch {
-      // Query failed — keep existing state
-    }
+  loadAutoSuggestions: () => {
+    void get().loadBudgets();
   },
 
   createBudget: async (categoryId, amount) => {
@@ -315,24 +252,6 @@ export const useBudgetStore = create<BudgetState & BudgetActions>((set, get) => 
     await get().loadBudgets();
   },
 
-  loadAutoSuggestions: () => {
-    if (!dbRef || !userIdRef) return;
-    const { currentMonth, budgets } = get();
-    try {
-      const currentDate = parseMonth(currentMonth);
-      const prevMonth = formatMonth(subMonths(currentDate, 1));
-      const prevSpending = getSpendingByCategoryAggregate(dbRef, userIdRef, prevMonth);
-      const existingCategoryIds = new Set(budgets.map((b) => b.categoryId));
-      const suggestions = deriveAutoSuggestBudgets(
-        prevSpending,
-        existingCategoryIds as ReadonlySet<CategoryId>
-      );
-      set({ autoSuggestions: suggestions as BudgetSuggestion[] });
-    } catch {
-      // Query failed — keep existing suggestions
-    }
-  },
-
   acceptSuggestions: async (budgetsByCategory) => {
     if (!dbRef || !userIdRef) return;
     const userId = userIdRef;
@@ -371,12 +290,21 @@ export const useBudgetStore = create<BudgetState & BudgetActions>((set, get) => 
   },
 
   acknowledgeAlert: (budgetId, threshold) => {
-    set((s) => ({
-      acknowledgedAlerts: new Set([...s.acknowledgedAlerts, `${budgetId}:${threshold}`]),
-      pendingAlerts: s.pendingAlerts.filter(
-        (a) => !(a.budgetId === budgetId && a.threshold === threshold)
-      ),
-    }));
+    set((state) => {
+      const nextState = budgetMonitoring.acknowledgeAlert({
+        budgetId,
+        threshold,
+        alertState: {
+          pendingAlerts: state.pendingAlerts,
+          acknowledgedAlerts: state.acknowledgedAlerts,
+        },
+      });
+
+      return {
+        acknowledgedAlerts: new Set(nextState.acknowledgedAlerts),
+        pendingAlerts: nextState.pendingAlerts,
+      };
+    });
   },
 
   clearPendingPermissionRequest: () => {

--- a/apps/mobile/features/budget/store.ts
+++ b/apps/mobile/features/budget/store.ts
@@ -140,12 +140,15 @@ export const useBudgetStore = create<BudgetState & BudgetActions>((set, get) => 
         month: requestedMonth,
         previous,
       });
-      if (
-        loadBudgetsRequestId !== requestId ||
+      const superseded = loadBudgetsRequestId !== requestId;
+      const contextChanged =
         dbRef !== requestedDb ||
         userIdRef !== requestedUserId ||
-        get().currentMonth !== requestedMonth
-      ) {
+        get().currentMonth !== requestedMonth;
+      if (superseded || contextChanged) {
+        if (!superseded) {
+          set({ isLoading: false });
+        }
         return;
       }
       set((state) => ({
@@ -159,12 +162,7 @@ export const useBudgetStore = create<BudgetState & BudgetActions>((set, get) => 
         isLoading: false,
       }));
     } catch {
-      if (
-        loadBudgetsRequestId === requestId &&
-        dbRef === requestedDb &&
-        userIdRef === requestedUserId &&
-        get().currentMonth === requestedMonth
-      ) {
+      if (loadBudgetsRequestId === requestId) {
         set({ isLoading: false });
       }
     }

--- a/apps/mobile/features/budget/store.ts
+++ b/apps/mobile/features/budget/store.ts
@@ -1,12 +1,17 @@
 import { addMonths, format, subMonths } from "date-fns";
 import { create } from "zustand";
-import { CATEGORY_MAP, useTransactionStore } from "@/features/transactions";
 import { useNotificationStore } from "@/features/notifications";
 import { useSettingsStore } from "@/features/settings";
+import { CATEGORY_MAP, useTransactionStore } from "@/features/transactions";
 import type { AnyDb } from "@/shared/db";
 import { enqueueSync } from "@/shared/db";
 import { getCategoryLabel, useLocaleStore } from "@/shared/i18n";
-import { generateBudgetId, generateSyncQueueId, toIsoDateTime, trackBudgetCreated } from "@/shared/lib";
+import {
+  generateBudgetId,
+  generateSyncQueueId,
+  toIsoDateTime,
+  trackBudgetCreated,
+} from "@/shared/lib";
 import type { BudgetId, CategoryId, CopAmount, Month, UserId } from "@/shared/types/branded";
 import type { BudgetAlert, BudgetProgress, BudgetSuggestion } from "./lib/derive";
 import { createBudgetMonitoringModule } from "./lib/monitoring";
@@ -135,7 +140,8 @@ export const useBudgetStore = create<BudgetState & BudgetActions>((set, get) => 
         summary: snapshot.summary,
         autoSuggestions: snapshot.autoSuggestions as BudgetSuggestion[],
         pendingAlerts: snapshot.pendingAlerts,
-        pendingPermissionRequest: state.pendingPermissionRequest || snapshot.pendingPermissionRequest,
+        pendingPermissionRequest:
+          state.pendingPermissionRequest || snapshot.pendingPermissionRequest,
         isLoading: false,
       }));
     } catch {


### PR DESCRIPTION
refactor(mobile): deepen budget monitoring

- move alert orchestration to module
- add monitoring boundary tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized budget monitoring and alert orchestration into a dedicated module and wired the store to use it. Adds race guards, keeps auto‑suggestions side‑effect free, and clears stale loading state.

- **Refactors**
  - Added `features/budget/lib/monitoring.ts` with `createBudgetMonitoringModule` to compute progress, derive alerts, deliver notifications, and handle acknowledgments.
  - Updated the budget store to refresh the whole month via the module (including on transaction changes), guard refresh races with request-scoped ids, and load auto-suggestions without triggering delivery.
  - Exported monitoring factory and types from `features/budget/index.ts`.
  - Added boundary tests for monitoring and store (refresh race, suggestions path, stale context loading state).

- **Bug Fixes**
  - Ignores stale month refresh results when the month, user, or DB changes mid-request.
  - Clears loading when context changes without a newer refresh.
  - Skips delivering the same alert while it remains pending.
  - Triggers and exposes a permission request when scheduling requires it.
  - Inserts in-app notifications only for fresh alerts, using stable per-month dedup keys.

<sup>Written for commit 62de3b1df0dbb6f6576999e485f70f7ff861449e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

