### PR TITLE
refactor(mobile): deepen analytics seam

### DIFF
--- a/apps/mobile/__tests__/analytics/service.test.ts
+++ b/apps/mobile/__tests__/analytics/service.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAnalyticsService } from "@/features/analytics/services/create-analytics-service";
+import type { CategoryId, CopAmount, UserId } from "@/shared/types/branded";
+
+const mockGetIncomeExpenseForPeriod = vi.fn();
+const mockGetSpendingByCategoryForPeriod = vi.fn();
+
+describe("analytics service", () => {
+  it("builds the analytics snapshot for the selected period", async () => {
+    mockGetIncomeExpenseForPeriod
+      .mockReturnValueOnce({
+        income: 500000 as CopAmount,
+        expenses: 200000 as CopAmount,
+      })
+      .mockReturnValueOnce({
+        income: 450000 as CopAmount,
+        expenses: 100000 as CopAmount,
+      });
+    mockGetSpendingByCategoryForPeriod
+      .mockReturnValueOnce([
+        { categoryId: "food" as CategoryId, total: 150000 as CopAmount },
+        { categoryId: "transport" as CategoryId, total: 50000 as CopAmount },
+      ])
+      .mockReturnValueOnce([{ categoryId: "food" as CategoryId, total: 100000 as CopAmount }]);
+
+    const service = createAnalyticsService({
+      getNow: () => new Date(2026, 2, 23),
+      getIncomeExpenseForPeriod: mockGetIncomeExpenseForPeriod,
+      getSpendingByCategoryForPeriod: mockGetSpendingByCategoryForPeriod,
+    });
+
+    const snapshot = await service.loadSnapshot({
+      db: {} as never,
+      userId: "user-1" as UserId,
+      period: "M",
+    });
+
+    expect(mockGetIncomeExpenseForPeriod).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      "user-1",
+      "2026-02-22",
+      "2026-03-23"
+    );
+    expect(mockGetIncomeExpenseForPeriod).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      "user-1",
+      "2026-01-23",
+      "2026-02-21"
+    );
+    expect(snapshot).toEqual({
+      incomeExpense: {
+        income: 500000,
+        expenses: 200000,
+        net: 300000,
+        netIsPositive: true,
+      },
+      categoryBreakdown: [
+        { categoryId: "food", total: 150000, percent: 75 },
+        { categoryId: "transport", total: 50000, percent: 25 },
+      ],
+      periodDelta: {
+        totalDelta: 100000,
+        totalDeltaPercent: 100,
+        spendingIncreased: true,
+        categoryDeltas: [
+          { categoryId: "food", delta: 50000, deltaPercent: 50, increased: true },
+          { categoryId: "transport", delta: 50000, deltaPercent: 100, increased: true },
+        ],
+      },
+    });
+  });
+});

