### PR TITLE
refactor(mobile): deepen state seams

### DIFF
--- a/apps/mobile/__tests__/budget/store.test.ts
+++ b/apps/mobile/__tests__/budget/store.test.ts
@@ -171,8 +171,10 @@ describe("useBudgetStore", () => {
     store.getState().initStore(mockDb, USER_ID);
     store.setState({ currentMonth: "2026-03" as Month });
 
+    const monitoringCallsBeforeLoad = mockCreateBudgetMonitoringModule.mock.calls.length;
     const load = store.getState().loadBudgets();
-    const initialMonitoringPorts = mockCreateBudgetMonitoringModule.mock.calls[0]?.[0];
+    const initialMonitoringPorts =
+      mockCreateBudgetMonitoringModule.mock.calls[monitoringCallsBeforeLoad]?.[0];
 
     expect(initialMonitoringPorts).toBeDefined();
 

--- a/apps/mobile/__tests__/budget/store.test.ts
+++ b/apps/mobile/__tests__/budget/store.test.ts
@@ -16,11 +16,7 @@ vi.mock("@/features/budget/lib/monitoring", () => ({
 }));
 
 vi.mock("@/features/notifications", () => ({
-  useNotificationStore: {
-    getState: () => ({
-      insertNotification: vi.fn(),
-    }),
-  },
+  insertNotificationRecord: vi.fn(),
 }));
 
 vi.mock("@/features/settings", () => ({

--- a/apps/mobile/__tests__/budget/store.test.ts
+++ b/apps/mobile/__tests__/budget/store.test.ts
@@ -2,13 +2,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CategoryId, CopAmount, Month, UserId } from "@/shared/types/branded";
 
+const mockCreateBudgetMonitoringModule = vi.fn();
 const mockRefreshMonth = vi.fn();
 const mockLoadAutoSuggestions = vi.fn();
 const mockAcknowledgeAlert = vi.fn();
+const mockInsertNotificationRecord = vi.fn();
 const mockSubscribe = vi.fn(() => vi.fn());
 
 vi.mock("@/features/budget/lib/monitoring", () => ({
-  createBudgetMonitoringModule: vi.fn(() => ({
+  createBudgetMonitoringModule: mockCreateBudgetMonitoringModule.mockImplementation(() => ({
     refreshMonth: mockRefreshMonth,
     loadAutoSuggestions: mockLoadAutoSuggestions,
     acknowledgeAlert: mockAcknowledgeAlert,
@@ -16,7 +18,7 @@ vi.mock("@/features/budget/lib/monitoring", () => ({
 }));
 
 vi.mock("@/features/notifications", () => ({
-  insertNotificationRecord: vi.fn(),
+  insertNotificationRecord: (...args: unknown[]) => mockInsertNotificationRecord(...args),
 }));
 
 vi.mock("@/features/settings", () => ({
@@ -151,6 +153,52 @@ describe("useBudgetStore", () => {
     await load;
 
     expect(store.getState().isLoading).toBe(false);
+  });
+
+  it("drops stale notification side effects after the active user changes", async () => {
+    const deferredSnapshot = createDeferred<{
+      budgets: any[];
+      budgetProgress: any[];
+      summary: { totalBudget: number; totalSpent: number; percentUsed: number };
+      autoSuggestions: any[];
+      pendingAlerts: any[];
+      pendingPermissionRequest: boolean;
+    }>();
+
+    mockRefreshMonth.mockReturnValueOnce(deferredSnapshot.promise);
+
+    const store = await getStore();
+    store.getState().initStore(mockDb, USER_ID);
+    store.setState({ currentMonth: "2026-03" as Month });
+
+    const load = store.getState().loadBudgets();
+    const initialMonitoringPorts = mockCreateBudgetMonitoringModule.mock.calls[0]?.[0];
+
+    expect(initialMonitoringPorts).toBeDefined();
+
+    store.getState().initStore(mockDb, "user-2" as UserId);
+
+    initialMonitoringPorts.insertNotification({
+      type: "budget_alert",
+      dedupKey: "budget_alert:food:80:2026-03",
+      categoryId: "food" as CategoryId,
+      goalId: null,
+      titleKey: "notifications.budgetWarning",
+      messageKey: "notifications.budgetWarningMsg",
+      params: null,
+    });
+
+    expect(mockInsertNotificationRecord).not.toHaveBeenCalled();
+
+    deferredSnapshot.resolve({
+      budgets: [],
+      budgetProgress: [],
+      summary: { totalBudget: 0, totalSpent: 0, percentUsed: 0 },
+      autoSuggestions: [],
+      pendingAlerts: [],
+      pendingPermissionRequest: false,
+    });
+    await load;
   });
 
   it("loads auto suggestions without triggering the full refresh path", async () => {

--- a/apps/mobile/__tests__/capture-sources/hooks.test.ts
+++ b/apps/mobile/__tests__/capture-sources/hooks.test.ts
@@ -87,6 +87,8 @@ describe("setupApplePayCapture", () => {
     await setupApplePayCapture(mockDb, USER_ID);
     capturedListener({ amount: 50000, merchant: "Farmatodo" });
 
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
     expect(mockProcessApplePayIntent).toHaveBeenCalledWith(mockDb, USER_ID, {
       amount: 50000,
       merchant: "Farmatodo",
@@ -174,6 +176,8 @@ describe("setupNotificationCapture", () => {
       timestamp: Date.now(),
     };
     capturedListener(notificationData);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(mockProcessNotification).toHaveBeenCalledWith(mockDb, USER_ID, notificationData);
   });

--- a/apps/mobile/__tests__/capture-sources/store.test.ts
+++ b/apps/mobile/__tests__/capture-sources/store.test.ts
@@ -1,7 +1,13 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: mock db needs flexible typing
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { useCaptureSourcesStore } from "@/features/capture-sources/store";
+import {
+  hydrateCaptureSources,
+  refreshCaptureSourceStatus,
+  refreshDetectedSmsCount,
+  toggleCaptureSourcePackage,
+  useCaptureSourcesStore,
+} from "@/features/capture-sources/store";
 
 const mockGetEnabledPackages = vi.fn().mockResolvedValue([]);
 const mockUpsertNotificationSource = vi.fn();
@@ -26,7 +32,6 @@ const USER_ID = "user-1";
 describe("useCaptureSourcesStore", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useCaptureSourcesStore.getState()._resetRefs();
     useCaptureSourcesStore.setState({
       enabledPackages: [],
       isNotificationPermissionGranted: false,
@@ -38,109 +43,55 @@ describe("useCaptureSourcesStore", () => {
     mockGetTodaySmsEventCount.mockResolvedValue(0);
   });
 
-  describe("initStore", () => {
-    it("sets db and userId refs for subsequent actions", () => {
-      useCaptureSourcesStore.getState().initStore(mockDb, USER_ID);
-      expect(() => useCaptureSourcesStore.getState().initStore(mockDb, USER_ID)).not.toThrow();
+  it("hydrates capture-source state from the explicit boundary", async () => {
+    mockGetEnabledPackages.mockResolvedValueOnce([
+      "com.todo1.mobile.co.bancolombia",
+      "com.nequi.MobileApp",
+    ]);
+    mockHasProcessedCaptures.mockResolvedValueOnce(true);
+    mockGetTodaySmsEventCount.mockResolvedValueOnce(3);
+
+    await hydrateCaptureSources(mockDb, USER_ID);
+
+    expect(mockGetEnabledPackages).toHaveBeenCalledWith(mockDb, USER_ID);
+    expect(mockHasProcessedCaptures).toHaveBeenCalledWith(mockDb, "apple_pay");
+    expect(mockGetTodaySmsEventCount).toHaveBeenCalledWith(mockDb, USER_ID, expect.any(Date));
+    expect(useCaptureSourcesStore.getState()).toMatchObject({
+      enabledPackages: ["com.todo1.mobile.co.bancolombia", "com.nequi.MobileApp"],
+      isApplePaySetupComplete: true,
+      detectedSmsCount: 3,
     });
   });
 
-  describe("loadConfig", () => {
-    it("loads enabled packages from DB", async () => {
-      mockGetEnabledPackages.mockResolvedValueOnce([
-        "com.todo1.mobile.co.bancolombia",
-        "com.nequi.MobileApp",
-      ]);
+  it("toggles a package through the explicit boundary and updates store state", async () => {
+    await toggleCaptureSourcePackage(mockDb, USER_ID, "com.nequi.MobileApp", true);
 
-      useCaptureSourcesStore.getState().initStore(mockDb, USER_ID);
-      await useCaptureSourcesStore.getState().loadConfig();
-
-      expect(mockGetEnabledPackages).toHaveBeenCalledWith(mockDb, USER_ID);
-      expect(useCaptureSourcesStore.getState().enabledPackages).toEqual([
-        "com.todo1.mobile.co.bancolombia",
-        "com.nequi.MobileApp",
-      ]);
-    });
-
-    it("does nothing when db is not set", async () => {
-      await useCaptureSourcesStore.getState().loadConfig();
-
-      expect(mockGetEnabledPackages).not.toHaveBeenCalled();
-    });
+    expect(mockUpsertNotificationSource).toHaveBeenCalledWith(
+      mockDb,
+      USER_ID,
+      "com.nequi.MobileApp",
+      "Nequi",
+      true,
+      expect.any(String)
+    );
+    expect(useCaptureSourcesStore.getState().enabledPackages).toContain("com.nequi.MobileApp");
   });
 
-  describe("togglePackage", () => {
-    it("enables a package and upserts to DB", async () => {
-      useCaptureSourcesStore.getState().initStore(mockDb, USER_ID);
-      await useCaptureSourcesStore.getState().togglePackage("com.nequi.MobileApp", true);
+  it("refreshes Apple Pay setup status through the explicit boundary", async () => {
+    mockHasProcessedCaptures.mockResolvedValueOnce(true);
 
-      expect(mockUpsertNotificationSource).toHaveBeenCalledWith(
-        mockDb,
-        USER_ID,
-        "com.nequi.MobileApp",
-        "Nequi",
-        true,
-        expect.any(String)
-      );
-      expect(useCaptureSourcesStore.getState().enabledPackages).toContain("com.nequi.MobileApp");
-    });
+    await refreshCaptureSourceStatus(mockDb);
 
-    it("disables a package and removes from state", async () => {
-      useCaptureSourcesStore.getState().initStore(mockDb, USER_ID);
-      useCaptureSourcesStore.setState({ enabledPackages: ["com.nequi.MobileApp"] });
-
-      await useCaptureSourcesStore.getState().togglePackage("com.nequi.MobileApp", false);
-
-      expect(mockUpsertNotificationSource).toHaveBeenCalledWith(
-        mockDb,
-        USER_ID,
-        "com.nequi.MobileApp",
-        "Nequi",
-        false,
-        expect.any(String)
-      );
-      expect(useCaptureSourcesStore.getState().enabledPackages).not.toContain(
-        "com.nequi.MobileApp"
-      );
-    });
+    expect(mockHasProcessedCaptures).toHaveBeenCalledWith(mockDb, "apple_pay");
+    expect(useCaptureSourcesStore.getState().isApplePaySetupComplete).toBe(true);
   });
 
-  describe("refreshStatus", () => {
-    it("sets isApplePaySetupComplete when captures exist", async () => {
-      mockHasProcessedCaptures.mockResolvedValueOnce(true);
+  it("refreshes detected SMS count through the explicit boundary", async () => {
+    mockGetTodaySmsEventCount.mockResolvedValueOnce(3);
 
-      useCaptureSourcesStore.getState().initStore(mockDb, USER_ID);
-      await useCaptureSourcesStore.getState().refreshStatus();
+    await refreshDetectedSmsCount(mockDb, USER_ID);
 
-      expect(mockHasProcessedCaptures).toHaveBeenCalledWith(mockDb, "apple_pay");
-      expect(useCaptureSourcesStore.getState().isApplePaySetupComplete).toBe(true);
-    });
-
-    it("sets isApplePaySetupComplete false when no captures", async () => {
-      mockHasProcessedCaptures.mockResolvedValueOnce(false);
-
-      useCaptureSourcesStore.getState().initStore(mockDb, USER_ID);
-      await useCaptureSourcesStore.getState().refreshStatus();
-
-      expect(useCaptureSourcesStore.getState().isApplePaySetupComplete).toBe(false);
-    });
-  });
-
-  describe("refreshDetectedSms", () => {
-    it("updates detectedSmsCount from DB", async () => {
-      mockGetTodaySmsEventCount.mockResolvedValueOnce(3);
-
-      useCaptureSourcesStore.getState().initStore(mockDb, USER_ID);
-      await useCaptureSourcesStore.getState().refreshDetectedSms();
-
-      expect(mockGetTodaySmsEventCount).toHaveBeenCalledWith(mockDb, USER_ID, expect.any(Date));
-      expect(useCaptureSourcesStore.getState().detectedSmsCount).toBe(3);
-    });
-
-    it("does nothing when db is not set", async () => {
-      await useCaptureSourcesStore.getState().refreshDetectedSms();
-
-      expect(mockGetTodaySmsEventCount).not.toHaveBeenCalled();
-    });
+    expect(mockGetTodaySmsEventCount).toHaveBeenCalledWith(mockDb, USER_ID, expect.any(Date));
+    expect(useCaptureSourcesStore.getState().detectedSmsCount).toBe(3);
   });
 });

--- a/apps/mobile/__tests__/categories/store.test.ts
+++ b/apps/mobile/__tests__/categories/store.test.ts
@@ -51,13 +51,12 @@ describe("useCategoriesStore", () => {
     vi.resetModules();
   });
 
-  async function getStore() {
-    const { useCategoriesStore } = await import("@/features/categories/store");
-    return useCategoriesStore;
+  async function loadCategoriesModule() {
+    return import("@/features/categories/store");
   }
 
   it("exposes built-in and merged snapshots before refresh", async () => {
-    const store = await getStore();
+    const { useCategoriesStore: store } = await loadCategoriesModule();
     const state = store.getState();
 
     expect(state.builtIn).toEqual(CATEGORIES);
@@ -68,7 +67,7 @@ describe("useCategoriesStore", () => {
   });
 
   it("isValid defaults to built-in scope", async () => {
-    const store = await getStore();
+    const { useCategoriesStore: store } = await loadCategoriesModule();
     const state = store.getState();
 
     expect(state.isValid("food")).toBe(true);
@@ -89,9 +88,8 @@ describe("useCategoriesStore", () => {
     };
     vi.mocked(getUserCategoriesForUser).mockReturnValue([fakeRow]);
 
-    const store = await getStore();
-    store.getState().initStore(mockDb, "user-1" as UserId);
-    await store.getState().refresh();
+    const { refreshCategories, useCategoriesStore: store } = await loadCategoriesModule();
+    await refreshCategories(mockDb, "user-1" as UserId);
 
     const state = store.getState();
     expect(state.custom).toHaveLength(1);
@@ -109,10 +107,8 @@ describe("useCategoriesStore", () => {
     vi.mocked(getUserCategoriesForUser).mockReturnValue([]);
     vi.mocked(insertUserCategory).mockReturnValue(undefined);
 
-    const store = await getStore();
-    store.getState().initStore(mockDb, "user-1" as UserId);
-
-    const result = await store.getState().createCustom({
+    const { createCustomCategory } = await loadCategoriesModule();
+    const result = await createCustomCategory(mockDb, "user-1" as UserId, {
       name: "Groceries",
       iconName: "ShoppingCart",
       colorHex: "#4CAF50",
@@ -124,10 +120,8 @@ describe("useCategoriesStore", () => {
   });
 
   it("createCustom returns false when name is too short", async () => {
-    const store = await getStore();
-    store.getState().initStore(mockDb, "user-1" as UserId);
-
-    const result = await store.getState().createCustom({
+    const { createCustomCategory } = await loadCategoriesModule();
+    const result = await createCustomCategory(mockDb, "user-1" as UserId, {
       name: "A",
       iconName: "Zap",
       colorHex: "#FF0000",
@@ -138,10 +132,8 @@ describe("useCategoriesStore", () => {
   });
 
   it("createCustom returns false when name is too long", async () => {
-    const store = await getStore();
-    store.getState().initStore(mockDb, "user-1" as UserId);
-
-    const result = await store.getState().createCustom({
+    const { createCustomCategory } = await loadCategoriesModule();
+    const result = await createCustomCategory(mockDb, "user-1" as UserId, {
       name: "A".repeat(33),
       iconName: "Zap",
       colorHex: "#FF0000",
@@ -151,16 +143,15 @@ describe("useCategoriesStore", () => {
     expect(insertUserCategory).not.toHaveBeenCalled();
   });
 
-  it("createCustom returns false when DB refs are not set", async () => {
-    const store = await getStore();
-    // Don't call initStore
-
-    const result = await store.getState().createCustom({
+  it("createCustom returns false when the icon is invalid", async () => {
+    const { createCustomCategory } = await loadCategoriesModule();
+    const result = await createCustomCategory(mockDb, "user-1" as UserId, {
       name: "Test",
-      iconName: "Zap",
+      iconName: "UnknownIcon",
       colorHex: "#FF0000",
     });
 
     expect(result).toBe(false);
+    expect(insertUserCategory).not.toHaveBeenCalled();
   });
 });

--- a/apps/mobile/__tests__/notifications/store.test.ts
+++ b/apps/mobile/__tests__/notifications/store.test.ts
@@ -44,8 +44,7 @@ function createDeferred<T>() {
 }
 
 async function getStore() {
-  const { useNotificationStore } = await import("@/features/notifications/store");
-  return useNotificationStore;
+  return import("@/features/notifications/store");
 }
 
 async function flushMicrotasks() {
@@ -71,9 +70,9 @@ describe("useNotificationStore", () => {
       userId === USER_2 ? 2 : 7
     );
 
-    const store = await getStore();
-    const firstInit = store.getState().initStore(mockDb, USER_1);
-    const secondInit = store.getState().initStore(mockDb, USER_2);
+    const { initializeNotificationStore, useNotificationStore: store } = await getStore();
+    const firstInit = initializeNotificationStore(mockDb, USER_1);
+    const secondInit = initializeNotificationStore(mockDb, USER_2);
 
     deferredVisited.resolve(null);
     await firstInit;
@@ -88,9 +87,13 @@ describe("useNotificationStore", () => {
     const deferredCommit = createDeferred<{ success: true; didMutate: true }>();
     mockCommit.mockReturnValueOnce(deferredCommit.promise);
 
-    const store = await getStore();
-    await store.getState().initStore(mockDb, USER_1);
-    store.getState().insertNotification({
+    const {
+      initializeNotificationStore,
+      insertNotificationRecord,
+      useNotificationStore: store,
+    } = await getStore();
+    await initializeNotificationStore(mockDb, USER_1);
+    void insertNotificationRecord(mockDb, USER_1, {
       type: "budget_alert",
       dedupKey: "budget:1",
       categoryId: null,
@@ -100,7 +103,7 @@ describe("useNotificationStore", () => {
       params: null,
     });
 
-    await store.getState().initStore(mockDb, USER_2);
+    await initializeNotificationStore(mockDb, USER_2);
     deferredCommit.resolve({ success: true, didMutate: true });
     await flushMicrotasks();
 
@@ -117,16 +120,20 @@ describe("useNotificationStore", () => {
     const deferredCommit = createDeferred<{ success: true; didMutate: true }>();
     mockCommit.mockReturnValueOnce(deferredCommit.promise);
 
-    const store = await getStore();
-    await store.getState().initStore(mockDb, USER_1);
+    const {
+      clearAllNotifications,
+      initializeNotificationStore,
+      useNotificationStore: store,
+    } = await getStore();
+    await initializeNotificationStore(mockDb, USER_1);
     store.setState({
       notifications: [{ id: "old-user-notif" }] as any[],
       newCount: 4,
     });
 
-    store.getState().clearAll();
+    void clearAllNotifications(mockDb, USER_1);
 
-    await store.getState().initStore(mockDb, USER_2);
+    await initializeNotificationStore(mockDb, USER_2);
     store.setState({
       notifications: [{ id: "new-user-notif" }] as any[],
       newCount: 2,

--- a/apps/mobile/__tests__/search/store.test.ts
+++ b/apps/mobile/__tests__/search/store.test.ts
@@ -1,0 +1,121 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: search store tests use flexible mock rows
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EMPTY_FILTERS } from "@/features/search";
+import {
+  executeSearch,
+  loadNextSearchPage,
+  updateSearchQuery,
+  useSearchStore,
+} from "@/features/search/store";
+
+const mockSearchTransactionsPaginated = vi.fn();
+const mockSearchTransactionsAggregate = vi.fn();
+const mockToStoredTransaction = vi.fn((row: any) => ({
+  ...row,
+  converted: true,
+}));
+
+vi.mock("@/features/search/lib/repository", () => ({
+  searchTransactionsPaginated: (...args: any[]) => mockSearchTransactionsPaginated(...args),
+  searchTransactionsAggregate: (...args: any[]) => mockSearchTransactionsAggregate(...args),
+}));
+
+vi.mock("@/features/transactions", () => ({
+  toStoredTransaction: (row: any) => mockToStoredTransaction(row),
+}));
+
+const mockDb = {} as any;
+const USER_ID = "user-1";
+
+const makeRow = (id: string) => ({
+  id,
+  description: `Row ${id}`,
+  amount: 1000,
+  type: "expense",
+  categoryId: "food",
+  date: "2026-03-10",
+});
+
+describe("search store boundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSearchStore.getState().reset();
+    mockSearchTransactionsAggregate.mockReturnValue({ count: 0, total: 0 });
+    mockSearchTransactionsPaginated.mockReturnValue([]);
+  });
+
+  it("executes the first page through the explicit boundary", () => {
+    useSearchStore.setState({
+      filters: { ...EMPTY_FILTERS, query: "coffee" },
+    });
+    mockSearchTransactionsPaginated.mockReturnValueOnce([makeRow("tx-1"), makeRow("tx-2")]);
+    mockSearchTransactionsAggregate.mockReturnValueOnce({ count: 2, total: 2000 });
+
+    executeSearch(mockDb, USER_ID);
+
+    expect(mockSearchTransactionsPaginated).toHaveBeenCalledWith(
+      mockDb,
+      USER_ID,
+      expect.objectContaining({ query: "coffee" }),
+      30,
+      0
+    );
+    expect(mockSearchTransactionsAggregate).toHaveBeenCalledWith(
+      mockDb,
+      USER_ID,
+      expect.objectContaining({ query: "coffee" })
+    );
+    expect(useSearchStore.getState()).toMatchObject({
+      results: [expect.objectContaining({ id: "tx-1" }), expect.objectContaining({ id: "tx-2" })],
+      offset: 2,
+      hasMore: false,
+      summary: { count: 2, total: 2000 },
+      isSearching: false,
+    });
+  });
+
+  it("loads the next page through the explicit boundary", () => {
+    useSearchStore.setState({
+      results: [makeRow("tx-1")] as any,
+      offset: 1,
+      hasMore: true,
+    });
+    mockSearchTransactionsPaginated.mockReturnValueOnce([makeRow("tx-2"), makeRow("tx-3")]);
+
+    loadNextSearchPage(mockDb, USER_ID);
+
+    expect(mockSearchTransactionsPaginated).toHaveBeenCalledWith(
+      mockDb,
+      USER_ID,
+      EMPTY_FILTERS,
+      30,
+      1
+    );
+    expect(useSearchStore.getState().results).toEqual([
+      makeRow("tx-1"),
+      expect.objectContaining({ id: "tx-2" }),
+      expect.objectContaining({ id: "tx-3" }),
+    ]);
+    expect(useSearchStore.getState().offset).toBe(3);
+    expect(useSearchStore.getState().hasMore).toBe(false);
+  });
+
+  it("updates the query through the explicit boundary and reruns search", () => {
+    mockSearchTransactionsPaginated.mockReturnValueOnce([makeRow("tx-9")]);
+    mockSearchTransactionsAggregate.mockReturnValueOnce({ count: 1, total: 1000 });
+
+    updateSearchQuery(mockDb, USER_ID, "rent");
+
+    expect(useSearchStore.getState().filters.query).toBe("rent");
+    expect(mockSearchTransactionsPaginated).toHaveBeenCalledWith(
+      mockDb,
+      USER_ID,
+      expect.objectContaining({ query: "rent" }),
+      30,
+      0
+    );
+    expect(useSearchStore.getState().results).toEqual([
+      expect.objectContaining({ id: "tx-9", converted: true }),
+    ]);
+  });
+});

--- a/apps/mobile/__tests__/sync/sync-conflict-state.test.ts
+++ b/apps/mobile/__tests__/sync/sync-conflict-state.test.ts
@@ -1,0 +1,81 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: sync conflict state tests use flexible mock db
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  loadSyncConflicts,
+  resolveSyncConflictSelection,
+  useSyncConflictStore,
+} from "@/features/sync/store";
+
+const mockListConflicts = vi.fn();
+const mockResolveConflict = vi.fn();
+
+vi.mock("@/features/sync/services/sync", () => ({
+  listConflicts: (...args: any[]) => mockListConflicts(...args),
+  resolveConflict: (...args: any[]) => mockResolveConflict(...args),
+}));
+
+describe("sync conflict state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSyncConflictStore.setState({ conflicts: [], conflictCount: 0 });
+  });
+
+  it("loads conflicts into the store from the sync boundary", async () => {
+    mockListConflicts.mockResolvedValueOnce([
+      {
+        id: "conflict-1",
+        transactionId: "tx-1",
+        localData: {
+          id: "tx-1",
+          userId: "user-1",
+          type: "expense",
+          amount: 1000,
+          categoryId: "food",
+          description: "Local merchant",
+          date: "2026-03-10",
+          createdAt: "2026-03-10T08:00:00.000Z",
+          updatedAt: "2026-03-10T10:00:00.000Z",
+          deletedAt: null,
+          source: "manual",
+        },
+        serverData: {
+          id: "tx-1",
+          userId: "user-1",
+          type: "expense",
+          amount: 2000,
+          categoryId: "food",
+          description: "Server merchant",
+          date: "2026-03-10",
+          createdAt: "2026-03-10T08:00:00.000Z",
+          updatedAt: "2026-03-10T14:00:00.000Z",
+          deletedAt: null,
+          source: "email",
+        },
+        detectedAt: "2026-03-15T10:00:00.000Z",
+      },
+    ]);
+
+    await loadSyncConflicts({} as any);
+
+    expect(mockListConflicts).toHaveBeenCalledWith({ db: {} });
+    expect(useSyncConflictStore.getState().conflictCount).toBe(1);
+    expect(useSyncConflictStore.getState().conflicts[0]?.id).toBe("conflict-1");
+  });
+
+  it("resolves a conflict through the boundary and reloads store state", async () => {
+    mockResolveConflict.mockResolvedValueOnce({ unresolvedConflicts: 0 });
+    mockListConflicts.mockResolvedValueOnce([]);
+
+    await resolveSyncConflictSelection({} as any, "conflict-1", "local");
+
+    expect(mockResolveConflict).toHaveBeenCalledWith({
+      db: {},
+      conflictId: "conflict-1",
+      resolution: "local",
+    });
+    expect(mockListConflicts).toHaveBeenCalledWith({ db: {} });
+    expect(useSyncConflictStore.getState().conflicts).toEqual([]);
+    expect(useSyncConflictStore.getState().conflictCount).toBe(0);
+  });
+});

--- a/apps/mobile/__tests__/sync/sync-service.test.ts
+++ b/apps/mobile/__tests__/sync/sync-service.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createSyncService } from "@/features/sync/services/create-sync-service";
+
+describe("createSyncService", () => {
+  it("returns skipped_offline and does not touch remote sync when offline", async () => {
+    const isOnline = vi.fn().mockResolvedValue(false);
+    const getSupabase = vi.fn();
+    const syncPull = vi.fn();
+    const syncPush = vi.fn();
+    const refreshTransactions = vi.fn();
+    const getConflictRows = vi.fn().mockResolvedValue([
+      {
+        id: "conflict-1",
+        transactionId: "tx-1",
+        localData: JSON.stringify({
+          id: "tx-1",
+          userId: "user-1",
+          type: "expense",
+          amount: 1000,
+          categoryId: "food",
+          description: "Local merchant",
+          date: "2026-03-10",
+          createdAt: "2026-03-10T08:00:00.000Z",
+          updatedAt: "2026-03-10T10:00:00.000Z",
+          deletedAt: null,
+          source: "manual",
+        }),
+        serverData: JSON.stringify({
+          id: "tx-1",
+          userId: "user-1",
+          type: "expense",
+          amount: 2000,
+          categoryId: "food",
+          description: "Server merchant",
+          date: "2026-03-10",
+          createdAt: "2026-03-10T08:00:00.000Z",
+          updatedAt: "2026-03-10T14:00:00.000Z",
+          deletedAt: null,
+          source: "email",
+        }),
+        detectedAt: "2026-03-15T10:00:00.000Z",
+      },
+    ]);
+
+    const service = createSyncService({
+      isOnline,
+      getSupabase,
+      syncPull,
+      syncPush,
+      refreshTransactions,
+      getConflictRows,
+      upsertTransaction: vi.fn(),
+      enqueueTransactionSync: vi.fn(),
+      resolveConflictRow: vi.fn(),
+    });
+
+    const result = await service.run({
+      db: {} as never,
+      userId: "user-1",
+      reason: "foreground",
+    });
+
+    expect(result).toEqual({
+      status: "skipped_offline",
+      unresolvedConflicts: 1,
+    });
+    expect(getSupabase).not.toHaveBeenCalled();
+    expect(syncPull).not.toHaveBeenCalled();
+    expect(syncPush).not.toHaveBeenCalled();
+    expect(refreshTransactions).not.toHaveBeenCalled();
+  });
+
+  it("maps unresolved conflict rows into sync conflict records", async () => {
+    const service = createSyncService({
+      isOnline: vi.fn().mockResolvedValue(true),
+      getSupabase: vi.fn(),
+      syncPull: vi.fn(),
+      syncPush: vi.fn(),
+      refreshTransactions: vi.fn(),
+      getConflictRows: vi.fn().mockResolvedValue([
+        {
+          id: "conflict-1",
+          transactionId: "tx-1",
+          localData: JSON.stringify({
+            id: "tx-1",
+            userId: "user-1",
+            type: "expense",
+            amount: 1000,
+            categoryId: "food",
+            description: "Local merchant",
+            date: "2026-03-10",
+            createdAt: "2026-03-10T08:00:00.000Z",
+            updatedAt: "2026-03-10T10:00:00.000Z",
+            deletedAt: null,
+            source: "manual",
+          }),
+          serverData: JSON.stringify({
+            id: "tx-1",
+            userId: "user-1",
+            type: "expense",
+            amount: 2000,
+            categoryId: "food",
+            description: "Server merchant",
+            date: "2026-03-10",
+            createdAt: "2026-03-10T08:00:00.000Z",
+            updatedAt: "2026-03-10T14:00:00.000Z",
+            deletedAt: null,
+            source: "email",
+          }),
+          detectedAt: "2026-03-15T10:00:00.000Z",
+        },
+      ]),
+      upsertTransaction: vi.fn(),
+      enqueueTransactionSync: vi.fn(),
+      resolveConflictRow: vi.fn(),
+    });
+
+    const conflicts = await service.listConflicts({ db: {} as never });
+
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]).toEqual({
+      id: "conflict-1",
+      transactionId: "tx-1",
+      localData: expect.objectContaining({ amount: 1000, source: "manual" }),
+      serverData: expect.objectContaining({ amount: 2000, source: "email" }),
+      detectedAt: "2026-03-15T10:00:00.000Z",
+    });
+  });
+
+  it("re-enqueues the local transaction when resolving a conflict in favor of local data", async () => {
+    const upsertTransaction = vi.fn();
+    const enqueueTransactionSync = vi.fn();
+    const resolveConflictRow = vi.fn();
+    const refreshTransactions = vi.fn();
+    const getConflictRows = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          id: "conflict-1",
+          transactionId: "tx-1",
+          localData: JSON.stringify({
+            id: "tx-1",
+            userId: "user-1",
+            type: "expense",
+            amount: 1000,
+            categoryId: "food",
+            description: "Local merchant",
+            date: "2026-03-10",
+            createdAt: "2026-03-10T08:00:00.000Z",
+            updatedAt: "2026-03-10T10:00:00.000Z",
+            deletedAt: null,
+            source: "manual",
+          }),
+          serverData: JSON.stringify({
+            id: "tx-1",
+            userId: "user-1",
+            type: "expense",
+            amount: 2000,
+            categoryId: "food",
+            description: "Server merchant",
+            date: "2026-03-10",
+            createdAt: "2026-03-10T08:00:00.000Z",
+            updatedAt: "2026-03-10T14:00:00.000Z",
+            deletedAt: null,
+            source: "email",
+          }),
+          detectedAt: "2026-03-15T10:00:00.000Z",
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const service = createSyncService({
+      isOnline: vi.fn().mockResolvedValue(true),
+      getSupabase: vi.fn(),
+      syncPull: vi.fn(),
+      syncPush: vi.fn(),
+      refreshTransactions,
+      getConflictRows,
+      upsertTransaction,
+      enqueueTransactionSync,
+      resolveConflictRow,
+    });
+
+    const result = await service.resolveConflict({
+      db: {} as never,
+      conflictId: "conflict-1" as never,
+      resolution: "local",
+    });
+
+    expect(upsertTransaction).toHaveBeenCalledWith(
+      {} as never,
+      expect.objectContaining({
+        id: "tx-1",
+        amount: 1000,
+        source: "manual",
+        updatedAt: expect.any(String),
+      })
+    );
+    expect(enqueueTransactionSync).toHaveBeenCalledWith({} as never, "tx-1", expect.any(String));
+    expect(resolveConflictRow).toHaveBeenCalledWith(
+      {} as never,
+      "conflict-1",
+      "local",
+      expect.any(String)
+    );
+    expect(refreshTransactions).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ unresolvedConflicts: 0 });
+  });
+});

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -22,24 +22,23 @@ import { registerBackgroundTask } from "@/features/background-fetch";
 import { useBudgetStore } from "@/features/budget";
 import { useCalendarStore } from "@/features/calendar";
 import {
+  hydrateCaptureSources,
   useApplePayCapture,
-  useCaptureSourcesStore,
   useNotificationCapture,
   useSmsDetection,
   useWidgetCapture,
 } from "@/features/capture-sources";
-import { useCategoriesStore } from "@/features/categories";
+import { refreshCategories } from "@/features/categories";
 import { useEmailCapture, useEmailCaptureStore } from "@/features/email-capture";
 import { useGoalStore } from "@/features/goals";
-import { registerPushToken, useNotificationStore } from "@/features/notifications";
+import { initializeNotificationStore, registerPushToken } from "@/features/notifications";
 import {
   clearOnboardingFromStore,
   getOnboardingCompleteFromStore,
   isOnboardingComplete,
 } from "@/features/onboarding";
-import { useSearchStore } from "@/features/search";
 import { useSettingsStore } from "@/features/settings";
-import { useSync, useSyncConflictStore } from "@/features/sync";
+import { loadSyncConflicts, useSync } from "@/features/sync";
 import { useTransactionStore } from "@/features/transactions";
 import { ErrorFallback } from "@/shared/components";
 import { Platform, useColorScheme } from "@/shared/components/rn";
@@ -78,17 +77,13 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
   useSubscription(
     () => {
       useTransactionStore.getState().initStore(db, userId);
-      useSearchStore.getState().initStore(db, userId);
       useEmailCaptureStore.getState().initStore(db, userId);
-      useCaptureSourcesStore.getState().initStore(db, userId);
       useChatStore.getState().initStore(db, userId);
       useCalendarStore.getState().initStore(db, userId);
       useBudgetStore.getState().initStore(db, userId);
       useGoalStore.getState().initStore(db, userId);
       useAnalyticsStore.getState().initStore(db, userId);
-      useCategoriesStore.getState().initStore(db, userId);
-      void useNotificationStore.getState().initStore(db, userId);
-      useSyncConflictStore.getState().initStore(db);
+      void initializeNotificationStore(db, userId);
       Promise.all([
         useCalendarStore.getState().loadBills(),
         useCalendarStore.getState().loadPaymentsForMonth(),
@@ -102,24 +97,20 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
         .getState()
         .loadAnalytics()
         .catch(handleRecoverableError("Failed to load analytics"));
-      useCategoriesStore
-        .getState()
-        .refresh()
-        .catch(handleRecoverableError("Failed to load user categories"));
+      refreshCategories(db, userId).catch(handleRecoverableError("Failed to load user categories"));
       useChatStore
         .getState()
         .loadSessions()
         .then(() => useChatStore.getState().cleanupExpiredSessions())
         .catch(handleRecoverableError("Failed to load chat sessions"));
-      useCaptureSourcesStore
-        .getState()
-        .hydrate()
-        .catch(handleRecoverableError("Failed to load capture sources"));
+      hydrateCaptureSources(db, userId).catch(
+        handleRecoverableError("Failed to load capture sources")
+      );
       useTransactionStore
         .getState()
         .loadInitialPage()
         .catch(handleRecoverableError("Failed to load transactions"));
-      void useSyncConflictStore.getState().loadConflicts();
+      void loadSyncConflicts(db);
       useSettingsStore
         .getState()
         .hydrate()

--- a/apps/mobile/features/budget/store.ts
+++ b/apps/mobile/features/budget/store.ts
@@ -31,18 +31,34 @@ const parseMonth = (month: Month): Date => {
   return new Date(y, m - 1, 1);
 };
 
-const budgetMonitoring = createBudgetMonitoringModule({
-  getBudgetAlertsEnabled: () => useSettingsStore.getState().notificationPreferences.budgetAlerts,
-  getLocale: () => useLocaleStore.getState().locale,
-  resolveCategoryLabel: (categoryId, locale) => {
-    const category = CATEGORY_MAP[categoryId];
-    return category ? getCategoryLabel(category, locale) : categoryId;
-  },
-  scheduleBudgetAlert,
-  insertNotification: (input) => {
-    if (!dbRef || !userIdRef) return;
-    void insertNotificationRecord(dbRef, userIdRef, input);
-  },
+const createLiveBudgetMonitoring = (
+  db: AnyDb,
+  userId: UserId,
+  shouldDeliverSideEffects: () => boolean
+) =>
+  createBudgetMonitoringModule({
+    getBudgetAlertsEnabled: () => useSettingsStore.getState().notificationPreferences.budgetAlerts,
+    getLocale: () => useLocaleStore.getState().locale,
+    resolveCategoryLabel: (categoryId, locale) => {
+      const category = CATEGORY_MAP[categoryId];
+      return category ? getCategoryLabel(category, locale) : categoryId;
+    },
+    scheduleBudgetAlert: async (alert, categoryName, notificationsEnabled) => {
+      if (!shouldDeliverSideEffects()) return { type: "skipped" } as const;
+      return scheduleBudgetAlert(alert, categoryName, notificationsEnabled);
+    },
+    insertNotification: (input) => {
+      if (!shouldDeliverSideEffects()) return;
+      void insertNotificationRecord(db, userId, input);
+    },
+  });
+
+const budgetAlertStateManager = createBudgetMonitoringModule({
+  getBudgetAlertsEnabled: () => false,
+  getLocale: () => "es",
+  resolveCategoryLabel: (categoryId) => categoryId,
+  scheduleBudgetAlert: async () => ({ type: "skipped" }),
+  insertNotification: () => undefined,
 });
 
 type BudgetState = {
@@ -120,25 +136,30 @@ export const useBudgetStore = create<BudgetState & BudgetActions>((set, get) => 
     const requestedDb = dbRef;
     const requestedUserId = userIdRef;
     const requestedMonth = get().currentMonth;
+    const isCurrentRefresh = () =>
+      loadBudgetsRequestId === requestId &&
+      dbRef === requestedDb &&
+      userIdRef === requestedUserId &&
+      get().currentMonth === requestedMonth;
     const previous = {
       pendingAlerts: get().pendingAlerts,
       acknowledgedAlerts: get().acknowledgedAlerts,
     };
     set({ isLoading: true });
     try {
+      const budgetMonitoring = createLiveBudgetMonitoring(
+        requestedDb,
+        requestedUserId,
+        isCurrentRefresh
+      );
       const snapshot = await budgetMonitoring.refreshMonth({
         db: requestedDb,
         userId: requestedUserId,
         month: requestedMonth,
         previous,
       });
-      const superseded = loadBudgetsRequestId !== requestId;
-      const contextChanged =
-        dbRef !== requestedDb ||
-        userIdRef !== requestedUserId ||
-        get().currentMonth !== requestedMonth;
-      if (superseded || contextChanged) {
-        if (!superseded) {
+      if (!isCurrentRefresh()) {
+        if (loadBudgetsRequestId === requestId) {
           set({ isLoading: false });
         }
         return;
@@ -168,6 +189,7 @@ export const useBudgetStore = create<BudgetState & BudgetActions>((set, get) => 
     if (!dbRef || !userIdRef) return;
     const { currentMonth, budgets } = get();
     try {
+      const budgetMonitoring = createLiveBudgetMonitoring(dbRef, userIdRef, () => true);
       const autoSuggestions = budgetMonitoring.loadAutoSuggestions({
         db: dbRef,
         userId: userIdRef,
@@ -309,7 +331,7 @@ export const useBudgetStore = create<BudgetState & BudgetActions>((set, get) => 
 
   acknowledgeAlert: (budgetId, threshold) => {
     set((state) => {
-      const nextState = budgetMonitoring.acknowledgeAlert({
+      const nextState = budgetAlertStateManager.acknowledgeAlert({
         budgetId,
         threshold,
         alertState: {

--- a/apps/mobile/features/budget/store.ts
+++ b/apps/mobile/features/budget/store.ts
@@ -1,6 +1,6 @@
 import { addMonths, format, subMonths } from "date-fns";
 import { create } from "zustand";
-import { useNotificationStore } from "@/features/notifications";
+import { insertNotificationRecord } from "@/features/notifications";
 import { useSettingsStore } from "@/features/settings";
 import { CATEGORY_MAP, useTransactionStore } from "@/features/transactions";
 import { createWriteThroughMutationModule, type WriteThroughMutationModule } from "@/mutations";
@@ -39,7 +39,10 @@ const budgetMonitoring = createBudgetMonitoringModule({
     return category ? getCategoryLabel(category, locale) : categoryId;
   },
   scheduleBudgetAlert,
-  insertNotification: (input) => useNotificationStore.getState().insertNotification(input),
+  insertNotification: (input) => {
+    if (!dbRef || !userIdRef) return;
+    void insertNotificationRecord(dbRef, userIdRef, input);
+  },
 });
 
 type BudgetState = {

--- a/apps/mobile/features/capture-sources/components/NotificationSetupCard.tsx
+++ b/apps/mobile/features/capture-sources/components/NotificationSetupCard.tsx
@@ -1,8 +1,10 @@
+import { useAuthStore } from "@/features/auth";
 import { Bell, ExternalLink } from "@/shared/components/icons";
 import { Linking, Platform, Pressable, Switch, Text, View } from "@/shared/components/rn";
+import { getDb } from "@/shared/db";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { KNOWN_BANK_PACKAGES } from "../schema";
-import { useCaptureSourcesStore } from "../store";
+import { toggleCaptureSourcePackage, useCaptureSourcesStore } from "../store";
 
 const openNotificationListenerSettings = () => {
   if (Platform.OS === "android") {
@@ -16,9 +18,9 @@ const openNotificationListenerSettings = () => {
 
 export const NotificationSetupCard = () => {
   const { t } = useTranslation();
+  const userId = useAuthStore((s) => s.session?.user.id ?? null);
   const enabledPackages = useCaptureSourcesStore((s) => s.enabledPackages);
   const isPermissionGranted = useCaptureSourcesStore((s) => s.isNotificationPermissionGranted);
-  const togglePackage = useCaptureSourcesStore((s) => s.togglePackage);
 
   const iconColor = useThemeColor("accentGreen");
   const warningColor = useThemeColor("accentRed");
@@ -95,7 +97,10 @@ export const NotificationSetupCard = () => {
               </Text>
               <Switch
                 value={isEnabled}
-                onValueChange={(value) => togglePackage(pkg.packageName, value)}
+                onValueChange={(value) => {
+                  if (!userId) return;
+                  void toggleCaptureSourcePackage(getDb(userId), userId, pkg.packageName, value);
+                }}
                 trackColor={{ false: secondaryColor, true: iconColor }}
               />
             </View>

--- a/apps/mobile/features/capture-sources/hooks/useSmsDetection.ts
+++ b/apps/mobile/features/capture-sources/hooks/useSmsDetection.ts
@@ -2,24 +2,22 @@ import { Platform } from "@/shared/components/rn";
 import type { AnyDb } from "@/shared/db";
 import { useSubscription } from "@/shared/hooks";
 import { captureError } from "@/shared/lib";
-import { useCaptureSourcesStore } from "../store";
+import { refreshDetectedSmsCount } from "../store";
 import { setupSmsDetection } from "./setup";
 
 export function useSmsDetection(db: AnyDb | null, userId: string | null) {
-  const refreshDetectedSms = useCaptureSourcesStore((s) => s.refreshDetectedSms);
-
   useSubscription(
     () => {
       if (!db || !userId) return;
       const onRefresh = () => {
-        void refreshDetectedSms();
+        void refreshDetectedSmsCount(db, userId);
       };
       return setupSmsDetection(db, userId, onRefresh).catch((error: unknown) => {
         captureError(error);
         return () => undefined;
       });
     },
-    [db, userId, refreshDetectedSms],
+    [db, userId],
     Platform.OS === "ios" && db != null && userId != null
   );
 }

--- a/apps/mobile/features/capture-sources/index.ts
+++ b/apps/mobile/features/capture-sources/index.ts
@@ -25,4 +25,10 @@ export {
   type CaptureIngestionPort,
   createCaptureIngestionPort,
 } from "./services/capture-ingestion";
-export { useCaptureSourcesStore } from "./store";
+export {
+  hydrateCaptureSources,
+  refreshCaptureSourceStatus,
+  refreshDetectedSmsCount,
+  toggleCaptureSourcePackage,
+  useCaptureSourcesStore,
+} from "./store";

--- a/apps/mobile/features/capture-sources/services/capture-ingestion.ts
+++ b/apps/mobile/features/capture-sources/services/capture-ingestion.ts
@@ -1,9 +1,11 @@
+import { Effect } from "effect";
 import type {
   PipelineResult,
   ProcessEmails,
   ProcessRetries,
 } from "@/features/email-capture/pipeline.public";
 import type { AnyDb } from "@/shared/db";
+import { fromThunk, runAppEffect } from "@/shared/effect/runtime";
 import type { UserId } from "@/shared/types/branded";
 import type { ApplePayIntentData, NotificationData } from "../schema";
 import type { ApplePayPipelineResult } from "./apple-pay-pipeline";
@@ -107,25 +109,34 @@ export function createCaptureIngestionPort(
   db: AnyDb,
   deps: Partial<CaptureIngestionDeps> = {}
 ): CaptureIngestionPort | CaptureIngestionPortWithEmail {
-  const ingestDefault: CaptureIngestionPort["ingest"] = async (command) => {
-    switch (command.kind) {
-      case "notification": {
-        const processNotification =
-          deps.processNotification ?? (await loadDefaultDeps()).processNotification;
-        return processNotification(db, command.userId, command.notification);
-      }
-      case "apple_pay": {
-        const processApplePayIntent =
-          deps.processApplePayIntent ?? (await loadDefaultDeps()).processApplePayIntent;
-        return processApplePayIntent(db, command.userId, command.intent);
-      }
-      case "widget": {
-        const processWidgetTransactions =
-          deps.processWidgetTransactions ?? (await loadDefaultDeps()).processWidgetTransactions;
-        return processWidgetTransactions(db, command.userId);
-      }
-    }
-  };
+  const ingestDefault: CaptureIngestionPort["ingest"] = (command) =>
+    runAppEffect(
+      Effect.gen(function* () {
+        switch (command.kind) {
+          case "notification": {
+            const processNotification =
+              deps.processNotification ?? (yield* fromThunk(loadDefaultDeps)).processNotification;
+            return yield* fromThunk(() =>
+              processNotification(db, command.userId, command.notification)
+            );
+          }
+          case "apple_pay": {
+            const processApplePayIntent =
+              deps.processApplePayIntent ??
+              (yield* fromThunk(loadDefaultDeps)).processApplePayIntent;
+            return yield* fromThunk(() =>
+              processApplePayIntent(db, command.userId, command.intent)
+            );
+          }
+          case "widget": {
+            const processWidgetTransactions =
+              deps.processWidgetTransactions ??
+              (yield* fromThunk(loadDefaultDeps)).processWidgetTransactions;
+            return yield* fromThunk(() => processWidgetTransactions(db, command.userId));
+          }
+        }
+      })
+    );
 
   if (!deps.processEmails || !deps.processRetries) {
     return { ingest: ingestDefault };
@@ -138,19 +149,25 @@ export function createCaptureIngestionPort(
   function ingestWithEmail(
     command: EmailCaptureIngestionCommand
   ): Promise<EmailCaptureIngestionOutcome>;
-  async function ingestWithEmail(
+  function ingestWithEmail(
     command: AnyCaptureIngestionCommand
   ): Promise<AnyCaptureIngestionOutcome> {
-    switch (command.kind) {
-      case "notification":
-      case "apple_pay":
-      case "widget":
-        return ingestDefault(command);
-      case "email_batch":
-        return processEmails(db, command.userId, command.emails, command.onProgress);
-      case "email_retry":
-        return processRetries(db, command.userId);
-    }
+    return runAppEffect(
+      Effect.gen(function* () {
+        switch (command.kind) {
+          case "notification":
+          case "apple_pay":
+          case "widget":
+            return yield* fromThunk(() => ingestDefault(command));
+          case "email_batch":
+            return yield* fromThunk(() =>
+              processEmails(db, command.userId, command.emails, command.onProgress)
+            );
+          case "email_retry":
+            return yield* fromThunk(() => processRetries(db, command.userId));
+        }
+      })
+    );
   }
 
   return { ingest: ingestWithEmail };

--- a/apps/mobile/features/capture-sources/store.ts
+++ b/apps/mobile/features/capture-sources/store.ts
@@ -9,9 +9,6 @@ import {
 } from "./lib/repository";
 import { KNOWN_BANK_PACKAGES } from "./schema";
 
-let dbRef: AnyDb | null = null;
-let userIdRef: string | null = null;
-
 type CaptureSourcesState = {
   enabledPackages: string[];
   isNotificationPermissionGranted: boolean;
@@ -20,94 +17,101 @@ type CaptureSourcesState = {
 };
 
 type CaptureSourcesActions = {
-  initStore: (db: AnyDb, userId: string) => void;
-  hydrate: () => Promise<void>;
-  loadConfig: () => Promise<void>;
-  togglePackage: (packageName: string, enabled: boolean) => Promise<void>;
-  checkPermissions: () => Promise<void>;
-  refreshStatus: () => Promise<void>;
-  refreshDetectedSms: () => Promise<void>;
-  _resetRefs: () => void;
+  setEnabledPackages: (enabledPackages: readonly string[]) => void;
+  setNotificationPermissionGranted: (isNotificationPermissionGranted: boolean) => void;
+  setApplePaySetupComplete: (isApplePaySetupComplete: boolean) => void;
+  setDetectedSmsCount: (detectedSmsCount: number) => void;
 };
 
 export const useCaptureSourcesStore = create<CaptureSourcesState & CaptureSourcesActions>(
-  (set, get) => ({
+  (set) => ({
     enabledPackages: [],
     isNotificationPermissionGranted: false,
     isApplePaySetupComplete: false,
     detectedSmsCount: 0,
 
-    initStore: (db, userId) => {
-      dbRef = db;
-      userIdRef = userId;
-    },
+    setEnabledPackages: (enabledPackages) => set({ enabledPackages: [...enabledPackages] }),
 
-    _resetRefs: () => {
-      dbRef = null;
-      userIdRef = null;
-    },
+    setNotificationPermissionGranted: (isNotificationPermissionGranted) =>
+      set({ isNotificationPermissionGranted }),
 
-    hydrate: async () => {
-      const { loadConfig, checkPermissions, refreshStatus, refreshDetectedSms } = get();
-      await Promise.allSettled([
-        loadConfig(),
-        checkPermissions(),
-        refreshStatus(),
-        refreshDetectedSms(),
-      ]);
-    },
+    setApplePaySetupComplete: (isApplePaySetupComplete) => set({ isApplePaySetupComplete }),
 
-    loadConfig: async () => {
-      if (!dbRef || !userIdRef) return;
-      const enabledPackages = await getEnabledPackages(dbRef, userIdRef);
-      set({ enabledPackages });
-    },
-
-    checkPermissions: async () => {
-      if (Platform.OS !== "android") return;
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-require-imports -- conditional native module load; dynamic import() not supported for native modules
-        const mod = require("expo-android-notification-listener-service") as {
-          isPermissionGranted: () => Promise<boolean>;
-        };
-        const granted = await mod.isPermissionGranted();
-        set({ isNotificationPermissionGranted: granted });
-      } catch {
-        // Module not available — leave as false
-      }
-    },
-
-    togglePackage: async (packageName, enabled) => {
-      if (!dbRef || !userIdRef) return;
-
-      const knownPkg = KNOWN_BANK_PACKAGES.find((p) => p.packageName === packageName);
-      const label = knownPkg?.label ?? packageName;
-
-      await upsertNotificationSource(
-        dbRef,
-        userIdRef,
-        packageName,
-        label,
-        enabled,
-        new Date().toISOString()
-      );
-
-      const updated = enabled
-        ? [...get().enabledPackages, packageName]
-        : get().enabledPackages.filter((p) => p !== packageName);
-      set({ enabledPackages: updated });
-    },
-
-    refreshStatus: async () => {
-      if (!dbRef) return;
-      const isApplePaySetupComplete = await hasProcessedCaptures(dbRef, "apple_pay");
-      set({ isApplePaySetupComplete });
-    },
-
-    refreshDetectedSms: async () => {
-      if (!dbRef || !userIdRef) return;
-      const detectedSmsCount = await getTodaySmsEventCount(dbRef, userIdRef, new Date());
-      set({ detectedSmsCount });
-    },
+    setDetectedSmsCount: (detectedSmsCount) => set({ detectedSmsCount }),
   })
 );
+
+async function loadCaptureSourceConfig(db: AnyDb, userId: string): Promise<void> {
+  const enabledPackages = await getEnabledPackages(db, userId);
+  useCaptureSourcesStore.getState().setEnabledPackages(enabledPackages);
+}
+
+async function checkCaptureSourcePermissions(): Promise<void> {
+  if (Platform.OS !== "android") return;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- conditional native module load; dynamic import() not supported for native modules
+    const mod = require("expo-android-notification-listener-service") as {
+      isPermissionGranted: () => Promise<boolean>;
+    };
+    const granted = await mod.isPermissionGranted();
+    useCaptureSourcesStore.getState().setNotificationPermissionGranted(granted);
+  } catch {
+    // Module not available — leave as false
+  }
+}
+
+function getUpdatedEnabledPackages(
+  enabledPackages: readonly string[],
+  packageName: string,
+  enabled: boolean
+): string[] {
+  if (enabled) {
+    return enabledPackages.includes(packageName)
+      ? [...enabledPackages]
+      : [...enabledPackages, packageName];
+  }
+
+  return enabledPackages.filter((pkg) => pkg !== packageName);
+}
+
+export async function hydrateCaptureSources(db: AnyDb, userId: string): Promise<void> {
+  await Promise.allSettled([
+    loadCaptureSourceConfig(db, userId),
+    checkCaptureSourcePermissions(),
+    refreshCaptureSourceStatus(db),
+    refreshDetectedSmsCount(db, userId),
+  ]);
+}
+
+export async function toggleCaptureSourcePackage(
+  db: AnyDb,
+  userId: string,
+  packageName: string,
+  enabled: boolean
+): Promise<void> {
+  const knownPkg = KNOWN_BANK_PACKAGES.find((pkg) => pkg.packageName === packageName);
+  const label = knownPkg?.label ?? packageName;
+
+  await upsertNotificationSource(db, userId, packageName, label, enabled, new Date().toISOString());
+
+  const updated = getUpdatedEnabledPackages(
+    useCaptureSourcesStore.getState().enabledPackages,
+    packageName,
+    enabled
+  );
+  useCaptureSourcesStore.getState().setEnabledPackages(updated);
+}
+
+export async function refreshCaptureSourceStatus(db: AnyDb): Promise<void> {
+  const isApplePaySetupComplete = await hasProcessedCaptures(db, "apple_pay");
+  useCaptureSourcesStore.getState().setApplePaySetupComplete(isApplePaySetupComplete);
+}
+
+export async function refreshDetectedSmsCount(
+  db: AnyDb,
+  userId: string,
+  now: Date = new Date()
+): Promise<void> {
+  const detectedSmsCount = await getTodaySmsEventCount(db, userId, now);
+  useCaptureSourcesStore.getState().setDetectedSmsCount(detectedSmsCount);
+}

--- a/apps/mobile/features/categories/components/CreateCategorySheet.tsx
+++ b/apps/mobile/features/categories/components/CreateCategorySheet.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from "expo-router";
 import React, { useCallback, useState } from "react";
+import { useAuthStore } from "@/features/auth";
 import { Check, Ellipsis, type LucideIcon } from "@/shared/components/icons";
 import {
   FlatList,
@@ -11,10 +12,12 @@ import {
   TextInput,
   View,
 } from "@/shared/components/rn";
+import { getDb } from "@/shared/db";
 import { useAsyncGuard, useThemeColor, useTranslation } from "@/shared/hooks";
+import type { UserId } from "@/shared/types/branded";
 import { COLOR_SWATCHES, MAX_NAME_LENGTH, MIN_NAME_LENGTH } from "../lib/constants";
 import { ICON_MAP, SELECTABLE_ICONS } from "../lib/icon-map";
-import { useCategoriesStore } from "../store";
+import { createCustomCategory } from "../store";
 
 const ICON_GRID_COLUMNS = 6;
 
@@ -106,6 +109,7 @@ export function CreateCategorySheet() {
   const [selectedIcon, setSelectedIcon] = useState<string | null>(null);
   const [selectedColor, setSelectedColor] = useState<string | null>(null);
   const { isBusy, run: guardedCreate } = useAsyncGuard();
+  const userId = useAuthStore((state) => state.session?.user.id as UserId | undefined);
 
   const trimmedName = name.trim();
   const isFormValid =
@@ -123,16 +127,16 @@ export function CreateCategorySheet() {
   }, []);
 
   const handleCreate = useCallback(() => {
-    if (!selectedIcon || !selectedColor) return;
+    if (!selectedIcon || !selectedColor || !userId) return;
     void guardedCreate(async () => {
-      const success = await useCategoriesStore.getState().createCustom({
+      const success = await createCustomCategory(getDb(userId), userId, {
         name: name.trim(),
         iconName: selectedIcon,
         colorHex: selectedColor,
       });
       if (success) router.back();
     });
-  }, [name, selectedIcon, selectedColor, guardedCreate, router]);
+  }, [guardedCreate, name, router, selectedColor, selectedIcon, userId]);
 
   // Derive preview icon
   const PreviewIcon: LucideIcon = selectedIcon ? (ICON_MAP[selectedIcon] ?? Ellipsis) : Ellipsis;

--- a/apps/mobile/features/categories/components/CreateCategorySheet.tsx
+++ b/apps/mobile/features/categories/components/CreateCategorySheet.tsx
@@ -113,6 +113,7 @@ export function CreateCategorySheet() {
 
   const trimmedName = name.trim();
   const isFormValid =
+    userId != null &&
     trimmedName.length >= MIN_NAME_LENGTH &&
     trimmedName.length <= MAX_NAME_LENGTH &&
     selectedIcon !== null &&

--- a/apps/mobile/features/categories/index.ts
+++ b/apps/mobile/features/categories/index.ts
@@ -2,4 +2,4 @@ export { CategoriesScreen } from "./components/CategoriesScreen";
 export { CreateCategorySheet } from "./components/CreateCategorySheet";
 export type { CategoryRegistryScope, CategoryRegistrySnapshot } from "./lib/registry";
 export { createCategoryRegistrySnapshot, isCategoryIdValid } from "./lib/registry";
-export { useCategoriesStore } from "./store";
+export { createCustomCategory, refreshCategories, useCategoriesStore } from "./store";

--- a/apps/mobile/features/categories/store.ts
+++ b/apps/mobile/features/categories/store.ts
@@ -14,19 +14,12 @@ import {
 } from "./lib/registry";
 import { getUserCategoriesForUser } from "./lib/repository";
 
-// Module-level refs: Zustand doesn't serialize DB connections, so we keep them outside the store.
-let dbRef: AnyDb | null = null;
-let userIdRef: UserId | null = null;
-let mutations: WriteThroughMutationModule | null = null;
-
 const HEX_COLOR_REGEX = /^#[0-9A-Fa-f]{6}$/;
 
 type CategoriesState = CategoryRegistrySnapshot;
 
 type CategoriesActions = {
-  initStore(db: AnyDb, userId: UserId): void;
-  refresh(): Promise<void>;
-  createCustom(input: { name: string; iconName: string; colorHex: string }): Promise<boolean>;
+  replaceSnapshot: (snapshot: CategoryRegistrySnapshot) => void;
   isValid(id: string, scope?: CategoryRegistryScope): boolean;
 };
 
@@ -45,62 +38,69 @@ const toCustomCategoryRow = (row: {
 export const useCategoriesStore = create<CategoriesState & CategoriesActions>((set, get) => ({
   ...createCategoryRegistrySnapshot([]),
 
-  initStore: (db, userId) => {
-    dbRef = db;
-    userIdRef = userId;
-    mutations = createWriteThroughMutationModule(db);
-  },
-
-  refresh: async () => {
-    const db = dbRef;
-    const userId = userIdRef;
-    if (!db || !userId) return;
-
-    try {
-      const rows = getUserCategoriesForUser(db, userId).map(toCustomCategoryRow);
-      set(createCategoryRegistrySnapshot(rows));
-    } catch {
-      // keep existing state
-    }
-  },
-
-  createCustom: async (input) => {
-    const db = dbRef;
-    const userId = userIdRef;
-    if (!db || !userId) return false;
-
-    const trimmedName = input.name.trim();
-    if (trimmedName.length < MIN_NAME_LENGTH || trimmedName.length > MAX_NAME_LENGTH) return false;
-    if (!Object.hasOwn(ICON_MAP, input.iconName)) return false;
-    if (!HEX_COLOR_REGEX.test(input.colorHex)) return false;
-
-    const now = toIsoDateTime(new Date());
-    const id = generateUserCategoryId();
-    const mutationModule = mutations;
-    if (!mutationModule) return false;
-
-    try {
-      const result = await mutationModule.commit({
-        kind: "category.save",
-        row: {
-          id,
-          userId,
-          name: trimmedName,
-          iconName: input.iconName,
-          colorHex: input.colorHex,
-          createdAt: now,
-          updatedAt: now,
-          deletedAt: null,
-        },
-      });
-      if (!result.success) return false;
-    } catch {
-      return false;
-    }
-
-    await get().refresh();
-    return true;
-  },
+  replaceSnapshot: (snapshot) => set(snapshot),
 
   isValid: (id, scope = "built_in") => isCategoryIdValid(get(), id, scope),
 }));
+
+function isValidCustomCategoryInput(input: {
+  name: string;
+  iconName: string;
+  colorHex: string;
+}): boolean {
+  const trimmedName = input.name.trim();
+  return (
+    trimmedName.length >= MIN_NAME_LENGTH &&
+    trimmedName.length <= MAX_NAME_LENGTH &&
+    Object.hasOwn(ICON_MAP, input.iconName) &&
+    HEX_COLOR_REGEX.test(input.colorHex)
+  );
+}
+
+function createCategoryMutations(db: AnyDb): WriteThroughMutationModule {
+  return createWriteThroughMutationModule(db);
+}
+
+export async function refreshCategories(db: AnyDb, userId: UserId): Promise<void> {
+  try {
+    const rows = getUserCategoriesForUser(db, userId).map(toCustomCategoryRow);
+    useCategoriesStore.getState().replaceSnapshot(createCategoryRegistrySnapshot(rows));
+  } catch {
+    // keep existing state
+  }
+}
+
+export async function createCustomCategory(
+  db: AnyDb,
+  userId: UserId,
+  input: { name: string; iconName: string; colorHex: string }
+): Promise<boolean> {
+  if (!isValidCustomCategoryInput(input)) return false;
+
+  const trimmedName = input.name.trim();
+  const now = toIsoDateTime(new Date());
+  const id = generateUserCategoryId();
+  const mutations = createCategoryMutations(db);
+
+  try {
+    const result = await mutations.commit({
+      kind: "category.save",
+      row: {
+        id,
+        userId,
+        name: trimmedName,
+        iconName: input.iconName,
+        colorHex: input.colorHex,
+        createdAt: now,
+        updatedAt: now,
+        deletedAt: null,
+      },
+    });
+    if (!result.success) return false;
+  } catch {
+    return false;
+  }
+
+  await refreshCategories(db, userId);
+  return true;
+}

--- a/apps/mobile/features/goals/store.ts
+++ b/apps/mobile/features/goals/store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { scheduleLocalPush, useNotificationStore } from "@/features/notifications";
+import { insertNotificationRecord, scheduleLocalPush } from "@/features/notifications";
 import { getMonthlyTotalsByType, useTransactionStore } from "@/features/transactions";
 import { createWriteThroughMutationModule, type WriteThroughMutationModule } from "@/mutations";
 import type { AnyDb } from "@/shared/db";
@@ -38,7 +38,7 @@ import { addContributionSchema, createGoalSchema } from "./schema";
 
 // Module-level refs: Zustand doesn't serialize DB connections, so we keep them outside the store.
 let dbRef: AnyDb | null = null;
-let userIdRef: string | null = null;
+let userIdRef: UserId | null = null;
 let unsubscribeTxStore: (() => void) | null = null;
 let mutations: WriteThroughMutationModule | null = null;
 
@@ -59,7 +59,7 @@ type GoalState = {
 };
 
 type GoalActions = {
-  initStore: (db: AnyDb, userId: string) => void;
+  initStore: (db: AnyDb, userId: UserId) => void;
   loadGoals: () => Promise<void>;
   loadGoalContributions: (goalId: string) => void;
   createGoal: (input: {
@@ -261,6 +261,8 @@ export const useGoalStore = create<GoalState & GoalActions>((set, get) => ({
 
   addContribution: async (input) => {
     if (!dbRef || !userIdRef) return false;
+    const db = dbRef;
+    const userId = userIdRef;
     const validation = addContributionSchema.safeParse(input);
     if (!validation.success) return false;
     const mutationModule = mutations;
@@ -273,7 +275,7 @@ export const useGoalStore = create<GoalState & GoalActions>((set, get) => ({
         row: {
           id,
           goalId: input.goalId,
-          userId: userIdRef,
+          userId,
           amount: input.amount,
           note: input.note ?? null,
           date: input.date,
@@ -299,7 +301,7 @@ export const useGoalStore = create<GoalState & GoalActions>((set, get) => ({
       const milestones = [25, 50, 75, 100] as const;
       milestones.forEach((milestone) => {
         if (percentBefore < milestone && percentAfter >= milestone) {
-          useNotificationStore.getState().insertNotification({
+          void insertNotificationRecord(db, userId, {
             type: "goal_milestone",
             dedupKey: `goal_milestone:${input.goalId}:${milestone}`,
             categoryId: null,

--- a/apps/mobile/features/notifications/components/NotificationsScreen.tsx
+++ b/apps/mobile/features/notifications/components/NotificationsScreen.tsx
@@ -6,7 +6,7 @@ import { useAccountCreatedAt } from "@/features/auth/public";
 import { ScreenLayout } from "@/shared/components";
 import { Platform, Pressable, SectionList, StyleSheet, Text, View } from "@/shared/components/rn";
 import { getDb } from "@/shared/db";
-import { useMountEffect, useThemeColor, useTranslation } from "@/shared/hooks";
+import { useMountEffect, useSubscription, useThemeColor, useTranslation } from "@/shared/hooks";
 import { trackNotificationCenterOpened } from "@/shared/lib";
 import type { UserId } from "@/shared/types/branded";
 import { deriveNotificationDisplay, groupNotificationsBySection } from "../lib/display";
@@ -40,11 +40,18 @@ export const NotificationsScreen = () => {
   }, [userId]);
 
   useMountEffect(() => {
-    if (!userId) return;
     trackNotificationCenterOpened();
-    markNotificationsVisited(userId);
-    loadNotificationsForUser(getDb(userId), userId);
   });
+
+  useSubscription(
+    () => {
+      if (!userId) return;
+      markNotificationsVisited(userId);
+      loadNotificationsForUser(getDb(userId), userId);
+    },
+    [userId],
+    userId != null
+  );
 
   const sections = useMemo(() => {
     const displays = notifications.map((n) => deriveNotificationDisplay(n, t));

--- a/apps/mobile/features/notifications/components/NotificationsScreen.tsx
+++ b/apps/mobile/features/notifications/components/NotificationsScreen.tsx
@@ -1,21 +1,30 @@
 import { Stack, useRouter } from "expo-router";
 import { useCallback, useMemo } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useAuthStore } from "@/features/auth";
 import { useAccountCreatedAt } from "@/features/auth/public";
 import { ScreenLayout } from "@/shared/components";
 import { Platform, Pressable, SectionList, StyleSheet, Text, View } from "@/shared/components/rn";
+import { getDb } from "@/shared/db";
 import { useMountEffect, useThemeColor, useTranslation } from "@/shared/hooks";
 import { trackNotificationCenterOpened } from "@/shared/lib";
+import type { UserId } from "@/shared/types/branded";
 import { deriveNotificationDisplay, groupNotificationsBySection } from "../lib/display";
 import { isFirstWeek } from "../lib/first-week";
 import type { NotificationDisplay } from "../lib/types";
-import { useNotificationStore } from "../store";
+import {
+  clearAllNotifications,
+  loadNotificationsForUser,
+  markNotificationsVisited,
+  useNotificationStore,
+} from "../store";
 import { NotificationCard } from "./NotificationCard";
 import { NotificationEmptyState } from "./NotificationEmptyState";
 
 export const NotificationsScreen = () => {
   const router = useRouter();
   const { t } = useTranslation();
+  const userId = useAuthStore((state) => state.session?.user.id as UserId | undefined);
   const notifications = useNotificationStore((s) => s.notifications);
   const isLoading = useNotificationStore((s) => s.isLoading);
   const tertiaryColor = useThemeColor("tertiary");
@@ -26,13 +35,15 @@ export const NotificationsScreen = () => {
   const firstWeek = isFirstWeek(accountCreatedAt, new Date());
 
   const handleClearAll = useCallback(() => {
-    useNotificationStore.getState().clearAll();
-  }, []);
+    if (!userId) return;
+    void clearAllNotifications(getDb(userId), userId);
+  }, [userId]);
 
   useMountEffect(() => {
+    if (!userId) return;
     trackNotificationCenterOpened();
-    useNotificationStore.getState().markVisited();
-    useNotificationStore.getState().loadNotifications();
+    markNotificationsVisited(userId);
+    loadNotificationsForUser(getDb(userId), userId);
   });
 
   const sections = useMemo(() => {

--- a/apps/mobile/features/notifications/index.ts
+++ b/apps/mobile/features/notifications/index.ts
@@ -13,4 +13,11 @@ export type {
 } from "./lib/types";
 export { scheduleLocalPush } from "./services/local-push";
 export { deletePushToken, PROJECT_ID, registerPushToken } from "./services/push-token";
-export { useNotificationStore } from "./store";
+export {
+  clearAllNotifications,
+  initializeNotificationStore,
+  insertNotificationRecord,
+  loadNotificationsForUser,
+  markNotificationsVisited,
+  useNotificationStore,
+} from "./store";

--- a/apps/mobile/features/notifications/store.ts
+++ b/apps/mobile/features/notifications/store.ts
@@ -1,6 +1,6 @@
 import * as SecureStore from "expo-secure-store";
 import { create } from "zustand";
-import { createWriteThroughMutationModule, type WriteThroughMutationModule } from "@/mutations";
+import { createWriteThroughMutationModule } from "@/mutations";
 import type { AnyDb } from "@/shared/db";
 import { generateNotificationId, toIsoDateTime } from "@/shared/lib";
 import type { CategoryId, IsoDateTime, UserId } from "@/shared/types/branded";
@@ -8,11 +8,6 @@ import type { NotificationType, StoredNotification } from "./lib/types";
 import { countNotificationsSince, getNotifications } from "./repository";
 
 const lastVisitedKey = (userId: UserId) => `notification_last_visited_${userId}`;
-
-// Module-level refs: Zustand doesn't serialize DB connections, so we keep them outside the store.
-let dbRef: AnyDb | null = null;
-let userIdRef: UserId | null = null;
-let mutations: WriteThroughMutationModule | null = null;
 
 type InsertNotificationInput = {
   readonly type: NotificationType;
@@ -28,108 +23,129 @@ type NotificationState = {
   notifications: readonly StoredNotification[];
   newCount: number;
   isLoading: boolean;
+  activeUserId: UserId | null;
 };
 
 type NotificationActions = {
-  initStore: (db: AnyDb, userId: UserId) => Promise<void>;
-  loadNotifications: () => void;
-  insertNotification: (input: InsertNotificationInput) => void;
-  markVisited: () => void;
-  clearAll: () => void;
+  beginSession: (userId: UserId) => void;
+  setNewCount: (newCount: number) => void;
+  setNotifications: (notifications: readonly StoredNotification[]) => void;
+  setIsLoading: (isLoading: boolean) => void;
+  incrementNewCount: () => void;
+  clearState: () => void;
 };
 
-export const useNotificationStore = create<NotificationState & NotificationActions>(
-  (set, _get) => ({
-    notifications: [],
-    newCount: 0,
-    isLoading: false,
+export const useNotificationStore = create<NotificationState & NotificationActions>((set) => ({
+  notifications: [],
+  newCount: 0,
+  isLoading: false,
+  activeUserId: null,
 
-    initStore: async (db, userId) => {
-      dbRef = db;
-      userIdRef = userId;
-      mutations = createWriteThroughMutationModule(db);
-      const requestedUserId = userId;
+  beginSession: (userId) =>
+    set({
+      activeUserId: userId,
+      notifications: [],
+      newCount: 0,
+      isLoading: false,
+    }),
 
-      let lastVisitedAt: IsoDateTime | null = null;
-      try {
-        const stored = await SecureStore.getItemAsync(lastVisitedKey(userId));
-        lastVisitedAt = stored ? (stored as IsoDateTime) : null;
-      } catch {
-        // SecureStore may fail in tests — default to null
-      }
+  setNewCount: (newCount) => set({ newCount }),
 
-      if (userIdRef !== requestedUserId) return;
-      const newCount = countNotificationsSince(db, userId, lastVisitedAt);
-      set({ newCount });
+  setNotifications: (notifications) => set({ notifications: [...notifications], isLoading: false }),
+
+  setIsLoading: (isLoading) => set({ isLoading }),
+
+  incrementNewCount: () => set((state) => ({ newCount: state.newCount + 1 })),
+
+  clearState: () => set({ notifications: [], newCount: 0 }),
+}));
+
+function isActiveNotificationUser(userId: UserId): boolean {
+  return useNotificationStore.getState().activeUserId === userId;
+}
+
+export async function initializeNotificationStore(db: AnyDb, userId: UserId): Promise<void> {
+  useNotificationStore.getState().beginSession(userId);
+
+  let lastVisitedAt: IsoDateTime | null = null;
+  try {
+    const stored = await SecureStore.getItemAsync(lastVisitedKey(userId));
+    lastVisitedAt = stored ? (stored as IsoDateTime) : null;
+  } catch {
+    // SecureStore may fail in tests — default to null
+  }
+
+  if (!isActiveNotificationUser(userId)) return;
+  const newCount = countNotificationsSince(db, userId, lastVisitedAt);
+  useNotificationStore.getState().setNewCount(newCount);
+}
+
+export function loadNotificationsForUser(db: AnyDb, userId: UserId): void {
+  useNotificationStore.getState().setIsLoading(true);
+
+  try {
+    const rows = getNotifications(db, userId);
+    if (!isActiveNotificationUser(userId)) {
+      useNotificationStore.getState().setIsLoading(false);
+      return;
+    }
+    useNotificationStore.getState().setNotifications(rows as readonly StoredNotification[]);
+  } catch {
+    useNotificationStore.getState().setIsLoading(false);
+  }
+}
+
+export async function insertNotificationRecord(
+  db: AnyDb,
+  userId: UserId,
+  input: InsertNotificationInput
+): Promise<void> {
+  const now = toIsoDateTime(new Date());
+  const id = generateNotificationId();
+  const mutations = createWriteThroughMutationModule(db);
+
+  const result = await mutations.commit({
+    kind: "notification.insert",
+    row: {
+      id,
+      userId,
+      type: input.type,
+      dedupKey: input.dedupKey,
+      categoryId: input.categoryId,
+      goalId: input.goalId,
+      titleKey: input.titleKey,
+      messageKey: input.messageKey,
+      params: input.params,
+      createdAt: now,
+      updatedAt: now,
+      deletedAt: null,
     },
+  });
 
-    loadNotifications: () => {
-      if (!dbRef || !userIdRef) return;
-      set({ isLoading: true });
-      try {
-        const rows = getNotifications(dbRef, userIdRef);
-        set({ notifications: rows as readonly StoredNotification[], isLoading: false });
-      } catch {
-        set({ isLoading: false });
-      }
-    },
+  if (result.success && result.didMutate && isActiveNotificationUser(userId)) {
+    useNotificationStore.getState().incrementNewCount();
+  }
+}
 
-    insertNotification: (input) => {
-      if (!dbRef || !userIdRef) return;
-      const mutationModule = mutations;
-      if (!mutationModule) return;
-      const requestedUserId = userIdRef;
-      const now = toIsoDateTime(new Date());
-      const id = generateNotificationId();
-      void mutationModule
-        .commit({
-          kind: "notification.insert",
-          row: {
-            id,
-            userId: requestedUserId,
-            type: input.type,
-            dedupKey: input.dedupKey,
-            categoryId: input.categoryId,
-            goalId: input.goalId,
-            titleKey: input.titleKey,
-            messageKey: input.messageKey,
-            params: input.params,
-            createdAt: now,
-            updatedAt: now,
-            deletedAt: null,
-          },
-        })
-        .then((result) => {
-          if (result.success && result.didMutate && userIdRef === requestedUserId) {
-            set((state) => ({ newCount: state.newCount + 1 }));
-          }
-        });
-    },
+export function markNotificationsVisited(userId: UserId): void {
+  const now = toIsoDateTime(new Date());
+  void SecureStore.setItemAsync(lastVisitedKey(userId), now).catch(() => undefined);
 
-    markVisited: () => {
-      const now = toIsoDateTime(new Date());
-      if (!userIdRef) return;
-      void SecureStore.setItemAsync(lastVisitedKey(userIdRef), now).catch(() => undefined);
-      set({ newCount: 0 });
-    },
+  if (isActiveNotificationUser(userId)) {
+    useNotificationStore.getState().setNewCount(0);
+  }
+}
 
-    clearAll: () => {
-      if (!dbRef || !userIdRef) return;
-      const mutationModule = mutations;
-      if (!mutationModule) return;
-      const requestedUserId = userIdRef;
-      const now = toIsoDateTime(new Date());
-      void mutationModule
-        .commit({
-          kind: "notification.clearAll",
-          userId: requestedUserId,
-          now,
-        })
-        .then((result) => {
-          if (result.success && userIdRef === requestedUserId) {
-            set({ notifications: [], newCount: 0 });
-          }
-        });
-    },
-  })
-);
+export async function clearAllNotifications(db: AnyDb, userId: UserId): Promise<void> {
+  const mutations = createWriteThroughMutationModule(db);
+  const now = toIsoDateTime(new Date());
+  const result = await mutations.commit({
+    kind: "notification.clearAll",
+    userId,
+    now,
+  });
+
+  if (result.success && isActiveNotificationUser(userId)) {
+    useNotificationStore.getState().clearState();
+  }
+}

--- a/apps/mobile/features/search/components/SearchScreen.tsx
+++ b/apps/mobile/features/search/components/SearchScreen.tsx
@@ -1,16 +1,25 @@
 import { useRouter } from "expo-router";
 import { memo, useCallback, useMemo, useRef, useState } from "react";
+import { useAuthStore } from "@/features/auth";
 import { CATEGORY_MAP, makeDateLabel, type StoredTransaction } from "@/features/transactions";
 import { ScreenLayout, TAB_BAR_CLEARANCE, TransactionRow } from "@/shared/components";
 import { Ellipsis } from "@/shared/components/icons";
 import { FlatList, InteractionManager, Text, TextInput, View } from "@/shared/components/rn";
+import { getDb } from "@/shared/db";
 import { useMountEffect, useThemeColor, useTranslation } from "@/shared/hooks";
 import { getCategoryLabel, getDateFnsLocale } from "@/shared/i18n";
 import { formatSignedMoney, toIsoDate } from "@/shared/lib";
 import { amountDigitsToAmount } from "../lib/amount-utils";
 import { hasActiveFilters } from "../lib/filters";
 import type { SearchFilters } from "../lib/types";
-import { useSearchStore } from "../store";
+import {
+  clearSearchFilters,
+  executeSearch,
+  loadNextSearchPage,
+  updateSearchFilters,
+  updateSearchQuery,
+  useSearchStore,
+} from "../store";
 import { AmountFilter } from "./AmountFilter";
 import { CategoryFilter } from "./CategoryFilter";
 import { DateFilter } from "./DateFilter";
@@ -63,16 +72,13 @@ export const SearchScreen = () => {
   const primary = useThemeColor("primary");
   const secondary = useThemeColor("secondary");
   const peachLight = useThemeColor("peachLight");
+  const userId = useAuthStore((state) => state.session?.user.id ?? null);
+  const db = userId ? getDb(userId) : null;
 
   const filters = useSearchStore((s) => s.filters);
   const results = useSearchStore((s) => s.results);
   const hasMore = useSearchStore((s) => s.hasMore);
   const summary = useSearchStore((s) => s.summary);
-  const setQuery = useSearchStore((s) => s.setQuery);
-  const setFilters = useSearchStore((s) => s.setFilters);
-  const clearFilters = useSearchStore((s) => s.clearFilters);
-  const loadNextPage = useSearchStore((s) => s.loadNextPage);
-  const executeSearch = useSearchStore((s) => s.executeSearch);
   const reset = useSearchStore((s) => s.reset);
 
   const [ready, setReady] = useState(false);
@@ -86,7 +92,9 @@ export const SearchScreen = () => {
   useMountEffect(() => {
     const handle = InteractionManager.runAfterInteractions(() => {
       setReady(true);
-      executeSearch();
+      if (db && userId) {
+        executeSearch(db, userId);
+      }
       inputRef.current?.focus();
     });
     return () => {
@@ -101,10 +109,11 @@ export const SearchScreen = () => {
       setInputText(text);
       if (debounceRef.current) clearTimeout(debounceRef.current);
       debounceRef.current = setTimeout(() => {
-        setQuery(text);
+        if (!db || !userId) return;
+        updateSearchQuery(db, userId, text);
       }, DEBOUNCE_MS);
     },
-    [setQuery]
+    [db, userId]
   );
 
   const handleTogglePanel = useCallback((key: FilterKey) => {
@@ -117,9 +126,10 @@ export const SearchScreen = () => {
       const next = current.includes(categoryId)
         ? current.filter((id) => id !== categoryId)
         : [...current, categoryId];
-      setFilters({ categoryIds: next });
+      if (!db || !userId) return;
+      updateSearchFilters(db, userId, { categoryIds: next });
     },
-    [setFilters]
+    [db, userId]
   );
 
   const handleClearAll = useCallback(() => {
@@ -128,38 +138,48 @@ export const SearchScreen = () => {
     setMinDigits("");
     setMaxDigits("");
     setActivePanel(null);
-    clearFilters();
-  }, [clearFilters]);
+    if (!db || !userId) return;
+    clearSearchFilters(db, userId);
+  }, [db, userId]);
 
   const handleMinChange = useCallback(
     (digits: string) => {
       setMinDigits(digits);
-      setFilters({ amountMin: amountDigitsToAmount(digits) });
+      if (!db || !userId) return;
+      updateSearchFilters(db, userId, { amountMin: amountDigitsToAmount(digits) });
     },
-    [setFilters]
+    [db, userId]
   );
 
   const handleMaxChange = useCallback(
     (digits: string) => {
       setMaxDigits(digits);
-      setFilters({ amountMax: amountDigitsToAmount(digits) });
+      if (!db || !userId) return;
+      updateSearchFilters(db, userId, { amountMax: amountDigitsToAmount(digits) });
     },
-    [setFilters]
+    [db, userId]
   );
 
   const handleDateRangeChange = useCallback(
-    (from: string | null, to: string | null) => setFilters({ dateFrom: from, dateTo: to }),
-    [setFilters]
+    (from: string | null, to: string | null) => {
+      if (!db || !userId) return;
+      updateSearchFilters(db, userId, { dateFrom: from, dateTo: to });
+    },
+    [db, userId]
   );
 
   const handleTypeChange = useCallback(
-    (type: SearchFilters["type"]) => setFilters({ type }),
-    [setFilters]
+    (type: SearchFilters["type"]) => {
+      if (!db || !userId) return;
+      updateSearchFilters(db, userId, { type });
+    },
+    [db, userId]
   );
 
   const handleEndReached = useCallback(() => {
-    if (hasMore) loadNextPage();
-  }, [hasMore, loadNextPage]);
+    if (!db || !userId || !hasMore) return;
+    loadNextSearchPage(db, userId);
+  }, [db, hasMore, userId]);
 
   const dateBreaks = useMemo(() => {
     const breaks = new Set<string>();

--- a/apps/mobile/features/search/index.ts
+++ b/apps/mobile/features/search/index.ts
@@ -3,4 +3,11 @@ export { SearchScreen } from "./components/SearchScreen";
 export { countActiveFilters, hasActiveFilters } from "./lib/filters";
 export type { SearchFilters, SearchSummary } from "./lib/types";
 export { EMPTY_FILTERS } from "./lib/types";
-export { useSearchStore } from "./store";
+export {
+  clearSearchFilters,
+  executeSearch,
+  loadNextSearchPage,
+  updateSearchFilters,
+  updateSearchQuery,
+  useSearchStore,
+} from "./store";

--- a/apps/mobile/features/search/store.ts
+++ b/apps/mobile/features/search/store.ts
@@ -8,9 +8,6 @@ import { EMPTY_FILTERS } from "./lib/types";
 
 const PAGE_SIZE = 30;
 
-let dbRef: AnyDb | null = null;
-let userIdRef: string | null = null;
-
 type SearchState = {
   filters: SearchFilters;
   results: StoredTransaction[];
@@ -21,12 +18,16 @@ type SearchState = {
 };
 
 type SearchActions = {
-  initStore: (db: AnyDb, userId: string) => void;
   setQuery: (query: string) => void;
   setFilters: (partial: Partial<SearchFilters>) => void;
   clearFilters: () => void;
-  executeSearch: () => void;
-  loadNextPage: () => void;
+  setSearchResults: (
+    results: readonly StoredTransaction[],
+    hasMore: boolean,
+    summary: SearchSummary
+  ) => void;
+  appendSearchResults: (results: readonly StoredTransaction[], hasMore: boolean) => void;
+  setIsSearching: (isSearching: boolean) => void;
   reset: () => void;
 };
 
@@ -39,69 +40,88 @@ const INITIAL_STATE: SearchState = {
   isSearching: false,
 };
 
-export const useSearchStore = create<SearchState & SearchActions>((set, get) => ({
+export const useSearchStore = create<SearchState & SearchActions>((set) => ({
   ...INITIAL_STATE,
 
-  initStore: (db, userId) => {
-    dbRef = db;
-    userIdRef = userId;
-  },
-
   setQuery: (query) => {
-    set((s) => ({ filters: { ...s.filters, query } }));
-    get().executeSearch();
+    set((state) => ({ filters: { ...state.filters, query } }));
   },
 
   setFilters: (partial) => {
-    set((s) => ({ filters: { ...s.filters, ...partial } }));
-    get().executeSearch();
+    set((state) => ({ filters: { ...state.filters, ...partial } }));
   },
 
   clearFilters: () => {
     set({ filters: EMPTY_FILTERS });
-    get().executeSearch();
   },
 
-  executeSearch: () => {
-    if (!dbRef || !userIdRef) return;
-    set({ isSearching: true });
-    try {
-      const { filters } = get();
-      const rows = searchTransactionsPaginated(dbRef, userIdRef, filters, PAGE_SIZE, 0);
-      const hasMore = rows.length > PAGE_SIZE;
-      const pageData = hasMore ? rows.slice(0, PAGE_SIZE) : rows;
-      const summary = searchTransactionsAggregate(dbRef, userIdRef, filters);
-      set({
-        results: pageData.map(toStoredTransaction),
-        offset: pageData.length,
-        hasMore,
-        summary,
-        isSearching: false,
-      });
-    } catch {
-      set({ isSearching: false });
-    }
-  },
+  setSearchResults: (results, hasMore, summary) =>
+    set({
+      results: [...results],
+      offset: results.length,
+      hasMore,
+      summary,
+      isSearching: false,
+    }),
 
-  loadNextPage: () => {
-    if (!dbRef || !userIdRef) return;
-    const { hasMore, offset, filters } = get();
-    if (!hasMore) return;
-    try {
-      const rows = searchTransactionsPaginated(dbRef, userIdRef, filters, PAGE_SIZE, offset);
-      const moreAvailable = rows.length > PAGE_SIZE;
-      const pageData = moreAvailable ? rows.slice(0, PAGE_SIZE) : rows;
-      set((s) => ({
-        results: [...s.results, ...pageData.map(toStoredTransaction)],
-        offset: s.offset + pageData.length,
-        hasMore: moreAvailable,
-      }));
-    } catch {
-      // Keep existing state
-    }
-  },
+  appendSearchResults: (results, hasMore) =>
+    set((state) => ({
+      results: [...state.results, ...results],
+      offset: state.offset + results.length,
+      hasMore,
+    })),
+
+  setIsSearching: (isSearching) => set({ isSearching }),
 
   reset: () => {
     set(INITIAL_STATE);
   },
 }));
+
+export function executeSearch(db: AnyDb, userId: string): void {
+  const { filters, setIsSearching, setSearchResults } = useSearchStore.getState();
+  setIsSearching(true);
+
+  try {
+    const rows = searchTransactionsPaginated(db, userId, filters, PAGE_SIZE, 0);
+    const hasMore = rows.length > PAGE_SIZE;
+    const pageData = (hasMore ? rows.slice(0, PAGE_SIZE) : rows).map(toStoredTransaction);
+    const summary = searchTransactionsAggregate(db, userId, filters);
+    setSearchResults(pageData, hasMore, summary);
+  } catch {
+    setIsSearching(false);
+  }
+}
+
+export function loadNextSearchPage(db: AnyDb, userId: string): void {
+  const { hasMore, offset, filters, appendSearchResults } = useSearchStore.getState();
+  if (!hasMore) return;
+
+  try {
+    const rows = searchTransactionsPaginated(db, userId, filters, PAGE_SIZE, offset);
+    const hasMoreResults = rows.length > PAGE_SIZE;
+    const pageData = (hasMoreResults ? rows.slice(0, PAGE_SIZE) : rows).map(toStoredTransaction);
+    appendSearchResults(pageData, hasMoreResults);
+  } catch {
+    // Keep existing state
+  }
+}
+
+export function updateSearchQuery(db: AnyDb, userId: string, query: string): void {
+  useSearchStore.getState().setQuery(query);
+  executeSearch(db, userId);
+}
+
+export function updateSearchFilters(
+  db: AnyDb,
+  userId: string,
+  partial: Partial<SearchFilters>
+): void {
+  useSearchStore.getState().setFilters(partial);
+  executeSearch(db, userId);
+}
+
+export function clearSearchFilters(db: AnyDb, userId: string): void {
+  useSearchStore.getState().clearFilters();
+  executeSearch(db, userId);
+}

--- a/apps/mobile/features/sync/components/ConflictResolutionScreen.tsx
+++ b/apps/mobile/features/sync/components/ConflictResolutionScreen.tsx
@@ -1,31 +1,35 @@
 import { useRouter } from "expo-router";
 import { useCallback } from "react";
+import { useAuthStore } from "@/features/auth";
 import { ScreenLayout } from "@/shared/components";
 import { FlatList, Text, View } from "@/shared/components/rn";
+import { getDb } from "@/shared/db";
 import { useTranslation } from "@/shared/hooks";
 import type { SyncConflict } from "../store";
-import { useSyncConflictStore } from "../store";
+import { resolveSyncConflictSelection, useSyncConflictStore } from "../store";
 import { ConflictCard } from "./ConflictCard";
 
 export default function ConflictResolutionScreen() {
   const { t } = useTranslation();
   const router = useRouter();
+  const userId = useAuthStore((s) => s.session?.user.id ?? null);
   const conflicts = useSyncConflictStore((s) => s.conflicts);
-  const resolveConflict = useSyncConflictStore((s) => s.resolveConflict);
 
   const renderItem = useCallback(
     ({ item }: { item: SyncConflict }) => (
       <ConflictCard
         conflict={item}
         onKeepLocal={() => {
-          void resolveConflict(item.id, "local");
+          if (!userId) return;
+          void resolveSyncConflictSelection(getDb(userId), item.id, "local");
         }}
         onAcceptServer={() => {
-          void resolveConflict(item.id, "server");
+          if (!userId) return;
+          void resolveSyncConflictSelection(getDb(userId), item.id, "server");
         }}
       />
     ),
-    [resolveConflict]
+    [userId]
   );
 
   const keyExtractor = useCallback((item: SyncConflict) => item.id, []);

--- a/apps/mobile/features/sync/hooks/useSync.ts
+++ b/apps/mobile/features/sync/hooks/useSync.ts
@@ -5,7 +5,7 @@ import { useSubscription } from "@/shared/hooks";
 import { captureWarning } from "@/shared/lib";
 import { onConnectivityChange } from "../services/networkMonitor";
 import { sync } from "../services/sync";
-import { useSyncConflictStore } from "../store";
+import { loadSyncConflicts } from "../store";
 
 export function useSync(db: AnyDb | null, userId: string | null): boolean {
   const isSyncing = useRef(false);
@@ -30,7 +30,7 @@ export function useSync(db: AnyDb | null, userId: string | null): boolean {
         isSyncing.current = true;
         try {
           const result = await sync({ db, userId, reason: "foreground" });
-          await useSyncConflictStore.getState().loadConflicts();
+          await loadSyncConflicts(db);
           if (result.status === "synced") markInitialDone();
         } catch (error) {
           captureWarning("background_sync_failed", {

--- a/apps/mobile/features/sync/index.ts
+++ b/apps/mobile/features/sync/index.ts
@@ -6,4 +6,8 @@ export {
   resolveConflict,
   sync,
 } from "./services/sync";
-export { useSyncConflictStore } from "./store";
+export {
+  loadSyncConflicts,
+  resolveSyncConflictSelection,
+  useSyncConflictStore,
+} from "./store";

--- a/apps/mobile/features/sync/services/create-sync-service.ts
+++ b/apps/mobile/features/sync/services/create-sync-service.ts
@@ -1,0 +1,142 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { Effect } from "effect";
+import { fromThunk, runAppEffect } from "@/shared/effect/runtime";
+import { toIsoDateTime } from "@/shared/lib";
+import type { IsoDateTime } from "@/shared/types/branded";
+import type {
+  ConflictResolution,
+  ResolveConflictResult,
+  ResolveTransactionConflictInput,
+  SyncConflict,
+  SyncContext,
+  SyncInput,
+  SyncRunResult,
+  TransactionSnapshot,
+} from "./types";
+
+type SyncPull = (db: SyncInput["db"], supabase: SupabaseClient, userId: string) => Promise<boolean>;
+type SyncPush = (db: SyncInput["db"], supabase: SupabaseClient, userId: string) => Promise<void>;
+type ConflictRow = {
+  readonly id: string;
+  readonly transactionId: string;
+  readonly localData: string;
+  readonly serverData: string;
+  readonly detectedAt: string;
+};
+type UpsertTransaction = (db: SyncContext["db"], row: TransactionSnapshot) => void | Promise<void>;
+type EnqueueTransactionSync = (
+  db: SyncContext["db"],
+  transactionId: string,
+  createdAt: IsoDateTime
+) => void | Promise<void>;
+type ResolveConflictRow = (
+  db: SyncContext["db"],
+  conflictId: ResolveTransactionConflictInput["conflictId"],
+  resolution: ConflictResolution,
+  resolvedAt: IsoDateTime
+) => void | Promise<void>;
+
+type CreateSyncServiceDeps = {
+  readonly isOnline: () => Promise<boolean>;
+  readonly getSupabase: () => SupabaseClient;
+  readonly syncPull: SyncPull;
+  readonly syncPush: SyncPush;
+  readonly refreshTransactions: () => Promise<void>;
+  readonly getConflictRows: (input: SyncContext) => Promise<readonly ConflictRow[]>;
+  readonly upsertTransaction: UpsertTransaction;
+  readonly enqueueTransactionSync: EnqueueTransactionSync;
+  readonly resolveConflictRow: ResolveConflictRow;
+};
+
+export type SyncService = {
+  readonly run: (input: SyncInput) => Promise<SyncRunResult>;
+  readonly listConflicts: (input: SyncContext) => Promise<readonly SyncConflict[]>;
+  readonly resolveConflict: (
+    input: ResolveTransactionConflictInput
+  ) => Promise<ResolveConflictResult>;
+};
+
+export function createSyncService({
+  isOnline,
+  getSupabase,
+  syncPull,
+  syncPush,
+  refreshTransactions,
+  getConflictRows,
+  upsertTransaction,
+  enqueueTransactionSync,
+  resolveConflictRow,
+}: CreateSyncServiceDeps): SyncService {
+  const listConflicts = async ({ db }: SyncContext): Promise<readonly SyncConflict[]> =>
+    runAppEffect(
+      fromThunk(() => getConflictRows({ db })).pipe(
+        Effect.map((rows) =>
+          rows.map((row) => ({
+            id: row.id,
+            transactionId: row.transactionId,
+            localData: JSON.parse(row.localData) as TransactionSnapshot,
+            serverData: JSON.parse(row.serverData) as TransactionSnapshot,
+            detectedAt: row.detectedAt,
+          }))
+        )
+      )
+    );
+
+  return {
+    listConflicts,
+    resolveConflict: async ({ db, conflictId, resolution }) => {
+      return runAppEffect(
+        Effect.gen(function* () {
+          const rows = yield* fromThunk(() => getConflictRows({ db }));
+          const row = rows.find((conflict) => conflict.id === conflictId);
+          if (!row) {
+            return {
+              unresolvedConflicts: (yield* fromThunk(() => listConflicts({ db }))).length,
+            };
+          }
+
+          const resolvedAt = toIsoDateTime(new Date());
+
+          if (resolution === "local") {
+            const localData = JSON.parse(row.localData) as TransactionSnapshot;
+            yield* fromThunk(() => upsertTransaction(db, { ...localData, updatedAt: resolvedAt }));
+            yield* fromThunk(() => enqueueTransactionSync(db, row.transactionId, resolvedAt));
+          }
+
+          yield* fromThunk(() => resolveConflictRow(db, conflictId, resolution, resolvedAt));
+          yield* fromThunk(refreshTransactions);
+
+          return {
+            unresolvedConflicts: (yield* fromThunk(() => listConflicts({ db }))).length,
+          };
+        })
+      );
+    },
+    run: async ({ db, userId, reason: _reason = "foreground" }) => {
+      return runAppEffect(
+        Effect.gen(function* () {
+          void _reason;
+          const online = yield* fromThunk(isOnline);
+          if (!online) {
+            return {
+              status: "skipped_offline" as const,
+              unresolvedConflicts: (yield* fromThunk(() => listConflicts({ db }))).length,
+            };
+          }
+
+          const supabase = yield* fromThunk(getSupabase);
+          const pullOk = yield* fromThunk(() => syncPull(db, supabase, userId));
+          if (pullOk) {
+            yield* fromThunk(() => syncPush(db, supabase, userId));
+            yield* fromThunk(refreshTransactions);
+          }
+
+          return {
+            status: pullOk ? ("synced" as const) : ("failed_pull" as const),
+            unresolvedConflicts: (yield* fromThunk(() => listConflicts({ db }))).length,
+          };
+        })
+      );
+    },
+  };
+}

--- a/apps/mobile/features/sync/services/sync.ts
+++ b/apps/mobile/features/sync/services/sync.ts
@@ -1,152 +1,70 @@
 // biome-ignore-all lint/style/useNamingConvention: snake_case matches Supabase Postgres column names
 import { upsertTransaction, useTransactionStore } from "@/features/transactions";
-import { type AnyDb, enqueueSync, getSupabase } from "@/shared/db";
-import { generateSyncQueueId, toIsoDateTime } from "@/shared/lib";
-import type { SyncConflictId } from "@/shared/types/branded";
+import { enqueueSync, getSupabase } from "@/shared/db";
+import { generateSyncQueueId } from "@/shared/lib";
 import {
   getUnresolvedConflicts,
   resolveConflict as resolveConflictDb,
 } from "../lib/conflict-repository";
+import { createSyncService } from "./create-sync-service";
 import { isOnline } from "./networkMonitor";
 import { syncPull, syncPush } from "./syncEngine";
+import type {
+  ResolveConflictResult,
+  ResolveTransactionConflictInput,
+  SyncConflict,
+  SyncContext,
+  SyncInput,
+  SyncRunResult,
+} from "./types";
 
-export type TransactionSnapshot = {
-  readonly id: string;
-  readonly userId: string;
-  readonly type: string;
-  readonly amount: number;
-  readonly categoryId: string;
-  readonly description: string | null;
-  readonly date: string;
-  readonly createdAt: string;
-  readonly updatedAt: string;
-  readonly deletedAt: string | null;
-  readonly source: string;
-};
-
-export type SyncConflict = {
-  readonly id: string;
-  readonly transactionId: string;
-  readonly localData: TransactionSnapshot;
-  readonly serverData: TransactionSnapshot;
-  readonly detectedAt: string;
-};
-
-export type SyncContext = {
-  readonly db: AnyDb;
-};
-
-export type SyncReason = "startup" | "foreground" | "reconnected" | "manual";
-
-export type SyncInput = SyncContext & {
-  readonly userId: string;
-  readonly reason?: SyncReason;
-};
-
-export type SyncRunResult =
-  | {
-      readonly status: "synced";
-      readonly unresolvedConflicts: number;
-    }
-  | {
-      readonly status: "skipped_offline";
-      readonly unresolvedConflicts: number;
-    }
-  | {
-      readonly status: "failed_pull";
-      readonly unresolvedConflicts: number;
-    };
-
-export type ConflictResolution = "local" | "server";
-
-export type ResolveTransactionConflictInput = SyncContext & {
-  readonly conflictId: SyncConflictId;
-  readonly resolution: ConflictResolution;
-};
-
-export type ResolveConflictResult = {
-  readonly unresolvedConflicts: number;
-};
-
-function parseConflict(row: {
-  readonly id: string;
-  readonly transactionId: string;
-  readonly localData: string;
-  readonly serverData: string;
-  readonly detectedAt: string;
-}): SyncConflict {
-  return {
-    id: row.id,
-    transactionId: row.transactionId,
-    localData: JSON.parse(row.localData) as TransactionSnapshot,
-    serverData: JSON.parse(row.serverData) as TransactionSnapshot,
-    detectedAt: row.detectedAt,
-  };
-}
-
-export async function listConflicts({ db }: SyncContext): Promise<readonly SyncConflict[]> {
-  return getUnresolvedConflicts(db).map(parseConflict);
-}
-
-export async function sync({
-  db,
-  userId,
-  reason: _reason = "foreground",
-}: SyncInput): Promise<SyncRunResult> {
-  void _reason;
-  const online = await isOnline();
-  if (!online) {
-    return {
-      status: "skipped_offline",
-      unresolvedConflicts: (await listConflicts({ db })).length,
-    };
-  }
-
-  const supabase = getSupabase();
-  const pullOk = await syncPull(db, supabase, userId);
-  if (pullOk) {
-    await syncPush(db, supabase, userId);
+const syncService = createSyncService({
+  isOnline,
+  getSupabase,
+  syncPull,
+  syncPush,
+  refreshTransactions: async () => {
     await useTransactionStore.getState().refresh();
-  }
-
-  return {
-    status: pullOk ? "synced" : "failed_pull",
-    unresolvedConflicts: (await listConflicts({ db })).length,
-  };
-}
-
-export async function resolveConflict({
-  db,
-  conflictId,
-  resolution,
-}: ResolveTransactionConflictInput): Promise<ResolveConflictResult> {
-  const row = getUnresolvedConflicts(db).find((conflict) => conflict.id === conflictId);
-  if (!row) {
-    return {
-      unresolvedConflicts: (await listConflicts({ db })).length,
-    };
-  }
-
-  const resolvedAt = toIsoDateTime(new Date());
-
-  if (resolution === "local") {
-    const localData = JSON.parse(row.localData) as TransactionSnapshot;
-    upsertTransaction(db, { ...localData, updatedAt: resolvedAt } as Parameters<
-      typeof upsertTransaction
-    >[1]);
+  },
+  getConflictRows: async ({ db }) => getUnresolvedConflicts(db),
+  upsertTransaction: async (db, row) => {
+    upsertTransaction(db, row as Parameters<typeof upsertTransaction>[1]);
+  },
+  enqueueTransactionSync: async (db, transactionId, createdAt) => {
     enqueueSync(db, {
       id: generateSyncQueueId(),
       tableName: "transactions",
-      rowId: row.transactionId,
+      rowId: transactionId,
       operation: "update",
-      createdAt: resolvedAt,
+      createdAt,
     });
-  }
+  },
+  resolveConflictRow: async (db, conflictId, resolution, resolvedAt) => {
+    resolveConflictDb(db, conflictId, resolution, resolvedAt);
+  },
+});
 
-  resolveConflictDb(db, conflictId, resolution, resolvedAt);
-  await useTransactionStore.getState().refresh();
-
-  return {
-    unresolvedConflicts: (await listConflicts({ db })).length,
-  };
+export async function sync(input: SyncInput): Promise<SyncRunResult> {
+  return syncService.run(input);
 }
+
+export async function listConflicts(input: SyncContext): Promise<readonly SyncConflict[]> {
+  return syncService.listConflicts(input);
+}
+
+export async function resolveConflict({
+  ...input
+}: ResolveTransactionConflictInput): Promise<ResolveConflictResult> {
+  return syncService.resolveConflict(input);
+}
+
+export type {
+  ConflictResolution,
+  ResolveConflictResult,
+  ResolveTransactionConflictInput,
+  SyncConflict,
+  SyncContext,
+  SyncInput,
+  SyncRunResult,
+  TransactionSnapshot,
+} from "./types";

--- a/apps/mobile/features/sync/services/types.ts
+++ b/apps/mobile/features/sync/services/types.ts
@@ -1,0 +1,60 @@
+import type { AnyDb } from "@/shared/db";
+import type { SyncConflictId } from "@/shared/types/branded";
+
+export type TransactionSnapshot = {
+  readonly id: string;
+  readonly userId: string;
+  readonly type: string;
+  readonly amount: number;
+  readonly categoryId: string;
+  readonly description: string | null;
+  readonly date: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly deletedAt: string | null;
+  readonly source: string;
+};
+
+export type SyncConflict = {
+  readonly id: string;
+  readonly transactionId: string;
+  readonly localData: TransactionSnapshot;
+  readonly serverData: TransactionSnapshot;
+  readonly detectedAt: string;
+};
+
+export type SyncContext = {
+  readonly db: AnyDb;
+};
+
+export type SyncReason = "startup" | "foreground" | "reconnected" | "manual";
+
+export type SyncInput = SyncContext & {
+  readonly userId: string;
+  readonly reason?: SyncReason;
+};
+
+export type SyncRunResult =
+  | {
+      readonly status: "synced";
+      readonly unresolvedConflicts: number;
+    }
+  | {
+      readonly status: "skipped_offline";
+      readonly unresolvedConflicts: number;
+    }
+  | {
+      readonly status: "failed_pull";
+      readonly unresolvedConflicts: number;
+    };
+
+export type ConflictResolution = "local" | "server";
+
+export type ResolveTransactionConflictInput = SyncContext & {
+  readonly conflictId: SyncConflictId;
+  readonly resolution: ConflictResolution;
+};
+
+export type ResolveConflictResult = {
+  readonly unresolvedConflicts: number;
+};

--- a/apps/mobile/features/sync/store.ts
+++ b/apps/mobile/features/sync/store.ts
@@ -8,46 +8,44 @@ import {
   type SyncConflict,
 } from "./services/sync";
 
-let dbRef: AnyDb | null = null;
-
 type SyncConflictState = {
   conflicts: SyncConflict[];
   conflictCount: number;
 };
 
 type SyncConflictActions = {
-  initStore: (db: AnyDb) => void;
-  loadConflicts: () => Promise<void>;
-  resolveConflict: (id: string, resolution: "local" | "server") => Promise<void>;
+  setConflicts: (conflicts: readonly SyncConflict[]) => void;
 };
 
-export const useSyncConflictStore = create<SyncConflictState & SyncConflictActions>((set, get) => ({
+export const useSyncConflictStore = create<SyncConflictState & SyncConflictActions>((set) => ({
   conflicts: [],
   conflictCount: 0,
 
-  initStore: (db) => {
-    dbRef = db;
-  },
-
-  loadConflicts: async () => {
-    if (!dbRef) return;
-    try {
-      const conflicts = [...(await listConflicts({ db: dbRef }))];
-      set({ conflicts, conflictCount: conflicts.length });
-    } catch (err) {
-      captureError(err);
-    }
-  },
-
-  resolveConflict: async (id, resolution) => {
-    if (!dbRef) return;
-    await resolveConflictBoundary({
-      db: dbRef,
-      conflictId: id as SyncConflictId,
-      resolution,
-    });
-    await get().loadConflicts();
+  setConflicts: (conflicts) => {
+    set({ conflicts: [...conflicts], conflictCount: conflicts.length });
   },
 }));
+
+export async function loadSyncConflicts(db: AnyDb): Promise<void> {
+  try {
+    const conflicts = [...(await listConflicts({ db }))];
+    useSyncConflictStore.getState().setConflicts(conflicts);
+  } catch (err) {
+    captureError(err);
+  }
+}
+
+export async function resolveSyncConflictSelection(
+  db: AnyDb,
+  id: string,
+  resolution: "local" | "server"
+): Promise<void> {
+  await resolveConflictBoundary({
+    db,
+    conflictId: id as SyncConflictId,
+    resolution,
+  });
+  await loadSyncConflicts(db);
+}
 
 export type { SyncConflict } from "./services/sync";

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -42,6 +42,7 @@
     "burnt": "^0.13.0",
     "date-fns": "^4.1.0",
     "drizzle-orm": "0.45.2",
+    "effect": "3.21.0",
     "expo": "^55.0.0",
     "expo-android-notification-listener-service": "^1.1.0",
     "expo-background-task": "~55.0.9",

--- a/apps/mobile/shared/effect/runtime.ts
+++ b/apps/mobile/shared/effect/runtime.ts
@@ -1,0 +1,11 @@
+import { Effect } from "effect";
+
+export type AppEffect<A, E = unknown, R = never> = Effect.Effect<A, E, R>;
+
+export function runAppEffect<A, E>(effect: AppEffect<A, E>): Promise<A> {
+  return Effect.runPromise(effect);
+}
+
+export function fromThunk<A>(thunk: () => A | Promise<A>): AppEffect<A> {
+  return Effect.promise(() => Promise.resolve().then(thunk));
+}

--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,7 @@
         "burnt": "^0.13.0",
         "date-fns": "^4.1.0",
         "drizzle-orm": "0.45.2",
+        "effect": "3.21.0",
         "expo": "^55.0.0",
         "expo-android-notification-listener-service": "^1.1.0",
         "expo-background-task": "~55.0.9",
@@ -1411,6 +1412,8 @@
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
+    "effect": ["effect@3.21.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.313", "", {}, "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
@@ -1584,6 +1587,8 @@
     "express": ["express@4.22.1", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "~1.20.3", "content-disposition": "~0.5.4", "content-type": "~1.0.4", "cookie": "~0.7.1", "cookie-signature": "~1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "~1.3.1", "fresh": "~0.5.2", "http-errors": "~2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "~0.1.12", "proxy-addr": "~2.0.7", "qs": "~6.14.0", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "~0.19.0", "serve-static": "~1.16.2", "setprototypeof": "1.2.0", "statuses": "~2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g=="],
 
     "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
+
+    "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -2316,6 +2321,8 @@
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
     "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
 


### PR DESCRIPTION
- add effect runtime and sync service seam
- move search, categories, notifications, and capture sources to explicit boundaries
- add boundary-focused regression tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored mobile state to add clear boundaries around search, categories, notifications, capture sources, and sync conflicts, and introduced a thin `effect`-powered service layer for sync and capture ingestion. Also handled edge cases: notifications reload after auth hydrates, budget monitoring is scoped to the active context, and category creation is blocked when auth is unavailable.

- **Refactors**
  - New boundary APIs: Search (`executeSearch`, `loadNextSearchPage`, `updateSearchQuery`, `updateSearchFilters`, `clearSearchFilters`), Categories (`refreshCategories`, `createCustomCategory`), Notifications (`initializeNotificationStore`, `loadNotificationsForUser`, `insertNotificationRecord`, `clearAllNotifications`, `markNotificationsVisited`), Capture sources (`hydrateCaptureSources`, `toggleCaptureSourcePackage`, `refreshCaptureSourceStatus`, `refreshDetectedSmsCount`), Sync conflicts (`loadSyncConflicts`, `resolveSyncConflictSelection`).
  - Removed store-level refs; callers now pass `db` and `userId`. Added `create-sync-service` and a small `Effect` runtime used by sync and capture ingestion; `sync`, `listConflicts`, and `resolveConflict` delegate to it. Updated screens to call new boundaries and added tests (search, sync service, sync conflicts, budget monitoring). Added `effect@3.21.0`.

- **Bug Fixes**
  - Reload notifications when auth/session hydrates.
  - Scope budget refresh side effects to the active user/month.
  - Disable custom category creation when no authenticated user.

<sup>Written for commit a2571307ec42e67bca337727c36010a21290f178. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

