### PR TITLE
test(mobile): deepen repository coverage

### DIFF
--- a/apps/mobile/__tests__/analytics/repository.test.ts
+++ b/apps/mobile/__tests__/analytics/repository.test.ts
@@ -1,163 +1,147 @@
-// biome-ignore-all lint/suspicious/noExplicitAny: mock db needs flexible typing
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { CategoryId, CopAmount, IsoDate, UserId } from "@/shared/types/branded";
+// biome-ignore-all lint/suspicious/noExplicitAny: integration test uses a real SQLite DB
+import { resolve } from "node:path";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  getIncomeExpenseForPeriod,
+  getSpendingByCategoryForPeriod,
+} from "@/features/analytics/lib/repository";
+import { insertTransaction, softDeleteTransaction } from "@/features/transactions/lib/repository";
+import type {
+  CategoryId,
+  CopAmount,
+  IsoDate,
+  IsoDateTime,
+  TransactionId,
+  UserId,
+} from "@/shared/types/branded";
 
-const mockAll = vi.fn().mockReturnValue([]);
-const mockGet = vi.fn().mockReturnValue(null);
-const mockSelect = vi.fn().mockReturnThis();
-const mockFrom = vi.fn().mockReturnThis();
-const mockWhere = vi.fn().mockReturnThis();
-const mockGroupBy = vi.fn().mockReturnThis();
-const mockOrderBy = vi.fn().mockReturnThis();
+let sqlite: InstanceType<typeof Database>;
+let db: ReturnType<typeof drizzle>;
 
