### PR TITLE
docs(agents): harden opening-mr PR body handling

### DIFF
--- a/.agents/skills/opening-mr/SKILL.md
+++ b/.agents/skills/opening-mr/SKILL.md
@@ -67,12 +67,23 @@ Push to the feature branch after committing. Main is protected — direct pushes
 git push -u origin <branch-name>
 ```
 
-Then create a pull request targeting `main`. The PR title and body **must match the commit message exactly** (header → title, body → description). Do NOT use `--fill` — it breaks with multiple commits. Instead, explicitly pass the commit message:
+Then create a pull request targeting `main`. The PR title and body **must match the commit message exactly** (header -> title, body -> description). Do NOT use `--fill` - it breaks with multiple commits.
+
+PR body safety rules:
+- Never pass PR body text directly inside shell quotes if it may contain backticks, command substitutions, or multi-line content
+- Never paste raw terminal output into the PR body
+- Never include absolute local paths like `/Users/...`, worktree paths, temp paths, or ANSI escape sequences
+- Summarize verification results in plain language instead of dumping command output
+
+Write the PR body to a temporary markdown file and pass it with `--body-file`:
 
 ```bash
 TITLE=$(git log -1 --format=%s)
 BODY=$(git log -1 --format=%b)
-gh pr create --title "$TITLE" --body "$BODY"
+BODY_FILE=$(mktemp)
+printf '%s\n' "$BODY" > "$BODY_FILE"
+gh pr create --title "$TITLE" --body-file "$BODY_FILE"
+rm -f "$BODY_FILE"
 ```
 
 ## Step 9 — Merge (only when the user explicitly asks)


### PR DESCRIPTION
## Summary
- update the `opening-mr` skill to require shell-safe `gh pr create --body-file` usage
- explicitly forbid absolute local paths, raw terminal output, and ANSI escapes in PR descriptions
- require plain-language verification summaries instead of pasted command output

## Verification
- reviewed the skill diff for the new PR-body safety rules

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the `opening-mr` skill by requiring `gh pr create --body-file` for shell-safe PR bodies and adding guardrails against unsafe content. Keeps PR title/body in sync with the latest commit and favors plain-language verification summaries.

- **Refactors**
  - Replace inline `--body` with a temp file via `--body-file`; forbid `--fill`.
  - Add PR body safety rules: no shell-quoted multi-line content/backticks/substitutions; no absolute local/worktree/temp paths, raw terminal output, or ANSI escape sequences.
  - Update example to write the body to a temp file, pass with `--body-file`, then clean up; restate that title/body must match the latest commit message.

<sup>Written for commit 03b0563b951d11cb462540d41015dabd85196202. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