--- a/apps/mobile/__tests__/analytics/store.test.ts
+++ b/apps/mobile/__tests__/analytics/store.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  initializeAnalyticsSession,
+  loadAnalyticsForUser,
+  selectAnalyticsPeriod,
+  useAnalyticsStore,
+} from "@/features/analytics/store";
+import type { CategoryId, CopAmount, UserId } from "@/shared/types/branded";
+
+const mockLoadSnapshot = vi.fn();
+
+vi.mock("@/features/analytics/services/create-analytics-service", () => ({
+  createAnalyticsService: () => ({
+    loadSnapshot: (...args: unknown[]) => mockLoadSnapshot(...args),
+  }),
+}));
+
+function createDeferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("analytics store boundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAnalyticsStore.setState({
+      activeUserId: null,
+      period: "M",
+      incomeExpense: null,
+      categoryBreakdown: [],
+      periodDelta: null,
+      isLoading: false,
+    });
+  });
+
+  it("drops stale analytics results after the active user changes", async () => {
+    const deferred = createDeferred<{
+      incomeExpense: {
+        income: CopAmount;
+        expenses: CopAmount;
+        net: CopAmount;
+        netIsPositive: boolean;
+      };
+      categoryBreakdown: readonly { categoryId: CategoryId; total: CopAmount; percent: number }[];
+      periodDelta: {
+        totalDelta: CopAmount;
+        totalDeltaPercent: number;
+        spendingIncreased: boolean;
+        categoryDeltas: readonly {
+          categoryId: CategoryId;
+          delta: CopAmount;
+          deltaPercent: number;
+          increased: boolean;
+        }[];
+      };
+    }>();
+    mockLoadSnapshot.mockReturnValueOnce(deferred.promise);
+
+    initializeAnalyticsSession("user-1" as UserId);
+    const load = loadAnalyticsForUser({} as never, "user-1" as UserId);
+
+    initializeAnalyticsSession("user-2" as UserId);
+    deferred.resolve({
+      incomeExpense: {
+        income: 500000 as CopAmount,
+        expenses: 200000 as CopAmount,
+        net: 300000 as CopAmount,
+        netIsPositive: true,
+      },
+      categoryBreakdown: [
+        { categoryId: "food" as CategoryId, total: 200000 as CopAmount, percent: 100 },
+      ],
+      periodDelta: {
+        totalDelta: 100000 as CopAmount,
+        totalDeltaPercent: 100,
+        spendingIncreased: true,
+        categoryDeltas: [],
+      },
+    });
+
+    await load;
+
+    expect(useAnalyticsStore.getState()).toMatchObject({
+      activeUserId: "user-2",
+      incomeExpense: null,
+      categoryBreakdown: [],
+      periodDelta: null,
+      isLoading: false,
+    });
+  });
+
+  it("updates the selected period through the explicit boundary", async () => {
+    mockLoadSnapshot.mockResolvedValueOnce({
+      incomeExpense: {
+        income: 300000 as CopAmount,
+        expenses: 100000 as CopAmount,
+        net: 200000 as CopAmount,
+        netIsPositive: true,
+      },
+      categoryBreakdown: [],
+      periodDelta: {
+        totalDelta: 0 as CopAmount,
+        totalDeltaPercent: 0,
+        spendingIncreased: false,
+        categoryDeltas: [],
+      },
+    });
+
+    initializeAnalyticsSession("user-1" as UserId);
+    await selectAnalyticsPeriod({} as never, "user-1" as UserId, "Q");
+
+    expect(mockLoadSnapshot).toHaveBeenCalledWith({
+      db: expect.anything(),
+      userId: "user-1",
+      period: "Q",
+    });
+    expect(useAnalyticsStore.getState()).toMatchObject({
+      activeUserId: "user-1",
+      period: "Q",
+      incomeExpense: expect.objectContaining({ income: 300000 }),
+      isLoading: false,
+    });
+  });
+});

