### PR TITLE
refactor(mobile): centralize write-through mutations

### DIFF
--- a/.agents/skills/mobile-qa/SKILL.md
+++ b/.agents/skills/mobile-qa/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: mobile-qa
+description: >
+  Manual QA workflow for Fidy Expo/React Native iOS worktrees on the iPhone 17
+  simulator. Use when testing a branch or PR in apps/mobile, especially when
+  you need Metro + Expo dev client attachment, XcodeBuildMCP UI automation, and
+  branch-by-branch simulator verification without repeating setup mistakes.
+---
+
+# Mobile QA
+
+Use this skill for real manual QA on Fidy mobile branches. This is for simulator
+testing, not unit tests.
+
+## What This Skill Prevents
+
+- Launching the installed app icon before Metro is attached
+- Testing the wrong worktree
+- Assuming `127.0.0.1:8081` works when this environment expects `localhost:8081`
+- Reusing stale Metro state across branches
+- Mistaking simulator-only native limitations for branch regressions
+
+## Preconditions
+
+- Test only on `iPhone 17`
+- Prefer `apps/mobile/ios/Fidy.xcworkspace` with scheme `Fidy`
+- Verify UI automation tools first
+  - Prefer `mcp__XcodeBuildMCP__tap`, `swipe`, `type_text`, `snapshot_ui`, `screenshot`
+  - If those are unavailable, fall back to `axe describe-ui`, `axe tap`, `axe swipe`, `axe type`
+
+## Required Branch Setup
+
+For each worktree:
+
+1. Verify the tree is clean
+   - `git -C /abs/worktree status --short --branch`
+2. Install deps only if needed
+   - `cd /abs/worktree`
+   - `bun install`
+3. Start Metro from the target worktree app folder
+   - `cd /abs/worktree/apps/mobile`
+   - `CI=1 bun x expo start --dev-client --host localhost --port 8081 --clear`
+4. Wait until Metro is actually up
+   - `curl -sSf http://localhost:8081/status`
+   - Expected: `packager-status:running`
+
+Do not continue until the status endpoint succeeds.
+
+## Simulator Attach Flow
+
+Do not tap the `Fidy` app icon.
+
+Open the dev client explicitly:
+
+```bash
+xcrun simctl openurl booted "com.googleusercontent.apps.282682681790-630ti7lmdsjcm32o31m1kq50q20727pn://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081"
+```
+
+Rules:
+
+- Keep only the target branch's Metro server active on `8081`
+- Re-run the open-url command when switching branches
+- If the app shows `No script URL provided`, it is still not connected
+- In this repo environment, `localhost` worked and `127.0.0.1` did not
+
+## Worktree Switching
+
+When moving to the next branch:
+
+1. Stop the previous Metro process
+2. Start Metro from the new worktree's `apps/mobile`
+3. Re-check `curl -sSf http://localhost:8081/status`
+4. Re-open the dev client URL
+5. Wait for the new bundle to finish loading before testing
+
+Do not assume the simulator is running the new branch until Metro rebundles.
+
+## Manual QA Rules
+
+- Manual feature QA only, do not substitute test suites for user flows
+- Exercise the changed area directly from the UI whenever reachable
+- Use `snapshot_ui` before and after key actions
+- Capture screenshots for real findings
+- Record:
+  - pass/fail
+  - repro steps
+  - observed vs expected
+  - severity
+  - merge-blocking or regression-risk
+
+## Fidy-Specific Notes
+
+- `Connected Emails`, `Notifications`, `Categories`, budgets, sync conflicts, and similar screens are reachable from Settings or home banners
+- Some capture flows are native/background driven
+  - Widget capture uses the app group pending transaction store
+  - Apple Pay and SMS capture rely on iOS/native triggers and may need simulator-specific setup
+- Simulator warnings like background-task unavailability are not branch bugs by themselves
+- A failed Metro/dev-client attach is a harness problem, not a product finding
+
+## Minimal QA Checklist
+
+- UI automation available and simulator target correct
+- Git status clean
+- Metro started from the correct worktree
+- `curl -sSf http://localhost:8081/status` passes
+- Dev client opened by URL, not app icon
+- Bundle finishes loading
+- Feature area exercised manually
+- Findings captured with evidence
+
+## Stop Conditions
+
+Stop and fix the harness before testing if:
+
+- `curl` fails
+- the dev client shows `No script URL provided`
+- the app is clearly running an old branch bundle
+- simulator automation is unavailable and there is no fallback tool

--- a/apps/mobile/__tests__/calendar/bill-mutation-service.test.ts
+++ b/apps/mobile/__tests__/calendar/bill-mutation-service.test.ts
@@ -1,0 +1,330 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createCalendarBillMutationService } from "@/features/calendar/lib/bill-mutation-service";
+import type { Bill, BillPayment } from "@/features/calendar/schema";
+import type { WriteThroughMutationModule } from "@/shared/mutations";
+import type {
+  BillId,
+  BillPaymentId,
+  CategoryId,
+  CopAmount,
+  IsoDate,
+  IsoDateTime,
+  TransactionId,
+  UserId,
+} from "@/shared/types/branded";
+
+const now = new Date("2026-04-12T10:00:00.000Z");
+const nowIso = "2026-04-12T10:00:00.000Z" as IsoDateTime;
+
+const bill: Bill = {
+  id: "bill-1" as BillId,
+  name: "Rent",
+  amount: 100000 as CopAmount,
+  frequency: "monthly",
+  categoryId: "home" as CategoryId,
+  startDate: new Date("2026-04-01T00:00:00.000Z"),
+  isActive: true,
+};
+
+describe("calendar bill mutation service", () => {
+  type ServiceDeps = Parameters<typeof createCalendarBillMutationService>[0];
+
+  let currentCommit: WriteThroughMutationModule["commit"] | null;
+  let currentUserId: UserId | null;
+  let requestNotificationPermissions: ServiceDeps["requestNotificationPermissions"];
+  let scheduleBillNotifications: ServiceDeps["scheduleBillNotifications"];
+  let reportAsyncError: ServiceDeps["reportAsyncError"];
+  let addTransactionToCache: ServiceDeps["addTransactionToCache"];
+  let removeTransactionFromCache: ServiceDeps["removeTransactionFromCache"];
+  let trackCreated: ServiceDeps["trackCreated"];
+  let trackPaymentRecorded: ServiceDeps["trackPaymentRecorded"];
+  let requestNotificationPermissionsMock: ReturnType<typeof vi.fn>;
+  let scheduleBillNotificationsMock: ReturnType<typeof vi.fn>;
+  let reportAsyncErrorMock: ReturnType<typeof vi.fn>;
+  let addTransactionToCacheMock: ReturnType<typeof vi.fn>;
+  let removeTransactionFromCacheMock: ReturnType<typeof vi.fn>;
+  let trackCreatedMock: ReturnType<typeof vi.fn>;
+  let trackPaymentRecordedMock: ReturnType<typeof vi.fn>;
+
+  function createService() {
+    return createCalendarBillMutationService({
+      getCommit: () => currentCommit,
+      getUserId: () => currentUserId,
+      requestNotificationPermissions,
+      scheduleBillNotifications,
+      reportAsyncError,
+      addTransactionToCache,
+      removeTransactionFromCache,
+      trackCreated,
+      trackPaymentRecorded,
+      now: () => now,
+      createBillId: () => "bill-generated" as BillId,
+      createPaymentId: () => "pay-generated" as BillPaymentId,
+      createTransactionId: () => "txn-generated" as TransactionId,
+    });
+  }
+
+  beforeEach(() => {
+    currentCommit = vi.fn().mockResolvedValue({ success: true, didMutate: true });
+    currentUserId = "user-1" as UserId;
+    requestNotificationPermissionsMock = vi.fn().mockResolvedValue(true);
+    scheduleBillNotificationsMock = vi.fn().mockResolvedValue(undefined);
+    reportAsyncErrorMock = vi.fn();
+    addTransactionToCacheMock = vi.fn();
+    removeTransactionFromCacheMock = vi.fn();
+    trackCreatedMock = vi.fn();
+    trackPaymentRecordedMock = vi.fn();
+    requestNotificationPermissions =
+      requestNotificationPermissionsMock as ServiceDeps["requestNotificationPermissions"];
+    scheduleBillNotifications =
+      scheduleBillNotificationsMock as ServiceDeps["scheduleBillNotifications"];
+    reportAsyncError = reportAsyncErrorMock as ServiceDeps["reportAsyncError"];
+    addTransactionToCache = addTransactionToCacheMock as ServiceDeps["addTransactionToCache"];
+    removeTransactionFromCache =
+      removeTransactionFromCacheMock as ServiceDeps["removeTransactionFromCache"];
+    trackCreated = trackCreatedMock as ServiceDeps["trackCreated"];
+    trackPaymentRecorded = trackPaymentRecordedMock as ServiceDeps["trackPaymentRecorded"];
+  });
+
+  it("adds valid bills through the write-through boundary and schedules notifications", async () => {
+    const service = createService();
+
+    const result = await service.addBill({
+      name: "Rent",
+      amount: "100000",
+      frequency: "monthly",
+      categoryId: "home" as CategoryId,
+      startDate: new Date("2026-04-01T00:00:00.000Z"),
+    });
+    await Promise.resolve();
+
+    expect(result).toEqual({
+      success: true,
+      bill: expect.objectContaining({ id: "bill-generated", amount: 100000 }),
+    });
+    expect(currentCommit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "calendar.bill.save",
+      })
+    );
+    expect(trackCreatedMock).toHaveBeenCalledWith({ frequency: "monthly" });
+    expect(scheduleBillNotificationsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "bill-generated" })
+    );
+  });
+
+  it("does not schedule notifications when permissions are denied", async () => {
+    requestNotificationPermissionsMock.mockResolvedValue(false);
+    const service = createService();
+
+    await service.addBill({
+      name: "Rent",
+      amount: "100000",
+      frequency: "monthly",
+      categoryId: "home" as CategoryId,
+      startDate: new Date("2026-04-01T00:00:00.000Z"),
+    });
+    await Promise.resolve();
+
+    expect(scheduleBillNotificationsMock).not.toHaveBeenCalled();
+  });
+
+  it("reports async notification failures without failing bill creation", async () => {
+    requestNotificationPermissionsMock.mockRejectedValueOnce(new Error("permissions failed"));
+    const service = createService();
+
+    await expect(
+      service.addBill({
+        name: "Rent",
+        amount: "100000",
+        frequency: "monthly",
+        categoryId: "home" as CategoryId,
+        startDate: new Date("2026-04-01T00:00:00.000Z"),
+      })
+    ).resolves.toEqual({
+      success: true,
+      bill: expect.objectContaining({ id: "bill-generated" }),
+    });
+    await Promise.resolve();
+
+    expect(reportAsyncErrorMock).toHaveBeenCalledWith(expect.any(Error));
+
+    requestNotificationPermissionsMock.mockResolvedValueOnce(true);
+    scheduleBillNotificationsMock.mockRejectedValueOnce(new Error("schedule failed"));
+
+    await expect(
+      service.addBill({
+        name: "Utilities",
+        amount: "50000",
+        frequency: "monthly",
+        categoryId: "home" as CategoryId,
+        startDate: new Date("2026-04-01T00:00:00.000Z"),
+      })
+    ).resolves.toEqual({
+      success: true,
+      bill: expect.objectContaining({ id: "bill-generated" }),
+    });
+    await Promise.resolve();
+
+    expect(reportAsyncErrorMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects missing initialization, invalid amounts, and failed commits", async () => {
+    currentUserId = null;
+    const service = createService();
+    await expect(
+      service.addBill({
+        name: "Rent",
+        amount: "100000",
+        frequency: "monthly",
+        categoryId: "home" as CategoryId,
+        startDate: new Date("2026-04-01T00:00:00.000Z"),
+      })
+    ).resolves.toEqual({ success: false });
+
+    currentUserId = "user-1" as UserId;
+    await expect(
+      service.addBill({
+        name: "Rent",
+        amount: "0",
+        frequency: "monthly",
+        categoryId: "home" as CategoryId,
+        startDate: new Date("2026-04-01T00:00:00.000Z"),
+      })
+    ).resolves.toEqual({ success: false });
+
+    currentCommit = vi.fn().mockResolvedValue({ success: false, error: "db failed" });
+    await expect(
+      service.addBill({
+        name: "Rent",
+        amount: "100000",
+        frequency: "monthly",
+        categoryId: "home" as CategoryId,
+        startDate: new Date("2026-04-01T00:00:00.000Z"),
+      })
+    ).resolves.toEqual({ success: false });
+  });
+
+  it("updates bills by normalizing Date fields to ISO strings", async () => {
+    const service = createService();
+
+    const didUpdate = await service.updateBill("bill-1" as BillId, {
+      startDate: new Date("2026-05-01T00:00:00.000Z"),
+      name: "Updated Rent",
+    });
+
+    expect(didUpdate).toBe(true);
+    expect(currentCommit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "calendar.bill.update",
+        billId: "bill-1",
+        fields: expect.objectContaining({
+          startDate: "2026-05-01T00:00:00.000Z",
+          name: "Updated Rent",
+        }),
+      })
+    );
+  });
+
+  it("returns false for update and delete when commits are unavailable or fail", async () => {
+    currentCommit = null;
+    const service = createService();
+    await expect(service.updateBill("bill-1" as BillId, { name: "Updated" })).resolves.toBe(false);
+    await expect(service.deleteBill("bill-1" as BillId)).resolves.toBe(false);
+
+    currentCommit = vi.fn().mockResolvedValue({ success: false, error: "nope" });
+    await expect(service.deleteBill("bill-1" as BillId)).resolves.toBe(false);
+  });
+
+  it("marks bills paid and updates the transaction cache", async () => {
+    const service = createService();
+
+    const result = await service.markBillPaid([bill], bill.id as BillId, "2026-04-12" as IsoDate);
+
+    expect(result).toEqual({
+      success: true,
+      payment: {
+        id: "pay-generated" as BillPaymentId,
+        billId: bill.id as BillId,
+        dueDate: "2026-04-12" as IsoDate,
+        paidAt: nowIso,
+        transactionId: "txn-generated" as TransactionId,
+        createdAt: nowIso,
+      },
+    });
+    expect(currentCommit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "calendar.bill.markPaid",
+      })
+    );
+    expect(addTransactionToCacheMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "txn-generated",
+        description: "Rent",
+      })
+    );
+    expect(trackPaymentRecordedMock).toHaveBeenCalledOnce();
+  });
+
+  it("returns false for markBillPaid when initialization, lookup, or commit fails", async () => {
+    const service = createService();
+    await expect(
+      service.markBillPaid([], bill.id as BillId, "2026-04-12" as IsoDate)
+    ).resolves.toEqual({ success: false });
+
+    currentCommit = null;
+    await expect(
+      service.markBillPaid([bill], bill.id as BillId, "2026-04-12" as IsoDate)
+    ).resolves.toEqual({ success: false });
+
+    currentCommit = vi.fn().mockRejectedValue(new Error("boom"));
+    await expect(
+      service.markBillPaid([bill], bill.id as BillId, "2026-04-12" as IsoDate)
+    ).resolves.toEqual({ success: false });
+  });
+
+  it("unmarks payments and only clears cache when a linked transaction exists", async () => {
+    const service = createService();
+    const withTransaction: BillPayment = {
+      id: "pay-1" as BillPaymentId,
+      billId: bill.id as BillId,
+      dueDate: "2026-04-12" as IsoDate,
+      paidAt: nowIso,
+      transactionId: "txn-1" as TransactionId,
+      createdAt: nowIso,
+    };
+
+    await expect(
+      service.unmarkBillPaid([withTransaction], bill.id as BillId, withTransaction.dueDate)
+    ).resolves.toEqual({ success: true });
+    expect(removeTransactionFromCacheMock).toHaveBeenCalledWith("txn-1");
+
+    removeTransactionFromCacheMock.mockClear();
+    const withoutTransaction: BillPayment = {
+      ...withTransaction,
+      transactionId: null,
+    };
+    await expect(
+      service.unmarkBillPaid([withoutTransaction], bill.id as BillId, withoutTransaction.dueDate)
+    ).resolves.toEqual({ success: true });
+    expect(removeTransactionFromCacheMock).not.toHaveBeenCalled();
+  });
+
+  it("unmarks payments without cache writes when no matching payment exists", async () => {
+    const service = createService();
+
+    await expect(
+      service.unmarkBillPaid([], bill.id as BillId, "2026-04-19" as IsoDate)
+    ).resolves.toEqual({
+      success: true,
+    });
+
+    expect(currentCommit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "calendar.bill.unmarkPaid",
+        transactionId: null,
+      })
+    );
+    expect(removeTransactionFromCacheMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/__tests__/notifications/store.test.ts
+++ b/apps/mobile/__tests__/notifications/store.test.ts
@@ -1,0 +1,147 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: focused store test uses lightweight mocks
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { UserId } from "@/shared/types/branded";
+
+const mockGetItemAsync = vi.fn();
+const mockSetItemAsync = vi.fn();
+const mockCountNotificationsSince = vi.fn();
+const mockGetNotifications = vi.fn(() => []);
+const mockCommit = vi.fn();
+
+vi.mock("expo-secure-store", () => ({
+  getItemAsync: mockGetItemAsync,
+  setItemAsync: mockSetItemAsync,
+}));
+
+vi.mock("@/features/notifications/repository", () => ({
+  countNotificationsSince: mockCountNotificationsSince,
+  getNotifications: mockGetNotifications,
+}));
+
+vi.mock("@/shared/lib", () => ({
+  generateNotificationId: vi.fn(() => "notif-generated"),
+  toIsoDateTime: vi.fn(() => "2026-04-12T10:00:00.000Z"),
+}));
+
+vi.mock("@/shared/mutations", () => ({
+  createWriteThroughMutationModule: vi.fn(() => ({
+    commit: mockCommit,
+  })),
+}));
+
+const USER_1 = "user-1" as UserId;
+const USER_2 = "user-2" as UserId;
+const mockDb = {} as any;
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function getStore() {
+  const { useNotificationStore } = await import("@/features/notifications/store");
+  return useNotificationStore;
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("useNotificationStore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetItemAsync.mockResolvedValue(null);
+    mockCountNotificationsSince.mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it("ignores stale async initStore completion after the active user changes", async () => {
+    const deferredVisited = createDeferred<string | null>();
+    mockGetItemAsync.mockReturnValueOnce(deferredVisited.promise);
+    mockCountNotificationsSince.mockImplementation((_db, userId: UserId) =>
+      userId === USER_2 ? 2 : 7
+    );
+
+    const store = await getStore();
+    const firstInit = store.getState().initStore(mockDb, USER_1);
+    const secondInit = store.getState().initStore(mockDb, USER_2);
+
+    deferredVisited.resolve(null);
+    await firstInit;
+    await secondInit;
+
+    expect(store.getState().newCount).toBe(2);
+    expect(mockCountNotificationsSince).toHaveBeenLastCalledWith(mockDb, USER_2, null);
+    expect(mockCountNotificationsSince).not.toHaveBeenCalledWith(mockDb, USER_1, null);
+  });
+
+  it("does not increment newCount when an older user's insert completes later", async () => {
+    const deferredCommit = createDeferred<{ success: true; didMutate: true }>();
+    mockCommit.mockReturnValueOnce(deferredCommit.promise);
+
+    const store = await getStore();
+    await store.getState().initStore(mockDb, USER_1);
+    store.getState().insertNotification({
+      type: "budget_alert",
+      dedupKey: "budget:1",
+      categoryId: null,
+      goalId: null,
+      titleKey: "title",
+      messageKey: "message",
+      params: null,
+    });
+
+    await store.getState().initStore(mockDb, USER_2);
+    deferredCommit.resolve({ success: true, didMutate: true });
+    await flushMicrotasks();
+
+    expect(store.getState().newCount).toBe(0);
+    expect(mockCommit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "notification.insert",
+        row: expect.objectContaining({ userId: USER_1 }),
+      })
+    );
+  });
+
+  it("does not clear another user's state when an older clearAll completes later", async () => {
+    const deferredCommit = createDeferred<{ success: true; didMutate: true }>();
+    mockCommit.mockReturnValueOnce(deferredCommit.promise);
+
+    const store = await getStore();
+    await store.getState().initStore(mockDb, USER_1);
+    store.setState({
+      notifications: [{ id: "old-user-notif" }] as any[],
+      newCount: 4,
+    });
+
+    store.getState().clearAll();
+
+    await store.getState().initStore(mockDb, USER_2);
+    store.setState({
+      notifications: [{ id: "new-user-notif" }] as any[],
+      newCount: 2,
+    });
+
+    deferredCommit.resolve({ success: true, didMutate: true });
+    await flushMicrotasks();
+
+    expect(store.getState().notifications).toEqual([{ id: "new-user-notif" }]);
+    expect(store.getState().newCount).toBe(2);
+    expect(mockCommit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "notification.clearAll",
+        userId: USER_1,
+      })
+    );
+  });
+});

