### PR TITLE
test(coverage): add high-risk mutation and notification coverage

### DIFF
--- a/apps/mobile/__tests__/budget/notifications.test.ts
+++ b/apps/mobile/__tests__/budget/notifications.test.ts
@@ -76,6 +76,22 @@ describe("scheduleBudgetAlert", () => {
     expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
   });
 
+  it("returns { type: 'needs_permission' } when SecureStore lookup fails", async () => {
+    mockGetPermissionsAsync.mockResolvedValue({
+      status: "undetermined",
+      granted: false,
+      canAskAgain: true,
+    });
+    mockGetItemAsync.mockRejectedValue(new Error("secure store unavailable"));
+
+    const { scheduleBudgetAlert } = await import("@/features/budget/lib/notifications");
+
+    const result = await scheduleBudgetAlert(MOCK_ALERT, "Food");
+
+    expect(result).toEqual({ type: "needs_permission" });
+    expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+
   it("returns { type: 'skipped' } when permission is denied", async () => {
     mockGetPermissionsAsync.mockResolvedValue({
       status: "denied",
@@ -114,5 +130,14 @@ describe("scheduleBudgetAlert", () => {
 
     expect(result).toEqual({ type: "skipped" });
     expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+
+  it("returns { type: 'skipped' } when scheduling the notification throws", async () => {
+    mockScheduleNotificationAsync.mockRejectedValue(new Error("schedule failed"));
+    const { scheduleBudgetAlert } = await import("@/features/budget/lib/notifications");
+
+    const result = await scheduleBudgetAlert(MOCK_ALERT, "Food");
+
+    expect(result).toEqual({ type: "skipped" });
   });
 });

--- a/apps/mobile/__tests__/capture-sources/repository-sms-events.test.ts
+++ b/apps/mobile/__tests__/capture-sources/repository-sms-events.test.ts
@@ -5,10 +5,20 @@ import { drizzle } from "drizzle-orm/better-sqlite3";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  getNotificationSources,
+  getProcessedCapturesBySource,
   getUndismissedSmsEvents,
   insertDetectedSmsEvent,
+  insertProcessedCapture,
+  upsertNotificationSource,
 } from "@/features/capture-sources/lib/repository";
-import type { DetectedSmsEventId, IsoDateTime, UserId } from "@/shared/types/branded";
+import type {
+  DetectedSmsEventId,
+  IsoDateTime,
+  ProcessedCaptureId,
+  TransactionId,
+  UserId,
+} from "@/shared/types/branded";
 
 let sqlite: InstanceType<typeof Database>;
 let db: ReturnType<typeof drizzle>;
@@ -45,7 +55,87 @@ const insertSmsEventRow = (
     createdAt: CREATED_AT,
   });
 
+const insertProcessedCaptureRow = (
+  overrides: Partial<{
+    id: ProcessedCaptureId;
+    fingerprintHash: string;
+    source: string;
+    status: string;
+    rawText: string | null;
+    transactionId: TransactionId | null;
+    confidence: number | null;
+    receivedAt: IsoDateTime;
+  }> = {}
+) =>
+  insertProcessedCapture(db as any, {
+    id: overrides.id ?? ("pc-1" as ProcessedCaptureId),
+    fingerprintHash: overrides.fingerprintHash ?? "hash-1",
+    source: overrides.source ?? "sms",
+    status: overrides.status ?? "accepted",
+    rawText: overrides.rawText ?? "Compra aprobada",
+    transactionId: overrides.transactionId ?? null,
+    confidence: overrides.confidence ?? 0.9,
+    receivedAt: overrides.receivedAt ?? ("2026-04-10T08:00:00.000Z" as IsoDateTime),
+    createdAt: CREATED_AT,
+  });
+
+const insertNotificationSourceRow = (
+  overrides: Partial<{
+    userId: UserId;
+    packageName: string;
+    label: string;
+    isEnabled: boolean;
+  }> = {}
+) =>
+  upsertNotificationSource(
+    db as any,
+    overrides.userId ?? USER_ID,
+    overrides.packageName ?? "com.bank.app",
+    overrides.label ?? "Bank App",
+    overrides.isEnabled ?? true,
+    CREATED_AT
+  );
+
 describe("capture-sources repository SMS events", () => {
+  it("returns all notification sources for the requested user only", async () => {
+    await insertNotificationSourceRow({
+      packageName: "com.bank.app",
+      label: "Bank App",
+      isEnabled: true,
+    });
+    await insertNotificationSourceRow({
+      packageName: "com.wallet.app",
+      label: "Wallet App",
+      isEnabled: false,
+    });
+    await insertNotificationSourceRow({
+      userId: "user-2" as UserId,
+      packageName: "com.other.bank",
+      label: "Other User App",
+      isEnabled: true,
+    });
+
+    const sources = await getNotificationSources(db as any, USER_ID);
+
+    expect(sources).toHaveLength(2);
+    expect(
+      sources.map(({ packageName, label, isEnabled }) => ({ packageName, label, isEnabled }))
+    ).toEqual(
+      expect.arrayContaining([
+        {
+          packageName: "com.bank.app",
+          label: "Bank App",
+          isEnabled: true,
+        },
+        {
+          packageName: "com.wallet.app",
+          label: "Wallet App",
+          isEnabled: false,
+        },
+      ])
+    );
+  });
+
   it("returns only undismissed events for the current user in newest-first order", async () => {
     await insertSmsEventRow({
       id: "sms-1" as DetectedSmsEventId,
@@ -76,6 +166,38 @@ describe("capture-sources repository SMS events", () => {
     expect(events.map(({ senderLabel }) => senderLabel)).toEqual([
       "Newest visible",
       "Older visible",
+    ]);
+  });
+
+  it("returns only captures for the requested source in newest-first order", async () => {
+    await insertProcessedCaptureRow({
+      id: "pc-1" as ProcessedCaptureId,
+      fingerprintHash: "hash-1",
+      source: "sms",
+      receivedAt: "2026-04-10T08:00:00.000Z" as IsoDateTime,
+      rawText: "Older SMS capture",
+    });
+    await insertProcessedCaptureRow({
+      id: "pc-2" as ProcessedCaptureId,
+      fingerprintHash: "hash-2",
+      source: "push",
+      receivedAt: "2026-04-10T09:30:00.000Z" as IsoDateTime,
+      rawText: "Other source capture",
+    });
+    await insertProcessedCaptureRow({
+      id: "pc-3" as ProcessedCaptureId,
+      fingerprintHash: "hash-3",
+      source: "sms",
+      receivedAt: "2026-04-10T11:30:00.000Z" as IsoDateTime,
+      rawText: "Newest SMS capture",
+    });
+
+    const captures = await getProcessedCapturesBySource(db as any, "sms");
+
+    expect(captures.map(({ id }) => id)).toEqual(["pc-3", "pc-1"]);
+    expect(captures.map(({ rawText }) => rawText)).toEqual([
+      "Newest SMS capture",
+      "Older SMS capture",
     ]);
   });
 });

--- a/apps/mobile/__tests__/transactions/mutation-service.test.ts
+++ b/apps/mobile/__tests__/transactions/mutation-service.test.ts
@@ -158,6 +158,23 @@ describe("transaction mutation service", () => {
     expect(refreshMock).toHaveBeenCalledOnce();
   });
 
+  it("returns an update error without side effects when the write-through update fails", async () => {
+    currentCommit = vi.fn().mockResolvedValue({
+      success: false,
+      error: "update failed",
+    });
+    const service = createService();
+
+    await expect(service.update("txn-9" as TransactionId, input)).resolves.toEqual({
+      success: false,
+      error: "Failed to update transaction",
+    });
+
+    expect(trackEditedMock).not.toHaveBeenCalled();
+    expect(resetFormMock).not.toHaveBeenCalled();
+    expect(refreshMock).not.toHaveBeenCalled();
+  });
+
   it("throws on failed deletes and still refreshes when commits are unavailable", async () => {
     const failingCommit = vi.fn().mockResolvedValue({
       success: false,


### PR DESCRIPTION
## Summary
- add repository coverage for notification sources and processed captures
- add budget notification failure-path coverage
- add transaction update write-through failure coverage

## Verification
- `bun run test:coverage`
