### PR TITLE
chore(entropy): enable noUnusedImports

### DIFF
--- a/apps/mobile/features/capture-sources/services/notification-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/notification-pipeline.ts
@@ -32,7 +32,7 @@ import type { CategoryId, CopAmount, IsoDate, TransactionId, UserId } from "@/sh
 /** In-flight fingerprints guard against concurrent duplicate processing. */
 const inFlightFingerprints = new Set<string>();
 
-export type NotificationPipelineResult = {
+type NotificationPipelineResult = {
   saved: boolean;
   skippedDuplicate: boolean;
   transactionId: string | null;

--- a/biome.json
+++ b/biome.json
@@ -44,7 +44,8 @@
         "useNamingConvention": "warn"
       },
       "correctness": {
-        "noConstAssign": "error"
+        "noConstAssign": "error",
+        "noUnusedImports": "error"
       }
     }
   },

--- a/scripts/ralph/entropy-progress.txt
+++ b/scripts/ralph/entropy-progress.txt
@@ -2,3 +2,9 @@
 
 Started: not yet run
 ---
+
+## 2026-04-17 - Unused exported type in notification pipeline
+- Issue found: `NotificationPipelineResult` was exported from `apps/mobile/features/capture-sources/services/notification-pipeline.ts` even though it is only referenced inside that file.
+- Why it mattered: unnecessary exports widen a module's public surface and make it harder to tell which types are actual cross-module contracts.
+- Files changed: `apps/mobile/features/capture-sources/services/notification-pipeline.ts`, `scripts/ralph/entropy-progress.txt`
+- Validation run: `bun run --cwd apps/mobile typecheck`

--- a/scripts/ralph/prompts/AGENTS.md
+++ b/scripts/ralph/prompts/AGENTS.md
@@ -1,0 +1,46 @@
+# Ralph Maintenance Instructions
+
+You are running a Ralph maintenance loop, not a feature-story loop.
+
+## Bootstrap
+
+Before anything else:
+
+1. Read the repo root `AGENTS.md`
+2. Inspect `git status --short`
+3. Read the maintenance prompt file passed to this run
+4. Read the maintenance progress file passed to this run
+
+## Scope
+
+- Do not read or require `scripts/ralph/prd.json`
+- Do not read or require `scripts/ralph/progress.txt`
+- Do not expect a feature branch from PRD metadata
+- Work only from the maintenance prompt and maintenance progress file for this run
+
+## Workflow
+
+1. Follow the maintenance prompt exactly
+2. Keep each iteration scoped to one meaningful improvement
+3. Run the narrowest useful validation while iterating
+4. Leave the worktree in a working state
+5. Append progress only to the maintenance progress file for this run
+
+## Committing
+
+After checks pass, create a local iteration commit only.
+
+- Use a scoped header such as `chore(ralph): maintenance [topic]`
+- Do not push
+- Do not open or update a PR during the loop
+
+## AGENTS Updates
+
+If you discover durable, reusable knowledge, update the repo or nearby `AGENTS.md` files.
+Do not add story-specific details or temporary debugging notes.
+
+## Important
+
+- Treat this as maintenance, not feature delivery
+- Do not invent PRD work when none exists
+- The maintenance prompt and its progress file are the source of truth for the run