--- a/apps/mobile/__tests__/shared/write-through.test.ts
+++ b/apps/mobile/__tests__/shared/write-through.test.ts
@@ -64,7 +64,7 @@ vi.mock("@/features/calendar/lib/repository", () => ({
 
 const mockDb = {
   transaction: vi.fn((fn: (tx: AnyDb) => unknown) => fn(mockDb as AnyDb)),
-} as AnyDb;
+} as unknown as AnyDb;
 
 async function loadModule() {
   return import("@/shared/mutations");

--- a/apps/mobile/__tests__/shared/write-through.test.ts
+++ b/apps/mobile/__tests__/shared/write-through.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getMutationPolicy } from "@/shared/mutations";
 import type { AnyDb } from "@/shared/db";
+import { getMutationPolicy } from "@/shared/mutations";
 import type {
   BillId,
   BillPaymentId,

--- a/apps/mobile/__tests__/shared/write-through.test.ts
+++ b/apps/mobile/__tests__/shared/write-through.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getMutationPolicy } from "@/shared/mutations";
+import type { AnyDb } from "@/shared/db";
+import type {
+  BillId,
+  BillPaymentId,
+  BudgetId,
+  CategoryId,
+  CopAmount,
+  IsoDate,
+  IsoDateTime,
+  Month,
+  TransactionId,
+  UserId,
+} from "@/shared/types/branded";
+
+vi.mock("@/shared/db/enqueue-sync", () => ({
+  enqueueSync: vi.fn(),
+}));
+
+vi.mock("@/shared/lib", () => ({
+  generateBudgetId: vi.fn().mockReturnValue("budget-generated"),
+  generateSyncQueueId: vi.fn().mockReturnValue("sync-generated"),
+}));
+
+vi.mock("@/features/transactions/lib/repository", () => ({
+  insertTransaction: vi.fn(),
+  softDeleteTransaction: vi.fn(),
+  upsertTransaction: vi.fn(),
+}));
+
+vi.mock("@/features/goals/lib/repository", () => ({
+  insertGoal: vi.fn(),
+  updateGoal: vi.fn(),
+  softDeleteGoal: vi.fn(),
+  insertContribution: vi.fn(),
+  softDeleteContribution: vi.fn(),
+}));
+
+vi.mock("@/features/budget/lib/repository", () => ({
+  insertBudget: vi.fn(),
+  updateBudgetAmount: vi.fn(),
+  softDeleteBudget: vi.fn(),
+  copyBudgetsToMonth: vi.fn().mockReturnValue(["budget-copy-1"]),
+}));
+
+vi.mock("@/features/notifications/repository", () => ({
+  insertNotification: vi.fn().mockReturnValue({ changes: 1 }),
+  getAllNotificationIds: vi.fn().mockReturnValue(["nf-1", "nf-2"]),
+  softDeleteAllNotifications: vi.fn(),
+}));
+
+vi.mock("@/features/categories/lib/repository", () => ({
+  insertUserCategory: vi.fn(),
+}));
+
+vi.mock("@/features/calendar/lib/repository", () => ({
+  insertBill: vi.fn(),
+  updateBill: vi.fn(),
+  deleteBill: vi.fn(),
+  insertBillPayment: vi.fn(),
+  deleteBillPayment: vi.fn(),
+}));
+
+const mockDb = {
+  transaction: (fn: (tx: AnyDb) => unknown) => fn(mockDb as AnyDb),
+} as AnyDb;
+
+async function loadModule() {
+  return import("@/shared/mutations");
+}
+
+describe("write-through mutations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("publishes the explicit sync policy", () => {
+    expect(getMutationPolicy("calendar.bill.save")).toBe("local-only");
+    expect(getMutationPolicy("transaction.save")).toBe("sync-backed");
+  });
+
+  it("writes sync-backed transaction saves through the boundary", async () => {
+    const { createWriteThroughMutationModule } = await loadModule();
+    const { insertTransaction } = await import("@/features/transactions/lib/repository");
+    const { enqueueSync } = await import("@/shared/db/enqueue-sync");
+    const module = createWriteThroughMutationModule(mockDb);
+    const now = "2026-04-12T10:00:00.000Z" as IsoDateTime;
+
+    const result = await module.commit({
+      kind: "transaction.save",
+      mode: "insert",
+      row: {
+        id: "tx-1" as TransactionId,
+        userId: "user-1" as UserId,
+        type: "expense",
+        amount: 1000 as CopAmount,
+        categoryId: "food" as CategoryId,
+        description: "Lunch",
+        date: "2026-04-12" as IsoDate,
+        createdAt: now,
+        updatedAt: now,
+        deletedAt: null,
+      },
+    });
+
+    expect(result).toEqual({ success: true, didMutate: true });
+    expect(insertTransaction).toHaveBeenCalledOnce();
+    expect(enqueueSync).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        tableName: "transactions",
+        operation: "insert",
+      })
+    );
+  });
+
+  it("keeps calendar bill CRUD local-only", async () => {
+    const { createWriteThroughMutationModule } = await loadModule();
+    const { insertBill } = await import("@/features/calendar/lib/repository");
+    const { enqueueSync } = await import("@/shared/db/enqueue-sync");
+    const module = createWriteThroughMutationModule(mockDb);
+
+    const result = await module.commit({
+      kind: "calendar.bill.save",
+      row: {
+        id: "bill-1" as BillId,
+        userId: "user-1" as UserId,
+        name: "Rent",
+        amount: 100000 as CopAmount,
+        frequency: "monthly",
+        categoryId: "home" as CategoryId,
+        startDate: "2026-04-01" as IsoDate,
+        isActive: true,
+        createdAt: "2026-04-12T10:00:00.000Z" as IsoDateTime,
+        updatedAt: "2026-04-12T10:00:00.000Z" as IsoDateTime,
+      },
+    });
+
+    expect(result).toEqual({ success: true, didMutate: true });
+    expect(insertBill).toHaveBeenCalledOnce();
+    expect(enqueueSync).not.toHaveBeenCalled();
+  });
+
+  it("marks bill payments paid in one write-through commit", async () => {
+    const { createWriteThroughMutationModule } = await loadModule();
+    const { insertTransaction } = await import("@/features/transactions/lib/repository");
+    const { insertBillPayment } = await import("@/features/calendar/lib/repository");
+    const { enqueueSync } = await import("@/shared/db/enqueue-sync");
+    const module = createWriteThroughMutationModule(mockDb);
+    const now = "2026-04-12T10:00:00.000Z" as IsoDateTime;
+
+    await module.commit({
+      kind: "calendar.bill.markPaid",
+      transactionRow: {
+        id: "tx-pay-1" as TransactionId,
+        userId: "user-1" as UserId,
+        type: "expense",
+        amount: 45000 as CopAmount,
+        categoryId: "services" as CategoryId,
+        description: "Internet",
+        date: "2026-04-12" as IsoDate,
+        createdAt: now,
+        updatedAt: now,
+        deletedAt: null,
+      },
+      paymentRow: {
+        id: "bp-1" as BillPaymentId,
+        billId: "bill-1" as BillId,
+        dueDate: "2026-04-12" as IsoDate,
+        paidAt: now,
+        transactionId: "tx-pay-1" as TransactionId,
+        createdAt: now,
+      },
+    });
+
+    expect(insertTransaction).toHaveBeenCalledOnce();
+    expect(insertBillPayment).toHaveBeenCalledOnce();
+    expect(enqueueSync).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        tableName: "transactions",
+        operation: "insert",
+      })
+    );
+  });
+
+  it("commits budget batches atomically", async () => {
+    const { createWriteThroughMutationModule } = await loadModule();
+    const { insertBudget } = await import("@/features/budget/lib/repository");
+    const { enqueueSync } = await import("@/shared/db/enqueue-sync");
+    const module = createWriteThroughMutationModule(mockDb);
+
+    const result = await module.commitBatch([
+      {
+        kind: "budget.save",
+        row: {
+          id: "budget-1" as BudgetId,
+          userId: "user-1" as UserId,
+          categoryId: "food" as CategoryId,
+          amount: 10000 as CopAmount,
+          month: "2026-04" as Month,
+          createdAt: "2026-04-12T10:00:00.000Z" as IsoDateTime,
+          updatedAt: "2026-04-12T10:00:00.000Z" as IsoDateTime,
+          deletedAt: null,
+        },
+      },
+      {
+        kind: "budget.save",
+        row: {
+          id: "budget-2" as BudgetId,
+          userId: "user-1" as UserId,
+          categoryId: "transport" as CategoryId,
+          amount: 20000 as CopAmount,
+          month: "2026-04" as Month,
+          createdAt: "2026-04-12T10:00:00.000Z" as IsoDateTime,
+          updatedAt: "2026-04-12T10:00:00.000Z" as IsoDateTime,
+          deletedAt: null,
+        },
+      },
+    ]);
+
+    expect(result).toEqual([
+      { success: true, didMutate: true },
+      { success: true, didMutate: true },
+    ]);
+    expect(insertBudget).toHaveBeenCalledTimes(2);
+    expect(enqueueSync).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/mobile/__tests__/shared/write-through.test.ts
+++ b/apps/mobile/__tests__/shared/write-through.test.ts
@@ -63,7 +63,7 @@ vi.mock("@/features/calendar/lib/repository", () => ({
 }));
 
 const mockDb = {
-  transaction: (fn: (tx: AnyDb) => unknown) => fn(mockDb as AnyDb),
+  transaction: vi.fn((fn: (tx: AnyDb) => unknown) => fn(mockDb as AnyDb)),
 } as AnyDb;
 
 async function loadModule() {
@@ -105,6 +105,7 @@ describe("write-through mutations", () => {
     });
 
     expect(result).toEqual({ success: true, didMutate: true });
+    expect(mockDb.transaction).toHaveBeenCalledOnce();
     expect(insertTransaction).toHaveBeenCalledOnce();
     expect(enqueueSync).toHaveBeenCalledWith(
       mockDb,
@@ -174,6 +175,7 @@ describe("write-through mutations", () => {
       },
     });
 
+    expect(mockDb.transaction).toHaveBeenCalledOnce();
     expect(insertTransaction).toHaveBeenCalledOnce();
     expect(insertBillPayment).toHaveBeenCalledOnce();
     expect(enqueueSync).toHaveBeenCalledWith(

--- a/apps/mobile/__tests__/transactions/mutation-service.test.ts
+++ b/apps/mobile/__tests__/transactions/mutation-service.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTransactionMutationService } from "@/features/transactions/lib/mutation-service";
+import type { WriteThroughMutationModule } from "@/shared/mutations";
+import type { CategoryId, TransactionId, UserId } from "@/shared/types/branded";
+
+const now = new Date("2026-04-12T10:00:00.000Z");
+
+const input = {
+  type: "expense" as const,
+  digits: "1200",
+  categoryId: "food" as CategoryId,
+  description: "Lunch",
+  date: new Date("2026-04-12T00:00:00.000Z"),
+};
+
+describe("transaction mutation service", () => {
+  type ServiceDeps = Parameters<typeof createTransactionMutationService>[0];
+
+  let currentCommit: WriteThroughMutationModule["commit"] | null;
+  let currentUserId: UserId | null;
+  let refresh: ServiceDeps["refresh"];
+  let resetForm: ServiceDeps["resetForm"];
+  let trackDeleted: ServiceDeps["trackDeleted"];
+  let trackEdited: ServiceDeps["trackEdited"];
+  let refreshMock: ReturnType<typeof vi.fn>;
+  let resetFormMock: ReturnType<typeof vi.fn>;
+  let trackDeletedMock: ReturnType<typeof vi.fn>;
+  let trackEditedMock: ReturnType<typeof vi.fn>;
+
+  function createService() {
+    return createTransactionMutationService({
+      getCommit: () => currentCommit,
+      getUserId: () => currentUserId,
+      refresh,
+      resetForm,
+      trackDeleted,
+      trackEdited,
+      now: () => now,
+      createId: () => "txn-1" as TransactionId,
+    });
+  }
+
+  beforeEach(() => {
+    currentUserId = "user-1" as UserId;
+    currentCommit = vi.fn();
+    refreshMock = vi.fn().mockResolvedValue(undefined);
+    resetFormMock = vi.fn();
+    trackDeletedMock = vi.fn();
+    trackEditedMock = vi.fn();
+    refresh = refreshMock as ServiceDeps["refresh"];
+    resetForm = resetFormMock as ServiceDeps["resetForm"];
+    trackDeleted = trackDeletedMock as ServiceDeps["trackDeleted"];
+    trackEdited = trackEditedMock as ServiceDeps["trackEdited"];
+  });
+
+  it("returns store-not-initialized when the user is unavailable", async () => {
+    currentUserId = null;
+    const service = createService();
+
+    await expect(service.save(input)).resolves.toEqual({
+      success: false,
+      error: "Store not initialized",
+    });
+  });
+
+  it("returns build validation failures directly", async () => {
+    const service = createService();
+    const result = await service.save({
+      ...input,
+      digits: "",
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toEqual(expect.any(String));
+  });
+
+  it("maps failed insert commits to a save error", async () => {
+    currentCommit = vi.fn().mockResolvedValue({
+      success: false,
+      error: "db failed",
+    });
+    const service = createService();
+
+    await expect(service.save(input)).resolves.toEqual({
+      success: false,
+      error: "Failed to save transaction",
+    });
+  });
+
+  it("saves valid transactions through the write-through boundary", async () => {
+    currentCommit = vi.fn().mockResolvedValue({ success: true, didMutate: true });
+    const service = createService();
+
+    const result = await service.save(input);
+
+    expect(result).toMatchObject({
+      success: true,
+      transaction: expect.objectContaining({
+        id: "txn-1",
+        userId: "user-1",
+        amount: 1200,
+        categoryId: "food",
+      }),
+    });
+    expect(currentCommit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "transaction.save",
+        mode: "insert",
+      })
+    );
+    expect(refreshMock).toHaveBeenCalledOnce();
+  });
+
+  it("treats missing or throwing commits as save/update failures", async () => {
+    currentCommit = null;
+    const service = createService();
+
+    await expect(service.save(input)).resolves.toEqual({
+      success: false,
+      error: "Store not initialized",
+    });
+
+    currentCommit = vi.fn().mockRejectedValue(new Error("boom"));
+    await expect(service.updateDirect("txn-9" as TransactionId, input)).resolves.toEqual({
+      success: false,
+      error: "Failed to update transaction",
+    });
+  });
+
+  it("updates transactions and resets the form on success", async () => {
+    currentCommit = vi.fn().mockResolvedValue({ success: true, didMutate: true });
+    const service = createService();
+
+    const result = await service.update("txn-9" as TransactionId, input);
+
+    expect(result).toMatchObject({
+      success: true,
+      transaction: expect.objectContaining({ id: "txn-9" }),
+    });
+    expect(trackEditedMock).toHaveBeenCalledWith({ category: "food" });
+    expect(resetFormMock).toHaveBeenCalledOnce();
+    expect(refreshMock).toHaveBeenCalledOnce();
+  });
+
+  it("updates transactions directly without resetting the form", async () => {
+    currentCommit = vi.fn().mockResolvedValue({ success: true, didMutate: true });
+    const service = createService();
+
+    const result = await service.updateDirect("txn-9" as TransactionId, input);
+
+    expect(result).toMatchObject({
+      success: true,
+      transaction: expect.objectContaining({ id: "txn-9" }),
+    });
+    expect(trackEditedMock).toHaveBeenCalledWith({ category: "food" });
+    expect(resetFormMock).not.toHaveBeenCalled();
+    expect(refreshMock).toHaveBeenCalledOnce();
+  });
+
+  it("throws on failed deletes and still refreshes when commits are unavailable", async () => {
+    const failingCommit = vi.fn().mockResolvedValue({
+      success: false,
+      error: "delete failed",
+    });
+    currentCommit = failingCommit;
+    const service = createService();
+
+    await expect(service.remove("txn-2" as TransactionId)).rejects.toThrow("delete failed");
+    expect(trackDeletedMock).not.toHaveBeenCalled();
+
+    currentCommit = null;
+    await service.remove("txn-3" as TransactionId);
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("tracks successful deletes and refreshes afterward", async () => {
+    currentCommit = vi.fn().mockResolvedValue({ success: true, didMutate: true });
+    const service = createService();
+
+    await service.remove("txn-4" as TransactionId);
+
+    expect(currentCommit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "transaction.delete",
+        transactionId: "txn-4",
+      })
+    );
+    expect(trackDeletedMock).toHaveBeenCalledOnce();
+    expect(refreshMock).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/mobile/__tests__/transactions/store.test.ts
+++ b/apps/mobile/__tests__/transactions/store.test.ts
@@ -7,6 +7,7 @@ import {
   softDeleteTransaction,
 } from "@/features/transactions/lib/repository";
 import { useTransactionStore } from "@/features/transactions/store";
+import type { AnyDb } from "@/shared/db";
 import { enqueueSync } from "@/shared/db/enqueue-sync";
 import type {
   CategoryId,
@@ -32,10 +33,9 @@ vi.mock("@/shared/db/enqueue-sync", () => ({
   enqueueSync: vi.fn(),
 }));
 
-// biome-ignore lint/suspicious/noExplicitAny: mock db needs flexible typing
 const mockDb = {
   transaction: vi.fn((fn: (tx: unknown) => unknown) => fn(mockDb)),
-} as any;
+} as unknown as AnyDb;
 const mockUserId = "user-1" as UserId;
 
 describe("useTransactionStore", () => {

--- a/apps/mobile/__tests__/transactions/store.test.ts
+++ b/apps/mobile/__tests__/transactions/store.test.ts
@@ -33,7 +33,9 @@ vi.mock("@/shared/db/enqueue-sync", () => ({
 }));
 
 // biome-ignore lint/suspicious/noExplicitAny: mock db needs flexible typing
-const mockDb = {} as any;
+const mockDb = {
+  transaction: vi.fn((fn: (tx: unknown) => unknown) => fn(mockDb)),
+} as any;
 const mockUserId = "user-1" as UserId;
 
 describe("useTransactionStore", () => {

--- a/apps/mobile/__tests__/transactions/store.test.ts
+++ b/apps/mobile/__tests__/transactions/store.test.ts
@@ -383,7 +383,9 @@ describe("useTransactionStore", () => {
       ],
     });
 
-    vi.mocked(softDeleteTransaction).mockRejectedValueOnce(new Error("db error"));
+    vi.mocked(softDeleteTransaction).mockImplementationOnce(() => {
+      throw new Error("db error");
+    });
     await expect(
       useTransactionStore.getState().removeTransaction("tx-1" as TransactionId)
     ).rejects.toThrow("db error");

--- a/apps/mobile/features/budget/store.ts
+++ b/apps/mobile/features/budget/store.ts
@@ -4,24 +4,17 @@ import { useNotificationStore } from "@/features/notifications";
 import { useSettingsStore } from "@/features/settings";
 import { CATEGORY_MAP, useTransactionStore } from "@/features/transactions";
 import type { AnyDb } from "@/shared/db";
-import { enqueueSync } from "@/shared/db";
 import { getCategoryLabel, useLocaleStore } from "@/shared/i18n";
 import {
   generateBudgetId,
-  generateSyncQueueId,
   toIsoDateTime,
   trackBudgetCreated,
 } from "@/shared/lib";
 import type { BudgetId, CategoryId, CopAmount, Month, UserId } from "@/shared/types/branded";
+import { createWriteThroughMutationModule, type WriteThroughMutationModule } from "@/shared/mutations";
 import type { BudgetAlert, BudgetProgress, BudgetSuggestion } from "./lib/derive";
 import { createBudgetMonitoringModule } from "./lib/monitoring";
 import { scheduleBudgetAlert } from "./lib/notifications";
-import {
-  copyBudgetsToMonth,
-  insertBudget,
-  softDeleteBudget,
-  updateBudgetAmount,
-} from "./lib/repository";
 import type { Budget } from "./schema";
 import { createBudgetSchema } from "./schema";
 
@@ -30,6 +23,7 @@ let dbRef: AnyDb | null = null;
 let userIdRef: UserId | null = null;
 let unsubscribeTxStore: (() => void) | null = null;
 let loadBudgetsRequestId = 0;
+let mutations: WriteThroughMutationModule | null = null;
 
 const formatMonth = (date: Date): Month => format(date, "yyyy-MM") as Month;
 
@@ -95,6 +89,7 @@ export const useBudgetStore = create<BudgetState & BudgetActions>((set, get) => 
   initStore: (db, userId) => {
     dbRef = db;
     userIdRef = userId;
+    mutations = createWriteThroughMutationModule(db);
     // Subscribe to transaction store changes to auto-refresh progress
     if (unsubscribeTxStore) unsubscribeTxStore();
     unsubscribeTxStore = useTransactionStore.subscribe(() => {
@@ -196,26 +191,25 @@ export const useBudgetStore = create<BudgetState & BudgetActions>((set, get) => 
       month: get().currentMonth,
     });
     if (!validation.success) return false;
+    const mutationModule = mutations;
+    if (!mutationModule) return false;
     const now = toIsoDateTime(new Date());
     const id = generateBudgetId();
     try {
-      insertBudget(dbRef, {
-        id,
-        userId: userIdRef,
-        categoryId,
-        amount,
-        month: get().currentMonth,
-        createdAt: now,
-        updatedAt: now,
-        deletedAt: null,
+      const result = await mutationModule.commit({
+        kind: "budget.save",
+        row: {
+          id,
+          userId: userIdRef,
+          categoryId,
+          amount,
+          month: get().currentMonth,
+          createdAt: now,
+          updatedAt: now,
+          deletedAt: null,
+        },
       });
-      enqueueSync(dbRef, {
-        id: generateSyncQueueId(),
-        tableName: "budgets",
-        rowId: id,
-        operation: "insert",
-        createdAt: now,
-      });
+      if (!result.success) return false;
     } catch {
       return false;
     }
@@ -226,16 +220,17 @@ export const useBudgetStore = create<BudgetState & BudgetActions>((set, get) => 
 
   updateBudget: async (id, amount) => {
     if (!dbRef) return;
+    const mutationModule = mutations;
+    if (!mutationModule) return;
     const now = toIsoDateTime(new Date());
     try {
-      updateBudgetAmount(dbRef, id, amount, now);
-      enqueueSync(dbRef, {
-        id: generateSyncQueueId(),
-        tableName: "budgets",
-        rowId: id,
-        operation: "update",
-        createdAt: now,
+      const result = await mutationModule.commit({
+        kind: "budget.update",
+        budgetId: id,
+        amount,
+        now,
       });
+      if (!result.success) return;
     } catch {
       return;
     }
@@ -244,16 +239,16 @@ export const useBudgetStore = create<BudgetState & BudgetActions>((set, get) => 
 
   deleteBudget: async (id) => {
     if (!dbRef) return;
+    const mutationModule = mutations;
+    if (!mutationModule) return;
     const now = toIsoDateTime(new Date());
     try {
-      softDeleteBudget(dbRef, id, now);
-      enqueueSync(dbRef, {
-        id: generateSyncQueueId(),
-        tableName: "budgets",
-        rowId: id,
-        operation: "delete",
-        createdAt: now,
+      const result = await mutationModule.commit({
+        kind: "budget.delete",
+        budgetId: id,
+        now,
       });
+      if (!result.success) return;
     } catch {
       return;
     }
@@ -264,23 +259,17 @@ export const useBudgetStore = create<BudgetState & BudgetActions>((set, get) => 
     if (!dbRef || !userIdRef) return;
     const userId = userIdRef;
     const now = toIsoDateTime(new Date());
+    const mutationModule = mutations;
+    if (!mutationModule) return;
     try {
-      dbRef.transaction((tx) => {
-        const db = tx as unknown as AnyDb;
-        const newIds = copyBudgetsToMonth(db, userId, get().currentMonth, targetMonth, now, () =>
-          generateBudgetId()
-        );
-        // Enqueue sync for each copied budget
-        newIds.forEach((newId) => {
-          enqueueSync(db, {
-            id: generateSyncQueueId(),
-            tableName: "budgets",
-            rowId: newId,
-            operation: "insert",
-            createdAt: now,
-          });
-        });
+      const result = await mutationModule.commit({
+        kind: "budget.copy",
+        sourceMonth: get().currentMonth,
+        targetMonth,
+        userId,
+        now,
       });
+      if (!result.success) return;
     } catch {
       return;
     }
@@ -296,30 +285,25 @@ export const useBudgetStore = create<BudgetState & BudgetActions>((set, get) => 
     const now = toIsoDateTime(new Date());
     const entries = Array.from(budgetsByCategory.entries());
     if (entries.length === 0) return;
+    const mutationModule = mutations;
+    if (!mutationModule) return;
     try {
-      dbRef.transaction((tx) => {
-        const db = tx as unknown as AnyDb;
-        entries.forEach(([categoryId, amount]) => {
-          const id = generateBudgetId();
-          insertBudget(db, {
-            id,
-            userId: userId,
+      const result = await mutationModule.commitBatch(
+        entries.map(([categoryId, amount]) => ({
+          kind: "budget.save",
+          row: {
+            id: generateBudgetId(),
+            userId,
             categoryId,
             amount,
             month: currentMonth,
             createdAt: now,
             updatedAt: now,
             deletedAt: null,
-          });
-          enqueueSync(db, {
-            id: generateSyncQueueId(),
-            tableName: "budgets",
-            rowId: id,
-            operation: "insert",
-            createdAt: now,
-          });
-        });
-      });
+          },
+        }))
+      );
+      if (result.some((item) => !item.success)) return;
     } catch {
       return;
     }

--- a/apps/mobile/features/budget/store.ts
+++ b/apps/mobile/features/budget/store.ts
@@ -5,13 +5,12 @@ import { useSettingsStore } from "@/features/settings";
 import { CATEGORY_MAP, useTransactionStore } from "@/features/transactions";
 import type { AnyDb } from "@/shared/db";
 import { getCategoryLabel, useLocaleStore } from "@/shared/i18n";
+import { generateBudgetId, toIsoDateTime, trackBudgetCreated } from "@/shared/lib";
 import {
-  generateBudgetId,
-  toIsoDateTime,
-  trackBudgetCreated,
-} from "@/shared/lib";
+  createWriteThroughMutationModule,
+  type WriteThroughMutationModule,
+} from "@/shared/mutations";
 import type { BudgetId, CategoryId, CopAmount, Month, UserId } from "@/shared/types/branded";
-import { createWriteThroughMutationModule, type WriteThroughMutationModule } from "@/shared/mutations";
 import type { BudgetAlert, BudgetProgress, BudgetSuggestion } from "./lib/derive";
 import { createBudgetMonitoringModule } from "./lib/monitoring";
 import { scheduleBudgetAlert } from "./lib/notifications";

--- a/apps/mobile/features/calendar/lib/bill-mutation-service.ts
+++ b/apps/mobile/features/calendar/lib/bill-mutation-service.ts
@@ -1,0 +1,268 @@
+import { toTransactionRow } from "@/features/transactions/lib/build-transaction";
+import type { StoredTransaction } from "@/features/transactions/schema";
+import {
+  generateBillId,
+  generateBillPaymentId,
+  generateTransactionId,
+  parseDigitsToAmount,
+  parseIsoDate,
+  toIsoDateTime,
+} from "@/shared/lib";
+import type { WriteThroughMutationModule } from "@/shared/mutations";
+import type {
+  BillId,
+  BillPaymentId,
+  CategoryId,
+  CopAmount,
+  IsoDate,
+  TransactionId,
+  UserId,
+} from "@/shared/types/branded";
+import {
+  type Bill,
+  type BillFrequency,
+  type BillPayment,
+  createBillSchema,
+  toBillRow,
+} from "../schema";
+import type { BillPaymentRow, BillRow } from "./repository";
+
+type AddBillInput = {
+  name: string;
+  amount: string;
+  frequency: BillFrequency;
+  categoryId: CategoryId;
+  startDate: Date;
+};
+
+type UpdateBillFields = Partial<
+  Pick<Bill, "name" | "amount" | "frequency" | "categoryId" | "startDate" | "isActive">
+>;
+
+type AddBillResult = { success: true; bill: Bill } | { success: false };
+type MarkBillPaidResult = { success: true; payment: BillPayment } | { success: false };
+type UnmarkBillPaidResult = { success: true } | { success: false };
+
+type CreateCalendarBillMutationServiceDeps = {
+  getCommit: () => WriteThroughMutationModule["commit"] | null;
+  getUserId: () => UserId | null;
+  requestNotificationPermissions: () => Promise<boolean>;
+  scheduleBillNotifications: (bill: Bill) => Promise<unknown> | unknown;
+  reportAsyncError: (error: unknown) => void;
+  addTransactionToCache: (transaction: StoredTransaction) => void;
+  removeTransactionFromCache: (transactionId: TransactionId) => void;
+  trackCreated: (input: { frequency: BillFrequency }) => void;
+  trackPaymentRecorded: () => void;
+  now?: () => Date;
+  createBillId?: () => BillId;
+  createPaymentId?: () => BillPaymentId;
+  createTransactionId?: () => TransactionId;
+};
+
+export type CalendarBillMutationService = {
+  addBill: (input: AddBillInput) => Promise<AddBillResult>;
+  updateBill: (id: BillId, fields: UpdateBillFields) => Promise<boolean>;
+  deleteBill: (id: BillId) => Promise<boolean>;
+  markBillPaid: (
+    bills: readonly Bill[],
+    billId: BillId,
+    dueDate: IsoDate
+  ) => Promise<MarkBillPaidResult>;
+  unmarkBillPaid: (
+    payments: readonly BillPayment[],
+    billId: BillId,
+    dueDate: IsoDate
+  ) => Promise<UnmarkBillPaidResult>;
+};
+
+function scheduleNotifications(deps: CreateCalendarBillMutationServiceDeps, bill: Bill) {
+  void deps
+    .requestNotificationPermissions()
+    .then((granted) => (granted ? deps.scheduleBillNotifications(bill) : undefined))
+    .catch(deps.reportAsyncError);
+}
+
+export function createCalendarBillMutationService(
+  deps: CreateCalendarBillMutationServiceDeps
+): CalendarBillMutationService {
+  const now = deps.now ?? (() => new Date());
+  const createBillId = deps.createBillId ?? generateBillId;
+  const createPaymentId = deps.createPaymentId ?? generateBillPaymentId;
+  const createTransactionId = deps.createTransactionId ?? generateTransactionId;
+
+  return {
+    addBill: async (input) => {
+      const userId = deps.getUserId();
+      const commit = deps.getCommit();
+      if (!userId || !commit) {
+        return { success: false };
+      }
+
+      const amountValue = parseDigitsToAmount(input.amount);
+      if (amountValue <= 0) {
+        return { success: false };
+      }
+
+      const parsed = createBillSchema.safeParse({
+        name: input.name,
+        amount: amountValue,
+        frequency: input.frequency,
+        categoryId: input.categoryId,
+        startDate: input.startDate,
+        isActive: true,
+      });
+      if (!parsed.success) {
+        return { success: false };
+      }
+
+      const bill: Bill = {
+        id: createBillId(),
+        ...parsed.data,
+      };
+
+      try {
+        const result = await commit({
+          kind: "calendar.bill.save",
+          row: toBillRow(bill, userId, toIsoDateTime(now())),
+        });
+        if (!result.success) {
+          return { success: false };
+        }
+      } catch {
+        return { success: false };
+      }
+
+      deps.trackCreated({ frequency: input.frequency });
+      scheduleNotifications(deps, bill);
+      return { success: true, bill };
+    },
+
+    updateBill: async (id, fields) => {
+      const commit = deps.getCommit();
+      if (!commit) {
+        return false;
+      }
+
+      const dbFields = Object.fromEntries(
+        Object.entries(fields)
+          .filter(([, value]) => value != null)
+          .map(([key, value]) => [
+            key,
+            key === "startDate" && value instanceof Date ? value.toISOString() : value,
+          ])
+      );
+
+      const result = await commit({
+        kind: "calendar.bill.update",
+        billId: id,
+        fields: dbFields as Partial<
+          Pick<BillRow, "name" | "amount" | "frequency" | "categoryId" | "startDate" | "isActive">
+        >,
+        now: toIsoDateTime(now()),
+      });
+
+      return result.success;
+    },
+
+    deleteBill: async (id) => {
+      const commit = deps.getCommit();
+      if (!commit) {
+        return false;
+      }
+
+      const result = await commit({
+        kind: "calendar.bill.delete",
+        billId: id,
+      });
+
+      return result.success;
+    },
+
+    markBillPaid: async (bills, billId, dueDate) => {
+      const userId = deps.getUserId();
+      const commit = deps.getCommit();
+      if (!userId || !commit) {
+        return { success: false };
+      }
+
+      const bill = bills.find((candidate) => candidate.id === billId);
+      if (!bill) {
+        return { success: false };
+      }
+
+      const timestamp = now();
+      const nowIso = toIsoDateTime(timestamp);
+      const transactionId = createTransactionId();
+      const transaction: StoredTransaction = {
+        id: transactionId,
+        userId,
+        type: "expense",
+        amount: bill.amount as CopAmount,
+        categoryId: bill.categoryId,
+        description: bill.name,
+        date: parseIsoDate(dueDate),
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        deletedAt: null,
+      };
+
+      const payment: BillPayment = {
+        id: createPaymentId(),
+        billId,
+        dueDate,
+        paidAt: nowIso,
+        transactionId,
+        createdAt: nowIso,
+      };
+
+      try {
+        const result = await commit({
+          kind: "calendar.bill.markPaid",
+          transactionRow: toTransactionRow(transaction),
+          paymentRow: payment as BillPaymentRow,
+        });
+        if (!result.success) {
+          return { success: false };
+        }
+      } catch {
+        return { success: false };
+      }
+
+      deps.addTransactionToCache(transaction);
+      deps.trackPaymentRecorded();
+      return { success: true, payment };
+    },
+
+    unmarkBillPaid: async (payments, billId, dueDate) => {
+      const commit = deps.getCommit();
+      if (!commit) {
+        return { success: false };
+      }
+
+      const payment = payments.find(
+        (candidate) => candidate.billId === billId && candidate.dueDate === dueDate
+      );
+
+      try {
+        const result = await commit({
+          kind: "calendar.bill.unmarkPaid",
+          billId,
+          dueDate,
+          transactionId: payment?.transactionId ?? null,
+          now: toIsoDateTime(now()),
+        });
+        if (!result.success) {
+          return { success: false };
+        }
+      } catch {
+        return { success: false };
+      }
+
+      if (payment?.transactionId) {
+        deps.removeTransactionFromCache(payment.transactionId);
+      }
+
+      return { success: true };
+    },
+  };
+}

--- a/apps/mobile/features/calendar/store.ts
+++ b/apps/mobile/features/calendar/store.ts
@@ -1,43 +1,17 @@
 import { addMonths, endOfMonth, startOfMonth, subMonths } from "date-fns";
 import { create } from "zustand";
-import {
-  type StoredTransaction,
-  toTransactionRow,
-  useTransactionStore,
-} from "@/features/transactions";
+import { useTransactionStore } from "@/features/transactions";
 import type { AnyDb } from "@/shared/db";
-import {
-  captureError,
-  generateBillId,
-  generateBillPaymentId,
-  generateTransactionId,
-  parseDigitsToAmount,
-  parseIsoDate,
-  toIsoDate,
-  toIsoDateTime,
-  trackBillCreated,
-  trackBillPaymentRecorded,
-} from "@/shared/lib";
+import { captureError, toIsoDate, trackBillCreated, trackBillPaymentRecorded } from "@/shared/lib";
 import {
   createWriteThroughMutationModule,
   type WriteThroughMutationModule,
 } from "@/shared/mutations";
-import type { BillId, CategoryId, CopAmount, IsoDate, UserId } from "@/shared/types/branded";
+import type { BillId, CategoryId, IsoDate, UserId } from "@/shared/types/branded";
+import { createCalendarBillMutationService } from "./lib/bill-mutation-service";
 import { requestNotificationPermissions, scheduleBillNotifications } from "./lib/notifications";
-import {
-  type BillPaymentRow,
-  type BillRow,
-  getAllBills,
-  getBillPaymentsForMonth,
-} from "./lib/repository";
-import {
-  type Bill,
-  type BillFrequency,
-  type BillPayment,
-  createBillSchema,
-  fromBillRow,
-  toBillRow,
-} from "./schema";
+import { getAllBills, getBillPaymentsForMonth } from "./lib/repository";
+import { type Bill, type BillFrequency, type BillPayment, fromBillRow } from "./schema";
 
 // Module-level refs: Zustand doesn't serialize DB connections, so we keep them outside the store.
 let dbRef: AnyDb | null = null;
@@ -75,216 +49,109 @@ type CalendarActions = {
   unmarkBillPaid: (billId: BillId, dueDate: IsoDate) => Promise<void>;
 };
 
-export const useCalendarStore = create<CalendarState & CalendarActions>((set, get) => ({
-  currentMonth: new Date(),
-  bills: [],
-  payments: [],
-  isLoading: false,
+export const useCalendarStore = create<CalendarState & CalendarActions>((set, get) => {
+  const billMutations = createCalendarBillMutationService({
+    getCommit: () => mutations?.commit ?? null,
+    getUserId: () => userIdRef,
+    requestNotificationPermissions,
+    scheduleBillNotifications,
+    reportAsyncError: captureError,
+    addTransactionToCache: (transaction) => useTransactionStore.getState().addToCache(transaction),
+    removeTransactionFromCache: (transactionId) =>
+      useTransactionStore.getState().removeFromCache(transactionId),
+    trackCreated: trackBillCreated,
+    trackPaymentRecorded: trackBillPaymentRecorded,
+  });
 
-  initStore: (db, userId) => {
-    dbRef = db;
-    userIdRef = userId;
-    mutations = createWriteThroughMutationModule(db);
-  },
+  return {
+    currentMonth: new Date(),
+    bills: [],
+    payments: [],
+    isLoading: false,
 
-  nextMonth: () => {
-    set((s) => ({ currentMonth: addMonths(s.currentMonth, 1) }));
-    get().loadPaymentsForMonth().catch(captureError);
-  },
+    initStore: (db, userId) => {
+      dbRef = db;
+      userIdRef = userId;
+      mutations = db ? createWriteThroughMutationModule(db) : null;
+    },
 
-  prevMonth: () => {
-    set((s) => ({ currentMonth: subMonths(s.currentMonth, 1) }));
-    get().loadPaymentsForMonth().catch(captureError);
-  },
+    nextMonth: () => {
+      set((s) => ({ currentMonth: addMonths(s.currentMonth, 1) }));
+      get().loadPaymentsForMonth().catch(captureError);
+    },
 
-  loadBills: async () => {
-    if (!dbRef || !userIdRef) return;
-    set({ isLoading: true });
-    try {
-      const rows = getAllBills(dbRef, userIdRef);
-      set({ bills: rows.map(fromBillRow), isLoading: false });
-    } catch (error) {
-      set({ isLoading: false });
-      throw error;
-    }
-  },
+    prevMonth: () => {
+      set((s) => ({ currentMonth: subMonths(s.currentMonth, 1) }));
+      get().loadPaymentsForMonth().catch(captureError);
+    },
 
-  loadPaymentsForMonth: async () => {
-    if (!dbRef) return;
-    const { currentMonth } = get();
-    const startIso = toIsoDate(startOfMonth(currentMonth));
-    const endIso = toIsoDate(endOfMonth(currentMonth));
-    const rows = getBillPaymentsForMonth(dbRef, startIso, endIso);
-    set({ payments: rows as BillPayment[] });
-  },
+    loadBills: async () => {
+      if (!dbRef || !userIdRef) return;
+      set({ isLoading: true });
+      try {
+        const rows = getAllBills(dbRef, userIdRef);
+        set({ bills: rows.map(fromBillRow), isLoading: false });
+      } catch (error) {
+        set({ isLoading: false });
+        throw error;
+      }
+    },
 
-  addBill: async (name, amount, frequency, category, startDate) => {
-    if (!dbRef || !userIdRef) return false;
+    loadPaymentsForMonth: async () => {
+      if (!dbRef) return;
+      const { currentMonth } = get();
+      const startIso = toIsoDate(startOfMonth(currentMonth));
+      const endIso = toIsoDate(endOfMonth(currentMonth));
+      const rows = getBillPaymentsForMonth(dbRef, startIso, endIso);
+      set({ payments: rows as BillPayment[] });
+    },
 
-    const amountValue = parseDigitsToAmount(amount);
-    if (amountValue <= 0) return false;
-
-    const result = createBillSchema.safeParse({
-      name,
-      amount: amountValue,
-      frequency,
-      categoryId: category,
-      startDate,
-      isActive: true,
-    });
-
-    if (!result.success) return false;
-
-    const newBill: Bill = {
-      id: generateBillId(),
-      ...result.data,
-    };
-
-    const mutationModule = mutations;
-    if (!mutationModule) return false;
-
-    try {
-      const result = await mutationModule.commit({
-        kind: "calendar.bill.save",
-        row: toBillRow(newBill, userIdRef, toIsoDateTime(new Date())),
+    addBill: async (name, amount, frequency, category, startDate) => {
+      const result = await billMutations.addBill({
+        name,
+        amount,
+        frequency,
+        categoryId: category,
+        startDate,
       });
       if (!result.success) return false;
-    } catch {
-      return false;
-    }
 
-    set((s) => ({
-      bills: [...s.bills, newBill],
-    }));
+      set((s) => ({
+        bills: [...s.bills, result.bill],
+      }));
 
-    trackBillCreated({ frequency });
+      return true;
+    },
 
-    // Schedule notifications (best-effort, don't block the add)
-    requestNotificationPermissions()
-      .then((granted) => (granted ? scheduleBillNotifications(newBill) : undefined))
-      .catch(captureError);
+    updateBill: async (id, fields) => {
+      const didUpdate = await billMutations.updateBill(id, fields);
+      if (!didUpdate) return;
+      set((s) => ({
+        bills: s.bills.map((b) => (b.id === id ? { ...b, ...fields } : b)),
+      }));
+    },
 
-    return true;
-  },
+    deleteBill: async (id) => {
+      const didDelete = await billMutations.deleteBill(id);
+      if (!didDelete) return;
+      set((s) => ({
+        bills: s.bills.filter((b) => b.id !== id),
+        payments: s.payments.filter((p) => p.billId !== id),
+      }));
+    },
 
-  updateBill: async (id, fields) => {
-    if (!dbRef) return;
-    const mutationModule = mutations;
-    if (!mutationModule) return;
-
-    const dbFields = Object.fromEntries(
-      Object.entries(fields)
-        .filter(([, v]) => v != null) // eslint-disable-line @typescript-eslint/no-unnecessary-condition -- Partial<> fields may be undefined at runtime
-        .map(([k, v]) => [k, k === "startDate" && v instanceof Date ? v.toISOString() : v])
-    );
-
-    const result = await mutationModule.commit({
-      kind: "calendar.bill.update",
-      billId: id,
-      fields: dbFields as Partial<
-        Pick<BillRow, "name" | "amount" | "frequency" | "categoryId" | "startDate" | "isActive">
-      >,
-      now: toIsoDateTime(new Date()),
-    });
-    if (!result.success) return;
-    set((s) => ({
-      bills: s.bills.map((b) => (b.id === id ? { ...b, ...fields } : b)),
-    }));
-  },
-
-  deleteBill: async (id) => {
-    if (!dbRef) return;
-    const mutationModule = mutations;
-    if (!mutationModule) return;
-    const result = await mutationModule.commit({
-      kind: "calendar.bill.delete",
-      billId: id,
-    });
-    if (!result.success) return;
-    set((s) => ({
-      bills: s.bills.filter((b) => b.id !== id),
-      payments: s.payments.filter((p) => p.billId !== id),
-    }));
-  },
-
-  markBillPaid: async (billId, dueDate) => {
-    if (!dbRef || !userIdRef) return;
-
-    const bill = get().bills.find((b) => b.id === billId);
-    if (!bill) return;
-
-    const now = new Date();
-    const nowIso = toIsoDateTime(now);
-
-    // Create an expense transaction for this bill payment
-    const txId = generateTransactionId();
-    const transaction: StoredTransaction = {
-      id: txId,
-      userId: userIdRef,
-      type: "expense",
-      amount: bill.amount as CopAmount,
-      categoryId: bill.categoryId,
-      description: bill.name,
-      date: parseIsoDate(dueDate),
-      createdAt: now,
-      updatedAt: now,
-      deletedAt: null,
-    };
-
-    const payment: BillPayment = {
-      id: generateBillPaymentId(),
-      billId,
-      dueDate,
-      paidAt: nowIso,
-      transactionId: txId,
-      createdAt: nowIso,
-    };
-
-    const mutationModule = mutations;
-    if (!mutationModule) return;
-
-    try {
-      const result = await mutationModule.commit({
-        kind: "calendar.bill.markPaid",
-        transactionRow: toTransactionRow(transaction),
-        paymentRow: payment as BillPaymentRow,
-      });
+    markBillPaid: async (billId, dueDate) => {
+      const result = await billMutations.markBillPaid(get().bills, billId, dueDate);
       if (!result.success) return;
+      set((s) => ({ payments: [...s.payments, result.payment] }));
+    },
 
-      set((s) => ({ payments: [...s.payments, payment] }));
-      useTransactionStore.getState().addToCache(transaction);
-    } catch {
-      return; // Transaction rolled back — state unchanged
-    }
-    trackBillPaymentRecorded();
-  },
-
-  unmarkBillPaid: async (billId, dueDate) => {
-    if (!dbRef) return;
-
-    const payment = get().payments.find((p) => p.billId === billId && p.dueDate === dueDate);
-    const mutationModule = mutations;
-    if (!mutationModule) return;
-    const nowIso = toIsoDateTime(new Date());
-
-    try {
-      const result = await mutationModule.commit({
-        kind: "calendar.bill.unmarkPaid",
-        billId,
-        dueDate,
-        transactionId: payment?.transactionId ?? null,
-        now: nowIso,
-      });
+    unmarkBillPaid: async (billId, dueDate) => {
+      const result = await billMutations.unmarkBillPaid(get().payments, billId, dueDate);
       if (!result.success) return;
-
-      if (payment?.transactionId) {
-        useTransactionStore.getState().removeFromCache(payment.transactionId);
-      }
       set((s) => ({
         payments: s.payments.filter((p) => !(p.billId === billId && p.dueDate === dueDate)),
       }));
-    } catch {
-      // DB operation failed — keep state unchanged
-    }
-  },
-}));
+    },
+  };
+});

--- a/apps/mobile/features/calendar/store.ts
+++ b/apps/mobile/features/calendar/store.ts
@@ -1,19 +1,11 @@
 import { addMonths, endOfMonth, startOfMonth, subMonths } from "date-fns";
 import { create } from "zustand";
-import {
-  insertTransaction,
-  type StoredTransaction,
-  softDeleteTransaction,
-  toTransactionRow,
-  useTransactionStore,
-} from "@/features/transactions";
+import { type StoredTransaction, toTransactionRow, useTransactionStore } from "@/features/transactions";
 import type { AnyDb } from "@/shared/db";
-import { enqueueSync } from "@/shared/db";
 import {
   captureError,
   generateBillId,
   generateBillPaymentId,
-  generateSyncQueueId,
   generateTransactionId,
   parseDigitsToAmount,
   parseIsoDate,
@@ -23,15 +15,13 @@ import {
   trackBillPaymentRecorded,
 } from "@/shared/lib";
 import type { BillId, CategoryId, CopAmount, IsoDate, UserId } from "@/shared/types/branded";
+import { createWriteThroughMutationModule, type WriteThroughMutationModule } from "@/shared/mutations";
 import { requestNotificationPermissions, scheduleBillNotifications } from "./lib/notifications";
 import {
-  deleteBill as dbDeleteBill,
-  deleteBillPayment as dbDeleteBillPayment,
-  updateBill as dbUpdateBill,
   getAllBills,
   getBillPaymentsForMonth,
-  insertBill,
-  insertBillPayment,
+  type BillPaymentRow,
+  type BillRow,
 } from "./lib/repository";
 import {
   type Bill,
@@ -45,6 +35,7 @@ import {
 // Module-level refs: Zustand doesn't serialize DB connections, so we keep them outside the store.
 let dbRef: AnyDb | null = null;
 let userIdRef: UserId | null = null;
+let mutations: WriteThroughMutationModule | null = null;
 
 type CalendarState = {
   currentMonth: Date;
@@ -86,6 +77,7 @@ export const useCalendarStore = create<CalendarState & CalendarActions>((set, ge
   initStore: (db, userId) => {
     dbRef = db;
     userIdRef = userId;
+    mutations = createWriteThroughMutationModule(db);
   },
 
   nextMonth: () => {
@@ -141,8 +133,15 @@ export const useCalendarStore = create<CalendarState & CalendarActions>((set, ge
       ...result.data,
     };
 
+    const mutationModule = mutations;
+    if (!mutationModule) return false;
+
     try {
-      insertBill(dbRef, toBillRow(newBill, userIdRef, toIsoDateTime(new Date())));
+      const result = await mutationModule.commit({
+        kind: "calendar.bill.save",
+        row: toBillRow(newBill, userIdRef, toIsoDateTime(new Date())),
+      });
+      if (!result.success) return false;
     } catch {
       return false;
     }
@@ -163,6 +162,8 @@ export const useCalendarStore = create<CalendarState & CalendarActions>((set, ge
 
   updateBill: async (id, fields) => {
     if (!dbRef) return;
+    const mutationModule = mutations;
+    if (!mutationModule) return;
 
     const dbFields = Object.fromEntries(
       Object.entries(fields)
@@ -170,7 +171,15 @@ export const useCalendarStore = create<CalendarState & CalendarActions>((set, ge
         .map(([k, v]) => [k, k === "startDate" && v instanceof Date ? v.toISOString() : v])
     );
 
-    dbUpdateBill(dbRef, id, dbFields, toIsoDateTime(new Date()));
+    const result = await mutationModule.commit({
+      kind: "calendar.bill.update",
+      billId: id,
+      fields: dbFields as Partial<
+        Pick<BillRow, "name" | "amount" | "frequency" | "categoryId" | "startDate" | "isActive">
+      >,
+      now: toIsoDateTime(new Date()),
+    });
+    if (!result.success) return;
     set((s) => ({
       bills: s.bills.map((b) => (b.id === id ? { ...b, ...fields } : b)),
     }));
@@ -178,7 +187,13 @@ export const useCalendarStore = create<CalendarState & CalendarActions>((set, ge
 
   deleteBill: async (id) => {
     if (!dbRef) return;
-    dbDeleteBill(dbRef, id);
+    const mutationModule = mutations;
+    if (!mutationModule) return;
+    const result = await mutationModule.commit({
+      kind: "calendar.bill.delete",
+      billId: id,
+    });
+    if (!result.success) return;
     set((s) => ({
       bills: s.bills.filter((b) => b.id !== id),
       payments: s.payments.filter((p) => p.billId !== id),
@@ -218,19 +233,16 @@ export const useCalendarStore = create<CalendarState & CalendarActions>((set, ge
       createdAt: nowIso,
     };
 
+    const mutationModule = mutations;
+    if (!mutationModule) return;
+
     try {
-      dbRef.transaction((tx) => {
-        const db = tx as unknown as AnyDb;
-        insertTransaction(db, toTransactionRow(transaction));
-        enqueueSync(db, {
-          id: generateSyncQueueId(),
-          tableName: "transactions",
-          rowId: txId,
-          operation: "insert",
-          createdAt: nowIso,
-        });
-        insertBillPayment(db, payment);
+      const result = await mutationModule.commit({
+        kind: "calendar.bill.markPaid",
+        transactionRow: toTransactionRow(transaction),
+        paymentRow: payment as BillPaymentRow,
       });
+      if (!result.success) return;
 
       set((s) => ({ payments: [...s.payments, payment] }));
       useTransactionStore.getState().addToCache(transaction);
@@ -244,23 +256,19 @@ export const useCalendarStore = create<CalendarState & CalendarActions>((set, ge
     if (!dbRef) return;
 
     const payment = get().payments.find((p) => p.billId === billId && p.dueDate === dueDate);
+    const mutationModule = mutations;
+    if (!mutationModule) return;
     const nowIso = toIsoDateTime(new Date());
 
     try {
-      dbRef.transaction((tx) => {
-        const db = tx as unknown as AnyDb;
-        if (payment?.transactionId) {
-          softDeleteTransaction(db, payment.transactionId, nowIso);
-          enqueueSync(db, {
-            id: generateSyncQueueId(),
-            tableName: "transactions",
-            rowId: payment.transactionId,
-            operation: "delete",
-            createdAt: nowIso,
-          });
-        }
-        dbDeleteBillPayment(db, billId, dueDate);
+      const result = await mutationModule.commit({
+        kind: "calendar.bill.unmarkPaid",
+        billId,
+        dueDate,
+        transactionId: payment?.transactionId ?? null,
+        now: nowIso,
       });
+      if (!result.success) return;
 
       if (payment?.transactionId) {
         useTransactionStore.getState().removeFromCache(payment.transactionId);

--- a/apps/mobile/features/calendar/store.ts
+++ b/apps/mobile/features/calendar/store.ts
@@ -1,6 +1,10 @@
 import { addMonths, endOfMonth, startOfMonth, subMonths } from "date-fns";
 import { create } from "zustand";
-import { type StoredTransaction, toTransactionRow, useTransactionStore } from "@/features/transactions";
+import {
+  type StoredTransaction,
+  toTransactionRow,
+  useTransactionStore,
+} from "@/features/transactions";
 import type { AnyDb } from "@/shared/db";
 import {
   captureError,
@@ -14,14 +18,17 @@ import {
   trackBillCreated,
   trackBillPaymentRecorded,
 } from "@/shared/lib";
+import {
+  createWriteThroughMutationModule,
+  type WriteThroughMutationModule,
+} from "@/shared/mutations";
 import type { BillId, CategoryId, CopAmount, IsoDate, UserId } from "@/shared/types/branded";
-import { createWriteThroughMutationModule, type WriteThroughMutationModule } from "@/shared/mutations";
 import { requestNotificationPermissions, scheduleBillNotifications } from "./lib/notifications";
 import {
-  getAllBills,
-  getBillPaymentsForMonth,
   type BillPaymentRow,
   type BillRow,
+  getAllBills,
+  getBillPaymentsForMonth,
 } from "./lib/repository";
 import {
   type Bill,

--- a/apps/mobile/features/categories/store.ts
+++ b/apps/mobile/features/categories/store.ts
@@ -1,8 +1,8 @@
 import { create } from "zustand";
 import type { AnyDb } from "@/shared/db";
-import { enqueueSync } from "@/shared/db";
-import { generateSyncQueueId, generateUserCategoryId, toIsoDateTime } from "@/shared/lib";
+import { generateUserCategoryId, toIsoDateTime } from "@/shared/lib";
 import type { UserId } from "@/shared/types/branded";
+import { createWriteThroughMutationModule, type WriteThroughMutationModule } from "@/shared/mutations";
 import { MAX_NAME_LENGTH, MIN_NAME_LENGTH } from "./lib/constants";
 import { ICON_MAP } from "./lib/icon-map";
 import {
@@ -12,11 +12,12 @@ import {
   createCategoryRegistrySnapshot,
   isCategoryIdValid,
 } from "./lib/registry";
-import { getUserCategoriesForUser, insertUserCategory } from "./lib/repository";
+import { getUserCategoriesForUser } from "./lib/repository";
 
 // Module-level refs: Zustand doesn't serialize DB connections, so we keep them outside the store.
 let dbRef: AnyDb | null = null;
 let userIdRef: UserId | null = null;
+let mutations: WriteThroughMutationModule | null = null;
 
 const HEX_COLOR_REGEX = /^#[0-9A-Fa-f]{6}$/;
 
@@ -47,6 +48,7 @@ export const useCategoriesStore = create<CategoriesState & CategoriesActions>((s
   initStore: (db, userId) => {
     dbRef = db;
     userIdRef = userId;
+    mutations = createWriteThroughMutationModule(db);
   },
 
   refresh: async () => {
@@ -74,10 +76,13 @@ export const useCategoriesStore = create<CategoriesState & CategoriesActions>((s
 
     const now = toIsoDateTime(new Date());
     const id = generateUserCategoryId();
+    const mutationModule = mutations;
+    if (!mutationModule) return false;
 
     try {
-      db.transaction((tx) => {
-        insertUserCategory(tx as AnyDb, {
+      const result = await mutationModule.commit({
+        kind: "category.save",
+        row: {
           id,
           userId,
           name: trimmedName,
@@ -86,16 +91,9 @@ export const useCategoriesStore = create<CategoriesState & CategoriesActions>((s
           createdAt: now,
           updatedAt: now,
           deletedAt: null,
-        });
-
-        enqueueSync(tx as AnyDb, {
-          id: generateSyncQueueId(),
-          tableName: "userCategories",
-          rowId: id,
-          operation: "insert",
-          createdAt: now,
-        });
+        },
       });
+      if (!result.success) return false;
     } catch {
       return false;
     }

--- a/apps/mobile/features/categories/store.ts
+++ b/apps/mobile/features/categories/store.ts
@@ -1,8 +1,11 @@
 import { create } from "zustand";
 import type { AnyDb } from "@/shared/db";
 import { generateUserCategoryId, toIsoDateTime } from "@/shared/lib";
+import {
+  createWriteThroughMutationModule,
+  type WriteThroughMutationModule,
+} from "@/shared/mutations";
 import type { UserId } from "@/shared/types/branded";
-import { createWriteThroughMutationModule, type WriteThroughMutationModule } from "@/shared/mutations";
 import { MAX_NAME_LENGTH, MIN_NAME_LENGTH } from "./lib/constants";
 import { ICON_MAP } from "./lib/icon-map";
 import {

--- a/apps/mobile/features/goals/store.ts
+++ b/apps/mobile/features/goals/store.ts
@@ -10,8 +10,11 @@ import {
   trackGoalCreated,
   trackGoalMilestoneReached,
 } from "@/shared/lib";
+import {
+  createWriteThroughMutationModule,
+  type WriteThroughMutationModule,
+} from "@/shared/mutations";
 import type { UserId } from "@/shared/types/branded";
-import { createWriteThroughMutationModule, type WriteThroughMutationModule } from "@/shared/mutations";
 
 // Import from goals feature
 import type {

--- a/apps/mobile/features/goals/store.ts
+++ b/apps/mobile/features/goals/store.ts
@@ -2,17 +2,16 @@ import { create } from "zustand";
 import { scheduleLocalPush, useNotificationStore } from "@/features/notifications";
 import { getMonthlyTotalsByType, useTransactionStore } from "@/features/transactions";
 import type { AnyDb } from "@/shared/db";
-import { enqueueSync } from "@/shared/db";
 import { i18n } from "@/shared/i18n";
 import {
   generateId,
-  generateSyncQueueId,
   toIsoDateTime,
   trackGoalContributionAdded,
   trackGoalCreated,
   trackGoalMilestoneReached,
 } from "@/shared/lib";
 import type { UserId } from "@/shared/types/branded";
+import { createWriteThroughMutationModule, type WriteThroughMutationModule } from "@/shared/mutations";
 
 // Import from goals feature
 import type {
@@ -33,11 +32,6 @@ import {
   getContributionsForGoal,
   getGoalCurrentAmount,
   getGoalsForUser,
-  insertContribution,
-  insertGoal,
-  softDeleteContribution,
-  softDeleteGoal,
-  updateGoal,
 } from "./lib/repository";
 import type { Goal, GoalContribution } from "./schema";
 import { addContributionSchema, createGoalSchema } from "./schema";
@@ -46,6 +40,7 @@ import { addContributionSchema, createGoalSchema } from "./schema";
 let dbRef: AnyDb | null = null;
 let userIdRef: string | null = null;
 let unsubscribeTxStore: (() => void) | null = null;
+let mutations: WriteThroughMutationModule | null = null;
 
 export type GoalWithProgress = {
   readonly goal: Goal;
@@ -108,6 +103,7 @@ export const useGoalStore = create<GoalState & GoalActions>((set, get) => ({
   initStore: (db, userId) => {
     dbRef = db;
     userIdRef = userId;
+    mutations = createWriteThroughMutationModule(db);
     // Subscribe to transaction store changes to auto-refresh projections
     if (unsubscribeTxStore) unsubscribeTxStore();
     unsubscribeTxStore = useTransactionStore.subscribe(() => {
@@ -192,30 +188,29 @@ export const useGoalStore = create<GoalState & GoalActions>((set, get) => ({
     if (!dbRef || !userIdRef) return false;
     const validation = createGoalSchema.safeParse(input);
     if (!validation.success) return false;
+    const mutationModule = mutations;
+    if (!mutationModule) return false;
     const now = toIsoDateTime(new Date());
     const id = generateId("gl");
     try {
-      insertGoal(dbRef, {
-        id,
-        userId: userIdRef,
-        name: input.name,
-        type: input.type,
-        targetAmount: input.targetAmount,
-        targetDate: input.targetDate ?? null,
-        interestRatePercent: input.interestRatePercent ?? null,
-        iconName: input.iconName ?? null,
-        colorHex: input.colorHex ?? null,
-        createdAt: now,
-        updatedAt: now,
-        deletedAt: null,
+      const result = await mutationModule.commit({
+        kind: "goal.save",
+        row: {
+          id,
+          userId: userIdRef,
+          name: input.name,
+          type: input.type,
+          targetAmount: input.targetAmount,
+          targetDate: input.targetDate ?? null,
+          interestRatePercent: input.interestRatePercent ?? null,
+          iconName: input.iconName ?? null,
+          colorHex: input.colorHex ?? null,
+          createdAt: now,
+          updatedAt: now,
+          deletedAt: null,
+        },
       });
-      enqueueSync(dbRef, {
-        id: generateSyncQueueId(),
-        tableName: "goals",
-        rowId: id,
-        operation: "insert",
-        createdAt: now,
-      });
+      if (!result.success) return false;
     } catch {
       return false;
     }
@@ -226,16 +221,17 @@ export const useGoalStore = create<GoalState & GoalActions>((set, get) => ({
 
   updateGoal: async (id, data) => {
     if (!dbRef) return;
+    const mutationModule = mutations;
+    if (!mutationModule) return;
     const now = toIsoDateTime(new Date());
     try {
-      updateGoal(dbRef, id, data, now);
-      enqueueSync(dbRef, {
-        id: generateSyncQueueId(),
-        tableName: "goals",
-        rowId: id,
-        operation: "update",
-        createdAt: now,
+      const result = await mutationModule.commit({
+        kind: "goal.update",
+        goalId: id,
+        data,
+        now,
       });
+      if (!result.success) return;
     } catch {
       return;
     }
@@ -244,16 +240,16 @@ export const useGoalStore = create<GoalState & GoalActions>((set, get) => ({
 
   deleteGoal: async (id) => {
     if (!dbRef) return;
+    const mutationModule = mutations;
+    if (!mutationModule) return;
     const now = toIsoDateTime(new Date());
     try {
-      softDeleteGoal(dbRef, id, now);
-      enqueueSync(dbRef, {
-        id: generateSyncQueueId(),
-        tableName: "goals",
-        rowId: id,
-        operation: "delete",
-        createdAt: now,
+      const result = await mutationModule.commit({
+        kind: "goal.delete",
+        goalId: id,
+        now,
       });
+      if (!result.success) return;
     } catch {
       return;
     }
@@ -267,27 +263,26 @@ export const useGoalStore = create<GoalState & GoalActions>((set, get) => ({
     if (!dbRef || !userIdRef) return false;
     const validation = addContributionSchema.safeParse(input);
     if (!validation.success) return false;
+    const mutationModule = mutations;
+    if (!mutationModule) return false;
     const now = toIsoDateTime(new Date());
     const id = generateId("gc");
     try {
-      insertContribution(dbRef, {
-        id,
-        goalId: input.goalId,
-        userId: userIdRef,
-        amount: input.amount,
-        note: input.note ?? null,
-        date: input.date,
-        createdAt: now,
-        updatedAt: now,
-        deletedAt: null,
+      const result = await mutationModule.commit({
+        kind: "goalContribution.save",
+        row: {
+          id,
+          goalId: input.goalId,
+          userId: userIdRef,
+          amount: input.amount,
+          note: input.note ?? null,
+          date: input.date,
+          createdAt: now,
+          updatedAt: now,
+          deletedAt: null,
+        },
       });
-      enqueueSync(dbRef, {
-        id: generateSyncQueueId(),
-        tableName: "goalContributions",
-        rowId: id,
-        operation: "insert",
-        createdAt: now,
-      });
+      if (!result.success) return false;
     } catch {
       return false;
     }
@@ -341,16 +336,16 @@ export const useGoalStore = create<GoalState & GoalActions>((set, get) => ({
 
   deleteContribution: async (id) => {
     if (!dbRef) return;
+    const mutationModule = mutations;
+    if (!mutationModule) return;
     const now = toIsoDateTime(new Date());
     try {
-      softDeleteContribution(dbRef, id, now);
-      enqueueSync(dbRef, {
-        id: generateSyncQueueId(),
-        tableName: "goalContributions",
-        rowId: id,
-        operation: "delete",
-        createdAt: now,
+      const result = await mutationModule.commit({
+        kind: "goalContribution.delete",
+        contributionId: id,
+        now,
       });
+      if (!result.success) return;
     } catch {
       return;
     }

--- a/apps/mobile/features/notifications/store.ts
+++ b/apps/mobile/features/notifications/store.ts
@@ -50,6 +50,7 @@ export const useNotificationStore = create<NotificationState & NotificationActio
     dbRef = db;
     userIdRef = userId;
     mutations = createWriteThroughMutationModule(db);
+    const requestedUserId = userId;
 
     let lastVisitedAt: IsoDateTime | null = null;
     try {
@@ -59,6 +60,7 @@ export const useNotificationStore = create<NotificationState & NotificationActio
       // SecureStore may fail in tests — default to null
     }
 
+    if (userIdRef !== requestedUserId) return;
     const newCount = countNotificationsSince(db, userId, lastVisitedAt);
     set({ newCount });
   },
@@ -78,29 +80,32 @@ export const useNotificationStore = create<NotificationState & NotificationActio
     if (!dbRef || !userIdRef) return;
     const mutationModule = mutations;
     if (!mutationModule) return;
+    const requestedUserId = userIdRef;
     const now = toIsoDateTime(new Date());
     const id = generateNotificationId();
-    void mutationModule.commit({
-      kind: "notification.insert",
-      row: {
-        id,
-        userId: userIdRef,
-        type: input.type,
-        dedupKey: input.dedupKey,
-        categoryId: input.categoryId,
-        goalId: input.goalId,
-        titleKey: input.titleKey,
-        messageKey: input.messageKey,
-        params: input.params,
-        createdAt: now,
-        updatedAt: now,
-        deletedAt: null,
-      },
-    }).then((result) => {
-      if (result.success && result.didMutate) {
-        set({ newCount: get().newCount + 1 });
-      }
-    });
+    void mutationModule
+      .commit({
+        kind: "notification.insert",
+        row: {
+          id,
+          userId: requestedUserId,
+          type: input.type,
+          dedupKey: input.dedupKey,
+          categoryId: input.categoryId,
+          goalId: input.goalId,
+          titleKey: input.titleKey,
+          messageKey: input.messageKey,
+          params: input.params,
+          createdAt: now,
+          updatedAt: now,
+          deletedAt: null,
+        },
+      })
+      .then((result) => {
+        if (result.success && result.didMutate && userIdRef === requestedUserId) {
+          set((state) => ({ newCount: state.newCount + 1 }));
+        }
+      });
   },
 
   markVisited: () => {
@@ -114,15 +119,18 @@ export const useNotificationStore = create<NotificationState & NotificationActio
     if (!dbRef || !userIdRef) return;
     const mutationModule = mutations;
     if (!mutationModule) return;
+    const requestedUserId = userIdRef;
     const now = toIsoDateTime(new Date());
-    void mutationModule.commit({
-      kind: "notification.clearAll",
-      userId: userIdRef,
-      now,
-    }).then((result) => {
-      if (result.success) {
-        set({ notifications: [], newCount: 0 });
-      }
-    });
+    void mutationModule
+      .commit({
+        kind: "notification.clearAll",
+        userId: requestedUserId,
+        now,
+      })
+      .then((result) => {
+        if (result.success && userIdRef === requestedUserId) {
+          set({ notifications: [], newCount: 0 });
+        }
+      });
   },
 }));

--- a/apps/mobile/features/notifications/store.ts
+++ b/apps/mobile/features/notifications/store.ts
@@ -41,7 +41,7 @@ type NotificationActions = {
   clearAll: () => void;
 };
 
-export const useNotificationStore = create<NotificationState & NotificationActions>((set, get) => ({
+export const useNotificationStore = create<NotificationState & NotificationActions>((set, _get) => ({
   notifications: [],
   newCount: 0,
   isLoading: false,

--- a/apps/mobile/features/notifications/store.ts
+++ b/apps/mobile/features/notifications/store.ts
@@ -2,13 +2,13 @@ import * as SecureStore from "expo-secure-store";
 import { create } from "zustand";
 import type { AnyDb } from "@/shared/db";
 import { generateNotificationId, toIsoDateTime } from "@/shared/lib";
-import type { CategoryId, IsoDateTime, UserId } from "@/shared/types/branded";
-import { createWriteThroughMutationModule, type WriteThroughMutationModule } from "@/shared/mutations";
-import type { NotificationType, StoredNotification } from "./lib/types";
 import {
-  countNotificationsSince,
-  getNotifications,
-} from "./repository";
+  createWriteThroughMutationModule,
+  type WriteThroughMutationModule,
+} from "@/shared/mutations";
+import type { CategoryId, IsoDateTime, UserId } from "@/shared/types/branded";
+import type { NotificationType, StoredNotification } from "./lib/types";
+import { countNotificationsSince, getNotifications } from "./repository";
 
 const lastVisitedKey = (userId: UserId) => `notification_last_visited_${userId}`;
 

--- a/apps/mobile/features/notifications/store.ts
+++ b/apps/mobile/features/notifications/store.ts
@@ -1,16 +1,13 @@
 import * as SecureStore from "expo-secure-store";
 import { create } from "zustand";
 import type { AnyDb } from "@/shared/db";
-import { enqueueSync } from "@/shared/db";
-import { generateNotificationId, generateSyncQueueId, toIsoDateTime } from "@/shared/lib";
+import { generateNotificationId, toIsoDateTime } from "@/shared/lib";
 import type { CategoryId, IsoDateTime, UserId } from "@/shared/types/branded";
+import { createWriteThroughMutationModule, type WriteThroughMutationModule } from "@/shared/mutations";
 import type { NotificationType, StoredNotification } from "./lib/types";
 import {
   countNotificationsSince,
-  getAllNotificationIds,
   getNotifications,
-  insertNotification as insertNotificationRow,
-  softDeleteAllNotifications,
 } from "./repository";
 
 const lastVisitedKey = (userId: UserId) => `notification_last_visited_${userId}`;
@@ -18,6 +15,7 @@ const lastVisitedKey = (userId: UserId) => `notification_last_visited_${userId}`
 // Module-level refs: Zustand doesn't serialize DB connections, so we keep them outside the store.
 let dbRef: AnyDb | null = null;
 let userIdRef: UserId | null = null;
+let mutations: WriteThroughMutationModule | null = null;
 
 type InsertNotificationInput = {
   readonly type: NotificationType;
@@ -51,6 +49,7 @@ export const useNotificationStore = create<NotificationState & NotificationActio
   initStore: async (db, userId) => {
     dbRef = db;
     userIdRef = userId;
+    mutations = createWriteThroughMutationModule(db);
 
     let lastVisitedAt: IsoDateTime | null = null;
     try {
@@ -77,10 +76,13 @@ export const useNotificationStore = create<NotificationState & NotificationActio
 
   insertNotification: (input) => {
     if (!dbRef || !userIdRef) return;
+    const mutationModule = mutations;
+    if (!mutationModule) return;
     const now = toIsoDateTime(new Date());
     const id = generateNotificationId();
-    try {
-      const result = insertNotificationRow(dbRef, {
+    void mutationModule.commit({
+      kind: "notification.insert",
+      row: {
         id,
         userId: userIdRef,
         type: input.type,
@@ -93,19 +95,12 @@ export const useNotificationStore = create<NotificationState & NotificationActio
         createdAt: now,
         updatedAt: now,
         deletedAt: null,
-      });
-      if (result.changes === 0) return;
-      enqueueSync(dbRef, {
-        id: generateSyncQueueId(),
-        tableName: "notifications",
-        rowId: id,
-        operation: "insert",
-        createdAt: now,
-      });
-    } catch {
-      return;
-    }
-    set({ newCount: get().newCount + 1 });
+      },
+    }).then((result) => {
+      if (result.success && result.didMutate) {
+        set({ newCount: get().newCount + 1 });
+      }
+    });
   },
 
   markVisited: () => {
@@ -117,23 +112,17 @@ export const useNotificationStore = create<NotificationState & NotificationActio
 
   clearAll: () => {
     if (!dbRef || !userIdRef) return;
-    const db = dbRef;
+    const mutationModule = mutations;
+    if (!mutationModule) return;
     const now = toIsoDateTime(new Date());
-    try {
-      const allIds = getAllNotificationIds(db, userIdRef);
-      softDeleteAllNotifications(db, userIdRef, now);
-      allIds.forEach((id) => {
-        enqueueSync(db, {
-          id: generateSyncQueueId(),
-          tableName: "notifications",
-          rowId: id,
-          operation: "delete",
-          createdAt: now,
-        });
-      });
-    } catch {
-      return;
-    }
-    set({ notifications: [], newCount: 0 });
+    void mutationModule.commit({
+      kind: "notification.clearAll",
+      userId: userIdRef,
+      now,
+    }).then((result) => {
+      if (result.success) {
+        set({ notifications: [], newCount: 0 });
+      }
+    });
   },
 }));

--- a/apps/mobile/features/notifications/store.ts
+++ b/apps/mobile/features/notifications/store.ts
@@ -41,96 +41,98 @@ type NotificationActions = {
   clearAll: () => void;
 };
 
-export const useNotificationStore = create<NotificationState & NotificationActions>((set, _get) => ({
-  notifications: [],
-  newCount: 0,
-  isLoading: false,
+export const useNotificationStore = create<NotificationState & NotificationActions>(
+  (set, _get) => ({
+    notifications: [],
+    newCount: 0,
+    isLoading: false,
 
-  initStore: async (db, userId) => {
-    dbRef = db;
-    userIdRef = userId;
-    mutations = createWriteThroughMutationModule(db);
-    const requestedUserId = userId;
+    initStore: async (db, userId) => {
+      dbRef = db;
+      userIdRef = userId;
+      mutations = createWriteThroughMutationModule(db);
+      const requestedUserId = userId;
 
-    let lastVisitedAt: IsoDateTime | null = null;
-    try {
-      const stored = await SecureStore.getItemAsync(lastVisitedKey(userId));
-      lastVisitedAt = stored ? (stored as IsoDateTime) : null;
-    } catch {
-      // SecureStore may fail in tests — default to null
-    }
+      let lastVisitedAt: IsoDateTime | null = null;
+      try {
+        const stored = await SecureStore.getItemAsync(lastVisitedKey(userId));
+        lastVisitedAt = stored ? (stored as IsoDateTime) : null;
+      } catch {
+        // SecureStore may fail in tests — default to null
+      }
 
-    if (userIdRef !== requestedUserId) return;
-    const newCount = countNotificationsSince(db, userId, lastVisitedAt);
-    set({ newCount });
-  },
+      if (userIdRef !== requestedUserId) return;
+      const newCount = countNotificationsSince(db, userId, lastVisitedAt);
+      set({ newCount });
+    },
 
-  loadNotifications: () => {
-    if (!dbRef || !userIdRef) return;
-    set({ isLoading: true });
-    try {
-      const rows = getNotifications(dbRef, userIdRef);
-      set({ notifications: rows as readonly StoredNotification[], isLoading: false });
-    } catch {
-      set({ isLoading: false });
-    }
-  },
+    loadNotifications: () => {
+      if (!dbRef || !userIdRef) return;
+      set({ isLoading: true });
+      try {
+        const rows = getNotifications(dbRef, userIdRef);
+        set({ notifications: rows as readonly StoredNotification[], isLoading: false });
+      } catch {
+        set({ isLoading: false });
+      }
+    },
 
-  insertNotification: (input) => {
-    if (!dbRef || !userIdRef) return;
-    const mutationModule = mutations;
-    if (!mutationModule) return;
-    const requestedUserId = userIdRef;
-    const now = toIsoDateTime(new Date());
-    const id = generateNotificationId();
-    void mutationModule
-      .commit({
-        kind: "notification.insert",
-        row: {
-          id,
+    insertNotification: (input) => {
+      if (!dbRef || !userIdRef) return;
+      const mutationModule = mutations;
+      if (!mutationModule) return;
+      const requestedUserId = userIdRef;
+      const now = toIsoDateTime(new Date());
+      const id = generateNotificationId();
+      void mutationModule
+        .commit({
+          kind: "notification.insert",
+          row: {
+            id,
+            userId: requestedUserId,
+            type: input.type,
+            dedupKey: input.dedupKey,
+            categoryId: input.categoryId,
+            goalId: input.goalId,
+            titleKey: input.titleKey,
+            messageKey: input.messageKey,
+            params: input.params,
+            createdAt: now,
+            updatedAt: now,
+            deletedAt: null,
+          },
+        })
+        .then((result) => {
+          if (result.success && result.didMutate && userIdRef === requestedUserId) {
+            set((state) => ({ newCount: state.newCount + 1 }));
+          }
+        });
+    },
+
+    markVisited: () => {
+      const now = toIsoDateTime(new Date());
+      if (!userIdRef) return;
+      SecureStore.setItemAsync(lastVisitedKey(userIdRef), now).catch(() => {});
+      set({ newCount: 0 });
+    },
+
+    clearAll: () => {
+      if (!dbRef || !userIdRef) return;
+      const mutationModule = mutations;
+      if (!mutationModule) return;
+      const requestedUserId = userIdRef;
+      const now = toIsoDateTime(new Date());
+      void mutationModule
+        .commit({
+          kind: "notification.clearAll",
           userId: requestedUserId,
-          type: input.type,
-          dedupKey: input.dedupKey,
-          categoryId: input.categoryId,
-          goalId: input.goalId,
-          titleKey: input.titleKey,
-          messageKey: input.messageKey,
-          params: input.params,
-          createdAt: now,
-          updatedAt: now,
-          deletedAt: null,
-        },
-      })
-      .then((result) => {
-        if (result.success && result.didMutate && userIdRef === requestedUserId) {
-          set((state) => ({ newCount: state.newCount + 1 }));
-        }
-      });
-  },
-
-  markVisited: () => {
-    const now = toIsoDateTime(new Date());
-    if (!userIdRef) return;
-    SecureStore.setItemAsync(lastVisitedKey(userIdRef), now).catch(() => {});
-    set({ newCount: 0 });
-  },
-
-  clearAll: () => {
-    if (!dbRef || !userIdRef) return;
-    const mutationModule = mutations;
-    if (!mutationModule) return;
-    const requestedUserId = userIdRef;
-    const now = toIsoDateTime(new Date());
-    void mutationModule
-      .commit({
-        kind: "notification.clearAll",
-        userId: requestedUserId,
-        now,
-      })
-      .then((result) => {
-        if (result.success && userIdRef === requestedUserId) {
-          set({ notifications: [], newCount: 0 });
-        }
-      });
-  },
-}));
+          now,
+        })
+        .then((result) => {
+          if (result.success && userIdRef === requestedUserId) {
+            set({ notifications: [], newCount: 0 });
+          }
+        });
+    },
+  })
+);

--- a/apps/mobile/features/transactions/lib/mutation-service.ts
+++ b/apps/mobile/features/transactions/lib/mutation-service.ts
@@ -1,0 +1,168 @@
+import { generateTransactionId, toIsoDateTime } from "@/shared/lib";
+import type { WriteThroughMutationModule } from "@/shared/mutations";
+import type { CategoryId, TransactionId, UserId } from "@/shared/types/branded";
+import type { StoredTransaction, TransactionType } from "../schema";
+import { buildTransaction, toTransactionRow } from "./build-transaction";
+
+export type TransactionFormInput = {
+  type: TransactionType;
+  digits: string;
+  categoryId: CategoryId | null;
+  description: string;
+  date: Date;
+};
+
+export type TransactionMutationResult =
+  | { success: true; transaction: StoredTransaction }
+  | { success: false; error: string };
+
+type CreateTransactionMutationServiceDeps = {
+  getCommit: () => WriteThroughMutationModule["commit"] | null;
+  getUserId: () => UserId | null;
+  refresh: () => Promise<void>;
+  resetForm: () => void;
+  trackDeleted: () => void;
+  trackEdited: (input: { category: string }) => void;
+  now?: () => Date;
+  createId?: () => TransactionId;
+};
+
+export type TransactionMutationService = {
+  save: (input: TransactionFormInput) => Promise<TransactionMutationResult>;
+  update: (id: TransactionId, input: TransactionFormInput) => Promise<TransactionMutationResult>;
+  updateDirect: (
+    id: TransactionId,
+    input: TransactionFormInput
+  ) => Promise<TransactionMutationResult>;
+  remove: (id: TransactionId) => Promise<void>;
+};
+
+const fail = (error: string): TransactionMutationResult => ({ success: false, error });
+
+async function commitTransaction(
+  commit: WriteThroughMutationModule["commit"] | null,
+  mode: "insert" | "update",
+  transaction: StoredTransaction,
+  message: string
+) {
+  if (!commit) {
+    return fail("Store not initialized");
+  }
+
+  try {
+    const result = await commit({
+      kind: "transaction.save",
+      mode,
+      row: toTransactionRow(transaction),
+    });
+
+    return result.success ? result : fail(message);
+  } catch {
+    return fail(message);
+  }
+}
+
+function buildMutationTransaction(
+  input: TransactionFormInput,
+  userId: UserId | null,
+  id: TransactionId,
+  now: Date
+) {
+  if (!userId) {
+    return fail("Store not initialized");
+  }
+
+  const result = buildTransaction(input, userId, id, now);
+  return result.success ? result : fail(result.error);
+}
+
+export function createTransactionMutationService(
+  deps: CreateTransactionMutationServiceDeps
+): TransactionMutationService {
+  const now = deps.now ?? (() => new Date());
+  const createId = deps.createId ?? generateTransactionId;
+
+  return {
+    save: async (input) => {
+      const built = buildMutationTransaction(input, deps.getUserId(), createId(), now());
+      if (!built.success) {
+        return built;
+      }
+
+      const committed = await commitTransaction(
+        deps.getCommit(),
+        "insert",
+        built.transaction,
+        "Failed to save transaction"
+      );
+      if (!committed.success) {
+        return committed;
+      }
+
+      await deps.refresh();
+      return { success: true, transaction: built.transaction };
+    },
+
+    update: async (id, input) => {
+      const built = buildMutationTransaction(input, deps.getUserId(), id, now());
+      if (!built.success) {
+        return built;
+      }
+
+      const committed = await commitTransaction(
+        deps.getCommit(),
+        "update",
+        built.transaction,
+        "Failed to update transaction"
+      );
+      if (!committed.success) {
+        return committed;
+      }
+
+      deps.trackEdited({ category: String(built.transaction.categoryId) });
+      deps.resetForm();
+      await deps.refresh();
+      return { success: true, transaction: built.transaction };
+    },
+
+    updateDirect: async (id, input) => {
+      const built = buildMutationTransaction(input, deps.getUserId(), id, now());
+      if (!built.success) {
+        return built;
+      }
+
+      const committed = await commitTransaction(
+        deps.getCommit(),
+        "update",
+        built.transaction,
+        "Failed to update transaction"
+      );
+      if (!committed.success) {
+        return committed;
+      }
+
+      deps.trackEdited({ category: String(built.transaction.categoryId) });
+      await deps.refresh();
+      return { success: true, transaction: built.transaction };
+    },
+
+    remove: async (id) => {
+      const commit = deps.getCommit();
+      if (commit) {
+        const result = await commit({
+          kind: "transaction.delete",
+          transactionId: id,
+          now: toIsoDateTime(now()),
+        });
+
+        if (!result.success) {
+          throw new Error(result.error);
+        }
+
+        deps.trackDeleted();
+      }
+
+      await deps.refresh();
+    },
+  };
+}

--- a/apps/mobile/features/transactions/store.ts
+++ b/apps/mobile/features/transactions/store.ts
@@ -3,7 +3,6 @@ import type { AnyDb } from "@/shared/db";
 import {
   generateTransactionId,
   toIsoDate,
-  toIsoDateTime,
   toMonth,
   trackTransactionDeleted,
   trackTransactionEdited,
@@ -13,7 +12,8 @@ import {
   type WriteThroughMutationModule,
 } from "@/shared/mutations";
 import type { CategoryId, CopAmount, IsoDate, TransactionId, UserId } from "@/shared/types/branded";
-import { buildTransaction, toStoredTransaction, toTransactionRow } from "./lib/build-transaction";
+import { toStoredTransaction } from "./lib/build-transaction";
+import { createTransactionMutationService } from "./lib/mutation-service";
 import {
   getDailySpendingAggregate,
   getSpendingByCategoryAggregate,
@@ -116,290 +116,180 @@ const INITIAL_FORM: Pick<
   description: "",
 };
 
-export const useTransactionStore = create<TransactionState & TransactionActions>((set, get) => ({
-  ...INITIAL_FORM,
-  date: new Date(),
-  pages: [],
-  offset: 0,
-  hasMore: true,
-  balance: 0,
-  categorySpending: [],
-  dailySpending: [],
-  editingId: null,
+function toTransactionFormInput(
+  state: Pick<TransactionState, "type" | "digits" | "categoryId" | "description" | "date">
+) {
+  return {
+    type: state.type,
+    digits: state.digits,
+    categoryId: state.categoryId,
+    description: state.description,
+    date: state.date,
+  };
+}
 
-  initStore: (db, userId) => {
-    dbRef = db;
-    userIdRef = userId;
-    mutations = createWriteThroughMutationModule(db);
-  },
+export const useTransactionStore = create<TransactionState & TransactionActions>((set, get) => {
+  const mutationService = createTransactionMutationService({
+    getCommit: () => mutations?.commit ?? null,
+    getUserId: () => userIdRef,
+    refresh: () => get().refresh(),
+    resetForm: () => get().resetForm(),
+    trackDeleted: trackTransactionDeleted,
+    trackEdited: trackTransactionEdited,
+    createId: generateTransactionId,
+  });
 
-  setStep: (step) => set({ step }),
-  setType: (type) => set({ type }),
-  setDigits: (digits) => set({ digits }),
-  setCategoryId: (categoryId) => set({ categoryId }),
-  setDescription: (description) => set({ description }),
-  setDate: (date) => set({ date }),
+  return {
+    ...INITIAL_FORM,
+    date: new Date(),
+    pages: [],
+    offset: 0,
+    hasMore: true,
+    balance: 0,
+    categorySpending: [],
+    dailySpending: [],
+    editingId: null,
 
-  loadInitialPage: async () => {
-    if (!dbRef || !userIdRef) return;
-    try {
-      const rows = getTransactionsPaginated(dbRef, userIdRef, PAGE_SIZE, 0);
-      const hasMore = rows.length > PAGE_SIZE;
-      const pageData = hasMore ? rows.slice(0, PAGE_SIZE) : rows;
-      set({
-        pages: pageData.map(toStoredTransaction),
-        offset: pageData.length,
-        hasMore,
-      });
-      get().loadAggregates();
-    } catch {
-      // DB read failed — keep existing state
-    }
-  },
+    initStore: (db, userId) => {
+      dbRef = db;
+      userIdRef = userId;
+      mutations = db ? createWriteThroughMutationModule(db) : null;
+    },
 
-  loadNextPage: async () => {
-    if (!dbRef || !userIdRef) return;
-    const { hasMore, offset } = get();
-    if (!hasMore) return;
+    setStep: (step) => set({ step }),
+    setType: (type) => set({ type }),
+    setDigits: (digits) => set({ digits }),
+    setCategoryId: (categoryId) => set({ categoryId }),
+    setDescription: (description) => set({ description }),
+    setDate: (date) => set({ date }),
 
-    try {
-      const rows = getTransactionsPaginated(dbRef, userIdRef, PAGE_SIZE, offset);
-      const moreAvailable = rows.length > PAGE_SIZE;
-      const pageData = moreAvailable ? rows.slice(0, PAGE_SIZE) : rows;
-      set((s) => ({
-        pages: [...s.pages, ...pageData.map(toStoredTransaction)],
-        offset: s.offset + pageData.length,
-        hasMore: moreAvailable,
-      }));
-    } catch {
-      // DB read failed — keep existing state
-    }
-  },
-
-  loadAggregates: () => {
-    if (!dbRef || !userIdRef) return;
-    try {
-      const now = new Date();
-      const currentMonth = toMonth(now);
-      const thirtyDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30);
-      const startDate = toIsoDate(thirtyDaysAgo);
-      const endDate = toIsoDate(now);
-
-      const categorySpending = getSpendingByCategoryAggregate(dbRef, userIdRef, currentMonth);
-      const balance = categorySpending.reduce((sum, c) => sum + c.total, 0) as CopAmount;
-      const dailySpending = getDailySpendingAggregate(dbRef, userIdRef, startDate, endDate);
-
-      set({ balance, categorySpending, dailySpending });
-    } catch {
-      // Aggregate query failed — keep existing state
-    }
-  },
-
-  refresh: async () => {
-    if (!dbRef || !userIdRef) return;
-    try {
-      const currentOffset = get().offset;
-      const reloadSize = Math.max(currentOffset, PAGE_SIZE);
-      const rows = getTransactionsPaginated(dbRef, userIdRef, reloadSize, 0);
-      const hasMore = rows.length > reloadSize;
-      const pageData = hasMore ? rows.slice(0, reloadSize) : rows;
-
-      // Skip pages update if data hasn't changed — avoids FlatList re-layout
-      const currentPages = get().pages;
-      const currentKey = currentPages.map((p) => `${p.id}:${p.updatedAt.getTime()}`).join(",");
-      const newKey = pageData.map((r) => `${r.id}:${new Date(r.updatedAt).getTime()}`).join(",");
-      const sameData = currentKey === newKey;
-
-      if (!sameData) {
+    loadInitialPage: async () => {
+      if (!dbRef || !userIdRef) return;
+      try {
+        const rows = getTransactionsPaginated(dbRef, userIdRef, PAGE_SIZE, 0);
+        const hasMore = rows.length > PAGE_SIZE;
+        const pageData = hasMore ? rows.slice(0, PAGE_SIZE) : rows;
         set({
           pages: pageData.map(toStoredTransaction),
           offset: pageData.length,
           hasMore,
         });
+        get().loadAggregates();
+      } catch {
+        // DB read failed — keep existing state
       }
-      get().loadAggregates();
-    } catch {
-      // Refresh failed — keep existing state
-    }
-  },
+    },
 
-  saveTransaction: async () => {
-    if (!dbRef || !userIdRef) {
-      return { success: false as const, error: "Store not initialized" };
-    }
+    loadNextPage: async () => {
+      if (!dbRef || !userIdRef) return;
+      const { hasMore, offset } = get();
+      if (!hasMore) return;
 
-    const { type, digits, categoryId, description, date } = get();
-    const id = generateTransactionId();
-    const now = new Date();
+      try {
+        const rows = getTransactionsPaginated(dbRef, userIdRef, PAGE_SIZE, offset);
+        const moreAvailable = rows.length > PAGE_SIZE;
+        const pageData = moreAvailable ? rows.slice(0, PAGE_SIZE) : rows;
+        set((s) => ({
+          pages: [...s.pages, ...pageData.map(toStoredTransaction)],
+          offset: s.offset + pageData.length,
+          hasMore: moreAvailable,
+        }));
+      } catch {
+        // DB read failed — keep existing state
+      }
+    },
 
-    const result = buildTransaction(
-      { type, digits, categoryId, description, date },
-      userIdRef,
-      id,
-      now
-    );
-    if (!result.success) {
-      return { success: false as const, error: result.error };
-    }
+    loadAggregates: () => {
+      if (!dbRef || !userIdRef) return;
+      try {
+        const now = new Date();
+        const currentMonth = toMonth(now);
+        const thirtyDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30);
+        const startDate = toIsoDate(thirtyDaysAgo);
+        const endDate = toIsoDate(now);
 
-    const { transaction } = result;
+        const categorySpending = getSpendingByCategoryAggregate(dbRef, userIdRef, currentMonth);
+        const balance = categorySpending.reduce((sum, c) => sum + c.total, 0) as CopAmount;
+        const dailySpending = getDailySpendingAggregate(dbRef, userIdRef, startDate, endDate);
 
-    const mutationModule = mutations;
-    if (!mutationModule) {
-      return { success: false as const, error: "Store not initialized" };
-    }
+        set({ balance, categorySpending, dailySpending });
+      } catch {
+        // Aggregate query failed — keep existing state
+      }
+    },
 
-    try {
-      const mutationResult = await mutationModule.commit({
-        kind: "transaction.save",
-        mode: "insert",
-        row: toTransactionRow(transaction),
+    refresh: async () => {
+      if (!dbRef || !userIdRef) return;
+      try {
+        const currentOffset = get().offset;
+        const reloadSize = Math.max(currentOffset, PAGE_SIZE);
+        const rows = getTransactionsPaginated(dbRef, userIdRef, reloadSize, 0);
+        const hasMore = rows.length > reloadSize;
+        const pageData = hasMore ? rows.slice(0, reloadSize) : rows;
+
+        // Skip pages update if data hasn't changed — avoids FlatList re-layout
+        const currentPages = get().pages;
+        const currentKey = currentPages.map((p) => `${p.id}:${p.updatedAt.getTime()}`).join(",");
+        const newKey = pageData.map((r) => `${r.id}:${new Date(r.updatedAt).getTime()}`).join(",");
+        const sameData = currentKey === newKey;
+
+        if (!sameData) {
+          set({
+            pages: pageData.map(toStoredTransaction),
+            offset: pageData.length,
+            hasMore,
+          });
+        }
+        get().loadAggregates();
+      } catch {
+        // Refresh failed — keep existing state
+      }
+    },
+
+    saveTransaction: async () => mutationService.save(toTransactionFormInput(get())),
+
+    removeTransaction: async (id) => {
+      await mutationService.remove(id);
+    },
+
+    editTransaction: (id) => {
+      if (!dbRef) return;
+      const row = getTransactionById(dbRef, id);
+      if (!row) return;
+      const tx = toStoredTransaction(row);
+      set({
+        editingId: id,
+        type: tx.type,
+        digits: String(tx.amount),
+        categoryId: tx.categoryId,
+        description: tx.description,
+        date: tx.date,
       });
-      if (!mutationResult.success) {
-        return { success: false as const, error: "Failed to save transaction" };
-      }
-    } catch {
-      return { success: false as const, error: "Failed to save transaction" };
-    }
+    },
 
-    await get().refresh();
+    updateTransaction: async (id) => mutationService.update(id, toTransactionFormInput(get())),
 
-    return { success: true as const, transaction };
-  },
+    updateTransactionDirect: async (id, fields) => mutationService.updateDirect(id, fields),
 
-  removeTransaction: async (id) => {
-    const mutationModule = mutations;
-    if (dbRef && mutationModule) {
-      const now = new Date();
-      const result = await mutationModule.commit({
-        kind: "transaction.delete",
-        transactionId: id,
-        now: toIsoDateTime(now),
-      });
-      if (!result.success) {
-        throw new Error(result.error);
-      }
-      trackTransactionDeleted();
-    }
-    await get().refresh();
-  },
+    deleteTransaction: async (id) => {
+      await get().removeTransaction(id);
+    },
 
-  editTransaction: (id) => {
-    if (!dbRef) return;
-    const row = getTransactionById(dbRef, id);
-    if (!row) return;
-    const tx = toStoredTransaction(row);
-    set({
-      editingId: id,
-      type: tx.type,
-      digits: String(tx.amount),
-      categoryId: tx.categoryId,
-      description: tx.description,
-      date: tx.date,
-    });
-  },
+    addToCache: (tx) => set((s) => ({ pages: [tx, ...s.pages], offset: s.offset + 1 })),
 
-  updateTransaction: async (id) => {
-    if (!dbRef || !userIdRef) {
-      return { success: false as const, error: "Store not initialized" };
-    }
+    removeFromCache: (id) =>
+      set((s) => {
+        const filtered = s.pages.filter((t) => t.id !== id);
+        const removed = filtered.length < s.pages.length;
+        return { pages: filtered, offset: removed ? Math.max(0, s.offset - 1) : s.offset };
+      }),
 
-    const { type, digits, categoryId, description, date } = get();
-    const now = new Date();
+    resetForm: () => set({ ...INITIAL_FORM, date: new Date(), editingId: null }),
 
-    const result = buildTransaction(
-      { type, digits, categoryId, description, date },
-      userIdRef,
-      id,
-      now
-    );
-    if (!result.success) {
-      return { success: false as const, error: result.error };
-    }
-
-    const { transaction } = result;
-
-    const mutationModule = mutations;
-    if (!mutationModule) {
-      return { success: false as const, error: "Store not initialized" };
-    }
-
-    try {
-      const mutationResult = await mutationModule.commit({
-        kind: "transaction.save",
-        mode: "update",
-        row: toTransactionRow(transaction),
-      });
-      if (!mutationResult.success) {
-        return { success: false as const, error: "Failed to update transaction" };
-      }
-    } catch {
-      return { success: false as const, error: "Failed to update transaction" };
-    }
-
-    trackTransactionEdited({ category: String(transaction.categoryId) });
-    get().resetForm();
-    await get().refresh();
-
-    return { success: true as const, transaction };
-  },
-
-  updateTransactionDirect: async (id, fields) => {
-    if (!dbRef || !userIdRef) {
-      return { success: false as const, error: "Store not initialized" };
-    }
-
-    const now = new Date();
-
-    const result = buildTransaction(fields, userIdRef, id, now);
-    if (!result.success) {
-      return { success: false as const, error: result.error };
-    }
-
-    const { transaction } = result;
-
-    const mutationModule = mutations;
-    if (!mutationModule) {
-      return { success: false as const, error: "Store not initialized" };
-    }
-
-    try {
-      const mutationResult = await mutationModule.commit({
-        kind: "transaction.save",
-        mode: "update",
-        row: toTransactionRow(transaction),
-      });
-      if (!mutationResult.success) {
-        return { success: false as const, error: "Failed to update transaction" };
-      }
-    } catch {
-      return { success: false as const, error: "Failed to update transaction" };
-    }
-
-    trackTransactionEdited({ category: String(transaction.categoryId) });
-    await get().refresh();
-
-    return { success: true as const, transaction };
-  },
-
-  deleteTransaction: async (id) => {
-    await get().removeTransaction(id);
-  },
-
-  addToCache: (tx) => set((s) => ({ pages: [tx, ...s.pages], offset: s.offset + 1 })),
-
-  removeFromCache: (id) =>
-    set((s) => {
-      const filtered = s.pages.filter((t) => t.id !== id);
-      const removed = filtered.length < s.pages.length;
-      return { pages: filtered, offset: removed ? Math.max(0, s.offset - 1) : s.offset };
-    }),
-
-  resetForm: () => set({ ...INITIAL_FORM, date: new Date(), editingId: null }),
-
-  getTransactionById: (id) => {
-    if (!dbRef) return null;
-    const row = getTransactionById(dbRef, id);
-    return row ? toStoredTransaction(row) : null;
-  },
-}));
+    getTransactionById: (id) => {
+      if (!dbRef) return null;
+      const row = getTransactionById(dbRef, id);
+      return row ? toStoredTransaction(row) : null;
+    },
+  };
+});

--- a/apps/mobile/features/transactions/store.ts
+++ b/apps/mobile/features/transactions/store.ts
@@ -1,8 +1,6 @@
 import { create } from "zustand";
 import type { AnyDb } from "@/shared/db";
-import { enqueueSync } from "@/shared/db";
 import {
-  generateSyncQueueId,
   generateTransactionId,
   toIsoDate,
   toIsoDateTime,
@@ -11,15 +9,13 @@ import {
   trackTransactionEdited,
 } from "@/shared/lib";
 import type { CategoryId, CopAmount, IsoDate, TransactionId, UserId } from "@/shared/types/branded";
+import { createWriteThroughMutationModule, type WriteThroughMutationModule } from "@/shared/mutations";
 import { buildTransaction, toStoredTransaction, toTransactionRow } from "./lib/build-transaction";
 import {
   getDailySpendingAggregate,
   getSpendingByCategoryAggregate,
   getTransactionById,
   getTransactionsPaginated,
-  insertTransaction,
-  softDeleteTransaction,
-  upsertTransaction,
 } from "./lib/repository";
 import type { StoredTransaction, TransactionType } from "./schema";
 
@@ -30,6 +26,7 @@ const PAGE_SIZE = 30;
 // Module-level refs: Zustand doesn't serialize DB connections, so we keep them outside the store.
 let dbRef: AnyDb | null = null;
 let userIdRef: UserId | null = null;
+let mutations: WriteThroughMutationModule | null = null;
 
 type CategorySpendingItem = {
   readonly categoryId: CategoryId;
@@ -130,6 +127,7 @@ export const useTransactionStore = create<TransactionState & TransactionActions>
   initStore: (db, userId) => {
     dbRef = db;
     userIdRef = userId;
+    mutations = createWriteThroughMutationModule(db);
   },
 
   setStep: (step) => set({ step }),
@@ -243,16 +241,20 @@ export const useTransactionStore = create<TransactionState & TransactionActions>
 
     const { transaction } = result;
 
-    try {
-      await insertTransaction(dbRef, toTransactionRow(transaction));
+    const mutationModule = mutations;
+    if (!mutationModule) {
+      return { success: false as const, error: "Store not initialized" };
+    }
 
-      await enqueueSync(dbRef, {
-        id: generateSyncQueueId(),
-        tableName: "transactions",
-        rowId: transaction.id,
-        operation: "insert",
-        createdAt: toIsoDateTime(now),
+    try {
+      const mutationResult = await mutationModule.commit({
+        kind: "transaction.save",
+        mode: "insert",
+        row: toTransactionRow(transaction),
       });
+      if (!mutationResult.success) {
+        return { success: false as const, error: "Failed to save transaction" };
+      }
     } catch {
       return { success: false as const, error: "Failed to save transaction" };
     }
@@ -263,16 +265,17 @@ export const useTransactionStore = create<TransactionState & TransactionActions>
   },
 
   removeTransaction: async (id) => {
-    if (dbRef) {
-      const now = toIsoDateTime(new Date());
-      await softDeleteTransaction(dbRef, id, now);
-      await enqueueSync(dbRef, {
-        id: generateSyncQueueId(),
-        tableName: "transactions",
-        rowId: id,
-        operation: "delete",
-        createdAt: now,
+    const mutationModule = mutations;
+    if (dbRef && mutationModule) {
+      const now = new Date();
+      const result = await mutationModule.commit({
+        kind: "transaction.delete",
+        transactionId: id,
+        now: toIsoDateTime(now),
       });
+      if (!result.success) {
+        throw new Error(result.error);
+      }
       trackTransactionDeleted();
     }
     await get().refresh();
@@ -313,16 +316,20 @@ export const useTransactionStore = create<TransactionState & TransactionActions>
 
     const { transaction } = result;
 
-    try {
-      upsertTransaction(dbRef, toTransactionRow(transaction));
+    const mutationModule = mutations;
+    if (!mutationModule) {
+      return { success: false as const, error: "Store not initialized" };
+    }
 
-      await enqueueSync(dbRef, {
-        id: generateSyncQueueId(),
-        tableName: "transactions",
-        rowId: id,
-        operation: "update",
-        createdAt: toIsoDateTime(now),
+    try {
+      const mutationResult = await mutationModule.commit({
+        kind: "transaction.save",
+        mode: "update",
+        row: toTransactionRow(transaction),
       });
+      if (!mutationResult.success) {
+        return { success: false as const, error: "Failed to update transaction" };
+      }
     } catch {
       return { success: false as const, error: "Failed to update transaction" };
     }
@@ -348,16 +355,20 @@ export const useTransactionStore = create<TransactionState & TransactionActions>
 
     const { transaction } = result;
 
-    try {
-      upsertTransaction(dbRef, toTransactionRow(transaction));
+    const mutationModule = mutations;
+    if (!mutationModule) {
+      return { success: false as const, error: "Store not initialized" };
+    }
 
-      await enqueueSync(dbRef, {
-        id: generateSyncQueueId(),
-        tableName: "transactions",
-        rowId: id,
-        operation: "update",
-        createdAt: toIsoDateTime(now),
+    try {
+      const mutationResult = await mutationModule.commit({
+        kind: "transaction.save",
+        mode: "update",
+        row: toTransactionRow(transaction),
       });
+      if (!mutationResult.success) {
+        return { success: false as const, error: "Failed to update transaction" };
+      }
     } catch {
       return { success: false as const, error: "Failed to update transaction" };
     }

--- a/apps/mobile/features/transactions/store.ts
+++ b/apps/mobile/features/transactions/store.ts
@@ -8,8 +8,11 @@ import {
   trackTransactionDeleted,
   trackTransactionEdited,
 } from "@/shared/lib";
+import {
+  createWriteThroughMutationModule,
+  type WriteThroughMutationModule,
+} from "@/shared/mutations";
 import type { CategoryId, CopAmount, IsoDate, TransactionId, UserId } from "@/shared/types/branded";
-import { createWriteThroughMutationModule, type WriteThroughMutationModule } from "@/shared/mutations";
 import { buildTransaction, toStoredTransaction, toTransactionRow } from "./lib/build-transaction";
 import {
   getDailySpendingAggregate,

--- a/apps/mobile/shared/mutations/index.ts
+++ b/apps/mobile/shared/mutations/index.ts
@@ -1,0 +1,7 @@
+export {
+  getMutationPolicy,
+  type MutationCommand,
+  type MutationOutcome,
+  type WriteThroughMutationModule,
+  createWriteThroughMutationModule,
+} from "./write-through";

--- a/apps/mobile/shared/mutations/index.ts
+++ b/apps/mobile/shared/mutations/index.ts
@@ -1,7 +1,7 @@
 export {
+  createWriteThroughMutationModule,
   getMutationPolicy,
   type MutationCommand,
   type MutationOutcome,
   type WriteThroughMutationModule,
-  createWriteThroughMutationModule,
 } from "./write-through";

--- a/apps/mobile/shared/mutations/write-through.ts
+++ b/apps/mobile/shared/mutations/write-through.ts
@@ -502,7 +502,7 @@ export function createWriteThroughMutationModule(db: AnyDb): WriteThroughMutatio
   return {
     commit: async (command) => {
       try {
-        const result = applyCommand(db, command);
+        const result = db.transaction((tx) => applyCommand(tx as AnyDb, command));
         await runEffects(result.effects);
         return { success: true as const, didMutate: result.didMutate };
       } catch (error) {

--- a/apps/mobile/shared/mutations/write-through.ts
+++ b/apps/mobile/shared/mutations/write-through.ts
@@ -1,15 +1,10 @@
-import type { AnyDb, SyncOperation, SyncTableName } from "@/shared/db";
-import { enqueueSync } from "@/shared/db/enqueue-sync";
-import { generateBudgetId, generateSyncQueueId } from "@/shared/lib";
-import type {
-  BillId,
-  BudgetId,
-  IsoDate,
-  IsoDateTime,
-  Month,
-  TransactionId,
-  UserId,
-} from "@/shared/types/branded";
+import {
+  type BudgetRow,
+  copyBudgetsToMonth,
+  insertBudget,
+  softDeleteBudget,
+  updateBudgetAmount,
+} from "@/features/budget/lib/repository";
 import {
   type BillPaymentRow,
   type BillRow,
@@ -19,13 +14,7 @@ import {
   insertBillPayment,
   updateBill,
 } from "@/features/calendar/lib/repository";
-import {
-  type BudgetRow,
-  copyBudgetsToMonth,
-  insertBudget,
-  softDeleteBudget,
-  updateBudgetAmount,
-} from "@/features/budget/lib/repository";
+import { insertUserCategory, type UserCategoryRow } from "@/features/categories/lib/repository";
 import {
   type GoalContributionRow,
   type GoalRow,
@@ -36,23 +25,36 @@ import {
   updateGoal,
 } from "@/features/goals/lib/repository";
 import {
-  type NotificationRow,
   getAllNotificationIds,
   insertNotification,
+  type NotificationRow,
   softDeleteAllNotifications,
 } from "@/features/notifications/repository";
-import { type UserCategoryRow, insertUserCategory } from "@/features/categories/lib/repository";
 import {
-  type TransactionRow,
   insertTransaction,
   softDeleteTransaction,
+  type TransactionRow,
   upsertTransaction,
 } from "@/features/transactions/lib/repository";
-import type { CopAmount } from "@/shared/types/branded";
+import type { AnyDb, SyncOperation, SyncTableName } from "@/shared/db";
+import { enqueueSync } from "@/shared/db/enqueue-sync";
+import { generateBudgetId, generateSyncQueueId } from "@/shared/lib";
+import type {
+  BillId,
+  BudgetId,
+  CopAmount,
+  IsoDate,
+  IsoDateTime,
+  Month,
+  TransactionId,
+  UserId,
+} from "@/shared/types/branded";
 
 type MutationEffect = () => void | Promise<void>;
 
-export type MutationOutcome = { success: true; didMutate: boolean } | { success: false; error: string };
+export type MutationOutcome =
+  | { success: true; didMutate: boolean }
+  | { success: false; error: string };
 
 type TransactionSaveCommand = {
   kind: "transaction.save";
@@ -77,7 +79,12 @@ type GoalSaveCommand = {
 type GoalUpdateCommand = {
   kind: "goal.update";
   goalId: string;
-  data: Partial<Pick<GoalRow, "name" | "targetAmount" | "targetDate" | "interestRatePercent" | "iconName" | "colorHex">>;
+  data: Partial<
+    Pick<
+      GoalRow,
+      "name" | "targetAmount" | "targetDate" | "interestRatePercent" | "iconName" | "colorHex"
+    >
+  >;
   now: IsoDateTime;
   afterCommit?: readonly MutationEffect[];
 };
@@ -160,7 +167,9 @@ type CalendarBillSaveCommand = {
 type CalendarBillUpdateCommand = {
   kind: "calendar.bill.update";
   billId: BillId;
-  fields: Partial<Pick<BillRow, "name" | "amount" | "frequency" | "categoryId" | "startDate" | "isActive">>;
+  fields: Partial<
+    Pick<BillRow, "name" | "amount" | "frequency" | "categoryId" | "startDate" | "isActive">
+  >;
   now: IsoDateTime;
   afterCommit?: readonly MutationEffect[];
 };
@@ -262,13 +271,10 @@ function toSyncEntry(
 }
 
 async function runEffects(effects: readonly MutationEffect[]) {
-  await effects.reduce(
-    async (previous, effect) => {
-      await previous;
-      await effect();
-    },
-    Promise.resolve()
-  );
+  await effects.reduce(async (previous, effect) => {
+    await previous;
+    await effect();
+  }, Promise.resolve());
 }
 
 function applyTransactionSave(db: AnyDb, command: TransactionSaveCommand): CommandEffectResult {
@@ -280,7 +286,12 @@ function applyTransactionSave(db: AnyDb, command: TransactionSaveCommand): Comma
 
   enqueueSync(
     db,
-    toSyncEntry("transactions", command.row.id, command.mode === "insert" ? "insert" : "update", command.row.updatedAt)
+    toSyncEntry(
+      "transactions",
+      command.row.id,
+      command.mode === "insert" ? "insert" : "update",
+      command.row.updatedAt
+    )
   );
 
   return { didMutate: true, effects: command.afterCommit ?? [] };
@@ -320,12 +331,7 @@ function applyGoalContributionSave(
   insertContribution(db, command.row);
   enqueueSync(
     db,
-    toSyncEntry(
-      "goalContributions",
-      command.row.id,
-      "insert",
-      command.row.updatedAt as IsoDateTime
-    )
+    toSyncEntry("goalContributions", command.row.id, "insert", command.row.updatedAt as IsoDateTime)
   );
   return { didMutate: true, effects: command.afterCommit ?? [] };
 }
@@ -433,7 +439,12 @@ function applyCalendarBillMarkPaid(
   insertTransaction(db, command.transactionRow);
   enqueueSync(
     db,
-    toSyncEntry("transactions", command.transactionRow.id, "insert", command.transactionRow.updatedAt)
+    toSyncEntry(
+      "transactions",
+      command.transactionRow.id,
+      "insert",
+      command.transactionRow.updatedAt
+    )
   );
   insertBillPayment(db, command.paymentRow);
   return { didMutate: true, effects: command.afterCommit ?? [] };
@@ -522,10 +533,7 @@ export function createWriteThroughMutationModule(db: AnyDb): WriteThroughMutatio
             (acc, command) => {
               const next = applyCommand(tx as AnyDb, command);
               return {
-                outcomes: [
-                  ...acc.outcomes,
-                  { success: true as const, didMutate: next.didMutate },
-                ],
+                outcomes: [...acc.outcomes, { success: true as const, didMutate: next.didMutate }],
                 effects: [...acc.effects, ...next.effects],
               };
             },

--- a/apps/mobile/shared/mutations/write-through.ts
+++ b/apps/mobile/shared/mutations/write-through.ts
@@ -1,0 +1,543 @@
+import type { AnyDb, SyncOperation, SyncTableName } from "@/shared/db";
+import { enqueueSync } from "@/shared/db/enqueue-sync";
+import { generateBudgetId, generateSyncQueueId } from "@/shared/lib";
+import type {
+  BillId,
+  BudgetId,
+  IsoDate,
+  IsoDateTime,
+  Month,
+  TransactionId,
+  UserId,
+} from "@/shared/types/branded";
+import {
+  type BillPaymentRow,
+  type BillRow,
+  deleteBill,
+  deleteBillPayment,
+  insertBill,
+  insertBillPayment,
+  updateBill,
+} from "@/features/calendar/lib/repository";
+import {
+  type BudgetRow,
+  copyBudgetsToMonth,
+  insertBudget,
+  softDeleteBudget,
+  updateBudgetAmount,
+} from "@/features/budget/lib/repository";
+import {
+  type GoalContributionRow,
+  type GoalRow,
+  insertContribution,
+  insertGoal,
+  softDeleteContribution,
+  softDeleteGoal,
+  updateGoal,
+} from "@/features/goals/lib/repository";
+import {
+  type NotificationRow,
+  getAllNotificationIds,
+  insertNotification,
+  softDeleteAllNotifications,
+} from "@/features/notifications/repository";
+import { type UserCategoryRow, insertUserCategory } from "@/features/categories/lib/repository";
+import {
+  type TransactionRow,
+  insertTransaction,
+  softDeleteTransaction,
+  upsertTransaction,
+} from "@/features/transactions/lib/repository";
+import type { CopAmount } from "@/shared/types/branded";
+
+type MutationEffect = () => void | Promise<void>;
+
+export type MutationOutcome = { success: true; didMutate: boolean } | { success: false; error: string };
+
+type TransactionSaveCommand = {
+  kind: "transaction.save";
+  mode: "insert" | "update";
+  row: TransactionRow;
+  afterCommit?: readonly MutationEffect[];
+};
+
+type TransactionDeleteCommand = {
+  kind: "transaction.delete";
+  transactionId: TransactionId;
+  now: IsoDateTime;
+  afterCommit?: readonly MutationEffect[];
+};
+
+type GoalSaveCommand = {
+  kind: "goal.save";
+  row: GoalRow;
+  afterCommit?: readonly MutationEffect[];
+};
+
+type GoalUpdateCommand = {
+  kind: "goal.update";
+  goalId: string;
+  data: Partial<Pick<GoalRow, "name" | "targetAmount" | "targetDate" | "interestRatePercent" | "iconName" | "colorHex">>;
+  now: IsoDateTime;
+  afterCommit?: readonly MutationEffect[];
+};
+
+type GoalDeleteCommand = {
+  kind: "goal.delete";
+  goalId: string;
+  now: IsoDateTime;
+  afterCommit?: readonly MutationEffect[];
+};
+
+type GoalContributionSaveCommand = {
+  kind: "goalContribution.save";
+  row: GoalContributionRow;
+  afterCommit?: readonly MutationEffect[];
+};
+
+type GoalContributionDeleteCommand = {
+  kind: "goalContribution.delete";
+  contributionId: string;
+  now: IsoDateTime;
+  afterCommit?: readonly MutationEffect[];
+};
+
+type BudgetSaveCommand = {
+  kind: "budget.save";
+  row: BudgetRow;
+  afterCommit?: readonly MutationEffect[];
+};
+
+type BudgetUpdateCommand = {
+  kind: "budget.update";
+  budgetId: BudgetId;
+  amount: CopAmount;
+  now: IsoDateTime;
+  afterCommit?: readonly MutationEffect[];
+};
+
+type BudgetDeleteCommand = {
+  kind: "budget.delete";
+  budgetId: BudgetId;
+  now: IsoDateTime;
+  afterCommit?: readonly MutationEffect[];
+};
+
+type BudgetCopyCommand = {
+  kind: "budget.copy";
+  sourceMonth: Month;
+  targetMonth: Month;
+  userId: UserId;
+  now: IsoDateTime;
+  afterCommit?: readonly MutationEffect[];
+};
+
+type NotificationInsertCommand = {
+  kind: "notification.insert";
+  row: NotificationRow;
+  afterCommit?: readonly MutationEffect[];
+};
+
+type NotificationClearAllCommand = {
+  kind: "notification.clearAll";
+  userId: UserId;
+  now: IsoDateTime;
+  afterCommit?: readonly MutationEffect[];
+};
+
+type CategorySaveCommand = {
+  kind: "category.save";
+  row: UserCategoryRow;
+  afterCommit?: readonly MutationEffect[];
+};
+
+type CalendarBillSaveCommand = {
+  kind: "calendar.bill.save";
+  row: BillRow;
+  afterCommit?: readonly MutationEffect[];
+};
+
+type CalendarBillUpdateCommand = {
+  kind: "calendar.bill.update";
+  billId: BillId;
+  fields: Partial<Pick<BillRow, "name" | "amount" | "frequency" | "categoryId" | "startDate" | "isActive">>;
+  now: IsoDateTime;
+  afterCommit?: readonly MutationEffect[];
+};
+
+type CalendarBillDeleteCommand = {
+  kind: "calendar.bill.delete";
+  billId: BillId;
+  afterCommit?: readonly MutationEffect[];
+};
+
+type CalendarBillMarkPaidCommand = {
+  kind: "calendar.bill.markPaid";
+  transactionRow: TransactionRow;
+  paymentRow: BillPaymentRow;
+  afterCommit?: readonly MutationEffect[];
+};
+
+type CalendarBillUnmarkPaidCommand = {
+  kind: "calendar.bill.unmarkPaid";
+  billId: BillId;
+  dueDate: IsoDate;
+  transactionId: TransactionId | null;
+  now: IsoDateTime;
+  afterCommit?: readonly MutationEffect[];
+};
+
+export type MutationCommand =
+  | TransactionSaveCommand
+  | TransactionDeleteCommand
+  | GoalSaveCommand
+  | GoalUpdateCommand
+  | GoalDeleteCommand
+  | GoalContributionSaveCommand
+  | GoalContributionDeleteCommand
+  | BudgetSaveCommand
+  | BudgetUpdateCommand
+  | BudgetDeleteCommand
+  | BudgetCopyCommand
+  | NotificationInsertCommand
+  | NotificationClearAllCommand
+  | CategorySaveCommand
+  | CalendarBillSaveCommand
+  | CalendarBillUpdateCommand
+  | CalendarBillDeleteCommand
+  | CalendarBillMarkPaidCommand
+  | CalendarBillUnmarkPaidCommand;
+
+export type MutationPolicy = "local-only" | "sync-backed";
+
+const MUTATION_POLICY: Record<MutationCommand["kind"], MutationPolicy> = {
+  "transaction.save": "sync-backed",
+  "transaction.delete": "sync-backed",
+  "goal.save": "sync-backed",
+  "goal.update": "sync-backed",
+  "goal.delete": "sync-backed",
+  "goalContribution.save": "sync-backed",
+  "goalContribution.delete": "sync-backed",
+  "budget.save": "sync-backed",
+  "budget.update": "sync-backed",
+  "budget.delete": "sync-backed",
+  "budget.copy": "sync-backed",
+  "notification.insert": "sync-backed",
+  "notification.clearAll": "sync-backed",
+  "category.save": "sync-backed",
+  "calendar.bill.save": "local-only",
+  "calendar.bill.update": "local-only",
+  "calendar.bill.delete": "local-only",
+  "calendar.bill.markPaid": "sync-backed",
+  "calendar.bill.unmarkPaid": "sync-backed",
+};
+
+export function getMutationPolicy(kind: MutationCommand["kind"]): MutationPolicy {
+  return MUTATION_POLICY[kind];
+}
+
+export type WriteThroughMutationModule = {
+  commit: (command: MutationCommand) => Promise<MutationOutcome>;
+  commitBatch: (commands: readonly MutationCommand[]) => Promise<readonly MutationOutcome[]>;
+};
+
+type CommandEffectResult = {
+  didMutate: boolean;
+  effects: readonly MutationEffect[];
+};
+
+function toSyncEntry(
+  tableName: SyncTableName,
+  rowId: string,
+  operation: SyncOperation,
+  createdAt: IsoDateTime
+) {
+  return {
+    id: generateSyncQueueId(),
+    tableName,
+    rowId,
+    operation,
+    createdAt,
+  };
+}
+
+async function runEffects(effects: readonly MutationEffect[]) {
+  await effects.reduce(
+    async (previous, effect) => {
+      await previous;
+      await effect();
+    },
+    Promise.resolve()
+  );
+}
+
+function applyTransactionSave(db: AnyDb, command: TransactionSaveCommand): CommandEffectResult {
+  if (command.mode === "insert") {
+    insertTransaction(db, command.row);
+  } else {
+    upsertTransaction(db, command.row);
+  }
+
+  enqueueSync(
+    db,
+    toSyncEntry("transactions", command.row.id, command.mode === "insert" ? "insert" : "update", command.row.updatedAt)
+  );
+
+  return { didMutate: true, effects: command.afterCommit ?? [] };
+}
+
+function applyTransactionDelete(db: AnyDb, command: TransactionDeleteCommand): CommandEffectResult {
+  softDeleteTransaction(db, command.transactionId, command.now);
+  enqueueSync(db, toSyncEntry("transactions", command.transactionId, "delete", command.now));
+  return { didMutate: true, effects: command.afterCommit ?? [] };
+}
+
+function applyGoalSave(db: AnyDb, command: GoalSaveCommand): CommandEffectResult {
+  insertGoal(db, command.row);
+  enqueueSync(
+    db,
+    toSyncEntry("goals", command.row.id, "insert", command.row.updatedAt as IsoDateTime)
+  );
+  return { didMutate: true, effects: command.afterCommit ?? [] };
+}
+
+function applyGoalUpdate(db: AnyDb, command: GoalUpdateCommand): CommandEffectResult {
+  updateGoal(db, command.goalId, command.data, command.now);
+  enqueueSync(db, toSyncEntry("goals", command.goalId, "update", command.now));
+  return { didMutate: true, effects: command.afterCommit ?? [] };
+}
+
+function applyGoalDelete(db: AnyDb, command: GoalDeleteCommand): CommandEffectResult {
+  softDeleteGoal(db, command.goalId, command.now);
+  enqueueSync(db, toSyncEntry("goals", command.goalId, "delete", command.now));
+  return { didMutate: true, effects: command.afterCommit ?? [] };
+}
+
+function applyGoalContributionSave(
+  db: AnyDb,
+  command: GoalContributionSaveCommand
+): CommandEffectResult {
+  insertContribution(db, command.row);
+  enqueueSync(
+    db,
+    toSyncEntry(
+      "goalContributions",
+      command.row.id,
+      "insert",
+      command.row.updatedAt as IsoDateTime
+    )
+  );
+  return { didMutate: true, effects: command.afterCommit ?? [] };
+}
+
+function applyGoalContributionDelete(
+  db: AnyDb,
+  command: GoalContributionDeleteCommand
+): CommandEffectResult {
+  softDeleteContribution(db, command.contributionId, command.now);
+  enqueueSync(db, toSyncEntry("goalContributions", command.contributionId, "delete", command.now));
+  return { didMutate: true, effects: command.afterCommit ?? [] };
+}
+
+function applyBudgetSave(db: AnyDb, command: BudgetSaveCommand): CommandEffectResult {
+  insertBudget(db, command.row);
+  enqueueSync(db, toSyncEntry("budgets", command.row.id, "insert", command.row.updatedAt));
+  return { didMutate: true, effects: command.afterCommit ?? [] };
+}
+
+function applyBudgetUpdate(db: AnyDb, command: BudgetUpdateCommand): CommandEffectResult {
+  updateBudgetAmount(db, command.budgetId, command.amount, command.now);
+  enqueueSync(db, toSyncEntry("budgets", command.budgetId, "update", command.now));
+  return { didMutate: true, effects: command.afterCommit ?? [] };
+}
+
+function applyBudgetDelete(db: AnyDb, command: BudgetDeleteCommand): CommandEffectResult {
+  softDeleteBudget(db, command.budgetId, command.now);
+  enqueueSync(db, toSyncEntry("budgets", command.budgetId, "delete", command.now));
+  return { didMutate: true, effects: command.afterCommit ?? [] };
+}
+
+function applyBudgetCopy(db: AnyDb, command: BudgetCopyCommand): CommandEffectResult {
+  const copiedIds = copyBudgetsToMonth(
+    db,
+    command.userId,
+    command.sourceMonth,
+    command.targetMonth,
+    command.now,
+    () => generateBudgetId()
+  );
+
+  copiedIds.forEach((id) => {
+    enqueueSync(db, toSyncEntry("budgets", id, "insert", command.now));
+  });
+
+  return { didMutate: copiedIds.length > 0, effects: command.afterCommit ?? [] };
+}
+
+function applyNotificationInsert(
+  db: AnyDb,
+  command: NotificationInsertCommand
+): CommandEffectResult {
+  const result = insertNotification(db, command.row);
+  if (result.changes === 0) {
+    return { didMutate: false, effects: command.afterCommit ?? [] };
+  }
+
+  enqueueSync(db, toSyncEntry("notifications", command.row.id, "insert", command.row.updatedAt));
+  return { didMutate: true, effects: command.afterCommit ?? [] };
+}
+
+function applyNotificationClearAll(
+  db: AnyDb,
+  command: NotificationClearAllCommand
+): CommandEffectResult {
+  const allIds = getAllNotificationIds(db, command.userId);
+  softDeleteAllNotifications(db, command.userId, command.now);
+  allIds.forEach((id) => {
+    enqueueSync(db, toSyncEntry("notifications", id, "delete", command.now));
+  });
+  return { didMutate: allIds.length > 0, effects: command.afterCommit ?? [] };
+}
+
+function applyCategorySave(db: AnyDb, command: CategorySaveCommand): CommandEffectResult {
+  insertUserCategory(db, command.row);
+  enqueueSync(db, toSyncEntry("userCategories", command.row.id, "insert", command.row.updatedAt));
+  return { didMutate: true, effects: command.afterCommit ?? [] };
+}
+
+function applyCalendarBillSave(db: AnyDb, command: CalendarBillSaveCommand): CommandEffectResult {
+  insertBill(db, command.row);
+  return { didMutate: true, effects: command.afterCommit ?? [] };
+}
+
+function applyCalendarBillUpdate(
+  db: AnyDb,
+  command: CalendarBillUpdateCommand
+): CommandEffectResult {
+  updateBill(db, command.billId, command.fields, command.now);
+  return { didMutate: true, effects: command.afterCommit ?? [] };
+}
+
+function applyCalendarBillDelete(
+  db: AnyDb,
+  command: CalendarBillDeleteCommand
+): CommandEffectResult {
+  deleteBill(db, command.billId);
+  return { didMutate: true, effects: command.afterCommit ?? [] };
+}
+
+function applyCalendarBillMarkPaid(
+  db: AnyDb,
+  command: CalendarBillMarkPaidCommand
+): CommandEffectResult {
+  insertTransaction(db, command.transactionRow);
+  enqueueSync(
+    db,
+    toSyncEntry("transactions", command.transactionRow.id, "insert", command.transactionRow.updatedAt)
+  );
+  insertBillPayment(db, command.paymentRow);
+  return { didMutate: true, effects: command.afterCommit ?? [] };
+}
+
+function applyCalendarBillUnmarkPaid(
+  db: AnyDb,
+  command: CalendarBillUnmarkPaidCommand
+): CommandEffectResult {
+  if (command.transactionId) {
+    softDeleteTransaction(db, command.transactionId, command.now);
+    enqueueSync(db, toSyncEntry("transactions", command.transactionId, "delete", command.now));
+  }
+
+  deleteBillPayment(db, command.billId, command.dueDate);
+  return { didMutate: true, effects: command.afterCommit ?? [] };
+}
+
+function applyCommand(db: AnyDb, command: MutationCommand): CommandEffectResult {
+  switch (command.kind) {
+    case "transaction.save":
+      return applyTransactionSave(db, command);
+    case "transaction.delete":
+      return applyTransactionDelete(db, command);
+    case "goal.save":
+      return applyGoalSave(db, command);
+    case "goal.update":
+      return applyGoalUpdate(db, command);
+    case "goal.delete":
+      return applyGoalDelete(db, command);
+    case "goalContribution.save":
+      return applyGoalContributionSave(db, command);
+    case "goalContribution.delete":
+      return applyGoalContributionDelete(db, command);
+    case "budget.save":
+      return applyBudgetSave(db, command);
+    case "budget.update":
+      return applyBudgetUpdate(db, command);
+    case "budget.delete":
+      return applyBudgetDelete(db, command);
+    case "budget.copy":
+      return applyBudgetCopy(db, command);
+    case "notification.insert":
+      return applyNotificationInsert(db, command);
+    case "notification.clearAll":
+      return applyNotificationClearAll(db, command);
+    case "category.save":
+      return applyCategorySave(db, command);
+    case "calendar.bill.save":
+      return applyCalendarBillSave(db, command);
+    case "calendar.bill.update":
+      return applyCalendarBillUpdate(db, command);
+    case "calendar.bill.delete":
+      return applyCalendarBillDelete(db, command);
+    case "calendar.bill.markPaid":
+      return applyCalendarBillMarkPaid(db, command);
+    case "calendar.bill.unmarkPaid":
+      return applyCalendarBillUnmarkPaid(db, command);
+  }
+
+  const exhaustiveCheck: never = command;
+  return exhaustiveCheck;
+}
+
+export function createWriteThroughMutationModule(db: AnyDb): WriteThroughMutationModule {
+  return {
+    commit: async (command) => {
+      try {
+        const result = applyCommand(db, command);
+        await runEffects(result.effects);
+        return { success: true as const, didMutate: result.didMutate };
+      } catch (error) {
+        return {
+          success: false as const,
+          error: error instanceof Error ? error.message : "Mutation failed",
+        };
+      }
+    },
+    commitBatch: async (commands) => {
+      try {
+        const result = db.transaction((tx) =>
+          commands.reduce<{
+            outcomes: readonly MutationOutcome[];
+            effects: readonly MutationEffect[];
+          }>(
+            (acc, command) => {
+              const next = applyCommand(tx as AnyDb, command);
+              return {
+                outcomes: [
+                  ...acc.outcomes,
+                  { success: true as const, didMutate: next.didMutate },
+                ],
+                effects: [...acc.effects, ...next.effects],
+              };
+            },
+            { outcomes: [], effects: [] }
+          )
+        );
+        await runEffects(result.effects);
+        return result.outcomes;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Mutation failed";
+        return commands.map(() => ({ success: false as const, error: message }));
+      }
+    },
+  };
+}


### PR DESCRIPTION
refactor(mobile): centralize write-through mutations

- add shared mutation module
- delegate RFC store writes
- keep calendar bill sync policy explicit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes mobile write-through mutations in `@/shared/mutations` with transactional commits and explicit sync policies (RFC-137). Extracts transaction and calendar bill mutation services; bills stay local-only while bill payments and other entities sync; notification updates are scoped to the active user; adds a `mobile-qa` simulator QA skill for manual testing.

- **Refactors**
  - Added `@/shared/mutations` with `createWriteThroughMutationModule`, `commit`, `commitBatch`, and `getMutationPolicy`; all commits (including single) run inside `db.transaction`, with write-through completion guarded by the active user.
  - Updated budget, calendar, categories, goals, notifications, and transactions stores to delegate DB writes and sync queueing; enabled batch commits for budget bulk create/copy; bill mark/unmark paid commits both steps atomically via `calendar/lib/bill-mutation-service`; extracted `transactions/lib/mutation-service` for add/update/delete flows.
  - Added tests for mutation policies and transactional behavior, active-user guards in notifications, boundary coverage for transaction and calendar bill mutation services, and store mocks with `transaction` support.

<sup>Written for commit 9a3ae20ccceb99b85e982fe1f09c80610074b70f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

