### PR TITLE
fix(hooks): enforce pre-push validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,10 @@ The role of this file is to describe common mistakes and confusion points that a
 
 The global test setup (`__tests__/setup.ts`) must NOT use `vi.mock("...", async (importOriginal) => ...)` for heavy modules like `date-fns`. The async `importOriginal` call creates module-loading contention across parallel Vitest workers, causing intermittent timeouts in tests that dynamically import large module trees (e.g. `syncEngine.ts` → budget + goals + transactions). Fix: remove the global mock entirely, or provide a synchronous factory. Tests needing deterministic behavior should mock at the file level with `vi.doMock` or `vi.mock`.
 
+### Lefthook pre-push can silently skip in detached HEAD (⚠️ AGENT SURPRISE)
+
+`lefthook`'s default pre-push file detection can skip every command when the checkout is on detached `HEAD` or lacks a local base branch/upstream (for example, `git diff HEAD @{push}` and `git diff HEAD main` both fail). In this repo, pre-push commands should enumerate tracked files explicitly so lint/typecheck/test still run in linked worktrees and detached checkouts.
+
 ## Testing Strategy
 
 Use these rules:

--- a/apps/mobile/features/capture-sources/hooks/useWidgetCapture.ts
+++ b/apps/mobile/features/capture-sources/hooks/useWidgetCapture.ts
@@ -1,42 +1,45 @@
-import { useEffect } from "react";
-import { AppState } from "react-native";
-import { processWidgetTransactions } from "@/features/capture-sources/services/widget-pipeline";
-import { Platform } from "@/shared/components/rn";
+import { processWidgetTransactions } from "@/features/capture-sources";
+import { AppState, Platform } from "@/shared/components/rn";
 import type { AnyDb } from "@/shared/db";
+import { useSubscription } from "@/shared/hooks";
 import { captureError } from "@/shared/lib";
 import type { UserId } from "@/shared/types/branded";
 import { createCaptureIngestionPort } from "../services/capture-ingestion";
 
 export function useWidgetCapture(db: AnyDb | null, userId: string | null): void {
-  useEffect(() => {
-    if (Platform.OS !== "ios" || !db || !userId) {
-      return;
-    }
+  useSubscription(
+    () => {
+      if (!db || !userId) {
+        return;
+      }
 
-    const uid = userId as UserId;
-    const captureIngestion = createCaptureIngestionPort(db, {
-      processWidgetTransactions,
-    });
-
-    captureIngestion
-      .ingest({ kind: "widget", userId: uid })
-      .catch(function handleInitialError(err) {
-        captureError(err);
+      const uid = userId as UserId;
+      const captureIngestion = createCaptureIngestionPort(db, {
+        processWidgetTransactions,
       });
 
-    const subscription = AppState.addEventListener(
-      "change",
-      function handleAppStateChange(nextState) {
-        if (nextState !== "active") return;
-
+      const ingestWidgetTransactions = () => {
         captureIngestion
           .ingest({ kind: "widget", userId: uid })
-          .catch(function handleAppStateError(err) {
+          .catch(function handleWidgetCaptureError(err) {
             captureError(err);
           });
-      }
-    );
+      };
 
-    return () => subscription.remove();
-  }, [db, userId]);
+      ingestWidgetTransactions();
+
+      const subscription = AppState.addEventListener(
+        "change",
+        function handleAppStateChange(nextState) {
+          if (nextState === "active") {
+            ingestWidgetTransactions();
+          }
+        }
+      );
+
+      return () => subscription.remove();
+    },
+    [db, userId],
+    Platform.OS === "ios" && db != null && userId != null
+  );
 }

--- a/apps/mobile/features/capture-sources/hooks/useWidgetCapture.ts
+++ b/apps/mobile/features/capture-sources/hooks/useWidgetCapture.ts
@@ -1,10 +1,10 @@
-import { processWidgetTransactions } from "@/features/capture-sources";
 import { AppState, Platform } from "@/shared/components/rn";
 import type { AnyDb } from "@/shared/db";
 import { useSubscription } from "@/shared/hooks";
 import { captureError } from "@/shared/lib";
 import type { UserId } from "@/shared/types/branded";
 import { createCaptureIngestionPort } from "../services/capture-ingestion";
+import { processWidgetTransactions } from "../services/widget-pipeline";
 
 export function useWidgetCapture(db: AnyDb | null, userId: string | null): void {
   useSubscription(

--- a/apps/mobile/features/capture-sources/index.ts
+++ b/apps/mobile/features/capture-sources/index.ts
@@ -25,5 +25,4 @@ export {
   type CaptureIngestionPort,
   createCaptureIngestionPort,
 } from "./services/capture-ingestion";
-export { processWidgetTransactions } from "./services/widget-pipeline";
 export { useCaptureSourcesStore } from "./store";

--- a/apps/mobile/features/capture-sources/index.ts
+++ b/apps/mobile/features/capture-sources/index.ts
@@ -25,4 +25,5 @@ export {
   type CaptureIngestionPort,
   createCaptureIngestionPort,
 } from "./services/capture-ingestion";
+export { processWidgetTransactions } from "./services/widget-pipeline";
 export { useCaptureSourcesStore } from "./store";

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -33,14 +33,18 @@ commit-msg:
 pre-push:
   commands:
     root-biome:
-      run: bun run lint
+      files: git ls-files
+      run: ./scripts/run-pre-push-check.sh root-biome {files}
       skip_output: false
     mobile-eslint:
-      run: bun run lint:mobile
+      files: git ls-files
+      run: ./scripts/run-pre-push-check.sh mobile-eslint {files}
       skip_output: false
     mobile-typecheck:
-      run: bun run typecheck
+      files: git ls-files
+      run: ./scripts/run-pre-push-check.sh mobile-typecheck {files}
       skip_output: false
     tests:
-      run: bun run test
+      files: git ls-files
+      run: ./scripts/run-pre-push-check.sh tests {files}
       skip_output: false

--- a/scripts/run-pre-push-check.sh
+++ b/scripts/run-pre-push-check.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -eu
+
+check_name="$1"
+
+case "$check_name" in
+  root-biome)
+    bun run lint
+    ;;
+  mobile-eslint)
+    bun run lint:mobile
+    ;;
+  mobile-typecheck)
+    bun run typecheck
+    ;;
+  tests)
+    bun run test
+    ;;
+  *)
+    echo "Unknown pre-push check: $check_name" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
- run checks in detached worktrees
- move widget capture to useSubscription
- export widget pipeline from feature barrel

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces reliable pre-push checks in all git states and stabilizes iOS widget transaction capture with `useSubscription`. Removes an import cycle and restores the architecture lint pass.

- **Bug Fixes**
  - Run `lefthook` pre-push tasks with `git ls-files` so lint/typecheck/tests run in detached HEAD and worktrees.
  - Add `scripts/run-pre-push-check.sh` and update `lefthook.yml` to use it.
  - Document detached HEAD behavior in `AGENTS.md`.

- **Refactors**
  - Move widget capture to `useSubscription` with a conditional start (iOS only; requires `db` and `userId`) and ingest again when the app becomes active.
  - Import `processWidgetTransactions` directly from `../services/widget-pipeline` and drop the barrel re-export to remove the cycle and restore the architecture lint.

<sup>Written for commit a65e9f77a535453d0bb7f1bb834f02ed62364ffd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