--- a/scripts/ralph/ralph.sh
+++ b/scripts/ralph/ralph.sh
@@ -58,7 +58,7 @@ map_path_to_worktree() {
     return
   fi
 
-  if [[ "$source_path" == "$source_root"* ]]; then
+  if [[ "$source_path" == "$source_root" || "$source_path" == "$source_root"/* ]]; then
     echo "$target_root${source_path#$source_root}"
     return
   fi
@@ -69,8 +69,27 @@ map_path_to_worktree() {
 ensure_maintenance_worktree() {
   local branch_name="$1"
   local worktree_path="$2"
+  local target_head
+  local current_branch
+  local worktree_status
+
+  target_head="$(git -C "$REPO_ROOT" rev-parse HEAD)"
 
   if git -C "$REPO_ROOT" worktree list --porcelain | grep -Fqx "worktree $worktree_path"; then
+    current_branch="$(git -C "$worktree_path" branch --show-current)"
+
+    if [[ "$current_branch" != "$branch_name" ]]; then
+      echo "Error: Maintenance worktree $worktree_path is on branch '$current_branch', expected '$branch_name'."
+      exit 1
+    fi
+
+    worktree_status="$(git -C "$worktree_path" status --porcelain)"
+    if [[ -n "$worktree_status" ]]; then
+      echo "Error: Maintenance worktree $worktree_path has uncommitted changes. Commit or clean it before rerunning Ralph."
+      exit 1
+    fi
+
+    git -C "$worktree_path" reset --hard "$target_head" >/dev/null
     return
   fi
 
@@ -80,11 +99,12 @@ ensure_maintenance_worktree() {
   fi
 
   if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$branch_name"; then
+    git -C "$REPO_ROOT" branch -f "$branch_name" "$target_head" >/dev/null
     git -C "$REPO_ROOT" worktree add "$worktree_path" "$branch_name"
     return
   fi
 
-  git -C "$REPO_ROOT" worktree add -b "$branch_name" "$worktree_path" HEAD
+  git -C "$REPO_ROOT" worktree add -b "$branch_name" "$worktree_path" "$target_head"
 }
 
 while [[ $# -gt 0 ]]; do
@@ -141,6 +161,7 @@ LAST_BRANCH_FILE="$SCRIPT_DIR/.last-branch"
 DEFAULT_PROMPT_FILE="$SCRIPT_DIR/AGENTS.md"
 OPENCODE_PROMPT_FILE="$SCRIPT_DIR/prompt-opencode.md"
 DEFAULT_INSTRUCTIONS_FILE="$SCRIPT_DIR/AGENTS.md"
+MAINTENANCE_INSTRUCTIONS_FILE="$SCRIPT_DIR/prompts/AGENTS.md"
 PROMPT_FILE="${CUSTOM_PROMPT_FILE:-$DEFAULT_PROMPT_FILE}"
 INSTRUCTIONS_FILE="$DEFAULT_INSTRUCTIONS_FILE"
 ACTIVE_PROGRESS_FILE="$PROGRESS_FILE"
@@ -157,7 +178,7 @@ if [[ "$MODE" == "maintenance" ]]; then
     exit 1
   fi
 
-  INSTRUCTIONS_FILE="$CUSTOM_PROMPT_FILE"
+  INSTRUCTIONS_FILE="$MAINTENANCE_INSTRUCTIONS_FILE"
   ACTIVE_PROGRESS_FILE="${CUSTOM_PROGRESS_FILE:-$SCRIPT_DIR/maintenance-progress.txt}"
 fi
 
@@ -174,6 +195,8 @@ if [[ "$MODE" == "maintenance" && "$RALPH_WORKTREE_ACTIVE" != "1" ]]; then
 
     echo "Using maintenance worktree: $WORKTREE_PATH"
     echo "Using maintenance branch: $MAINTENANCE_NAME"
+
+    cd "$WORKTREE_PATH"
 
     exec env RALPH_WORKTREE_ACTIVE=1 \
       "$WORKTREE_PATH/scripts/ralph/ralph.sh" \


### PR DESCRIPTION
## Summary
- enable Biome's `noUnusedImports` rule and clean up the remaining unused import/export issues on this branch
- align Ralph maintenance scripts with isolated worktrees so entropy automation targets the correct checkout
- keep the mobile notification pipeline behavior unchanged while tightening type-only cleanup

## QA
- `bun x vitest run __tests__/capture-sources/notification-pipeline.test.ts __tests__/capture-sources/hooks.test.ts`
- `bun x tsc --noEmit`
- iPhone 17 Expo dev-client smoke launch on this branch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforced Biome’s `noUnusedImports` and removed an unused export to tighten code hygiene without changing runtime behavior. Updated Ralph maintenance flow to use isolated worktrees pinned to current HEAD so entropy automation targets the correct checkout.

- **Refactors**
  - Enable `noUnusedImports` in `biome.json`.
  - Make `NotificationPipelineResult` internal (no export) in the notification pipeline.
  - Add maintenance instructions at `scripts/ralph/prompts/AGENTS.md`.

- **Bug Fixes**
  - Refresh maintenance worktrees to repo HEAD and require correct branch/clean state before reuse.
  - Fix path mapping when the source path equals the repo root.
  - Use dedicated maintenance instructions in maintenance mode and re-exec from the worktree directory.

<sup>Written for commit 01795eec8860299ea603684892f90421f5a542e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