--- a/apps/mobile/__tests__/analytics/transaction-subscription.test.ts
+++ b/apps/mobile/__tests__/analytics/transaction-subscription.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+import { subscribeAnalyticsToTransactions } from "@/features/analytics/services/subscribe-analytics-to-transactions";
+
+describe("analytics transaction subscription", () => {
+  it("reloads only after analytics has loaded and the transaction pages reference changes", () => {
+    let notify: () => void = () => undefined;
+    let hasLoadedAnalytics = false;
+    let currentPages: readonly string[] = ["tx-1"];
+
+    const unsubscribe = vi.fn();
+    const reload = vi.fn();
+
+    const cleanup = subscribeAnalyticsToTransactions({
+      subscribeTransactions: (listener) => {
+        notify = listener;
+        return unsubscribe;
+      },
+      getTransactionPages: () => currentPages,
+      hasLoadedAnalytics: () => hasLoadedAnalytics,
+      reload,
+    });
+
+    notify();
+    expect(reload).not.toHaveBeenCalled();
+
+    hasLoadedAnalytics = true;
+    notify();
+    expect(reload).not.toHaveBeenCalled();
+
+    currentPages = ["tx-1", "tx-2"];
+    notify();
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    cleanup();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -16,7 +16,12 @@ import { StatusBar } from "expo-status-bar";
 import { useMemo } from "react";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { useChatStore } from "@/features/ai-chat";
-import { useAnalyticsStore } from "@/features/analytics";
+import {
+  initializeAnalyticsSession,
+  loadAnalyticsForUser,
+  subscribeAnalyticsToTransactions,
+  useAnalyticsStore,
+} from "@/features/analytics";
 import { useAuthStore } from "@/features/auth";
 import { registerBackgroundTask } from "@/features/background-fetch";
 import { useBudgetStore } from "@/features/budget";
@@ -82,7 +87,7 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
       useCalendarStore.getState().initStore(db, userId);
       useBudgetStore.getState().initStore(db, userId);
       useGoalStore.getState().initStore(db, userId);
-      useAnalyticsStore.getState().initStore(db, userId);
+      initializeAnalyticsSession(userId);
       void initializeNotificationStore(db, userId);
       Promise.all([
         useCalendarStore.getState().loadBills(),
@@ -93,10 +98,7 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
         .loadBudgets()
         .catch(handleRecoverableError("Failed to load budgets"));
       useGoalStore.getState().loadGoals().catch(handleRecoverableError("Failed to load goals"));
-      useAnalyticsStore
-        .getState()
-        .loadAnalytics()
-        .catch(handleRecoverableError("Failed to load analytics"));
+      loadAnalyticsForUser(db, userId).catch(handleRecoverableError("Failed to load analytics"));
       refreshCategories(db, userId).catch(handleRecoverableError("Failed to load user categories"));
       useChatStore
         .getState()
@@ -117,6 +119,22 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
         .catch(handleRecoverableError("Failed to hydrate settings"));
       void registerBackgroundTask().catch(captureError);
     },
+    [db, userId],
+    migrationsReady
+  );
+
+  useSubscription(
+    () =>
+      subscribeAnalyticsToTransactions({
+        subscribeTransactions: useTransactionStore.subscribe,
+        getTransactionPages: () => useTransactionStore.getState().pages,
+        hasLoadedAnalytics: () => useAnalyticsStore.getState().incomeExpense !== null,
+        reload: () => {
+          void loadAnalyticsForUser(db, userId).catch(
+            handleRecoverableError("Failed to load analytics")
+          );
+        },
+      }),
     [db, userId],
     migrationsReady
   );

--- a/apps/mobile/features/analytics/components/AnalyticsScreen.tsx
+++ b/apps/mobile/features/analytics/components/AnalyticsScreen.tsx
@@ -1,10 +1,13 @@
-import { memo } from "react";
+import { memo, useCallback } from "react";
+import { useAuthStore } from "@/features/auth";
 import type { ViewStyle } from "@/shared/components/rn";
 import { Pressable, ScrollView, StyleSheet, Text, View } from "@/shared/components/rn";
+import { getDb } from "@/shared/db";
 import { useMountEffect, useThemeColor, useTranslation } from "@/shared/hooks";
 import { captureError } from "@/shared/lib";
+import type { UserId } from "@/shared/types/branded";
 import type { AnalyticsPeriod } from "../lib/derive";
-import { useAnalyticsStore } from "../store";
+import { loadAnalyticsForUser, selectAnalyticsPeriod, useAnalyticsStore } from "../store";
 import { CategoryBreakdownCard } from "./CategoryBreakdownCard";
 import { IncomeExpenseCard } from "./IncomeExpenseCard";
 import { PeriodDeltaCard } from "./PeriodDeltaCard";
@@ -58,15 +61,22 @@ export function AnalyticsScreen() {
   const categoryBreakdown = useAnalyticsStore((s) => s.categoryBreakdown);
   const periodDelta = useAnalyticsStore((s) => s.periodDelta);
   const isLoading = useAnalyticsStore((s) => s.isLoading);
-  const setPeriod = useAnalyticsStore((s) => s.setPeriod);
-  const loadAnalytics = useAnalyticsStore((s) => s.loadAnalytics);
+  const userId = useAuthStore((s) => s.session?.user.id ?? null) as UserId | null;
 
   // Load data on mount if boot-time load failed or hasn't completed
   useMountEffect(() => {
-    if (!incomeExpense && !isLoading) {
-      loadAnalytics().catch(captureError);
+    if (userId && !incomeExpense && !isLoading) {
+      loadAnalyticsForUser(getDb(userId), userId).catch(captureError);
     }
   });
+
+  const handleSelectPeriod = useCallback(
+    (nextPeriod: AnalyticsPeriod) => {
+      if (!userId) return;
+      void selectAnalyticsPeriod(getDb(userId), userId, nextPeriod).catch(captureError);
+    },
+    [userId]
+  );
 
   const pageBg = useThemeColor("page");
   const secondaryColor = useThemeColor("secondary");
@@ -80,7 +90,7 @@ export function AnalyticsScreen() {
       contentContainerStyle={styles.contentContainer}
       showsVerticalScrollIndicator={false}
     >
-      <PeriodSelector activePeriod={period} onSelect={setPeriod} />
+      <PeriodSelector activePeriod={period} onSelect={handleSelectPeriod} />
 
       {showEmpty ? (
         <View style={styles.emptyState}>

--- a/apps/mobile/features/analytics/index.ts
+++ b/apps/mobile/features/analytics/index.ts
@@ -21,5 +21,11 @@ export {
   getIncomeExpenseForPeriod,
   getSpendingByCategoryForPeriod,
 } from "./lib/repository";
+export { subscribeAnalyticsToTransactions } from "./services/subscribe-analytics-to-transactions";
 // Store
-export { useAnalyticsStore } from "./store";
+export {
+  initializeAnalyticsSession,
+  loadAnalyticsForUser,
+  selectAnalyticsPeriod,
+  useAnalyticsStore,
+} from "./store";

--- a/apps/mobile/features/analytics/services/create-analytics-service.ts
+++ b/apps/mobile/features/analytics/services/create-analytics-service.ts
@@ -1,0 +1,72 @@
+import type { AnyDb } from "@/shared/db";
+import type { UserId } from "@/shared/types/branded";
+import type {
+  AnalyticsPeriod,
+  CategoryBreakdownItem,
+  IncomeExpenseResult,
+  PeriodDelta,
+} from "../lib/derive";
+import {
+  computePeriodRange,
+  deriveCategoryBreakdown,
+  deriveIncomeExpense,
+  derivePeriodDelta,
+} from "../lib/derive";
+import { getIncomeExpenseForPeriod, getSpendingByCategoryForPeriod } from "../lib/repository";
+
+export type AnalyticsSnapshot = {
+  readonly incomeExpense: IncomeExpenseResult;
+  readonly categoryBreakdown: readonly CategoryBreakdownItem[];
+  readonly periodDelta: PeriodDelta;
+};
+
+type LoadAnalyticsInput = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly period: AnalyticsPeriod;
+};
+
+type CreateAnalyticsServiceDeps = {
+  readonly getNow?: () => Date;
+  readonly getIncomeExpenseForPeriod?: typeof getIncomeExpenseForPeriod;
+  readonly getSpendingByCategoryForPeriod?: typeof getSpendingByCategoryForPeriod;
+};
+
+export function createAnalyticsService({
+  getNow = () => new Date(),
+  getIncomeExpenseForPeriod: loadIncomeExpense = getIncomeExpenseForPeriod,
+  getSpendingByCategoryForPeriod: loadSpendingByCategory = getSpendingByCategoryForPeriod,
+}: CreateAnalyticsServiceDeps = {}) {
+  return {
+    loadSnapshot: async ({
+      db,
+      userId,
+      period,
+    }: LoadAnalyticsInput): Promise<AnalyticsSnapshot> => {
+      const { current, previous } = computePeriodRange(period, getNow());
+
+      const currentIncomeExpense = loadIncomeExpense(db, userId, current.start, current.end);
+      const previousIncomeExpense = loadIncomeExpense(db, userId, previous.start, previous.end);
+      const currentSpending = loadSpendingByCategory(db, userId, current.start, current.end);
+      const previousSpending = loadSpendingByCategory(db, userId, previous.start, previous.end);
+
+      return {
+        incomeExpense: deriveIncomeExpense(
+          currentIncomeExpense.income,
+          currentIncomeExpense.expenses
+        ),
+        categoryBreakdown: deriveCategoryBreakdown(currentSpending, currentIncomeExpense.expenses),
+        periodDelta: derivePeriodDelta(
+          {
+            totalExpenses: currentIncomeExpense.expenses,
+            categorySpending: currentSpending,
+          },
+          {
+            totalExpenses: previousIncomeExpense.expenses,
+            categorySpending: previousSpending,
+          }
+        ),
+      };
+    },
+  };
+}

--- a/apps/mobile/features/analytics/services/subscribe-analytics-to-transactions.ts
+++ b/apps/mobile/features/analytics/services/subscribe-analytics-to-transactions.ts
@@ -1,0 +1,23 @@
+type SubscribeAnalyticsToTransactionsInput = {
+  readonly subscribeTransactions: (listener: () => void) => () => void;
+  readonly getTransactionPages: () => unknown;
+  readonly hasLoadedAnalytics: () => boolean;
+  readonly reload: () => void;
+};
+
+export function subscribeAnalyticsToTransactions({
+  subscribeTransactions,
+  getTransactionPages,
+  hasLoadedAnalytics,
+  reload,
+}: SubscribeAnalyticsToTransactionsInput): () => void {
+  let previousPages = getTransactionPages();
+
+  return subscribeTransactions(() => {
+    const currentPages = getTransactionPages();
+    if (currentPages === previousPages) return;
+    previousPages = currentPages;
+    if (!hasLoadedAnalytics()) return;
+    reload();
+  });
+}

--- a/apps/mobile/features/analytics/store.ts
+++ b/apps/mobile/features/analytics/store.ts
@@ -1,5 +1,4 @@
 import { create } from "zustand";
-import { useTransactionStore } from "@/features/transactions";
 import type { AnyDb } from "@/shared/db";
 import { captureError } from "@/shared/lib";
 import type { UserId } from "@/shared/types/branded";
@@ -9,22 +8,15 @@ import type {
   IncomeExpenseResult,
   PeriodDelta,
 } from "./lib/derive";
-import {
-  computePeriodRange,
-  deriveCategoryBreakdown,
-  deriveIncomeExpense,
-  derivePeriodDelta,
-} from "./lib/derive";
-import { getIncomeExpenseForPeriod, getSpendingByCategoryForPeriod } from "./lib/repository";
+import type { AnalyticsSnapshot } from "./services/create-analytics-service";
+import { createAnalyticsService } from "./services/create-analytics-service";
 
-// Module-level refs: Zustand doesn't serialize DB connections, so we keep them outside the store.
-let dbRef: AnyDb | null = null;
-let userIdRef: UserId | null = null;
-let unsubscribeTxStore: (() => void) | null = null;
-// Track previous pages reference to skip form-field state changes
-let prevPagesRef: unknown = null;
+let loadAnalyticsRequestId = 0;
+
+const analyticsService = createAnalyticsService();
 
 type AnalyticsState = {
+  readonly activeUserId: UserId | null;
   readonly period: AnalyticsPeriod;
   readonly incomeExpense: IncomeExpenseResult | null;
   readonly categoryBreakdown: readonly CategoryBreakdownItem[];
@@ -33,97 +25,86 @@ type AnalyticsState = {
 };
 
 type AnalyticsActions = {
-  initStore(db: AnyDb, userId: UserId): void;
+  beginSession(userId: UserId): void;
   setPeriod(period: AnalyticsPeriod): void;
-  loadAnalytics(): Promise<void>;
+  setSnapshot(snapshot: AnalyticsSnapshot): void;
+  setIsLoading(isLoading: boolean): void;
 };
 
-export const useAnalyticsStore = create<AnalyticsState & AnalyticsActions>((set, get) => ({
+export const useAnalyticsStore = create<AnalyticsState & AnalyticsActions>((set) => ({
+  activeUserId: null,
   period: "M",
   incomeExpense: null,
   categoryBreakdown: [],
   periodDelta: null,
   isLoading: false,
 
-  initStore: (db, userId) => {
-    dbRef = db;
-    userIdRef = userId;
-    // Subscribe to transaction store changes to auto-refresh analytics
-    if (unsubscribeTxStore) unsubscribeTxStore();
-    prevPagesRef = useTransactionStore.getState().pages;
-    unsubscribeTxStore = useTransactionStore.subscribe(() => {
-      // Only refresh when transaction data changes, not form field edits
-      const currentPages = useTransactionStore.getState().pages;
-      if (currentPages === prevPagesRef) return;
-      prevPagesRef = currentPages;
-      if (get().incomeExpense !== null) {
-        void get().loadAnalytics();
-      }
-    });
-  },
+  beginSession: (userId) =>
+    set({
+      activeUserId: userId,
+      incomeExpense: null,
+      categoryBreakdown: [],
+      periodDelta: null,
+      isLoading: false,
+    }),
 
-  setPeriod: (period) => {
-    set({ period });
-    void get().loadAnalytics();
-  },
+  setPeriod: (period) => set({ period }),
 
-  loadAnalytics: async () => {
-    if (!dbRef || !userIdRef) return;
-    const db = dbRef;
-    const userId = userIdRef;
-    set({ isLoading: true });
-    try {
-      const { current, previous } = computePeriodRange(get().period, new Date());
+  setSnapshot: (snapshot) =>
+    set({
+      incomeExpense: snapshot.incomeExpense,
+      categoryBreakdown: snapshot.categoryBreakdown,
+      periodDelta: snapshot.periodDelta,
+      isLoading: false,
+    }),
 
-      // Not parallel — synchronous SQLite must be called sequentially
-      const currentIncomeExpense = getIncomeExpenseForPeriod(
-        db,
-        userId,
-        current.start,
-        current.end
-      );
-      const previousIncomeExpense = getIncomeExpenseForPeriod(
-        db,
-        userId,
-        previous.start,
-        previous.end
-      );
-      const currentSpending = getSpendingByCategoryForPeriod(
-        db,
-        userId,
-        current.start,
-        current.end
-      );
-      const previousSpending = getSpendingByCategoryForPeriod(
-        db,
-        userId,
-        previous.start,
-        previous.end
-      );
-
-      const incomeExpense = deriveIncomeExpense(
-        currentIncomeExpense.income,
-        currentIncomeExpense.expenses
-      );
-      const categoryBreakdown = deriveCategoryBreakdown(
-        currentSpending,
-        currentIncomeExpense.expenses
-      );
-      const periodDelta = derivePeriodDelta(
-        {
-          totalExpenses: currentIncomeExpense.expenses,
-          categorySpending: currentSpending,
-        },
-        {
-          totalExpenses: previousIncomeExpense.expenses,
-          categorySpending: previousSpending,
-        }
-      );
-
-      set({ incomeExpense, categoryBreakdown, periodDelta, isLoading: false });
-    } catch (error) {
-      captureError(error);
-      set({ isLoading: false });
-    }
-  },
+  setIsLoading: (isLoading) => set({ isLoading }),
 }));
+
+function isCurrentAnalyticsRequest(
+  requestId: number,
+  userId: UserId,
+  period: AnalyticsPeriod
+): boolean {
+  return (
+    loadAnalyticsRequestId === requestId &&
+    useAnalyticsStore.getState().activeUserId === userId &&
+    useAnalyticsStore.getState().period === period
+  );
+}
+
+export function initializeAnalyticsSession(userId: UserId): void {
+  loadAnalyticsRequestId += 1;
+  useAnalyticsStore.getState().beginSession(userId);
+}
+
+export async function loadAnalyticsForUser(db: AnyDb, userId: UserId): Promise<void> {
+  const period = useAnalyticsStore.getState().period;
+  const requestId = ++loadAnalyticsRequestId;
+  useAnalyticsStore.getState().setIsLoading(true);
+
+  try {
+    const snapshot = await analyticsService.loadSnapshot({ db, userId, period });
+    if (!isCurrentAnalyticsRequest(requestId, userId, period)) {
+      if (loadAnalyticsRequestId === requestId) {
+        useAnalyticsStore.getState().setIsLoading(false);
+      }
+      return;
+    }
+    useAnalyticsStore.getState().setSnapshot(snapshot);
+  } catch (error) {
+    captureError(error);
+    if (loadAnalyticsRequestId === requestId) {
+      useAnalyticsStore.getState().setIsLoading(false);
+    }
+  }
+}
+
+export async function selectAnalyticsPeriod(
+  db: AnyDb,
+  userId: UserId,
+  period: AnalyticsPeriod
+): Promise<void> {
+  useAnalyticsStore.getState().setPeriod(period);
+  await loadAnalyticsForUser(db, userId);
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Deepened the analytics seam by introducing a dedicated service and explicit store boundary, and added auto-reload when transactions change. This makes analytics loading safer, avoids stale data, and simplifies initialization.

- **Refactors**
  - Added `create-analytics-service` to build a single analytics snapshot (income/expense, category breakdown, period delta).
  - Reworked store into a thin boundary with `initializeAnalyticsSession`, `loadAnalyticsForUser`, and `selectAnalyticsPeriod`; removed module-level DB/user refs.
  - Moved transaction coupling to `subscribe-analytics-to-transactions` and wired it in `_layout`; `AnalyticsScreen` now uses the new boundary.
  - Updated exports in `features/analytics/index.ts`. Added tests for the service, store boundary, and subscription.

- **New Features**
  - Auto-reload analytics when transaction pages change (only after analytics has loaded), avoiding reloads on form edits.
  - Safer loading: ignore stale results on user/period changes, clear state on session switch, and manage `isLoading` consistently.

<sup>Written for commit b68129552449cace7d75607e8f83751ef5262fe3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

