### PR TITLE
fix(ralph): isolate maintenance loops across worktrees

### DIFF
--- a/scripts/ralph/prompts/AGENTS.md
+++ b/scripts/ralph/prompts/AGENTS.md
@@ -1,0 +1,46 @@
+# Ralph Maintenance Instructions
+
+You are running a Ralph maintenance loop, not a feature-story loop.
+
+## Bootstrap
+
+Before anything else:
+
+1. Read the repo root `AGENTS.md`
+2. Inspect `git status --short`
+3. Read the maintenance prompt file passed to this run
+4. Read the maintenance progress file passed to this run
+
+## Scope
+
+- Do not read or require `scripts/ralph/prd.json`
+- Do not read or require `scripts/ralph/progress.txt`
+- Do not expect a feature branch from PRD metadata
+- Work only from the maintenance prompt and maintenance progress file for this run
+
+## Workflow
+
+1. Follow the maintenance prompt exactly
+2. Keep each iteration scoped to one meaningful improvement
+3. Run the narrowest useful validation while iterating
+4. Leave the worktree in a working state
+5. Append progress only to the maintenance progress file for this run
+
+## Committing
+
+After checks pass, create a local iteration commit only.
+
+- Use a scoped header such as `chore(ralph): maintenance [topic]`
+- Do not push
+- Do not open or update a PR during the loop
+
+## AGENTS Updates
+
+If you discover durable, reusable knowledge, update the repo or nearby `AGENTS.md` files.
+Do not add story-specific details or temporary debugging notes.
+
+## Important
+
+- Treat this as maintenance, not feature delivery
+- Do not invent PRD work when none exists
+- The maintenance prompt and its progress file are the source of truth for the run

