### PR TITLE
chore(entropy): enable noUnusedImports

### DIFF
--- a/apps/mobile/features/capture-sources/services/notification-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/notification-pipeline.ts
@@ -32,7 +32,7 @@ import type { CategoryId, CopAmount, IsoDate, TransactionId, UserId } from "@/sh
 /** In-flight fingerprints guard against concurrent duplicate processing. */
 const inFlightFingerprints = new Set<string>();
 
-export type NotificationPipelineResult = {
+type NotificationPipelineResult = {
   saved: boolean;
   skippedDuplicate: boolean;
   transactionId: string | null;

--- a/biome.json
+++ b/biome.json
@@ -44,7 +44,8 @@
         "useNamingConvention": "warn"
       },
       "correctness": {
-        "noConstAssign": "error"
+        "noConstAssign": "error",
+        "noUnusedImports": "error"
       }
     }
   },

--- a/scripts/ralph/entropy-progress.template.txt
+++ b/scripts/ralph/entropy-progress.template.txt
@@ -2,3 +2,9 @@
 
 Started: not yet run
 ---
+
+## 2026-04-17 - Unused exported type in notification pipeline
+- Issue found: `NotificationPipelineResult` was exported from `apps/mobile/features/capture-sources/services/notification-pipeline.ts` even though it is only referenced inside that file.
+- Why it mattered: unnecessary exports widen a module's public surface and make it harder to tell which types are actual cross-module contracts.
+- Files changed: `apps/mobile/features/capture-sources/services/notification-pipeline.ts`, `scripts/ralph/entropy-progress.txt`
+- Validation run: `bun run --cwd apps/mobile typecheck`


### PR DESCRIPTION
## Summary
- enable Biome's \ rule
- remove an unused exported type from the notification pipeline
- record the cleanup in the Ralph entropy progress log

## Verification
- \Checked 544 files in 172ms. No fixes applied.
Found 1 warning.
env: load .env
env: export EXPO_PUBLIC_GMAIL_CLIENT_ID EXPO_PUBLIC_OUTLOOK_CLIENT_ID EXPO_PUBLIC_POSTHOG_API_KEY EXPO_PUBLIC_SENTRY_DSN EXPO_PUBLIC_SUPABASE_ANON_KEY EXPO_PUBLIC_SUPABASE_URL

[1m[46m RUN [49m[22m [36mv4.1.0 [39m[90m/Users/obarbozaa/Documents/fidy/apps/mobile[39m


[2m Test Files [22m [1m[32m130 passed[39m[22m[90m (130)[39m
[2m      Tests [22m [1m[32m1269 passed[39m[22m[90m (1269)[39m
[2m   Start at [22m 09:25:53
[2m   Duration [22m 16.33s[2m (transform 4.24s, setup 1.97s, import 58.34s, tests 27.36s, environment 11ms)[22m

## Notes
- pre-existing non-blocking Biome naming warning remains in \

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables Biome’s `noUnusedImports` as an error to block unused imports and scopes the mobile notification pipeline result type to internal. This tightens our module surface and prevents dead code.

- **Refactors**
  - Set `noUnusedImports` to error in `biome.json`.
  - Made `NotificationPipelineResult` internal in the mobile notification pipeline.
  - Logged the cleanup in `scripts/ralph/entropy-progress.template.txt`.

<sup>Written for commit e86c5358cd31886b0ba2e89f44f68c318b5a83bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

