### PR TITLE
chore(mobile): tighten lint rules

### DIFF
--- a/apps/mobile/eslint.config.js
+++ b/apps/mobile/eslint.config.js
@@ -62,18 +62,24 @@ module.exports = defineConfig([
       "@typescript-eslint/no-unsafe-member-access": "error",
       "@typescript-eslint/no-unsafe-return": "error",
       "@typescript-eslint/no-unsafe-argument": "error",
+      "@typescript-eslint/only-throw-error": "error",
       "@typescript-eslint/restrict-template-expressions": "error",
       "@typescript-eslint/prefer-nullish-coalescing": "error",
+      "@typescript-eslint/no-redundant-type-constituents": "error",
       "@typescript-eslint/no-unnecessary-type-assertion": "error",
 
       // — Syntax-only rules —
       "@typescript-eslint/no-explicit-any": "error",
+      "@typescript-eslint/no-require-imports": "error",
       "@typescript-eslint/no-non-null-assertion": "error",
       "@typescript-eslint/prefer-optional-chain": "error",
       "@typescript-eslint/consistent-type-imports": [
         "error",
         { prefer: "type-imports", fixStyle: "inline-type-imports" },
       ],
+      "object-shorthand": ["error", "always"],
+      "no-constant-binary-expression": "error",
+      "no-useless-catch": "error",
 
       // — FP-mandate rules (align with CLAUDE.md) —
       "no-param-reassign": "error",
@@ -85,6 +91,33 @@ module.exports = defineConfig([
 
       // — Import rules —
       "import/no-cycle": "error",
+    },
+  },
+
+  // ── Pure module FP guardrails (lib/schema/utils only) ───────────────
+  {
+    files: [
+      "features/**/lib/**/*.ts",
+      "features/**/lib/**/*.tsx",
+      "shared/lib/**/*.ts",
+      "shared/lib/**/*.tsx",
+      "features/**/schema.ts",
+      "features/**/schema/**/*.ts",
+      "features/**/utils/**/*.ts",
+      "features/**/utils/**/*.tsx",
+      "shared/utils/**/*.ts",
+      "shared/utils/**/*.tsx",
+    ],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "ForStatement, ForInStatement, ForOfStatement, WhileStatement, DoWhileStatement",
+          message:
+            "Pure modules in lib/schema/utils must stay declarative. Use map/filter/reduce or recursion instead of imperative loops.",
+        },
+      ],
     },
   },
 

--- a/apps/mobile/features/calendar/lib/bill-mutation-service.ts
+++ b/apps/mobile/features/calendar/lib/bill-mutation-service.ts
@@ -47,7 +47,7 @@ type CreateCalendarBillMutationServiceDeps = {
   getCommit: () => WriteThroughMutationModule["commit"] | null;
   getUserId: () => UserId | null;
   requestNotificationPermissions: () => Promise<boolean>;
-  scheduleBillNotifications: (bill: Bill) => Promise<unknown> | unknown;
+  scheduleBillNotifications: (bill: Bill) => unknown;
   reportAsyncError: (error: unknown) => void;
   addTransactionToCache: (transaction: StoredTransaction) => void;
   removeTransactionFromCache: (transactionId: TransactionId) => void;
@@ -78,7 +78,9 @@ export type CalendarBillMutationService = {
 function scheduleNotifications(deps: CreateCalendarBillMutationServiceDeps, bill: Bill) {
   void deps
     .requestNotificationPermissions()
-    .then((granted) => (granted ? deps.scheduleBillNotifications(bill) : undefined))
+    .then((granted) =>
+      granted ? Promise.resolve(deps.scheduleBillNotifications(bill)) : undefined
+    )
     .catch(deps.reportAsyncError);
 }
 

--- a/apps/mobile/features/capture-sources/services/notification-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/notification-pipeline.ts
@@ -79,7 +79,7 @@ export async function processNotification(
       rawText: sanitizedText,
       transactionId: null,
       confidence: null,
-      receivedAt: receivedAt,
+      receivedAt,
       createdAt: toIsoDateTime(new Date()),
     });
     capturePipelineEvent({
@@ -143,7 +143,7 @@ export async function processNotification(
         rawText: sanitizedText,
         transactionId: existingTxId as TransactionId,
         confidence: parsed.confidence,
-        receivedAt: receivedAt,
+        receivedAt,
         createdAt: toIsoDateTime(new Date()),
       });
       capturePipelineEvent({
@@ -197,7 +197,7 @@ export async function processNotification(
       rawText: sanitizedText,
       transactionId: txId,
       confidence: parsed.confidence,
-      receivedAt: receivedAt,
+      receivedAt,
       createdAt: now,
     });
 

--- a/apps/mobile/features/email-capture/services/email-pipeline.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline.ts
@@ -86,7 +86,7 @@ async function saveTransaction(
     userId: userId as UserId,
     type: validated.type,
     amount: validated.amount as CopAmount,
-    categoryId: categoryId,
+    categoryId,
     description: validated.description,
     date: validated.date as IsoDate,
     source,

--- a/apps/mobile/features/settings/components/ProfileScreen.tsx
+++ b/apps/mobile/features/settings/components/ProfileScreen.tsx
@@ -81,7 +81,7 @@ export function ProfileScreen() {
               height: 52,
               gap: 8,
               borderWidth: 1,
-              borderColor: borderColor,
+              borderColor,
             }}
           >
             <Brain size={20} color={secondaryColor} />
@@ -98,7 +98,7 @@ export function ProfileScreen() {
               height: 52,
               gap: 8,
               borderWidth: 1,
-              borderColor: borderColor,
+              borderColor,
             }}
           >
             <LogOut size={20} color={secondaryColor} />

--- a/apps/mobile/nativewind-preset.d.ts
+++ b/apps/mobile/nativewind-preset.d.ts
@@ -1,0 +1,7 @@
+declare module "nativewind/preset" {
+  import type { Config } from "tailwindcss";
+
+  const nativewindPreset: Config;
+
+  export default nativewindPreset;
+}

--- a/apps/mobile/tailwind.config.ts
+++ b/apps/mobile/tailwind.config.ts
@@ -1,8 +1,9 @@
+import nativewindPreset from "nativewind/preset";
 import type { Config } from "tailwindcss";
 
 const config: Config = {
   content: ["./app/**/*.{ts,tsx}", "./features/**/*.{ts,tsx}", "./shared/**/*.{ts,tsx}"],
-  presets: [require("nativewind/preset")],
+  presets: [nativewindPreset],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Tightened mobile ESLint rules to enforce safer TypeScript and a declarative FP style in `lib`/`schema`/`utils`. Updated code and the Tailwind preset import to comply, with small cleanups and consistent async handling for bill notifications.

- **Refactors**
  - ESLint: enable `only-throw-error`, `no-require-imports`, `no-redundant-type-constituents`, `object-shorthand`, `no-constant-binary-expression`, `no-useless-catch`; ban imperative loops in `lib`/`schema`/`utils`.
  - Tailwind: replace `require("nativewind/preset")` with `import nativewindPreset from "nativewind/preset"` and add a local `nativewind-preset.d.ts`.
  - Code tweaks: use object shorthand in pipelines and settings; make `scheduleBillNotifications` sync-friendly and wrap calls with `Promise.resolve`.

<sup>Written for commit 82b46f9f9a98ca1acbbceaa8b896e720b78f6fba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