--- a/scripts/ralph/ralph.sh
+++ b/scripts/ralph/ralph.sh
@@ -58,7 +58,7 @@ map_path_to_worktree() {
     return
   fi
 
-  if [[ "$source_path" == "$source_root"* ]]; then
+  if [[ "$source_path" == "$source_root" || "$source_path" == "$source_root"/* ]]; then
     echo "$target_root${source_path#$source_root}"
     return
   fi
@@ -69,8 +69,27 @@ map_path_to_worktree() {
 ensure_maintenance_worktree() {
   local branch_name="$1"
   local worktree_path="$2"
+  local target_head
+  local current_branch
+  local worktree_status
+
+  target_head="$(git -C "$REPO_ROOT" rev-parse HEAD)"
 
   if git -C "$REPO_ROOT" worktree list --porcelain | grep -Fqx "worktree $worktree_path"; then
+    current_branch="$(git -C "$worktree_path" branch --show-current)"
+
+    if [[ "$current_branch" != "$branch_name" ]]; then
+      echo "Error: Maintenance worktree $worktree_path is on branch '$current_branch', expected '$branch_name'."
+      exit 1
+    fi
+
+    worktree_status="$(git -C "$worktree_path" status --porcelain)"
+    if [[ -n "$worktree_status" ]]; then
+      echo "Error: Maintenance worktree $worktree_path has uncommitted changes. Commit or clean it before rerunning Ralph."
+      exit 1
+    fi
+
+    git -C "$worktree_path" reset --hard "$target_head" >/dev/null
     return
   fi
 
@@ -80,11 +99,12 @@ ensure_maintenance_worktree() {
   fi
 
   if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$branch_name"; then
+    git -C "$REPO_ROOT" branch -f "$branch_name" "$target_head" >/dev/null
     git -C "$REPO_ROOT" worktree add "$worktree_path" "$branch_name"
     return
   fi
 
-  git -C "$REPO_ROOT" worktree add -b "$branch_name" "$worktree_path" HEAD
+  git -C "$REPO_ROOT" worktree add -b "$branch_name" "$worktree_path" "$target_head"
 }
 
 while [[ $# -gt 0 ]]; do
@@ -141,6 +161,7 @@ LAST_BRANCH_FILE="$SCRIPT_DIR/.last-branch"
 DEFAULT_PROMPT_FILE="$SCRIPT_DIR/AGENTS.md"
 OPENCODE_PROMPT_FILE="$SCRIPT_DIR/prompt-opencode.md"
 DEFAULT_INSTRUCTIONS_FILE="$SCRIPT_DIR/AGENTS.md"
+MAINTENANCE_INSTRUCTIONS_FILE="$SCRIPT_DIR/prompts/AGENTS.md"
 PROMPT_FILE="${CUSTOM_PROMPT_FILE:-$DEFAULT_PROMPT_FILE}"
 INSTRUCTIONS_FILE="$DEFAULT_INSTRUCTIONS_FILE"
 ACTIVE_PROGRESS_FILE="$PROGRESS_FILE"
@@ -157,7 +178,7 @@ if [[ "$MODE" == "maintenance" ]]; then
     exit 1
   fi
 
-  INSTRUCTIONS_FILE="$CUSTOM_PROMPT_FILE"
+  INSTRUCTIONS_FILE="$MAINTENANCE_INSTRUCTIONS_FILE"
   ACTIVE_PROGRESS_FILE="${CUSTOM_PROGRESS_FILE:-$SCRIPT_DIR/maintenance-progress.txt}"
 fi
 
@@ -174,6 +195,8 @@ if [[ "$MODE" == "maintenance" && "$RALPH_WORKTREE_ACTIVE" != "1" ]]; then
 
     echo "Using maintenance worktree: $WORKTREE_PATH"
     echo "Using maintenance branch: $MAINTENANCE_NAME"
+
+    cd "$WORKTREE_PATH"
 
     exec env RALPH_WORKTREE_ACTIVE=1 \
       "$WORKTREE_PATH/scripts/ralph/ralph.sh" \

--- a/scripts/ralph/ralph.sh
+++ b/scripts/ralph/ralph.sh
@@ -69,11 +69,8 @@ map_path_to_worktree() {
 ensure_maintenance_worktree() {
   local branch_name="$1"
   local worktree_path="$2"
-  local target_head
   local current_branch
   local worktree_status
-
-  target_head="$(git -C "$REPO_ROOT" rev-parse HEAD)"
 
   if git -C "$REPO_ROOT" worktree list --porcelain | grep -Fqx "worktree $worktree_path"; then
     current_branch="$(git -C "$worktree_path" branch --show-current)"
@@ -89,7 +86,6 @@ ensure_maintenance_worktree() {
       exit 1
     fi
 
-    git -C "$worktree_path" reset --hard "$target_head" >/dev/null
     return
   fi
 
@@ -99,12 +95,11 @@ ensure_maintenance_worktree() {
   fi
 
   if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$branch_name"; then
-    git -C "$REPO_ROOT" branch -f "$branch_name" "$target_head" >/dev/null
     git -C "$REPO_ROOT" worktree add "$worktree_path" "$branch_name"
     return
   fi
 
-  git -C "$REPO_ROOT" worktree add -b "$branch_name" "$worktree_path" "$target_head"
+  git -C "$REPO_ROOT" worktree add -b "$branch_name" "$worktree_path" HEAD
 }
 
 while [[ $# -gt 0 ]]; do
@@ -186,7 +181,13 @@ if [[ "$MODE" == "maintenance" ]]; then
     exit 1
   fi
 
-  INSTRUCTIONS_FILE="$MAINTENANCE_INSTRUCTIONS_FILE"
+  MAINTENANCE_PROMPT_FILE=$(mktemp)
+  cat "$MAINTENANCE_INSTRUCTIONS_FILE" > "$MAINTENANCE_PROMPT_FILE"
+  printf '\n\n## Active Maintenance Prompt\n\n' >> "$MAINTENANCE_PROMPT_FILE"
+  cat "$CUSTOM_PROMPT_FILE" >> "$MAINTENANCE_PROMPT_FILE"
+  trap '[[ -n "$MAINTENANCE_PROMPT_FILE" && -f "$MAINTENANCE_PROMPT_FILE" ]] && rm -f "$MAINTENANCE_PROMPT_FILE"' EXIT
+
+  INSTRUCTIONS_FILE="$MAINTENANCE_PROMPT_FILE"
   ACTIVE_PROGRESS_FILE="${CUSTOM_PROGRESS_FILE:-$SCRIPT_DIR/maintenance-progress.txt}"
 fi
 

--- a/scripts/ralph/ralph.sh
+++ b/scripts/ralph/ralph.sh
@@ -154,6 +154,14 @@ if [[ "$TOOL" != "auto" && "$TOOL" != "opencode" && "$TOOL" != "codex" && "$TOOL
 fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+COMMON_GIT_DIR="$(git -C "$REPO_ROOT" rev-parse --git-common-dir)"
+
+if [[ "$COMMON_GIT_DIR" = /* ]]; then
+  CANONICAL_REPO_ROOT="$(cd "$COMMON_GIT_DIR/.." && pwd)"
+else
+  CANONICAL_REPO_ROOT="$(cd "$REPO_ROOT/$COMMON_GIT_DIR/.." && pwd)"
+fi
+
 PRD_FILE="$SCRIPT_DIR/prd.json"
 PROGRESS_FILE="$SCRIPT_DIR/progress.txt"
 ARCHIVE_DIR="$SCRIPT_DIR/archive"
@@ -186,8 +194,8 @@ if [[ "$MODE" == "maintenance" && "$RALPH_WORKTREE_ACTIVE" != "1" ]]; then
   MAINTENANCE_NAME="$(infer_maintenance_name "$CUSTOM_PROMPT_FILE" "$ACTIVE_PROGRESS_FILE")"
 
   if [[ -n "$MAINTENANCE_NAME" ]]; then
-    WORKTREE_PARENT="$(dirname "$REPO_ROOT")"
-    WORKTREE_PATH="$WORKTREE_PARENT/$(basename "$REPO_ROOT")-$MAINTENANCE_NAME"
+    WORKTREE_PARENT="$(dirname "$CANONICAL_REPO_ROOT")"
+    WORKTREE_PATH="$WORKTREE_PARENT/$(basename "$CANONICAL_REPO_ROOT")-$MAINTENANCE_NAME"
     ensure_maintenance_worktree "$MAINTENANCE_NAME" "$WORKTREE_PATH"
 
     WORKTREE_PROMPT_FILE="$(map_path_to_worktree "$CUSTOM_PROMPT_FILE" "$REPO_ROOT" "$WORKTREE_PATH")"


### PR DESCRIPTION
## Summary
- add dedicated maintenance instructions instead of using the story PRD flow
- refresh and re-exec maintenance runs inside their isolated worktree cwd
- derive maintenance worktree paths from the canonical repo root so any checkout targets the same coverage, entropy, and lint worktrees

## Verification
- 
- reran one lint maintenance iteration and confirmed the resulting edits landed in  instead of the launching checkout

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates Ralph maintenance loops in dedicated, clean worktrees anchored to the canonical repo. Runs now use a combined maintenance instructions + prompt and execute from the worktree cwd, so edits never touch the launching checkout.

- **New Features**
  - Anchor maintenance worktrees to the canonical repo via `git rev-parse --git-common-dir`, standardizing paths across linked checkouts.
  - Validate existing maintenance worktrees: require the expected branch and a clean state; preserve branch state (no resets); re-exec from the worktree cwd.
  - Use maintenance-specific instructions at `scripts/ralph/prompts/AGENTS.md` and merge them with the active maintenance prompt into a single runner input; ignore story PRD/progress during maintenance.
  - Fix path mapping to match the repo root exactly, avoiding partial-prefix collisions.

- **Migration**
  - If a maintenance worktree is dirty or on the wrong branch, commit/clean or remove it before rerunning.

<sup>Written for commit 2d64bf2bda9767ab99e6d0b000e6aa650d397c5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