-const mockDb = {
-  select: mockSelect,
-  from: mockFrom,
-  where: mockWhere,
-} as any;
+const USER_ID = "user-1" as UserId;
+const OTHER_USER_ID = "user-2" as UserId;
+const PERIOD_START = "2026-03-01" as IsoDate;
+const PERIOD_END = "2026-03-31" as IsoDate;
+const CREATED_AT = "2026-03-01T00:00:00.000Z" as IsoDateTime;
+const DELETED_AT = "2026-03-20T12:00:00.000Z" as IsoDateTime;
+
+beforeEach(() => {
+  sqlite = new Database(":memory:");
+  db = drizzle(sqlite);
+  migrate(db, { migrationsFolder: resolve(__dirname, "../../drizzle") });
+});
+
+afterEach(() => {
+  sqlite.close();
+});
+
+const insertTransactionRow = (
+  overrides: Partial<{
+    id: TransactionId;
+    userId: UserId;
+    type: "expense" | "income";
+    amount: CopAmount;
+    categoryId: CategoryId;
+    description: string | null;
+    date: IsoDate;
+  }> = {}
+) =>
+  insertTransaction(db as any, {
+    id: overrides.id ?? ("tx-1" as TransactionId),
+    userId: overrides.userId ?? USER_ID,
+    type: overrides.type ?? "expense",
+    amount: overrides.amount ?? (100000 as CopAmount),
+    categoryId: overrides.categoryId ?? ("other" as CategoryId),
+    description: overrides.description ?? "merchant",
+    date: overrides.date ?? PERIOD_START,
+    createdAt: CREATED_AT,
+    updatedAt: CREATED_AT,
+    deletedAt: null,
+    source: "manual",
+  });
 
 describe("analytics repository", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockAll.mockReturnValue([]);
-    mockGet.mockReturnValue(null);
-    mockSelect.mockReturnValue({ from: mockFrom });
-    mockFrom.mockReturnValue({ where: mockWhere, all: mockAll, get: mockGet });
-    mockWhere.mockReturnValue({
-      all: mockAll,
-      get: mockGet,
-      groupBy: mockGroupBy,
-      orderBy: mockOrderBy,
+  it("builds period aggregates from active in-range transactions only", () => {
+    insertTransactionRow({
+      id: "income-active" as TransactionId,
+      type: "income",
+      amount: 500000 as CopAmount,
+      categoryId: "salary" as CategoryId,
+      description: "Salary",
+      date: "2026-03-03" as IsoDate,
     });
-    mockGroupBy.mockReturnValue({ all: mockAll, orderBy: mockOrderBy });
-    mockOrderBy.mockReturnValue({ all: mockAll });
-  });
-
-  describe("getIncomeExpenseForPeriod", () => {
-    it("calls db.select, from, where, and get", async () => {
-      const { getIncomeExpenseForPeriod } = await import("@/features/analytics/lib/repository");
-
-      getIncomeExpenseForPeriod(
-        mockDb,
-        "user-1" as UserId,
-        "2026-03-01" as IsoDate,
-        "2026-03-31" as IsoDate
-      );
-
-      expect(mockSelect).toHaveBeenCalled();
-      expect(mockFrom).toHaveBeenCalled();
-      expect(mockWhere).toHaveBeenCalled();
-      expect(mockGet).toHaveBeenCalled();
+    insertTransactionRow({
+      id: "income-deleted" as TransactionId,
+      type: "income",
+      amount: 150000 as CopAmount,
+      categoryId: "salary" as CategoryId,
+      description: "Bonus",
+      date: "2026-03-04" as IsoDate,
     });
-
-    it("returns zero defaults when db returns null", async () => {
-      mockGet.mockReturnValueOnce(null);
-
-      const { getIncomeExpenseForPeriod } = await import("@/features/analytics/lib/repository");
-
-      const result = getIncomeExpenseForPeriod(
-        mockDb,
-        "user-1" as UserId,
-        "2026-03-01" as IsoDate,
-        "2026-03-31" as IsoDate
-      );
-
-      expect(result).toEqual({ income: 0, expenses: 0 });
+    insertTransactionRow({
+      id: "expense-food-1" as TransactionId,
+      type: "expense",
+      amount: 120000 as CopAmount,
+      categoryId: "food" as CategoryId,
+      description: "Groceries",
+      date: "2026-03-05" as IsoDate,
     });
-
-    it("returns zero defaults when row fields are null", async () => {
-      mockGet.mockReturnValueOnce({ income: null, expenses: null });
-
-      const { getIncomeExpenseForPeriod } = await import("@/features/analytics/lib/repository");
-
-      const result = getIncomeExpenseForPeriod(
-        mockDb,
-        "user-1" as UserId,
-        "2026-03-01" as IsoDate,
-        "2026-03-31" as IsoDate
-      );
-
-      expect(result).toEqual({ income: 0, expenses: 0 });
+    insertTransactionRow({
+      id: "expense-food-2" as TransactionId,
+      type: "expense",
+      amount: 40000 as CopAmount,
+      categoryId: "food" as CategoryId,
+      description: "Snacks",
+      date: "2026-03-15" as IsoDate,
     });
-
-    it("returns income and expenses from db row", async () => {
-      mockGet.mockReturnValueOnce({ income: 500000, expenses: 350000 });
-
-      const { getIncomeExpenseForPeriod } = await import("@/features/analytics/lib/repository");
-
-      const result = getIncomeExpenseForPeriod(
-        mockDb,
-        "user-1" as UserId,
-        "2026-03-01" as IsoDate,
-        "2026-03-31" as IsoDate
-      );
-
-      expect(result).toEqual({
-        income: 500000 as CopAmount,
-        expenses: 350000 as CopAmount,
-      });
+    insertTransactionRow({
+      id: "expense-transport" as TransactionId,
+      type: "expense",
+      amount: 80000 as CopAmount,
+      categoryId: "transport" as CategoryId,
+      description: "Taxi",
+      date: "2026-03-10" as IsoDate,
     });
-  });
-
-  describe("getSpendingByCategoryForPeriod", () => {
-    it("calls db.select, from, where, groupBy, orderBy, and all", async () => {
-      const { getSpendingByCategoryForPeriod } = await import(
-        "@/features/analytics/lib/repository"
-      );
-
-      getSpendingByCategoryForPeriod(
-        mockDb,
-        "user-1" as UserId,
-        "2026-03-01" as IsoDate,
-        "2026-03-31" as IsoDate
-      );
-
-      expect(mockSelect).toHaveBeenCalled();
-      expect(mockFrom).toHaveBeenCalled();
-      expect(mockWhere).toHaveBeenCalled();
-      expect(mockGroupBy).toHaveBeenCalled();
-      expect(mockOrderBy).toHaveBeenCalled();
-      expect(mockAll).toHaveBeenCalled();
+    insertTransactionRow({
+      id: "expense-deleted" as TransactionId,
+      type: "expense",
+      amount: 60000 as CopAmount,
+      categoryId: "subscriptions" as CategoryId,
+      description: "Streaming",
+      date: "2026-03-18" as IsoDate,
+    });
+    insertTransactionRow({
+      id: "expense-out-of-range" as TransactionId,
+      type: "expense",
+      amount: 999999 as CopAmount,
+      categoryId: "food" as CategoryId,
+      description: "February groceries",
+      date: "2026-02-28" as IsoDate,
+    });
+    insertTransactionRow({
+      id: "expense-other-user" as TransactionId,
+      userId: OTHER_USER_ID,
+      type: "expense",
+      amount: 30000 as CopAmount,
+      categoryId: "food" as CategoryId,
+      description: "Other user groceries",
+      date: "2026-03-08" as IsoDate,
     });
 
-    it("returns empty array when db returns no rows", async () => {
-      mockOrderBy.mockReturnValueOnce({ all: () => [] });
+    softDeleteTransaction(db as any, "income-deleted" as TransactionId, DELETED_AT);
+    softDeleteTransaction(db as any, "expense-deleted" as TransactionId, DELETED_AT);
 
-      const { getSpendingByCategoryForPeriod } = await import(
-        "@/features/analytics/lib/repository"
-      );
-
-      const result = getSpendingByCategoryForPeriod(
-        mockDb,
-        "user-1" as UserId,
-        "2026-03-01" as IsoDate,
-        "2026-03-31" as IsoDate
-      );
-
-      expect(result).toEqual([]);
+    expect(getIncomeExpenseForPeriod(db as any, USER_ID, PERIOD_START, PERIOD_END)).toEqual({
+      income: 500000 as CopAmount,
+      expenses: 240000 as CopAmount,
     });
 
-    it("returns category totals ordered by total descending", async () => {
-      const mockRows = [
-        { categoryId: "food" as CategoryId, total: 200000 as CopAmount },
-        { categoryId: "transport" as CategoryId, total: 80000 as CopAmount },
-      ];
-      mockOrderBy.mockReturnValueOnce({ all: () => mockRows });
-
-      const { getSpendingByCategoryForPeriod } = await import(
-        "@/features/analytics/lib/repository"
-      );
-
-      const result = getSpendingByCategoryForPeriod(
-        mockDb,
-        "user-1" as UserId,
-        "2026-03-01" as IsoDate,
-        "2026-03-31" as IsoDate
-      );
-
-      expect(result).toEqual(mockRows);
-      expect(result[0]?.categoryId).toBe("food");
-      expect(result[0]?.total).toBe(200000);
-    });
+    expect(getSpendingByCategoryForPeriod(db as any, USER_ID, PERIOD_START, PERIOD_END)).toEqual([
+      { categoryId: "food" as CategoryId, total: 160000 as CopAmount },
+      { categoryId: "transport" as CategoryId, total: 80000 as CopAmount },
+    ]);
   });
 });

--- a/apps/mobile/__tests__/calendar/repository.test.ts
+++ b/apps/mobile/__tests__/calendar/repository.test.ts
@@ -1,54 +1,172 @@
-import { readFileSync } from "node:fs";
+// biome-ignore-all lint/suspicious/noExplicitAny: integration test uses a real SQLite DB
 import { resolve } from "node:path";
-import { describe, expect, test } from "vitest";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  deleteBill,
+  deleteBillPayment,
+  getAllBills,
+  getBillPaymentsForMonth,
+  insertBill,
+  insertBillPayment,
+  updateBill,
+} from "@/features/calendar/lib/repository";
+import type {
+  BillId,
+  BillPaymentId,
+  CategoryId,
+  CopAmount,
+  IsoDate,
+  IsoDateTime,
+  TransactionId,
+  UserId,
+} from "@/shared/types/branded";
 
-const repoSource = readFileSync(
-  resolve(__dirname, "../../features/calendar/lib/repository.ts"),
-  "utf-8"
-);
+let sqlite: InstanceType<typeof Database>;
+let db: ReturnType<typeof drizzle>;
+
+const USER_ID = "user-1" as UserId;
+const CREATED_AT = "2026-03-01T00:00:00.000Z" as IsoDateTime;
+const UPDATED_AT = "2026-03-02T12:00:00.000Z" as IsoDateTime;
+
+beforeEach(() => {
+  sqlite = new Database(":memory:");
+  db = drizzle(sqlite);
+  migrate(db, { migrationsFolder: resolve(__dirname, "../../drizzle") });
+});
+
+afterEach(() => {
+  sqlite.close();
+});
+
+const insertBillRow = (
+  overrides: Partial<{
+    id: BillId;
+    userId: UserId;
+    name: string;
+    amount: CopAmount;
+    frequency: string;
+    categoryId: CategoryId;
+    startDate: IsoDate;
+    isActive: boolean;
+  }> = {}
+) =>
+  insertBill(db as any, {
+    id: overrides.id ?? ("bill-1" as BillId),
+    userId: overrides.userId ?? USER_ID,
+    name: overrides.name ?? "Internet",
+    amount: overrides.amount ?? (120000 as CopAmount),
+    frequency: overrides.frequency ?? "monthly",
+    categoryId: overrides.categoryId ?? ("services" as CategoryId),
+    startDate: overrides.startDate ?? ("2026-03-01" as IsoDate),
+    isActive: overrides.isActive ?? true,
+    createdAt: CREATED_AT,
+    updatedAt: CREATED_AT,
+  });
+
+const insertBillPaymentRow = (
+  overrides: Partial<{
+    id: BillPaymentId;
+    billId: BillId;
+    dueDate: IsoDate;
+    paidAt: IsoDateTime;
+    transactionId: TransactionId | null;
+  }> = {}
+) =>
+  insertBillPayment(db as any, {
+    id: overrides.id ?? ("payment-1" as BillPaymentId),
+    billId: overrides.billId ?? ("bill-1" as BillId),
+    dueDate: overrides.dueDate ?? ("2026-04-05" as IsoDate),
+    paidAt: overrides.paidAt ?? ("2026-04-05T10:00:00.000Z" as IsoDateTime),
+    transactionId: overrides.transactionId ?? null,
+    createdAt: CREATED_AT,
+  });
 
 describe("calendar repository", () => {
-  test("exports insertBill function", () => {
-    expect(repoSource).toContain("export function insertBill");
-  });
+  it("removes deleted bill payments from monthly reads and cleans up dependent rows", () => {
+    insertBillRow();
+    insertBillRow({
+      id: "bill-2" as BillId,
+      name: "Water",
+      amount: 80000 as CopAmount,
+      categoryId: "utilities" as CategoryId,
+    });
 
-  test("exports getAllBills function", () => {
-    expect(repoSource).toContain("export function getAllBills");
-  });
+    updateBill(
+      db as any,
+      "bill-1" as BillId,
+      {
+        name: "Home Internet",
+        amount: 135000 as CopAmount,
+        isActive: false,
+      },
+      UPDATED_AT
+    );
 
-  test("exports updateBill function", () => {
-    expect(repoSource).toContain("export function updateBill");
-  });
+    expect(getAllBills(db as any, USER_ID)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "bill-1",
+          name: "Home Internet",
+          amount: 135000,
+          isActive: false,
+          updatedAt: UPDATED_AT,
+        }),
+        expect.objectContaining({
+          id: "bill-2",
+          name: "Water",
+        }),
+      ])
+    );
 
-  test("exports deleteBill function", () => {
-    expect(repoSource).toContain("export function deleteBill");
-  });
+    insertBillPaymentRow({
+      id: "payment-1" as BillPaymentId,
+      billId: "bill-1" as BillId,
+      dueDate: "2026-04-05" as IsoDate,
+      transactionId: "tx-1" as TransactionId,
+    });
+    insertBillPaymentRow({
+      id: "payment-2" as BillPaymentId,
+      billId: "bill-1" as BillId,
+      dueDate: "2026-04-20" as IsoDate,
+      paidAt: "2026-04-20T10:00:00.000Z" as IsoDateTime,
+      transactionId: "tx-2" as TransactionId,
+    });
+    insertBillPaymentRow({
+      id: "payment-3" as BillPaymentId,
+      billId: "bill-2" as BillId,
+      dueDate: "2026-04-10" as IsoDate,
+      paidAt: "2026-04-10T10:00:00.000Z" as IsoDateTime,
+      transactionId: "tx-3" as TransactionId,
+    });
+    insertBillPaymentRow({
+      id: "payment-4" as BillPaymentId,
+      billId: "bill-2" as BillId,
+      dueDate: "2026-05-02" as IsoDate,
+      paidAt: "2026-05-02T10:00:00.000Z" as IsoDateTime,
+      transactionId: "tx-4" as TransactionId,
+    });
 
-  test("exports insertBillPayment function", () => {
-    expect(repoSource).toContain("export function insertBillPayment");
-  });
+    deleteBillPayment(db as any, "bill-2" as BillId, "2026-04-10" as IsoDate);
 
-  test("exports getBillPaymentsForMonth function", () => {
-    expect(repoSource).toContain("export function getBillPaymentsForMonth");
-  });
+    expect(
+      getBillPaymentsForMonth(db as any, "2026-04-01" as IsoDate, "2026-04-30" as IsoDate)
+        .map(({ id }) => id)
+        .sort()
+    ).toEqual(["payment-1", "payment-2"]);
 
-  test("exports deleteBillPayment function", () => {
-    expect(repoSource).toContain("export function deleteBillPayment");
-  });
+    deleteBill(db as any, "bill-1" as BillId);
 
-  test("takes db as first parameter (dependency injection pattern)", () => {
-    const fns = repoSource.match(/export function \w+\(db: AnyDb/g);
-    expect(fns).not.toBeNull();
-    expect(fns?.length).toBeGreaterThanOrEqual(7);
-  });
-
-  test("uses drizzle query builders, not raw SQL", () => {
-    expect(repoSource).not.toContain("db.run(");
-    expect(repoSource).not.toContain("db.exec(");
-  });
-
-  test("imports bills and billPayments from schema", () => {
-    expect(repoSource).toContain("bills");
-    expect(repoSource).toContain("billPayments");
+    expect(getAllBills(db as any, USER_ID).map(({ id }) => id)).toEqual(["bill-2"]);
+    expect(
+      getBillPaymentsForMonth(db as any, "2026-04-01" as IsoDate, "2026-04-30" as IsoDate)
+    ).toEqual([]);
+    expect(
+      getBillPaymentsForMonth(db as any, "2026-05-01" as IsoDate, "2026-05-31" as IsoDate).map(
+        ({ id }) => id
+      )
+    ).toEqual(["payment-4"]);
   });
 });

--- a/apps/mobile/__tests__/capture-sources/repository-sms-events.test.ts
+++ b/apps/mobile/__tests__/capture-sources/repository-sms-events.test.ts
@@ -1,0 +1,81 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: integration test uses a real SQLite DB
+import { resolve } from "node:path";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  getUndismissedSmsEvents,
+  insertDetectedSmsEvent,
+} from "@/features/capture-sources/lib/repository";
+import type { DetectedSmsEventId, IsoDateTime, UserId } from "@/shared/types/branded";
+
+let sqlite: InstanceType<typeof Database>;
+let db: ReturnType<typeof drizzle>;
+
+const USER_ID = "user-1" as UserId;
+const CREATED_AT = "2026-04-01T00:00:00.000Z" as IsoDateTime;
+
+beforeEach(() => {
+  sqlite = new Database(":memory:");
+  db = drizzle(sqlite);
+  migrate(db, { migrationsFolder: resolve(__dirname, "../../drizzle") });
+});
+
+afterEach(() => {
+  sqlite.close();
+});
+
+const insertSmsEventRow = (
+  overrides: Partial<{
+    id: DetectedSmsEventId;
+    userId: UserId;
+    senderLabel: string;
+    detectedAt: IsoDateTime;
+    dismissed: boolean;
+  }> = {}
+) =>
+  insertDetectedSmsEvent(db as any, {
+    id: overrides.id ?? ("sms-1" as DetectedSmsEventId),
+    userId: overrides.userId ?? USER_ID,
+    senderLabel: overrides.senderLabel ?? "BankBot",
+    detectedAt: overrides.detectedAt ?? ("2026-04-10T08:00:00.000Z" as IsoDateTime),
+    dismissed: overrides.dismissed ?? false,
+    linkedTransactionId: null,
+    createdAt: CREATED_AT,
+  });
+
+describe("capture-sources repository SMS events", () => {
+  it("returns only undismissed events for the current user in newest-first order", async () => {
+    await insertSmsEventRow({
+      id: "sms-1" as DetectedSmsEventId,
+      senderLabel: "Older visible",
+      detectedAt: "2026-04-10T08:00:00.000Z" as IsoDateTime,
+    });
+    await insertSmsEventRow({
+      id: "sms-2" as DetectedSmsEventId,
+      senderLabel: "Newest visible",
+      detectedAt: "2026-04-10T11:30:00.000Z" as IsoDateTime,
+    });
+    await insertSmsEventRow({
+      id: "sms-3" as DetectedSmsEventId,
+      senderLabel: "Dismissed event",
+      detectedAt: "2026-04-10T12:00:00.000Z" as IsoDateTime,
+      dismissed: true,
+    });
+    await insertSmsEventRow({
+      id: "sms-4" as DetectedSmsEventId,
+      userId: "user-2" as UserId,
+      senderLabel: "Other user event",
+      detectedAt: "2026-04-10T13:00:00.000Z" as IsoDateTime,
+    });
+
+    const events = await getUndismissedSmsEvents(db as any, USER_ID);
+
+    expect(events.map(({ id }) => id)).toEqual(["sms-2", "sms-1"]);
+    expect(events.map(({ senderLabel }) => senderLabel)).toEqual([
+      "Newest visible",
+      "Older visible",
+    ]);
+  });
+});

--- a/apps/mobile/__tests__/goals/repository.test.ts
+++ b/apps/mobile/__tests__/goals/repository.test.ts
@@ -1,0 +1,195 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: integration test uses a real SQLite DB
+import { resolve } from "node:path";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  getContributionById,
+  getContributionMonthCount,
+  getContributionsForGoal,
+  getGoalById,
+  getGoalCurrentAmount,
+  getGoalsForUser,
+  insertContribution,
+  insertGoal,
+  softDeleteContribution,
+  softDeleteGoal,
+  updateGoal,
+} from "@/features/goals";
+
+let sqlite: InstanceType<typeof Database>;
+let db: ReturnType<typeof drizzle>;
+
+const USER_ID = "user-1";
+const CREATED_AT = "2026-03-01T00:00:00.000Z";
+const DELETED_AT = "2026-03-15T09:30:00.000Z";
+
+beforeEach(() => {
+  sqlite = new Database(":memory:");
+  db = drizzle(sqlite);
+  migrate(db, { migrationsFolder: resolve(__dirname, "../../drizzle") });
+});
+
+afterEach(() => {
+  sqlite.close();
+});
+
+const insertGoalRow = (
+  overrides: Partial<{
+    id: string;
+    userId: string;
+    name: string;
+    type: string;
+    targetAmount: number;
+    targetDate: string | null;
+  }> = {}
+) =>
+  insertGoal(db as any, {
+    id: overrides.id ?? "goal-1",
+    userId: overrides.userId ?? USER_ID,
+    name: overrides.name ?? "Emergency fund",
+    type: overrides.type ?? "savings",
+    targetAmount: overrides.targetAmount ?? 500000,
+    targetDate: overrides.targetDate ?? "2026-12-31",
+    interestRatePercent: null,
+    iconName: "wallet",
+    colorHex: "#0F766E",
+    createdAt: CREATED_AT,
+    updatedAt: CREATED_AT,
+    deletedAt: null,
+  });
+
+const insertContributionRow = (
+  overrides: Partial<{
+    id: string;
+    goalId: string;
+    userId: string;
+    amount: number;
+    note: string | null;
+    date: string;
+  }> = {}
+) =>
+  insertContribution(db as any, {
+    id: overrides.id ?? "contribution-1",
+    goalId: overrides.goalId ?? "goal-1",
+    userId: overrides.userId ?? USER_ID,
+    amount: overrides.amount ?? 100000,
+    note: overrides.note ?? "monthly transfer",
+    date: overrides.date ?? "2026-01-05",
+    createdAt: CREATED_AT,
+    updatedAt: CREATED_AT,
+    deletedAt: null,
+  });
+
+describe("goals repository", () => {
+  it("builds an active contribution summary for a goal", () => {
+    insertGoalRow();
+    insertGoalRow({
+      id: "goal-2",
+      name: "Vacation",
+      targetAmount: 1500000,
+      targetDate: "2026-09-01",
+    });
+
+    insertContributionRow({
+      id: "contribution-1",
+      goalId: "goal-1",
+      amount: 100000,
+      date: "2026-01-05",
+    });
+    insertContributionRow({
+      id: "contribution-2",
+      goalId: "goal-1",
+      amount: 150000,
+      date: "2026-02-10",
+    });
+    insertContributionRow({
+      id: "contribution-3",
+      goalId: "goal-1",
+      amount: 50000,
+      date: "2026-02-20",
+    });
+    insertContributionRow({
+      id: "contribution-4",
+      goalId: "goal-2",
+      amount: 999999,
+      date: "2026-02-15",
+    });
+
+    expect(getGoalsForUser(db as any, USER_ID)).toHaveLength(2);
+    expect(getGoalById(db as any, "goal-1")).toMatchObject({
+      id: "goal-1",
+      name: "Emergency fund",
+    });
+    expect(getContributionById(db as any, "contribution-2")).toMatchObject({
+      id: "contribution-2",
+      goalId: "goal-1",
+      amount: 150000,
+    });
+
+    softDeleteContribution(db as any, "contribution-3", DELETED_AT);
+
+    expect(getContributionsForGoal(db as any, "goal-1").map(({ id }) => id)).toEqual([
+      "contribution-2",
+      "contribution-1",
+    ]);
+    expect(getGoalCurrentAmount(db as any, "goal-1")).toBe(250000);
+    expect(getContributionMonthCount(db as any, "goal-1")).toBe(2);
+  });
+
+  it("applies partial goal updates without overwriting omitted fields", () => {
+    insertGoalRow({
+      id: "goal-1",
+      name: "Emergency fund",
+      targetAmount: 500000,
+      targetDate: "2026-12-31",
+    });
+
+    updateGoal(
+      db as any,
+      "goal-1",
+      {
+        name: "Renovation fund",
+        targetAmount: 750000,
+        colorHex: "#1D4ED8",
+        targetDate: null,
+      },
+      "2026-04-01T12:00:00.000Z"
+    );
+
+    expect(getGoalById(db as any, "goal-1")).toMatchObject({
+      id: "goal-1",
+      name: "Renovation fund",
+      type: "savings",
+      targetAmount: 750000,
+      targetDate: null,
+      interestRatePercent: null,
+      iconName: "wallet",
+      colorHex: "#1D4ED8",
+      createdAt: CREATED_AT,
+      updatedAt: "2026-04-01T12:00:00.000Z",
+      deletedAt: null,
+    });
+  });
+
+  it("soft deletes a goal so it disappears from active listings but remains queryable by id", () => {
+    insertGoalRow({
+      id: "goal-1",
+      name: "Emergency fund",
+    });
+    insertGoalRow({
+      id: "goal-2",
+      name: "Vacation",
+    });
+
+    softDeleteGoal(db as any, "goal-1", DELETED_AT);
+
+    expect(getGoalsForUser(db as any, USER_ID).map(({ id }) => id)).toEqual(["goal-2"]);
+    expect(getGoalById(db as any, "goal-1")).toMatchObject({
+      id: "goal-1",
+      deletedAt: DELETED_AT,
+      updatedAt: DELETED_AT,
+    });
+  });
+});

--- a/apps/mobile/__tests__/transactions/repository-monthly-totals.test.ts
+++ b/apps/mobile/__tests__/transactions/repository-monthly-totals.test.ts
@@ -1,0 +1,149 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: integration test uses a real SQLite DB
+import { resolve } from "node:path";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getMonthlyTotalsByType,
+  insertTransaction,
+  softDeleteTransaction,
+} from "@/features/transactions/lib/repository";
+import type {
+  CategoryId,
+  CopAmount,
+  IsoDate,
+  IsoDateTime,
+  TransactionId,
+  UserId,
+} from "@/shared/types/branded";
+
+let sqlite: InstanceType<typeof Database>;
+let db: ReturnType<typeof drizzle>;
+
+const USER_ID = "user-1" as UserId;
+const OTHER_USER_ID = "user-2" as UserId;
+const CREATED_AT = "2026-03-01T00:00:00.000Z" as IsoDateTime;
+const DELETED_AT = "2026-03-18T10:00:00.000Z" as IsoDateTime;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-03-20T12:00:00.000Z"));
+  sqlite = new Database(":memory:");
+  db = drizzle(sqlite);
+  migrate(db, { migrationsFolder: resolve(__dirname, "../../drizzle") });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  sqlite.close();
+});
+
+const insertTransactionRow = (
+  overrides: Partial<{
+    id: TransactionId;
+    userId: UserId;
+    type: "expense" | "income";
+    amount: CopAmount;
+    categoryId: CategoryId;
+    description: string | null;
+    date: IsoDate;
+  }> = {}
+) =>
+  insertTransaction(db as any, {
+    id: overrides.id ?? ("tx-1" as TransactionId),
+    userId: overrides.userId ?? USER_ID,
+    type: overrides.type ?? "expense",
+    amount: overrides.amount ?? (100000 as CopAmount),
+    categoryId: overrides.categoryId ?? ("other" as CategoryId),
+    description: overrides.description ?? "merchant",
+    date: overrides.date ?? ("2026-03-01" as IsoDate),
+    createdAt: CREATED_AT,
+    updatedAt: CREATED_AT,
+    deletedAt: null,
+    source: "manual",
+  });
+
+describe("transaction repository monthly totals", () => {
+  it("returns active monthly totals for the rolling window only", () => {
+    insertTransactionRow({
+      id: "mar-income" as TransactionId,
+      type: "income",
+      amount: 700000 as CopAmount,
+      categoryId: "salary" as CategoryId,
+      description: "Salary",
+      date: "2026-03-05" as IsoDate,
+    });
+    insertTransactionRow({
+      id: "mar-expense" as TransactionId,
+      type: "expense",
+      amount: 150000 as CopAmount,
+      categoryId: "food" as CategoryId,
+      description: "Groceries",
+      date: "2026-03-07" as IsoDate,
+    });
+    insertTransactionRow({
+      id: "feb-income" as TransactionId,
+      type: "income",
+      amount: 680000 as CopAmount,
+      categoryId: "salary" as CategoryId,
+      description: "Salary",
+      date: "2026-02-04" as IsoDate,
+    });
+    insertTransactionRow({
+      id: "feb-expense" as TransactionId,
+      type: "expense",
+      amount: 220000 as CopAmount,
+      categoryId: "rent" as CategoryId,
+      description: "Rent",
+      date: "2026-02-10" as IsoDate,
+    });
+    insertTransactionRow({
+      id: "jan-expense" as TransactionId,
+      type: "expense",
+      amount: 90000 as CopAmount,
+      categoryId: "transport" as CategoryId,
+      description: "Transit",
+      date: "2026-01-15" as IsoDate,
+    });
+    insertTransactionRow({
+      id: "jan-income-deleted" as TransactionId,
+      type: "income",
+      amount: 50000 as CopAmount,
+      categoryId: "salary" as CategoryId,
+      description: "Bonus",
+      date: "2026-01-18" as IsoDate,
+    });
+    insertTransactionRow({
+      id: "dec-expense" as TransactionId,
+      type: "expense",
+      amount: 999999 as CopAmount,
+      categoryId: "shopping" as CategoryId,
+      description: "Holiday shopping",
+      date: "2025-12-20" as IsoDate,
+    });
+    insertTransactionRow({
+      id: "mar-other-user" as TransactionId,
+      userId: OTHER_USER_ID,
+      type: "income",
+      amount: 123456 as CopAmount,
+      categoryId: "salary" as CategoryId,
+      description: "Other user",
+      date: "2026-03-10" as IsoDate,
+    });
+
+    softDeleteTransaction(db as any, "jan-income-deleted" as TransactionId, DELETED_AT);
+
+    const result = getMonthlyTotalsByType(db as any, USER_ID, 3).sort((left, right) =>
+      `${left.month}:${left.type}`.localeCompare(`${right.month}:${right.type}`)
+    );
+
+    expect(result).toEqual([
+      { month: "2026-01", type: "expense", total: 90000 },
+      { month: "2026-02", type: "expense", total: 220000 },
+      { month: "2026-02", type: "income", total: 680000 },
+      { month: "2026-03", type: "expense", total: 150000 },
+      { month: "2026-03", type: "income", total: 700000 },
+    ]);
+  });
+});

--- a/apps/mobile/__tests__/transactions/store.test.ts
+++ b/apps/mobile/__tests__/transactions/store.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getBalanceAggregate,
   getSpendingByCategoryAggregate,
+  getTransactionById,
   getTransactionsPaginated,
   insertTransaction,
   softDeleteTransaction,
@@ -56,6 +57,7 @@ describe("useTransactionStore", () => {
       balance: 0,
       categorySpending: [],
       dailySpending: [],
+      editingId: null,
     });
   });
 
@@ -316,6 +318,34 @@ describe("useTransactionStore", () => {
     await useTransactionStore.getState().loadNextPage();
 
     expect(getTransactionsPaginated).not.toHaveBeenCalled();
+  });
+
+  it("editTransaction hydrates edit mode from the stored transaction row", () => {
+    vi.mocked(getTransactionById).mockReturnValueOnce({
+      id: "tx-1" as TransactionId,
+      userId: mockUserId,
+      type: "income",
+      amount: 235000 as CopAmount,
+      categoryId: "food" as CategoryId,
+      description: "Payroll correction",
+      date: "2026-04-12" as IsoDate,
+      createdAt: "2026-04-12T08:00:00.000Z" as IsoDateTime,
+      updatedAt: "2026-04-13T09:00:00.000Z" as IsoDateTime,
+      deletedAt: null,
+      source: "manual",
+    });
+
+    useTransactionStore.getState().editTransaction("tx-1" as TransactionId);
+
+    const state = useTransactionStore.getState();
+    expect(state.editingId).toBe("tx-1");
+    expect(state.type).toBe("income");
+    expect(state.digits).toBe("235000");
+    expect(state.categoryId).toBe("food");
+    expect(state.description).toBe("Payroll correction");
+    expect(state.date.getFullYear()).toBe(2026);
+    expect(state.date.getMonth()).toBe(3);
+    expect(state.date.getDate()).toBe(12);
   });
 
   it("removeTransaction soft-deletes from DB, enqueues sync, and refreshes", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expand mobile repository tests into fast, in-memory integration tests using `better-sqlite3` and `drizzle-orm` migrations to verify real behavior: aggregates, soft-deletes, user/date scoping, and ordering across analytics, calendar, goals, capture sources, and transactions.

- **Refactors**
  - Switched analytics and calendar tests from mocks/source-inspection to real DB integration tests.
  - Added coverage for:
    - Transactions: rolling monthly totals and store edit mode hydration from `getTransactionById`.
    - Goals: CRUD, partial updates, current amount, month-count, and soft deletes.
    - Capture sources (SMS): undismissed-only, newest-first, per-user filtering.
    - Calendar: bill updates, deletions cleaning dependent payments, and monthly range filtering.
  - Validates exclusions for soft-deleted, out-of-range, and other-user rows; confirms category totals and period aggregates.

<sup>Written for commit 0d0c910c626ea57b9d492d191083d8684a5d701e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

