### PR TITLE
docs(agents): add vault skills

### DIFF
--- a/.agents/skills/obsidian-vault/SKILL.md
+++ b/.agents/skills/obsidian-vault/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: obsidian-vault
+description: Search, create, and maintain durable notes in Fidy's external vault. Use when work belongs in the shared knowledge base, when the user asks to search or update the vault, or when research, source digests, architecture notes, workflows, or domain knowledge should live outside the repo.
+---
+
+# Obsidian Vault
+
+Use this skill for Fidy's shared vault, not a generic local Obsidian setup.
+
+The upstream skill assumes a flat vault, Title Case note names, and `[[wikilinks]]`. None of that applies here. Fidy's vault has a typed directory structure, a repo-local bridge, and a required `index.md` / `log.md` maintenance flow.
+
+## Start Here
+
+1. Run `bun run vault:doctor` from the repo root. This validates the external vault and repairs `.context/fidy-vault` if needed.
+2. Read `.context/fidy-vault/AGENTS.md`.
+
+If `vault:doctor` fails, stop and report the missing bridge or files before touching the vault.
+
+## Paths And Commands
+
+- Stable workspace path: `.context/fidy-vault`
+- Print the machine-local vault path: `bun run vault:path`
+- Search the vault: `./scripts/fidy-vault search <pattern>`
+- Show recent vault activity: `bun run vault:recent`
+- Open the vault in Finder: `bun run vault:open`
+
+Use `rg` on `.context/fidy-vault` when you need tighter searches, but prefer the bridge path over hard-coded machine paths.
+
+The vault's directory contract, non-negotiables, page template, and ingest/query/lint workflows already live in `.context/fidy-vault/AGENTS.md`. Follow that file instead of duplicating it here.

--- a/.agents/skills/ubiquitous-language/SKILL.md
+++ b/.agents/skills/ubiquitous-language/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: ubiquitous-language
+description: Extract and harden Fidy domain terminology into a durable glossary, flagging ambiguous or conflicting terms. Use when the user wants a ubiquitous language, glossary, canonical terminology, DDD terminology review, or sharper domain language.
+---
+
+# Ubiquitous Language
+
+Use this skill to turn fuzzy product or engineering language into canonical Fidy terms.
+
+The upstream skill writes a generic `UBIQUITOUS_LANGUAGE.md` file from the current conversation alone. In this repo, that is too shallow. Terms should be checked against existing code and documentation, then written into the durable home that already owns the language.
+
+If the user wants an interactive grilling session that resolves each term one-by-one, also use `domain-model`. This skill is the extraction and codification pass once enough context exists.
+
+## Gather Context
+
+Before proposing terms, inspect the relevant sources that already exist:
+
+- the current conversation
+- the relevant code and tests
+- `CONTEXT.md` or `CONTEXT-MAP.md` when present
+- `docs/adr/` when decisions affect terminology
+- `.context/fidy-vault/index.md`
+- `.context/fidy-vault/wiki/domains/`
+- `.context/fidy-vault/wiki/decisions/`
+
+Run `bun run vault:doctor` first if you expect to read or update the vault.
+
+## What To Look For
+
+- one term used for multiple concepts
+- multiple terms used for the same concept
+- vague or overloaded language
+- code or schema names leaking into the domain language
+- contradictions between code, docs, and the current discussion
+
+## Preferred Output Location
+
+Do not default to a new root-level markdown file.
+
+Write the glossary into the most appropriate durable home:
+
+1. update the existing domain page in `.context/fidy-vault/wiki/domains/` when one already owns the topic
+2. otherwise update the relevant `CONTEXT.md`
+3. only create a standalone glossary page when no existing page is a natural fit
+
+If you create a new vault page, place it under `.context/fidy-vault/wiki/domains/` and follow the vault maintenance rules in `.context/fidy-vault/AGENTS.md`.
+
+## Output Shape
+
+Produce a compact glossary with:
+
+- grouped tables with `Term`, `Definition`, and `Aliases to avoid`
+- a short `Relationships` section describing how the terms connect
+- a `Flagged ambiguities` section for conflicts or overloaded words
+- a short example dialogue that uses the canonical terms naturally
+
+Group terms by subdomain, actor, or lifecycle when that clarifies the language.
+
+## Rules
+
+- Be opinionated. Pick one canonical term when several exist.
+- Keep definitions to one sentence and define what the thing is.
+- Include only domain-relevant concepts.
+- Skip generic implementation jargon unless it matters to users or domain experts.
+- Call out mismatches between code, docs, and conversation explicitly.
+- When a new canonical term replaces an old one, note what docs or code names should eventually align.
+
+## Finish
+
+- Summarize the chosen canonical terms inline for the user.
+- If you updated durable documentation, mention the file you changed.
+- If you updated the vault, also mention the `index.md` and `log.md` updates.


### PR DESCRIPTION
- add obsidian vault skill
- add ubiquitous language skill
- adapt to fidy vault workflow


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two agent skills tailored to Fidy’s external vault workflow: `obsidian-vault` and `ubiquitous-language`. They guide agents to use the repo-local bridge, update durable docs in the right place, and follow the vault’s maintenance rules.

- New Features
  - `obsidian-vault`: use the shared vault via `.context/fidy-vault`; run `bun run vault:doctor` first; provides `vault:path`, `vault:recent`, `vault:open`, and `./scripts/fidy-vault search`; prefer `rg` on the bridge path; follow `.context/fidy-vault/AGENTS.md`; no flat vault or `[[wikilinks]]` assumptions.
  - `ubiquitous-language`: extract and harden domain terms; check code/docs/vault before proposing; write updates to existing pages under `.context/fidy-vault/wiki/domains/` or `CONTEXT.md`; defines a compact glossary format (tables, relationships, flagged ambiguities, short dialogue); includes rules and finish steps, and when to pair with `domain-model`.

<sup>Written for commit 41fdd118624a3f836d5558d4c21d5bc87002f6d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

