### PR TITLE
fix(mobile): harden local failure guards

### DIFF
--- a/apps/mobile/__tests__/budget/monitoring.test.ts
+++ b/apps/mobile/__tests__/budget/monitoring.test.ts
@@ -233,6 +233,127 @@ describe("createBudgetMonitoringModule", () => {
     expect(mockInsertNotification).toHaveBeenCalledOnce();
   });
 
+  it("refreshMonth keeps succeeding when a later fresh alert delivery throws", async () => {
+    insertBudgetRow({
+      id: "budget-1" as BudgetId,
+      categoryId: "food" as CategoryId,
+      amount: 100000 as CopAmount,
+    });
+    insertBudgetRow({
+      id: "budget-2" as BudgetId,
+      categoryId: "transport" as CategoryId,
+      amount: 100000 as CopAmount,
+    });
+
+    insertExpense({
+      id: "tx-1",
+      categoryId: "food" as CategoryId,
+      amount: 85000 as CopAmount,
+    });
+    insertExpense({
+      id: "tx-2",
+      categoryId: "transport" as CategoryId,
+      amount: 90000 as CopAmount,
+    });
+
+    mockScheduleBudgetAlert
+      .mockResolvedValueOnce({ type: "scheduled", id: "notif-1" })
+      .mockRejectedValueOnce(new Error("push service down"));
+
+    const module = createBudgetMonitoringModule({
+      getBudgetAlertsEnabled: () => true,
+      getLocale: () => "es",
+      resolveCategoryLabel: mockResolveCategoryLabel,
+      scheduleBudgetAlert: mockScheduleBudgetAlert,
+      insertNotification: mockInsertNotification,
+    });
+
+    const result = await module.refreshMonth({
+      db: db as any,
+      userId: USER_ID,
+      month: CURRENT_MONTH,
+      previous: {
+        pendingAlerts: [],
+        acknowledgedAlerts: new Set(),
+      },
+    });
+
+    expect(result.pendingPermissionRequest).toBe(false);
+    expect(result.pendingAlerts).toHaveLength(2);
+    expect(mockScheduleBudgetAlert).toHaveBeenCalledTimes(2);
+    expect(mockInsertNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it("refreshMonth derives initial over-budget alerts without previous state", async () => {
+    insertBudgetRow({
+      id: "budget-1" as BudgetId,
+      categoryId: "food" as CategoryId,
+      amount: 100000 as CopAmount,
+    });
+    insertBudgetRow({
+      id: "budget-2" as BudgetId,
+      categoryId: "transport" as CategoryId,
+      amount: 50000 as CopAmount,
+    });
+
+    insertExpense({
+      id: "tx-1",
+      categoryId: "food" as CategoryId,
+      amount: 110000 as CopAmount,
+    });
+
+    const module = createBudgetMonitoringModule({
+      getBudgetAlertsEnabled: () => true,
+      getLocale: () => "es",
+      resolveCategoryLabel: mockResolveCategoryLabel,
+      scheduleBudgetAlert: mockScheduleBudgetAlert,
+      insertNotification: mockInsertNotification,
+    });
+
+    const result = await module.refreshMonth({
+      db: db as any,
+      userId: USER_ID,
+      month: CURRENT_MONTH,
+    });
+
+    expect(result.pendingPermissionRequest).toBe(false);
+    expect(result.budgetProgress).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          budgetId: "budget-1",
+          spent: 110000,
+          remaining: -10000,
+          percentUsed: 110,
+        }),
+        expect.objectContaining({
+          budgetId: "budget-2",
+          spent: 0,
+          remaining: 50000,
+          percentUsed: 0,
+        }),
+      ])
+    );
+    expect(result.pendingAlerts).toEqual([
+      expect.objectContaining({
+        budgetId: "budget-1",
+        threshold: 100,
+      }),
+    ]);
+    expect(mockScheduleBudgetAlert).toHaveBeenCalledOnce();
+    expect(mockScheduleBudgetAlert).toHaveBeenCalledWith(
+      expect.objectContaining({ budgetId: "budget-1", threshold: 100 }),
+      "es:food",
+      true
+    );
+    expect(mockInsertNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        titleKey: "notifications.budgetExceeded",
+        messageKey: "notifications.budgetExceededMsg",
+        dedupKey: "budget_alert:food:100:2026-03",
+      })
+    );
+  });
+
   it("loadAutoSuggestions derives suggestions without delivering alerts", () => {
     insertBudgetRow();
     insertExpense({

--- a/apps/mobile/__tests__/budget/notifications.test.ts
+++ b/apps/mobile/__tests__/budget/notifications.test.ts
@@ -60,6 +60,34 @@ describe("scheduleBudgetAlert", () => {
     expect(mockScheduleNotificationAsync).toHaveBeenCalledOnce();
   });
 
+  it("schedules the over-budget copy when the alert threshold is 100", async () => {
+    const { scheduleBudgetAlert } = await import("@/features/budget/lib/notifications");
+
+    const result = await scheduleBudgetAlert(
+      {
+        ...MOCK_ALERT,
+        threshold: 100,
+        percentUsed: 112,
+      },
+      "Comida"
+    );
+
+    expect(result).toEqual({ type: "scheduled", id: "notif-id-123" });
+    expect(mockScheduleNotificationAsync).toHaveBeenCalledWith({
+      content: {
+        title: "¡Presupuesto superado!",
+        body: "Comida excedió el presupuesto al 112%",
+        data: {
+          budgetId: "budget-1",
+          categoryId: "food",
+          threshold: 100,
+          route: "/(tabs)/(finance)",
+        },
+      },
+      trigger: null,
+    });
+  });
+
   it("returns { type: 'needs_permission' } when pre-permission is needed", async () => {
     mockGetPermissionsAsync.mockResolvedValue({
       status: "undetermined",
@@ -132,12 +160,13 @@ describe("scheduleBudgetAlert", () => {
     expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
   });
 
-  it("returns { type: 'skipped' } when scheduling the notification throws", async () => {
-    mockScheduleNotificationAsync.mockRejectedValue(new Error("schedule failed"));
+  it("returns { type: 'skipped' } when notification scheduling fails", async () => {
+    mockScheduleNotificationAsync.mockRejectedValueOnce(new Error("Expo failed"));
     const { scheduleBudgetAlert } = await import("@/features/budget/lib/notifications");
 
     const result = await scheduleBudgetAlert(MOCK_ALERT, "Food");
 
     expect(result).toEqual({ type: "skipped" });
+    expect(mockScheduleNotificationAsync).toHaveBeenCalledOnce();
   });
 });

--- a/apps/mobile/__tests__/calendar/bill-mutation-service.test.ts
+++ b/apps/mobile/__tests__/calendar/bill-mutation-service.test.ts
@@ -226,6 +226,13 @@ describe("calendar bill mutation service", () => {
     );
   });
 
+  it("returns false when updateBill commit throws", async () => {
+    currentCommit = vi.fn().mockRejectedValue(new Error("boom"));
+    const service = createService();
+
+    await expect(service.updateBill("bill-1" as BillId, { name: "Updated" })).resolves.toBe(false);
+  });
+
   it("returns false for update and delete when commits are unavailable or fail", async () => {
     currentCommit = null;
     const service = createService();
@@ -233,6 +240,13 @@ describe("calendar bill mutation service", () => {
     await expect(service.deleteBill("bill-1" as BillId)).resolves.toBe(false);
 
     currentCommit = vi.fn().mockResolvedValue({ success: false, error: "nope" });
+    await expect(service.deleteBill("bill-1" as BillId)).resolves.toBe(false);
+  });
+
+  it("returns false when deleteBill commit throws", async () => {
+    currentCommit = vi.fn().mockRejectedValue(new Error("boom"));
+    const service = createService();
+
     await expect(service.deleteBill("bill-1" as BillId)).resolves.toBe(false);
   });
 
@@ -283,6 +297,18 @@ describe("calendar bill mutation service", () => {
     ).resolves.toEqual({ success: false });
   });
 
+  it("returns false when markBillPaid receives a failed commit result", async () => {
+    currentCommit = vi.fn().mockResolvedValue({ success: false, error: "nope" });
+    const service = createService();
+
+    await expect(
+      service.markBillPaid([bill], bill.id as BillId, "2026-04-12" as IsoDate)
+    ).resolves.toEqual({ success: false });
+
+    expect(addTransactionToCacheMock).not.toHaveBeenCalled();
+    expect(trackPaymentRecordedMock).not.toHaveBeenCalled();
+  });
+
   it("unmarks payments and only clears cache when a linked transaction exists", async () => {
     const service = createService();
     const withTransaction: BillPayment = {
@@ -325,6 +351,25 @@ describe("calendar bill mutation service", () => {
         transactionId: null,
       })
     );
+    expect(removeTransactionFromCacheMock).not.toHaveBeenCalled();
+  });
+
+  it("returns false when unmarkBillPaid receives a failed commit result", async () => {
+    currentCommit = vi.fn().mockResolvedValue({ success: false, error: "nope" });
+    const service = createService();
+    const withTransaction: BillPayment = {
+      id: "pay-1" as BillPaymentId,
+      billId: bill.id as BillId,
+      dueDate: "2026-04-12" as IsoDate,
+      paidAt: nowIso,
+      transactionId: "txn-1" as TransactionId,
+      createdAt: nowIso,
+    };
+
+    await expect(
+      service.unmarkBillPaid([withTransaction], bill.id as BillId, withTransaction.dueDate)
+    ).resolves.toEqual({ success: false });
+
     expect(removeTransactionFromCacheMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/mobile/__tests__/capture-sources/notification-parser.test.ts
+++ b/apps/mobile/__tests__/capture-sources/notification-parser.test.ts
@@ -108,6 +108,19 @@ describe("parseNotificationLocally", () => {
     });
   });
 
+  describe("generic purchase fallback", () => {
+    it("parses unknown provider purchase notifications before falling back to the API", () => {
+      const result = parseNotificationLocally(
+        "Tu compra fue aprobada por $18,900 en CAFETERIA CENTRAL. "
+      );
+      expect(result).toEqual({
+        amount: 18900,
+        merchant: "CAFETERIA CENTRAL",
+        type: "expense",
+      });
+    });
+  });
+
   describe("amount parsing edge cases", () => {
     it("handles dot as thousands separator", () => {
       const result = parseNotificationLocally(

--- a/apps/mobile/__tests__/capture-sources/repository.test.ts
+++ b/apps/mobile/__tests__/capture-sources/repository.test.ts
@@ -26,9 +26,22 @@ vi.mock("date-fns", () => ({
 }));
 
 vi.mock("@/shared/db/schema", () => ({
-  processedCaptures: "processedCaptures",
-  notificationSources: "notificationSources",
-  detectedSmsEvents: "detectedSmsEvents",
+  processedCaptures: {
+    id: "processedCaptures.id",
+    source: "processedCaptures.source",
+    receivedAt: "processedCaptures.receivedAt",
+  },
+  notificationSources: {
+    userId: "notificationSources.userId",
+    packageName: "notificationSources.packageName",
+    isEnabled: "notificationSources.isEnabled",
+  },
+  detectedSmsEvents: {
+    id: "detectedSmsEvents.id",
+    userId: "detectedSmsEvents.userId",
+    dismissed: "detectedSmsEvents.dismissed",
+    detectedAt: "detectedSmsEvents.detectedAt",
+  },
 }));
 
 vi.mock("@/shared/lib/generate-id", () => ({
@@ -99,6 +112,25 @@ describe("capture-sources repository", () => {
 
   // -- hasProcessedCaptures --
 
+  it("getProcessedCapturesBySource returns source rows newest first", async () => {
+    const rows = [
+      { id: "pc-2", source: "sms", receivedAt: "2026-03-07T11:00:00Z" },
+      { id: "pc-1", source: "sms", receivedAt: "2026-03-07T10:00:00Z" },
+    ];
+    mockOrderBy.mockResolvedValueOnce(rows);
+
+    const { getProcessedCapturesBySource } = await import(
+      "@/features/capture-sources/lib/repository"
+    );
+    const result = await getProcessedCapturesBySource(mockDb, "sms");
+
+    expect(mockSelect).toHaveBeenCalled();
+    expect(mockFrom).toHaveBeenCalled();
+    expect(mockWhere).toHaveBeenCalledWith({ eq: ["processedCaptures.source", "sms"] });
+    expect(mockOrderBy).toHaveBeenCalledWith({ desc: ["processedCaptures.receivedAt"] });
+    expect(result).toEqual(rows);
+  });
+
   it("hasProcessedCaptures returns true when records exist", async () => {
     mockLimit.mockResolvedValueOnce([{ id: "pc-1" }]);
 
@@ -122,6 +154,22 @@ describe("capture-sources repository", () => {
   });
 
   // -- getEnabledPackages --
+
+  it("getNotificationSources returns rows for the requested user", async () => {
+    const rows = [
+      { id: "ns-1", userId: "user-1", packageName: "com.bank.app", isEnabled: true },
+      { id: "ns-2", userId: "user-1", packageName: "com.wallet.app", isEnabled: false },
+    ];
+    mockWhere.mockResolvedValueOnce(rows);
+
+    const { getNotificationSources } = await import("@/features/capture-sources/lib/repository");
+    const result = await getNotificationSources(mockDb, "user-1");
+
+    expect(mockSelect).toHaveBeenCalled();
+    expect(mockFrom).toHaveBeenCalled();
+    expect(mockWhere).toHaveBeenCalledWith({ eq: ["notificationSources.userId", "user-1"] });
+    expect(result).toEqual(rows);
+  });
 
   it("getEnabledPackages returns array of package names", async () => {
     mockWhere.mockResolvedValueOnce([

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -77,7 +77,7 @@ vi.mock("@/shared/db/enqueue-sync", () => ({
 }));
 
 const mockRefresh = vi.fn();
-vi.mock("@/features/transactions/store", () => ({
+vi.mock("@/features/transactions", () => ({
   useTransactionStore: {
     getState: () => ({ refresh: mockRefresh }),
   },

--- a/apps/mobile/__tests__/notifications/display.test.ts
+++ b/apps/mobile/__tests__/notifications/display.test.ts
@@ -162,6 +162,20 @@ describe("deriveNotificationDisplay", () => {
     expect(result.iconName).toBe("circle-x");
     expect(result.iconColor).toBe("#D45B5B");
   });
+
+  it("falls back gracefully when stored params JSON is invalid", () => {
+    const n = makeNotification({
+      type: "budget_alert",
+      params: "{not-valid-json",
+    });
+    const result = deriveNotificationDisplay(n, mockT);
+    expect(result.title).toBe("notifications.budget_alert.title");
+    expect(result.message).toBe("notifications.budget_alert.message");
+    expect(result.iconName).toBe("circle-x");
+    expect(result.iconColor).toBe("#D45B5B");
+    expect(result.iconBgColor).toBe("#FFEBEE");
+    expect(result.route).toBe("/(tabs)/(finance)");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/mobile/__tests__/transactions/mutation-service.test.ts
+++ b/apps/mobile/__tests__/transactions/mutation-service.test.ts
@@ -143,6 +143,22 @@ describe("transaction mutation service", () => {
     expect(refreshMock).toHaveBeenCalledOnce();
   });
 
+  it("returns a failed update result when the commit reports no mutation", async () => {
+    currentCommit = vi.fn().mockResolvedValue({
+      success: false,
+      error: "write-through rejected update",
+    });
+    const service = createService();
+
+    await expect(service.update("txn-9" as TransactionId, input)).resolves.toEqual({
+      success: false,
+      error: "Failed to update transaction",
+    });
+    expect(trackEditedMock).not.toHaveBeenCalled();
+    expect(resetFormMock).not.toHaveBeenCalled();
+    expect(refreshMock).not.toHaveBeenCalled();
+  });
+
   it("updates transactions directly without resetting the form", async () => {
     currentCommit = vi.fn().mockResolvedValue({ success: true, didMutate: true });
     const service = createService();
@@ -170,6 +186,31 @@ describe("transaction mutation service", () => {
       error: "Failed to update transaction",
     });
 
+    expect(trackEditedMock).not.toHaveBeenCalled();
+    expect(resetFormMock).not.toHaveBeenCalled();
+    expect(refreshMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "update",
+      (service: ReturnType<typeof createService>) =>
+        service.update("txn-9" as TransactionId, { ...input, digits: "" }),
+    ],
+    [
+      "updateDirect",
+      (service: ReturnType<typeof createService>) =>
+        service.updateDirect("txn-9" as TransactionId, { ...input, digits: "" }),
+    ],
+  ])("returns validation failures from %s without side effects", async (_method, runMutation) => {
+    const service = createService();
+
+    const result = await runMutation(service);
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toEqual(expect.any(String));
+    expect(currentCommit).not.toHaveBeenCalled();
     expect(trackEditedMock).not.toHaveBeenCalled();
     expect(resetFormMock).not.toHaveBeenCalled();
     expect(refreshMock).not.toHaveBeenCalled();

--- a/apps/mobile/__tests__/transactions/store.test.ts
+++ b/apps/mobile/__tests__/transactions/store.test.ts
@@ -320,6 +320,94 @@ describe("useTransactionStore", () => {
     expect(getTransactionsPaginated).not.toHaveBeenCalled();
   });
 
+  it("refresh updates pagination metadata even when transaction rows are unchanged", async () => {
+    useTransactionStore.setState({
+      pages: [
+        {
+          id: "tx-1" as TransactionId,
+          userId: mockUserId,
+          type: "expense",
+          amount: 1000 as CopAmount,
+          categoryId: "food" as CategoryId,
+          description: "Lunch",
+          date: new Date("2026-03-04T00:00:00.000Z"),
+          createdAt: new Date("2026-03-04T10:00:00.000Z"),
+          updatedAt: new Date("2026-03-04T10:00:00.000Z"),
+          deletedAt: null,
+        },
+      ],
+      offset: 1,
+      hasMore: true,
+    });
+
+    vi.mocked(getTransactionsPaginated).mockReturnValueOnce([
+      {
+        id: "tx-1" as TransactionId,
+        userId: mockUserId,
+        type: "expense",
+        amount: 1000 as CopAmount,
+        categoryId: "food" as CategoryId,
+        description: "Lunch",
+        date: "2026-03-04" as IsoDate,
+        createdAt: "2026-03-04T10:00:00.000Z" as IsoDateTime,
+        updatedAt: "2026-03-04T10:00:00.000Z" as IsoDateTime,
+        deletedAt: null,
+        source: "manual",
+      },
+    ]);
+
+    await useTransactionStore.getState().refresh();
+
+    expect(useTransactionStore.getState().hasMore).toBe(false);
+  });
+
+  it("refresh keeps existing pages and aggregates when the DB read fails", async () => {
+    const existingDate = new Date("2026-03-04T00:00:00.000Z");
+    const existingUpdatedAt = new Date("2026-03-04T10:00:00.000Z");
+    const existingCategorySpending = [
+      { categoryId: "food" as CategoryId, total: 42000 as CopAmount },
+    ];
+    const existingDailySpending = [{ date: "2026-03-04" as IsoDate, total: 42000 as CopAmount }];
+
+    useTransactionStore.setState({
+      pages: [
+        {
+          id: "tx-1" as TransactionId,
+          userId: mockUserId,
+          type: "expense",
+          amount: 42000 as CopAmount,
+          categoryId: "food" as CategoryId,
+          description: "Existing lunch",
+          date: existingDate,
+          createdAt: existingUpdatedAt,
+          updatedAt: existingUpdatedAt,
+          deletedAt: null,
+        },
+      ],
+      offset: 1,
+      hasMore: true,
+      balance: 42000,
+      categorySpending: existingCategorySpending,
+      dailySpending: existingDailySpending,
+    });
+
+    vi.mocked(getTransactionsPaginated).mockImplementationOnce(() => {
+      throw new Error("db read failed");
+    });
+
+    await useTransactionStore.getState().refresh();
+
+    const state = useTransactionStore.getState();
+    expect(state.pages).toHaveLength(1);
+    expect(state.pages[0]?.id).toBe("tx-1");
+    expect(state.offset).toBe(1);
+    expect(state.hasMore).toBe(true);
+    expect(state.balance).toBe(42000);
+    expect(state.categorySpending).toEqual(existingCategorySpending);
+    expect(state.dailySpending).toEqual(existingDailySpending);
+    expect(getSpendingByCategoryAggregate).not.toHaveBeenCalled();
+  });
+
   it("editTransaction hydrates edit mode from the stored transaction row", () => {
     vi.mocked(getTransactionById).mockReturnValueOnce({
       id: "tx-1" as TransactionId,
@@ -346,6 +434,68 @@ describe("useTransactionStore", () => {
     expect(state.date.getFullYear()).toBe(2026);
     expect(state.date.getMonth()).toBe(3);
     expect(state.date.getDate()).toBe(12);
+  });
+
+  it("editTransaction clears stale edit state when the requested row is missing", () => {
+    useTransactionStore.setState({
+      editingId: "tx-stale" as TransactionId,
+      step: 2,
+      type: "income",
+      digits: "235000",
+      categoryId: "food" as CategoryId,
+      description: "Stale draft",
+      date: new Date("2026-04-12T00:00:00.000Z"),
+    });
+
+    vi.mocked(getTransactionById).mockReturnValueOnce(null);
+
+    useTransactionStore.getState().editTransaction("tx-missing" as TransactionId);
+
+    const state = useTransactionStore.getState();
+    expect(state.editingId).toBeNull();
+    expect(state.step).toBe(1);
+    expect(state.type).toBe("expense");
+    expect(state.digits).toBe("");
+    expect(state.categoryId).toBeNull();
+    expect(state.description).toBe("");
+  });
+
+  it("editTransaction clears stale edit state when the DB read throws", () => {
+    useTransactionStore.setState({
+      editingId: "tx-stale" as TransactionId,
+      step: 2,
+      type: "income",
+      digits: "235000",
+      categoryId: "food" as CategoryId,
+      description: "Stale draft",
+      date: new Date("2026-04-12T00:00:00.000Z"),
+    });
+
+    vi.mocked(getTransactionById).mockImplementationOnce(() => {
+      throw new Error("db read failed");
+    });
+
+    expect(() =>
+      useTransactionStore.getState().editTransaction("tx-broken" as TransactionId)
+    ).not.toThrow();
+
+    const state = useTransactionStore.getState();
+    expect(state.editingId).toBeNull();
+    expect(state.step).toBe(1);
+    expect(state.type).toBe("expense");
+    expect(state.digits).toBe("");
+    expect(state.categoryId).toBeNull();
+    expect(state.description).toBe("");
+  });
+
+  it("getTransactionById returns null when the DB read throws", () => {
+    vi.mocked(getTransactionById).mockImplementationOnce(() => {
+      throw new Error("db read failed");
+    });
+
+    const result = useTransactionStore.getState().getTransactionById("tx-1" as TransactionId);
+
+    expect(result).toBeNull();
   });
 
   it("removeTransaction soft-deletes from DB, enqueues sync, and refreshes", async () => {

--- a/apps/mobile/features/calendar/lib/bill-mutation-service.ts
+++ b/apps/mobile/features/calendar/lib/bill-mutation-service.ts
@@ -154,16 +154,20 @@ export function createCalendarBillMutationService(
           ])
       );
 
-      const result = await commit({
-        kind: "calendar.bill.update",
-        billId: id,
-        fields: dbFields as Partial<
-          Pick<BillRow, "name" | "amount" | "frequency" | "categoryId" | "startDate" | "isActive">
-        >,
-        now: toIsoDateTime(now()),
-      });
+      try {
+        const result = await commit({
+          kind: "calendar.bill.update",
+          billId: id,
+          fields: dbFields as Partial<
+            Pick<BillRow, "name" | "amount" | "frequency" | "categoryId" | "startDate" | "isActive">
+          >,
+          now: toIsoDateTime(now()),
+        });
 
-      return result.success;
+        return result.success;
+      } catch {
+        return false;
+      }
     },
 
     deleteBill: async (id) => {
@@ -172,12 +176,16 @@ export function createCalendarBillMutationService(
         return false;
       }
 
-      const result = await commit({
-        kind: "calendar.bill.delete",
-        billId: id,
-      });
+      try {
+        const result = await commit({
+          kind: "calendar.bill.delete",
+          billId: id,
+        });
 
-      return result.success;
+        return result.success;
+      } catch {
+        return false;
+      }
     },
 
     markBillPaid: async (bills, billId, dueDate) => {

--- a/apps/mobile/features/capture-sources/services/notification-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/notification-pipeline.ts
@@ -32,7 +32,7 @@ import type { CategoryId, CopAmount, IsoDate, TransactionId, UserId } from "@/sh
 /** In-flight fingerprints guard against concurrent duplicate processing. */
 const inFlightFingerprints = new Set<string>();
 
-export type NotificationPipelineResult = {
+type NotificationPipelineResult = {
   saved: boolean;
   skippedDuplicate: boolean;
   transactionId: string | null;

--- a/apps/mobile/features/transactions/store.ts
+++ b/apps/mobile/features/transactions/store.ts
@@ -239,6 +239,11 @@ export const useTransactionStore = create<TransactionState & TransactionActions>
             offset: pageData.length,
             hasMore,
           });
+        } else {
+          set({
+            offset: pageData.length,
+            hasMore,
+          });
         }
         get().loadAggregates();
       } catch {
@@ -254,17 +259,25 @@ export const useTransactionStore = create<TransactionState & TransactionActions>
 
     editTransaction: (id) => {
       if (!dbRef) return;
-      const row = getTransactionById(dbRef, id);
-      if (!row) return;
-      const tx = toStoredTransaction(row);
-      set({
-        editingId: id,
-        type: tx.type,
-        digits: String(tx.amount),
-        categoryId: tx.categoryId,
-        description: tx.description,
-        date: tx.date,
-      });
+      try {
+        const row = getTransactionById(dbRef, id);
+        if (!row) {
+          get().resetForm();
+          return;
+        }
+
+        const tx = toStoredTransaction(row);
+        set({
+          editingId: id,
+          type: tx.type,
+          digits: String(tx.amount),
+          categoryId: tx.categoryId,
+          description: tx.description,
+          date: tx.date,
+        });
+      } catch {
+        get().resetForm();
+      }
     },
 
     updateTransaction: async (id) => mutationService.update(id, toTransactionFormInput(get())),
@@ -288,8 +301,12 @@ export const useTransactionStore = create<TransactionState & TransactionActions>
 
     getTransactionById: (id) => {
       if (!dbRef) return null;
-      const row = getTransactionById(dbRef, id);
-      return row ? toStoredTransaction(row) : null;
+      try {
+        const row = getTransactionById(dbRef, id);
+        return row ? toStoredTransaction(row) : null;
+      } catch {
+        return null;
+      }
     },
   };
 });

--- a/scripts/ralph/entropy-progress.template.txt
+++ b/scripts/ralph/entropy-progress.template.txt
@@ -2,3 +2,9 @@
 
 Started: not yet run
 ---
+
+## 2026-04-17 - Unused exported type in notification pipeline
+- Issue found: `NotificationPipelineResult` was exported from `apps/mobile/features/capture-sources/services/notification-pipeline.ts` even though it is only referenced inside that file.
+- Why it mattered: unnecessary exports widen a module's public surface and make it harder to tell which types are actual cross-module contracts.
+- Files changed: `apps/mobile/features/capture-sources/services/notification-pipeline.ts`, `scripts/ralph/entropy-progress.txt`
+- Validation run: `bun run --cwd apps/mobile typecheck`

--- a/scripts/ralph/ralph.sh
+++ b/scripts/ralph/ralph.sh
@@ -69,8 +69,11 @@ map_path_to_worktree() {
 ensure_maintenance_worktree() {
   local branch_name="$1"
   local worktree_path="$2"
+  local target_head
   local current_branch
   local worktree_status
+
+  target_head="$(git -C "$REPO_ROOT" rev-parse HEAD)"
 
   if git -C "$REPO_ROOT" worktree list --porcelain | grep -Fqx "worktree $worktree_path"; then
     current_branch="$(git -C "$worktree_path" branch --show-current)"
@@ -86,6 +89,7 @@ ensure_maintenance_worktree() {
       exit 1
     fi
 
+    git -C "$worktree_path" reset --hard "$target_head" >/dev/null
     return
   fi
 
@@ -95,11 +99,12 @@ ensure_maintenance_worktree() {
   fi
 
   if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$branch_name"; then
+    git -C "$REPO_ROOT" branch -f "$branch_name" "$target_head" >/dev/null
     git -C "$REPO_ROOT" worktree add "$worktree_path" "$branch_name"
     return
   fi
 
-  git -C "$REPO_ROOT" worktree add -b "$branch_name" "$worktree_path" HEAD
+  git -C "$REPO_ROOT" worktree add -b "$branch_name" "$worktree_path" "$target_head"
 }
 
 while [[ $# -gt 0 ]]; do

--- a/scripts/ralph/ralph.sh
+++ b/scripts/ralph/ralph.sh
@@ -89,7 +89,6 @@ ensure_maintenance_worktree() {
       exit 1
     fi
 
-    git -C "$worktree_path" reset --hard "$target_head" >/dev/null
     return
   fi
 


### PR DESCRIPTION
- handle local read failures

- guard bill mutation commits

- expand regression coverage

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened mobile failure guards to avoid crashes or bad state when local reads or commits fail, with expanded tests to prevent regressions. Preserves maintenance branch progress across runs while creating worktrees from the current `HEAD`, and internalized an unused type with unused import cleanup enforced.

- **Bug Fixes**
  - Bills: `updateBill`/`deleteBill` now return false if commit throws; `markBillPaid`/`unmarkBillPaid` abort on failed commit results and skip cache side effects.
  - Transactions: refresh updates `offset`/`hasMore` even when rows are unchanged; on DB read errors, keep existing pages/aggregates; `editTransaction` and `getTransactionById` handle read failures by resetting/returning null; mutation service returns validation errors without side effects and treats “no mutation” commits as failures.
  - Budget/notifications: budget refresh continues when a later alert delivery fails; correct over‑budget (100%) copy; invalid stored params JSON falls back to defaults; scheduling failures return `{ type: 'skipped' }`.
  - Capture sources/tooling: tighter queries and ordering for processed captures and notification sources; made `NotificationPipelineResult` internal; `ralph.sh` preserves maintenance branch progress and stops hard‑resetting clean worktrees, while new worktrees/branches are created from the current `HEAD`; enabled Biome’s unused import rule and recorded the cleanup in entropy logs.

<sup>Written for commit 34bd1092eabe178d1b0442666e7b2783199e1fbf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

