### PR TITLE
refactor(mobile): deepen calendar seam

### DIFF
--- a/apps/mobile/__tests__/calendar/add-bill-screen.test.ts
+++ b/apps/mobile/__tests__/calendar/add-bill-screen.test.ts
@@ -47,6 +47,12 @@ describe("add-bill formSheet screen", () => {
     expect(source).toContain("if (success) onDone()");
   });
 
+  test("gates bill mutations on migration readiness", () => {
+    expect(source).toContain("useMigrations");
+    expect(source).toContain("canSubmit={migrationsReady}");
+    expect(source).toContain("!userId || !db || !migrationsReady");
+  });
+
   test("dismisses keyboard on chip press", () => {
     expect(source).toContain("Keyboard.dismiss");
   });

--- a/apps/mobile/__tests__/calendar/add-bill-screen.test.ts
+++ b/apps/mobile/__tests__/calendar/add-bill-screen.test.ts
@@ -50,7 +50,8 @@ describe("add-bill formSheet screen", () => {
   test("gates bill mutations on migration readiness", () => {
     expect(source).toContain("useMigrations");
     expect(source).toContain("canSubmit={migrationsReady}");
-    expect(source).toContain("!userId || !db || !migrationsReady");
+    expect(source).toContain("if (!migrationsReady) return Promise.resolve(false)");
+    expect(source).not.toContain("undefined as never");
   });
 
   test("dismisses keyboard on chip press", () => {

--- a/apps/mobile/__tests__/calendar/add-bill-screen.test.ts
+++ b/apps/mobile/__tests__/calendar/add-bill-screen.test.ts
@@ -42,6 +42,11 @@ describe("add-bill formSheet screen", () => {
     expect(source).toContain("billId");
   });
 
+  test("only closes edit mode after a successful update", () => {
+    expect(source).toContain("const success = await onUpdateBill");
+    expect(source).toContain("if (success) onDone()");
+  });
+
   test("dismisses keyboard on chip press", () => {
     expect(source).toContain("Keyboard.dismiss");
   });

--- a/apps/mobile/__tests__/calendar/query-service.test.ts
+++ b/apps/mobile/__tests__/calendar/query-service.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import { createCalendarQueryService } from "@/features/calendar/services/create-calendar-query-service";
+import type {
+  BillId,
+  BillPaymentId,
+  CategoryId,
+  CopAmount,
+  IsoDate,
+  IsoDateTime,
+  UserId,
+} from "@/shared/types/branded";
+
+describe("calendar query service", () => {
+  it("maps bill rows into calendar bill domain objects", async () => {
+    const getAllBills = vi.fn().mockReturnValue([
+      {
+        id: "bill-1" as BillId,
+        userId: "user-1" as UserId,
+        name: "Netflix",
+        amount: 35000 as CopAmount,
+        frequency: "monthly",
+        categoryId: "services" as CategoryId,
+        startDate: "2026-01-15T00:00:00.000Z" as IsoDate,
+        isActive: true,
+        createdAt: "2026-01-01T00:00:00.000Z" as IsoDateTime,
+        updatedAt: "2026-01-01T00:00:00.000Z" as IsoDateTime,
+      },
+    ]);
+
+    const service = createCalendarQueryService({ getAllBills });
+    const bills = await service.loadBills({ db: {} as never, userId: "user-1" as UserId });
+
+    expect(getAllBills).toHaveBeenCalledWith(expect.anything(), "user-1");
+    expect(bills).toEqual([
+      expect.objectContaining({
+        id: "bill-1",
+        name: "Netflix",
+        startDate: expect.any(Date),
+      }),
+    ]);
+  });
+
+  it("uses calendar-month date bounds when loading payments", async () => {
+    const getBillPaymentsForMonth = vi.fn().mockReturnValue([
+      {
+        id: "pay-1" as BillPaymentId,
+        billId: "bill-1" as BillId,
+        dueDate: "2026-03-15" as IsoDate,
+        paidAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
+        transactionId: null,
+        createdAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
+      },
+    ]);
+
+    const service = createCalendarQueryService({ getBillPaymentsForMonth });
+    const payments = await service.loadPaymentsForMonth({
+      db: {} as never,
+      month: new Date(2026, 2, 15),
+    });
+
+    expect(getBillPaymentsForMonth).toHaveBeenCalledWith(
+      expect.anything(),
+      "2026-03-01",
+      "2026-03-31"
+    );
+    expect(payments).toEqual([
+      expect.objectContaining({
+        id: "pay-1",
+        dueDate: "2026-03-15",
+      }),
+    ]);
+  });
+});

--- a/apps/mobile/__tests__/calendar/store.test.ts
+++ b/apps/mobile/__tests__/calendar/store.test.ts
@@ -1,6 +1,14 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
-import { useCalendarStore } from "@/features/calendar/store";
-import { useTransactionStore } from "@/features/transactions/store";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  addBill,
+  deleteBill,
+  initializeCalendarSession,
+  loadBills,
+  markBillPaid,
+  nextMonth,
+  unmarkBillPaid,
+  useCalendarStore,
+} from "@/features/calendar/store";
 import type {
   BillId,
   BillPaymentId,
@@ -12,35 +20,51 @@ import type {
   UserId,
 } from "@/shared/types/branded";
 
-// Mock the calendar repository module (all fns are synchronous Drizzle wrappers)
-vi.mock("@/features/calendar/lib/repository", () => ({
-  insertBill: vi.fn(),
-  getAllBills: vi.fn().mockReturnValue([]),
-  updateBill: vi.fn(),
-  deleteBill: vi.fn(),
-  insertBillPayment: vi.fn(),
-  getBillPaymentsForMonth: vi.fn().mockReturnValue([]),
-  deleteBillPayment: vi.fn(),
+const mockLoadBills = vi.fn();
+const mockLoadPaymentsForMonth = vi.fn();
+const mockAddBill = vi.fn();
+const mockDeleteBill = vi.fn();
+const mockMarkBillPaid = vi.fn();
+const mockUnmarkBillPaid = vi.fn();
+
+vi.mock("@/features/calendar/services/create-calendar-query-service", () => ({
+  createCalendarQueryService: () => ({
+    loadBills: (...args: unknown[]) => mockLoadBills(...args),
+    loadPaymentsForMonth: (...args: unknown[]) => mockLoadPaymentsForMonth(...args),
+  }),
 }));
 
-// Mock the transaction repository module (all fns are synchronous Drizzle wrappers)
-vi.mock("@/features/transactions/lib/repository", () => ({
-  insertTransaction: vi.fn(),
-  softDeleteTransaction: vi.fn(),
+vi.mock("@/features/calendar/lib/bill-mutation-service", () => ({
+  createCalendarBillMutationService: () => ({
+    addBill: (...args: unknown[]) => mockAddBill(...args),
+    updateBill: vi.fn(),
+    deleteBill: (...args: unknown[]) => mockDeleteBill(...args),
+    markBillPaid: (...args: unknown[]) => mockMarkBillPaid(...args),
+    unmarkBillPaid: (...args: unknown[]) => mockUnmarkBillPaid(...args),
+  }),
 }));
 
-vi.mock("@/shared/db/enqueue-sync", () => ({
-  enqueueSync: vi.fn(),
+vi.mock("@/mutations", () => ({
+  createWriteThroughMutationModule: () => ({
+    commit: vi.fn(),
+  }),
 }));
 
-const mockDb = { transaction: (fn: (tx: unknown) => void) => fn(mockDb) } as never;
-const mockUserId = "user-1" as UserId;
-const testDate = new Date(2026, 2, 15);
+function createDeferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
 
-describe("useCalendarStore", () => {
+describe("calendar store boundary", () => {
   beforeEach(() => {
-    useCalendarStore.getState().initStore(mockDb, mockUserId);
+    vi.clearAllMocks();
     useCalendarStore.setState({
+      activeUserId: null,
       currentMonth: new Date(2026, 2, 1),
       bills: [],
       payments: [],
@@ -48,559 +72,184 @@ describe("useCalendarStore", () => {
     });
   });
 
-  // ─── Navigation ───
+  it("drops stale bill results after the active user changes", async () => {
+    const deferred =
+      createDeferred<
+        readonly {
+          id: BillId;
+          name: string;
+          amount: CopAmount;
+          frequency: "monthly";
+          categoryId: CategoryId;
+          startDate: Date;
+          isActive: boolean;
+        }[]
+      >();
+    mockLoadBills.mockReturnValueOnce(deferred.promise);
 
-  test("nextMonth advances by one month", () => {
-    useCalendarStore.getState().nextMonth();
-    expect(useCalendarStore.getState().currentMonth.getMonth()).toBe(3);
-  });
+    initializeCalendarSession("user-1" as UserId);
+    const load = loadBills({} as never, "user-1" as UserId);
 
-  test("prevMonth goes back by one month", () => {
-    useCalendarStore.getState().prevMonth();
-    expect(useCalendarStore.getState().currentMonth.getMonth()).toBe(1);
-  });
-
-  // ─── initStore ───
-
-  test("initStore sets module-level refs", () => {
-    // After initStore, addBill should not fail with "Store not initialized"
-    expect(() => useCalendarStore.getState().initStore(mockDb, mockUserId)).not.toThrow();
-  });
-
-  // ─── addBill ───
-
-  test("addBill with valid data adds bill and returns true", async () => {
-    const result = await useCalendarStore
-      .getState()
-      .addBill("Netflix", "35000", "monthly", "services" as CategoryId, testDate);
-    expect(result).toBe(true);
-    expect(useCalendarStore.getState().bills).toHaveLength(1);
-    const bill = useCalendarStore.getState().bills[0]!;
-    expect(bill.name).toBe("Netflix");
-    expect(bill.amount).toBe(35000);
-    expect(bill.frequency).toBe("monthly");
-    expect(bill.categoryId).toBe("services");
-    expect(bill.isActive).toBe(true);
-  });
-
-  test("addBill returns false for empty name", async () => {
-    const result = await useCalendarStore
-      .getState()
-      .addBill("", "35000", "monthly", "services" as CategoryId, testDate);
-    expect(result).toBe(false);
-    expect(useCalendarStore.getState().bills).toHaveLength(0);
-  });
-
-  test("addBill returns false for empty amount", async () => {
-    const result = await useCalendarStore
-      .getState()
-      .addBill("Netflix", "", "monthly", "services" as CategoryId, testDate);
-    expect(result).toBe(false);
-  });
-
-  test("addBill returns false for zero amount", async () => {
-    const result = await useCalendarStore
-      .getState()
-      .addBill("Netflix", "0", "monthly", "services" as CategoryId, testDate);
-    expect(result).toBe(false);
-  });
-
-  test("addBill strips non-digit chars and uses remaining digits", async () => {
-    const result = await useCalendarStore
-      .getState()
-      .addBill("Netflix", "50.000", "monthly", "services" as CategoryId, testDate);
-    expect(result).toBe(true);
-    const bills = useCalendarStore.getState().bills;
-    expect(bills[0]?.amount).toBe(50000);
-  });
-
-  test("addBill returns false for non-numeric amount", async () => {
-    const result = await useCalendarStore
-      .getState()
-      .addBill("Netflix", "abc", "monthly", "services" as CategoryId, testDate);
-    expect(result).toBe(false);
-  });
-
-  test("addBill validates frequency via schema", async () => {
-    const result = await useCalendarStore
-      .getState()
-      // @ts-expect-error testing invalid frequency
-      .addBill("Netflix", "35000", "daily", "services", testDate);
-    expect(result).toBe(false);
-    expect(useCalendarStore.getState().bills).toHaveLength(0);
-  });
-
-  test("addBill validates categoryId via schema", async () => {
-    const result = await useCalendarStore
-      .getState()
-      .addBill("Netflix", "35000", "monthly", "invalid" as CategoryId, testDate);
-    expect(result).toBe(false);
-    expect(useCalendarStore.getState().bills).toHaveLength(0);
-  });
-
-  // ─── State shape ───
-
-  test("has payments array in state", () => {
-    expect(useCalendarStore.getState().payments).toEqual([]);
-  });
-
-  test("has isLoading in state", () => {
-    expect(useCalendarStore.getState().isLoading).toBe(false);
-  });
-
-  // ─── No popup state ───
-
-  test("does not have popup state", () => {
-    expect("popup" in useCalendarStore.getState()).toBe(false);
-  });
-
-  test("does not have selectedBillId state", () => {
-    expect("selectedBillId" in useCalendarStore.getState()).toBe(false);
-  });
-
-  // ─── loadBills ───
-
-  test("loadBills populates bills from DB rows", async () => {
-    const { getAllBills } = await import("@/features/calendar/lib/repository");
-    vi.mocked(getAllBills).mockReturnValueOnce([
+    initializeCalendarSession("user-2" as UserId);
+    deferred.resolve([
       {
         id: "bill-1" as BillId,
-        userId: "user-1" as UserId,
         name: "Netflix",
         amount: 35000 as CopAmount,
         frequency: "monthly",
         categoryId: "services" as CategoryId,
-        startDate: "2026-01-15T00:00:00.000Z" as IsoDate,
+        startDate: new Date("2026-01-15T00:00:00.000Z"),
         isActive: true,
-        createdAt: "2026-01-01T00:00:00.000Z" as IsoDateTime,
-        updatedAt: "2026-01-01T00:00:00.000Z" as IsoDateTime,
       },
     ]);
 
-    await useCalendarStore.getState().loadBills();
+    await load;
 
-    const { bills, isLoading } = useCalendarStore.getState();
-    expect(isLoading).toBe(false);
-    expect(bills).toHaveLength(1);
-    expect(bills[0]?.name).toBe("Netflix");
-    expect(bills[0]?.startDate).toBeInstanceOf(Date);
-    expect(bills[0]?.isActive).toBe(true);
-  });
-
-  test("loadBills sets isLoading false on error", async () => {
-    const { getAllBills } = await import("@/features/calendar/lib/repository");
-    vi.mocked(getAllBills).mockImplementationOnce(() => {
-      throw new Error("DB error");
+    expect(useCalendarStore.getState()).toMatchObject({
+      activeUserId: "user-2",
+      bills: [],
+      isLoading: false,
     });
-
-    await expect(useCalendarStore.getState().loadBills()).rejects.toThrow("DB error");
-
-    expect(useCalendarStore.getState().isLoading).toBe(false);
   });
 
-  test("loadBills does nothing without initStore", async () => {
-    const { getAllBills } = await import("@/features/calendar/lib/repository");
-    vi.mocked(getAllBills).mockClear();
-    useCalendarStore.getState().initStore(null as never, null as never);
-
-    await useCalendarStore.getState().loadBills();
-
-    expect(getAllBills).not.toHaveBeenCalled();
-  });
-
-  // ─── addBill error path ───
-
-  test("addBill returns false when insertBill throws", async () => {
-    const { insertBill } = await import("@/features/calendar/lib/repository");
-    vi.mocked(insertBill).mockImplementationOnce(() => {
-      throw new Error("DB write error");
-    });
-
-    const result = await useCalendarStore
-      .getState()
-      .addBill("Netflix", "35000", "monthly", "services" as CategoryId, testDate);
-
-    expect(result).toBe(false);
-    expect(useCalendarStore.getState().bills).toHaveLength(0);
-  });
-
-  // ─── updateBill ───
-
-  test("updateBill updates bill in state", async () => {
-    await useCalendarStore
-      .getState()
-      .addBill("Netflix", "35000", "monthly", "services" as CategoryId, testDate);
-    const billId = useCalendarStore.getState().bills[0]?.id as BillId;
-
-    await useCalendarStore.getState().updateBill(billId, { name: "Hulu" });
-
-    const updated = useCalendarStore.getState().bills[0]!;
-    expect(updated.name).toBe("Hulu");
-  });
-
-  test("updateBill converts startDate Date to ISO string for DB", async () => {
-    const { updateBill: dbUpdateBill } = await import("@/features/calendar/lib/repository");
-    vi.mocked(dbUpdateBill).mockClear();
-
-    await useCalendarStore
-      .getState()
-      .addBill("Netflix", "35000", "monthly", "services" as CategoryId, testDate);
-    const billId = useCalendarStore.getState().bills[0]?.id as BillId;
-    const newDate = new Date("2026-06-01T00:00:00.000Z");
-
-    await useCalendarStore.getState().updateBill(billId, { startDate: newDate });
-
-    expect(dbUpdateBill).toHaveBeenCalledWith(
-      mockDb,
-      billId,
-      expect.objectContaining({ startDate: "2026-06-01T00:00:00.000Z" }),
-      expect.any(String)
-    );
-  });
-
-  test("updateBill does nothing without initStore", async () => {
-    const { updateBill: dbUpdateBill } = await import("@/features/calendar/lib/repository");
-    vi.mocked(dbUpdateBill).mockClear();
-    useCalendarStore.getState().initStore(null as never, null as never);
-
-    await useCalendarStore.getState().updateBill("bill-1" as BillId, { name: "Hulu" });
-
-    expect(dbUpdateBill).not.toHaveBeenCalled();
-  });
-
-  // ─── deleteBill ───
-
-  test("deleteBill removes bill and its payments from state", async () => {
-    await useCalendarStore
-      .getState()
-      .addBill("Netflix", "35000", "monthly", "services" as CategoryId, testDate);
-    const billId = useCalendarStore.getState().bills[0]?.id as BillId;
-
-    // Manually add a payment for this bill
-    useCalendarStore.setState((s) => ({
-      payments: [
-        ...s.payments,
-        {
-          id: "pay-1" as BillPaymentId,
-          billId,
-          dueDate: "2026-03-15" as IsoDate,
-          paidAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
-          transactionId: null,
-          createdAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
-        },
-      ],
-    }));
-
-    await useCalendarStore.getState().deleteBill(billId);
-
-    expect(useCalendarStore.getState().bills).toHaveLength(0);
-    expect(useCalendarStore.getState().payments).toHaveLength(0);
-  });
-
-  test("deleteBill preserves linked transactions", async () => {
-    const { softDeleteTransaction } = await import("@/features/transactions/lib/repository");
-    vi.mocked(softDeleteTransaction).mockClear();
-
-    await useCalendarStore
-      .getState()
-      .addBill("Netflix", "35000", "monthly", "services" as CategoryId, testDate);
-    const billId = useCalendarStore.getState().bills[0]?.id as BillId;
-
-    // Seed payment with a linked transaction
-    useTransactionStore.setState({
-      pages: [
-        {
-          id: "tx-linked" as TransactionId,
-          userId: "user-1" as UserId,
-          type: "expense",
-          amount: 35000 as CopAmount,
-          categoryId: "services" as CategoryId,
-          description: "Netflix",
-          date: new Date(2026, 2, 15),
-          createdAt: new Date(),
-          updatedAt: new Date(),
-          deletedAt: null,
-        },
-      ],
-    });
-    useCalendarStore.setState((s) => ({
-      payments: [
-        ...s.payments,
-        {
-          id: "pay-1" as BillPaymentId,
-          billId,
-          dueDate: "2026-03-15" as IsoDate,
-          paidAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
-          transactionId: "tx-linked" as TransactionId,
-          createdAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
-        },
-      ],
-    }));
-
-    await useCalendarStore.getState().deleteBill(billId);
-
-    // Past transactions should NOT be deleted — they represent real expenses
-    expect(softDeleteTransaction).not.toHaveBeenCalled();
-    expect(useTransactionStore.getState().pages).toHaveLength(1);
-  });
-
-  test("deleteBill does nothing without initStore", async () => {
-    const { deleteBill: dbDeleteBill } = await import("@/features/calendar/lib/repository");
-    vi.mocked(dbDeleteBill).mockClear();
-    useCalendarStore.getState().initStore(null as never, null as never);
-
-    await useCalendarStore.getState().deleteBill("bill-1" as BillId);
-
-    expect(dbDeleteBill).not.toHaveBeenCalled();
-  });
-
-  // ─── markBillPaid ───
-
-  test("markBillPaid adds payment to state and calls insertBillPayment", async () => {
-    const { insertBillPayment } = await import("@/features/calendar/lib/repository");
-    vi.mocked(insertBillPayment).mockClear();
-
-    // Seed a bill so markBillPaid can look it up
-    await useCalendarStore
-      .getState()
-      .addBill("Netflix", "35000", "monthly", "services" as CategoryId, testDate);
-    const billId = useCalendarStore.getState().bills[0]?.id as BillId;
-
-    await useCalendarStore.getState().markBillPaid(billId, "2026-03-15" as IsoDate);
-
-    const { payments } = useCalendarStore.getState();
-    expect(payments).toHaveLength(1);
-    expect(payments[0]?.billId).toBe(billId);
-    expect(payments[0]?.dueDate).toBe("2026-03-15");
-    expect(payments[0]?.paidAt).toBeDefined();
-    expect(insertBillPayment).toHaveBeenCalledTimes(1);
-  });
-
-  test("markBillPaid creates an expense transaction", async () => {
-    const { insertTransaction } = await import("@/features/transactions/lib/repository");
-    vi.mocked(insertTransaction).mockClear();
-
-    await useCalendarStore
-      .getState()
-      .addBill("Netflix", "35000", "monthly", "services" as CategoryId, testDate);
-    const billId = useCalendarStore.getState().bills[0]?.id as BillId;
-
-    await useCalendarStore.getState().markBillPaid(billId, "2026-03-15" as IsoDate);
-
-    expect(insertTransaction).toHaveBeenCalledTimes(1);
-    const txRow = vi.mocked(insertTransaction).mock.calls[0]![1];
-    expect(txRow.type).toBe("expense");
-    expect(txRow.amount).toBe(35000);
-    expect(txRow.categoryId).toBe("services");
-    expect(txRow.description).toBe("Netflix");
-  });
-
-  test("markBillPaid stores transactionId on payment", async () => {
-    await useCalendarStore
-      .getState()
-      .addBill("Netflix", "35000", "monthly", "services" as CategoryId, testDate);
-    const billId = useCalendarStore.getState().bills[0]?.id as BillId;
-
-    await useCalendarStore.getState().markBillPaid(billId, "2026-03-15" as IsoDate);
-
-    const { payments } = useCalendarStore.getState();
-    expect(payments[0]?.transactionId).toBeDefined();
-    expect(payments[0]?.transactionId).toMatch(/^txn-/);
-  });
-
-  test("markBillPaid updates transaction store state", async () => {
-    useTransactionStore.setState({ pages: [] });
-
-    await useCalendarStore
-      .getState()
-      .addBill("Netflix", "35000", "monthly", "services" as CategoryId, testDate);
-    const billId = useCalendarStore.getState().bills[0]?.id as BillId;
-
-    await useCalendarStore.getState().markBillPaid(billId, "2026-03-15" as IsoDate);
-
-    const txs = useTransactionStore.getState().pages;
-    expect(txs).toHaveLength(1);
-    expect(txs[0]?.type).toBe("expense");
-    expect(txs[0]?.amount).toBe(35000);
-    expect(txs[0]?.description).toBe("Netflix");
-  });
-
-  test("markBillPaid enqueues sync for the transaction", async () => {
-    const { enqueueSync } = await import("@/shared/db/enqueue-sync");
-    vi.mocked(enqueueSync).mockClear();
-
-    await useCalendarStore
-      .getState()
-      .addBill("Netflix", "35000", "monthly", "services" as CategoryId, testDate);
-    const billId = useCalendarStore.getState().bills[0]?.id as BillId;
-
-    await useCalendarStore.getState().markBillPaid(billId, "2026-03-15" as IsoDate);
-
-    expect(enqueueSync).toHaveBeenCalledWith(
-      mockDb,
-      expect.objectContaining({
-        tableName: "transactions",
-        operation: "insert",
-      })
-    );
-  });
-
-  test("markBillPaid does nothing when bill not found", async () => {
-    const { insertTransaction } = await import("@/features/transactions/lib/repository");
-    vi.mocked(insertTransaction).mockClear();
-
-    await useCalendarStore
-      .getState()
-      .markBillPaid("nonexistent-bill" as BillId, "2026-03-15" as IsoDate);
-
-    expect(insertTransaction).not.toHaveBeenCalled();
-    expect(useCalendarStore.getState().payments).toHaveLength(0);
-  });
-
-  test("markBillPaid does nothing without initStore", async () => {
-    const { insertBillPayment } = await import("@/features/calendar/lib/repository");
-    vi.mocked(insertBillPayment).mockClear();
-    useCalendarStore.getState().initStore(null as never, null as never);
-
-    await useCalendarStore.getState().markBillPaid("bill-1" as BillId, "2026-03-15" as IsoDate);
-
-    expect(insertBillPayment).not.toHaveBeenCalled();
-    expect(useCalendarStore.getState().payments).toHaveLength(0);
-  });
-
-  // ─── unmarkBillPaid ───
-
-  test("unmarkBillPaid removes matching payment from state", async () => {
-    const { deleteBillPayment } = await import("@/features/calendar/lib/repository");
-    vi.mocked(deleteBillPayment).mockClear();
-
-    // Seed a payment in state
-    useCalendarStore.setState({
-      payments: [
-        {
-          id: "pay-1" as BillPaymentId,
-          billId: "bill-1" as BillId,
-          dueDate: "2026-03-15" as IsoDate,
-          paidAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
-          transactionId: null,
-          createdAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
-        },
-      ],
-    });
-
-    await useCalendarStore.getState().unmarkBillPaid("bill-1" as BillId, "2026-03-15" as IsoDate);
-
-    expect(useCalendarStore.getState().payments).toHaveLength(0);
-    expect(deleteBillPayment).toHaveBeenCalledWith(mockDb, "bill-1", "2026-03-15");
-  });
-
-  test("unmarkBillPaid soft-deletes the linked transaction", async () => {
-    const { softDeleteTransaction } = await import("@/features/transactions/lib/repository");
-    const { enqueueSync } = await import("@/shared/db/enqueue-sync");
-    vi.mocked(softDeleteTransaction).mockClear();
-    vi.mocked(enqueueSync).mockClear();
-
-    // Seed a payment with a transactionId
-    useTransactionStore.setState({
-      pages: [
-        {
-          id: "tx-linked" as TransactionId,
-          userId: "user-1" as UserId,
-          type: "expense",
-          amount: 35000 as CopAmount,
-          categoryId: "services" as CategoryId,
-          description: "Netflix",
-          date: new Date(2026, 2, 15),
-          createdAt: new Date(),
-          updatedAt: new Date(),
-          deletedAt: null,
-        },
-      ],
-    });
-    useCalendarStore.setState({
-      payments: [
-        {
-          id: "pay-1" as BillPaymentId,
-          billId: "bill-1" as BillId,
-          dueDate: "2026-03-15" as IsoDate,
-          paidAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
-          transactionId: "tx-linked" as TransactionId,
-          createdAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
-        },
-      ],
-    });
-
-    await useCalendarStore.getState().unmarkBillPaid("bill-1" as BillId, "2026-03-15" as IsoDate);
-
-    expect(softDeleteTransaction).toHaveBeenCalledWith(mockDb, "tx-linked", expect.any(String));
-    expect(enqueueSync).toHaveBeenCalledWith(
-      mockDb,
-      expect.objectContaining({
-        tableName: "transactions",
-        rowId: "tx-linked",
-        operation: "delete",
-      })
-    );
-    expect(useTransactionStore.getState().pages).toHaveLength(0);
-  });
-
-  test("unmarkBillPaid does nothing without initStore", async () => {
-    const { deleteBillPayment } = await import("@/features/calendar/lib/repository");
-    vi.mocked(deleteBillPayment).mockClear();
-    useCalendarStore.getState().initStore(null as never, null as never);
-
-    await useCalendarStore.getState().unmarkBillPaid("bill-1" as BillId, "2026-03-15" as IsoDate);
-
-    expect(deleteBillPayment).not.toHaveBeenCalled();
-  });
-
-  // ─── loadPaymentsForMonth ───
-
-  test("loadPaymentsForMonth populates payments from DB", async () => {
-    const { getBillPaymentsForMonth } = await import("@/features/calendar/lib/repository");
-    vi.mocked(getBillPaymentsForMonth).mockReturnValueOnce([
+  it("advances the month and reloads payments through the explicit boundary", async () => {
+    mockLoadPaymentsForMonth.mockResolvedValueOnce([
       {
+        id: "pay-1" as BillPaymentId,
+        billId: "bill-1" as BillId,
+        dueDate: "2026-04-15" as IsoDate,
+        paidAt: "2026-04-10T00:00:00.000Z" as IsoDateTime,
+        transactionId: null,
+        createdAt: "2026-04-10T00:00:00.000Z" as IsoDateTime,
+      },
+    ]);
+
+    initializeCalendarSession("user-1" as UserId);
+    await nextMonth({} as never);
+
+    expect(mockLoadPaymentsForMonth).toHaveBeenCalledWith({
+      db: expect.anything(),
+      month: new Date(2026, 3, 1),
+    });
+    expect(useCalendarStore.getState()).toMatchObject({
+      currentMonth: new Date(2026, 3, 1),
+      payments: [expect.objectContaining({ id: "pay-1" })],
+    });
+  });
+
+  it("appends a bill when the explicit add boundary succeeds", async () => {
+    mockAddBill.mockResolvedValueOnce({
+      success: true,
+      bill: {
+        id: "bill-1" as BillId,
+        name: "Netflix",
+        amount: 35000 as CopAmount,
+        frequency: "monthly",
+        categoryId: "services" as CategoryId,
+        startDate: new Date("2026-01-15T00:00:00.000Z"),
+        isActive: true,
+      },
+    });
+
+    const result = await addBill(
+      {} as never,
+      "user-1" as UserId,
+      "Netflix",
+      "35000",
+      "monthly",
+      "services" as CategoryId,
+      new Date("2026-01-15T00:00:00.000Z")
+    );
+
+    expect(result).toBe(true);
+    expect(useCalendarStore.getState().bills).toEqual([
+      expect.objectContaining({
+        id: "bill-1",
+        name: "Netflix",
+      }),
+    ]);
+  });
+
+  it("removes a deleted bill and its payments from state", async () => {
+    useCalendarStore.setState({
+      bills: [
+        {
+          id: "bill-1" as BillId,
+          name: "Netflix",
+          amount: 35000 as CopAmount,
+          frequency: "monthly",
+          categoryId: "services" as CategoryId,
+          startDate: new Date("2026-01-15T00:00:00.000Z"),
+          isActive: true,
+        },
+      ],
+      payments: [
+        {
+          id: "pay-1" as BillPaymentId,
+          billId: "bill-1" as BillId,
+          dueDate: "2026-03-15" as IsoDate,
+          paidAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
+          transactionId: null,
+          createdAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
+        },
+      ],
+    });
+    mockDeleteBill.mockResolvedValueOnce(true);
+
+    await deleteBill({} as never, "user-1" as UserId, "bill-1" as BillId);
+
+    expect(useCalendarStore.getState()).toMatchObject({
+      bills: [],
+      payments: [],
+    });
+  });
+
+  it("updates payment state through the paid and unpaid boundaries", async () => {
+    useCalendarStore.setState({
+      bills: [
+        {
+          id: "bill-1" as BillId,
+          name: "Netflix",
+          amount: 35000 as CopAmount,
+          frequency: "monthly",
+          categoryId: "services" as CategoryId,
+          startDate: new Date("2026-01-15T00:00:00.000Z"),
+          isActive: true,
+        },
+      ],
+    });
+    mockMarkBillPaid.mockResolvedValueOnce({
+      success: true,
+      payment: {
         id: "pay-1" as BillPaymentId,
         billId: "bill-1" as BillId,
         dueDate: "2026-03-15" as IsoDate,
         paidAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
-        transactionId: null,
+        transactionId: "txn-1" as TransactionId,
         createdAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
       },
+    });
+    mockUnmarkBillPaid.mockResolvedValueOnce({ success: true });
+
+    await markBillPaid(
+      {} as never,
+      "user-1" as UserId,
+      "bill-1" as BillId,
+      "2026-03-15" as IsoDate
+    );
+    expect(useCalendarStore.getState().payments).toEqual([
+      expect.objectContaining({
+        id: "pay-1",
+        transactionId: "txn-1",
+      }),
     ]);
 
-    await useCalendarStore.getState().loadPaymentsForMonth();
-
-    const { payments } = useCalendarStore.getState();
-    expect(payments).toHaveLength(1);
-    expect(payments[0]?.billId).toBe("bill-1");
-  });
-
-  test("loadPaymentsForMonth preserves existing payments on error", async () => {
-    const { getBillPaymentsForMonth } = await import("@/features/calendar/lib/repository");
-
-    // Seed existing payments
-    useCalendarStore.setState({
-      payments: [
-        {
-          id: "pay-existing" as BillPaymentId,
-          billId: "bill-1" as BillId,
-          dueDate: "2026-03-15" as IsoDate,
-          paidAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
-          transactionId: null,
-          createdAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
-        },
-      ],
-    });
-
-    vi.mocked(getBillPaymentsForMonth).mockImplementationOnce(() => {
-      throw new Error("DB error");
-    });
-
-    await expect(useCalendarStore.getState().loadPaymentsForMonth()).rejects.toThrow("DB error");
-
-    const { payments } = useCalendarStore.getState();
-    expect(payments).toHaveLength(1);
-    expect(payments[0]?.id).toBe("pay-existing");
+    await unmarkBillPaid(
+      {} as never,
+      "user-1" as UserId,
+      "bill-1" as BillId,
+      "2026-03-15" as IsoDate
+    );
+    expect(useCalendarStore.getState().payments).toEqual([]);
   });
 });

--- a/apps/mobile/__tests__/calendar/store.test.ts
+++ b/apps/mobile/__tests__/calendar/store.test.ts
@@ -7,6 +7,7 @@ import {
   markBillPaid,
   nextMonth,
   unmarkBillPaid,
+  updateBill,
   useCalendarStore,
 } from "@/features/calendar/store";
 import type {
@@ -26,6 +27,7 @@ const mockAddBill = vi.fn();
 const mockDeleteBill = vi.fn();
 const mockMarkBillPaid = vi.fn();
 const mockUnmarkBillPaid = vi.fn();
+const mockUpdateBill = vi.fn();
 
 vi.mock("@/features/calendar/services/create-calendar-query-service", () => ({
   createCalendarQueryService: () => ({
@@ -37,7 +39,7 @@ vi.mock("@/features/calendar/services/create-calendar-query-service", () => ({
 vi.mock("@/features/calendar/lib/bill-mutation-service", () => ({
   createCalendarBillMutationService: () => ({
     addBill: (...args: unknown[]) => mockAddBill(...args),
-    updateBill: vi.fn(),
+    updateBill: (...args: unknown[]) => mockUpdateBill(...args),
     deleteBill: (...args: unknown[]) => mockDeleteBill(...args),
     markBillPaid: (...args: unknown[]) => mockMarkBillPaid(...args),
     unmarkBillPaid: (...args: unknown[]) => mockUnmarkBillPaid(...args),
@@ -150,6 +152,7 @@ describe("calendar store boundary", () => {
         isActive: true,
       },
     });
+    initializeCalendarSession("user-1" as UserId);
 
     const result = await addBill(
       {} as never,
@@ -168,6 +171,85 @@ describe("calendar store boundary", () => {
         name: "Netflix",
       }),
     ]);
+  });
+
+  it("drops stale bill mutation results after the active user changes", async () => {
+    const deferred = createDeferred<{
+      success: true;
+      bill: {
+        id: BillId;
+        name: string;
+        amount: CopAmount;
+        frequency: "monthly";
+        categoryId: CategoryId;
+        startDate: Date;
+        isActive: boolean;
+      };
+    }>();
+    mockAddBill.mockReturnValueOnce(deferred.promise);
+
+    initializeCalendarSession("user-1" as UserId);
+    const add = addBill(
+      {} as never,
+      "user-1" as UserId,
+      "Netflix",
+      "35000",
+      "monthly",
+      "services" as CategoryId,
+      new Date("2026-01-15T00:00:00.000Z")
+    );
+
+    initializeCalendarSession("user-2" as UserId);
+    deferred.resolve({
+      success: true,
+      bill: {
+        id: "bill-1" as BillId,
+        name: "Netflix",
+        amount: 35000 as CopAmount,
+        frequency: "monthly",
+        categoryId: "services" as CategoryId,
+        startDate: new Date("2026-01-15T00:00:00.000Z"),
+        isActive: true,
+      },
+    });
+
+    await expect(add).resolves.toBe(false);
+    expect(useCalendarStore.getState()).toMatchObject({
+      activeUserId: "user-2",
+      bills: [],
+    });
+  });
+
+  it("drops stale update results after the active user changes", async () => {
+    const deferred = createDeferred<boolean>();
+    mockUpdateBill.mockReturnValueOnce(deferred.promise);
+    useCalendarStore.setState({
+      bills: [
+        {
+          id: "bill-1" as BillId,
+          name: "Netflix",
+          amount: 35000 as CopAmount,
+          frequency: "monthly",
+          categoryId: "services" as CategoryId,
+          startDate: new Date("2026-01-15T00:00:00.000Z"),
+          isActive: true,
+        },
+      ],
+    });
+
+    initializeCalendarSession("user-1" as UserId);
+    const update = updateBill({} as never, "user-1" as UserId, "bill-1" as BillId, {
+      name: "Hulu",
+    });
+
+    initializeCalendarSession("user-2" as UserId);
+    deferred.resolve(true);
+
+    await expect(update).resolves.toBe(false);
+    expect(useCalendarStore.getState()).toMatchObject({
+      activeUserId: "user-2",
+      bills: [],
+    });
   });
 
   it("removes a deleted bill and its payments from state", async () => {
@@ -195,6 +277,7 @@ describe("calendar store boundary", () => {
       ],
     });
     mockDeleteBill.mockResolvedValueOnce(true);
+    initializeCalendarSession("user-1" as UserId);
 
     await deleteBill({} as never, "user-1" as UserId, "bill-1" as BillId);
 
@@ -230,6 +313,7 @@ describe("calendar store boundary", () => {
       },
     });
     mockUnmarkBillPaid.mockResolvedValueOnce({ success: true });
+    initializeCalendarSession("user-1" as UserId);
 
     await markBillPaid(
       {} as never,
@@ -251,5 +335,60 @@ describe("calendar store boundary", () => {
       "2026-03-15" as IsoDate
     );
     expect(useCalendarStore.getState().payments).toEqual([]);
+  });
+
+  it("drops stale payment mutation results after the active user changes", async () => {
+    const deferred = createDeferred<{
+      success: true;
+      payment: {
+        id: BillPaymentId;
+        billId: BillId;
+        dueDate: IsoDate;
+        paidAt: IsoDateTime;
+        transactionId: TransactionId;
+        createdAt: IsoDateTime;
+      };
+    }>();
+    useCalendarStore.setState({
+      bills: [
+        {
+          id: "bill-1" as BillId,
+          name: "Netflix",
+          amount: 35000 as CopAmount,
+          frequency: "monthly",
+          categoryId: "services" as CategoryId,
+          startDate: new Date("2026-01-15T00:00:00.000Z"),
+          isActive: true,
+        },
+      ],
+    });
+    mockMarkBillPaid.mockReturnValueOnce(deferred.promise);
+
+    initializeCalendarSession("user-1" as UserId);
+    const mark = markBillPaid(
+      {} as never,
+      "user-1" as UserId,
+      "bill-1" as BillId,
+      "2026-03-15" as IsoDate
+    );
+
+    initializeCalendarSession("user-2" as UserId);
+    deferred.resolve({
+      success: true,
+      payment: {
+        id: "pay-1" as BillPaymentId,
+        billId: "bill-1" as BillId,
+        dueDate: "2026-03-15" as IsoDate,
+        paidAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
+        transactionId: "txn-1" as TransactionId,
+        createdAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
+      },
+    });
+
+    await mark;
+    expect(useCalendarStore.getState()).toMatchObject({
+      activeUserId: "user-2",
+      payments: [],
+    });
   });
 });

--- a/apps/mobile/__tests__/calendar/store.test.ts
+++ b/apps/mobile/__tests__/calendar/store.test.ts
@@ -253,6 +253,7 @@ describe("calendar store boundary", () => {
   });
 
   it("removes a deleted bill and its payments from state", async () => {
+    initializeCalendarSession("user-1" as UserId);
     useCalendarStore.setState({
       bills: [
         {
@@ -277,7 +278,6 @@ describe("calendar store boundary", () => {
       ],
     });
     mockDeleteBill.mockResolvedValueOnce(true);
-    initializeCalendarSession("user-1" as UserId);
 
     await deleteBill({} as never, "user-1" as UserId, "bill-1" as BillId);
 

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -25,7 +25,11 @@ import {
 import { useAuthStore } from "@/features/auth";
 import { registerBackgroundTask } from "@/features/background-fetch";
 import { useBudgetStore } from "@/features/budget";
-import { useCalendarStore } from "@/features/calendar";
+import {
+  initializeCalendarSession,
+  loadBills as loadCalendarBills,
+  loadPaymentsForMonth as loadCalendarPaymentsForMonth,
+} from "@/features/calendar";
 import {
   hydrateCaptureSources,
   useApplePayCapture,
@@ -84,15 +88,14 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
       useTransactionStore.getState().initStore(db, userId);
       useEmailCaptureStore.getState().initStore(db, userId);
       useChatStore.getState().initStore(db, userId);
-      useCalendarStore.getState().initStore(db, userId);
+      initializeCalendarSession(userId);
       useBudgetStore.getState().initStore(db, userId);
       useGoalStore.getState().initStore(db, userId);
       initializeAnalyticsSession(userId);
       void initializeNotificationStore(db, userId);
-      Promise.all([
-        useCalendarStore.getState().loadBills(),
-        useCalendarStore.getState().loadPaymentsForMonth(),
-      ]).catch(handleRecoverableError("Failed to load calendar data"));
+      Promise.all([loadCalendarBills(db, userId), loadCalendarPaymentsForMonth(db)]).catch(
+        handleRecoverableError("Failed to load calendar data")
+      );
       useBudgetStore
         .getState()
         .loadBudgets()

--- a/apps/mobile/app/add-bill.tsx
+++ b/apps/mobile/app/add-bill.tsx
@@ -247,15 +247,17 @@ function AddBillForm({
   );
 }
 
-export default function AddBillScreen() {
-  const router = useRouter();
-  const { billId } = useLocalSearchParams<{ billId?: string }>();
-  const bills = useCalendarStore((s) => s.bills);
-  const userId = useAuthStore((s) => s.session?.user.id ?? null) as UserId | null;
-  const db = userId ? getDb(userId) : null;
-  const { success: migrationsReady } = useMigrations(db ?? (undefined as never), migrations);
-
-  const existingBill = billId ? bills.find((b) => b.id === billId) : undefined;
+function AuthenticatedAddBillForm({
+  existingBill,
+  userId,
+  onDone,
+}: {
+  readonly existingBill: Bill | undefined;
+  readonly userId: UserId;
+  readonly onDone: () => void;
+}) {
+  const db = getDb(userId);
+  const { success: migrationsReady } = useMigrations(db, migrations);
 
   return (
     <AddBillForm
@@ -263,14 +265,45 @@ export default function AddBillScreen() {
       existingBill={existingBill}
       canSubmit={migrationsReady}
       onAddBill={(name, amount, frequency, categoryId, startDate) => {
-        if (!userId || !db || !migrationsReady) return Promise.resolve(false);
+        if (!migrationsReady) return Promise.resolve(false);
         return addBill(db, userId, name, amount, frequency, categoryId, startDate);
       }}
       onUpdateBill={(id, data) => {
-        if (!userId || !db || !migrationsReady) return Promise.resolve(false);
+        if (!migrationsReady) return Promise.resolve(false);
         return updateBill(db, userId, id, data);
       }}
-      onDone={() => router.back()}
+      onDone={onDone}
+    />
+  );
+}
+
+export default function AddBillScreen() {
+  const router = useRouter();
+  const { billId } = useLocalSearchParams<{ billId?: string }>();
+  const bills = useCalendarStore((s) => s.bills);
+  const userId = useAuthStore((s) => s.session?.user.id ?? null) as UserId | null;
+  const existingBill = billId ? bills.find((b) => b.id === billId) : undefined;
+  const handleDone = () => router.back();
+
+  if (!userId) {
+    return (
+      <AddBillForm
+        key={existingBill?.id ?? "new"}
+        existingBill={existingBill}
+        canSubmit={false}
+        onAddBill={() => Promise.resolve(false)}
+        onUpdateBill={() => Promise.resolve(false)}
+        onDone={handleDone}
+      />
+    );
+  }
+
+  return (
+    <AuthenticatedAddBillForm
+      key={existingBill?.id ?? "new"}
+      existingBill={existingBill}
+      userId={userId}
+      onDone={handleDone}
     />
   );
 }

--- a/apps/mobile/app/add-bill.tsx
+++ b/apps/mobile/app/add-bill.tsx
@@ -47,7 +47,7 @@ function AddBillForm({
     data: Partial<
       Pick<Bill, "name" | "amount" | "frequency" | "categoryId" | "startDate" | "isActive">
     >
-  ) => Promise<void>;
+  ) => Promise<boolean>;
   readonly onDone: () => void;
 }) {
   const { t, locale } = useTranslation();
@@ -82,14 +82,14 @@ function AddBillForm({
       if (existingBill) {
         const amountValue = parseDigitsToAmount(amount);
         if (amountValue <= 0) return;
-        await onUpdateBill(existingBill.id as BillId, {
+        const success = await onUpdateBill(existingBill.id as BillId, {
           name: trimmedName,
           amount: amountValue,
           frequency,
           categoryId: category,
           startDate,
         });
-        onDone();
+        if (success) onDone();
       } else {
         const success = await onAddBill(trimmedName, amount, frequency, category, startDate);
         if (success) onDone();
@@ -256,7 +256,7 @@ export default function AddBillScreen() {
         return addBill(getDb(userId), userId, name, amount, frequency, categoryId, startDate);
       }}
       onUpdateBill={(id, data) => {
-        if (!userId) return Promise.resolve();
+        if (!userId) return Promise.resolve(false);
         return updateBill(getDb(userId), userId, id, data);
       }}
       onDone={() => router.back()}

--- a/apps/mobile/app/add-bill.tsx
+++ b/apps/mobile/app/add-bill.tsx
@@ -1,7 +1,15 @@
 import DateTimePicker from "@react-native-community/datetimepicker";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useRef, useState } from "react";
-import { type Bill, type BillFrequency, FREQUENCIES, useCalendarStore } from "@/features/calendar";
+import { useAuthStore } from "@/features/auth";
+import {
+  addBill,
+  type Bill,
+  type BillFrequency,
+  FREQUENCIES,
+  updateBill,
+  useCalendarStore,
+} from "@/features/calendar";
 import { CATEGORIES, type CategoryId, isValidCategoryId } from "@/features/transactions";
 import {
   Keyboard,
@@ -14,10 +22,11 @@ import {
   TextInput,
   View,
 } from "@/shared/components/rn";
+import { getDb } from "@/shared/db";
 import { useAsyncGuard, useThemeColor, useTranslation } from "@/shared/hooks";
 import { getCategoryLabel } from "@/shared/i18n";
 import { parseDigitsToAmount } from "@/shared/lib";
-import type { BillId } from "@/shared/types/branded";
+import type { BillId, UserId } from "@/shared/types/branded";
 
 function AddBillForm({
   existingBill,
@@ -234,8 +243,7 @@ export default function AddBillScreen() {
   const router = useRouter();
   const { billId } = useLocalSearchParams<{ billId?: string }>();
   const bills = useCalendarStore((s) => s.bills);
-  const addBill = useCalendarStore((s) => s.addBill);
-  const updateBill = useCalendarStore((s) => s.updateBill);
+  const userId = useAuthStore((s) => s.session?.user.id ?? null) as UserId | null;
 
   const existingBill = billId ? bills.find((b) => b.id === billId) : undefined;
 
@@ -243,8 +251,14 @@ export default function AddBillScreen() {
     <AddBillForm
       key={existingBill?.id ?? "new"}
       existingBill={existingBill}
-      onAddBill={addBill}
-      onUpdateBill={updateBill}
+      onAddBill={(name, amount, frequency, categoryId, startDate) => {
+        if (!userId) return Promise.resolve(false);
+        return addBill(getDb(userId), userId, name, amount, frequency, categoryId, startDate);
+      }}
+      onUpdateBill={(id, data) => {
+        if (!userId) return Promise.resolve();
+        return updateBill(getDb(userId), userId, id, data);
+      }}
       onDone={() => router.back()}
     />
   );

--- a/apps/mobile/app/add-bill.tsx
+++ b/apps/mobile/app/add-bill.tsx
@@ -1,4 +1,5 @@
 import DateTimePicker from "@react-native-community/datetimepicker";
+import { useMigrations } from "drizzle-orm/expo-sqlite/migrator";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useRef, useState } from "react";
 import { useAuthStore } from "@/features/auth";
@@ -27,12 +28,14 @@ import { useAsyncGuard, useThemeColor, useTranslation } from "@/shared/hooks";
 import { getCategoryLabel } from "@/shared/i18n";
 import { parseDigitsToAmount } from "@/shared/lib";
 import type { BillId, UserId } from "@/shared/types/branded";
+import migrations from "../drizzle/migrations";
 
 function AddBillForm({
   existingBill,
   onAddBill,
   onUpdateBill,
   onDone,
+  canSubmit,
 }: {
   readonly existingBill: Bill | undefined;
   readonly onAddBill: (
@@ -49,6 +52,7 @@ function AddBillForm({
     >
   ) => Promise<boolean>;
   readonly onDone: () => void;
+  readonly canSubmit: boolean;
 }) {
   const { t, locale } = useTranslation();
   const isEdit = Boolean(existingBill);
@@ -76,6 +80,7 @@ function AddBillForm({
 
   const handleSave = () => {
     void guardedSave(async () => {
+      if (!canSubmit) return;
       const trimmedName = name.trim();
       if (!trimmedName) return;
 
@@ -226,9 +231,12 @@ function AddBillForm({
         </View>
 
         <Pressable
-          style={[styles.saveButton, { backgroundColor: accentGreen, opacity: isSaving ? 0.5 : 1 }]}
+          style={[
+            styles.saveButton,
+            { backgroundColor: accentGreen, opacity: isSaving || !canSubmit ? 0.5 : 1 },
+          ]}
           onPress={handleSave}
-          disabled={isSaving}
+          disabled={isSaving || !canSubmit}
         >
           <Text style={styles.saveButtonText}>
             {isEdit ? t("bills.saveChanges") : t("bills.add")}
@@ -244,6 +252,8 @@ export default function AddBillScreen() {
   const { billId } = useLocalSearchParams<{ billId?: string }>();
   const bills = useCalendarStore((s) => s.bills);
   const userId = useAuthStore((s) => s.session?.user.id ?? null) as UserId | null;
+  const db = userId ? getDb(userId) : null;
+  const { success: migrationsReady } = useMigrations(db ?? (undefined as never), migrations);
 
   const existingBill = billId ? bills.find((b) => b.id === billId) : undefined;
 
@@ -251,13 +261,14 @@ export default function AddBillScreen() {
     <AddBillForm
       key={existingBill?.id ?? "new"}
       existingBill={existingBill}
+      canSubmit={migrationsReady}
       onAddBill={(name, amount, frequency, categoryId, startDate) => {
-        if (!userId) return Promise.resolve(false);
-        return addBill(getDb(userId), userId, name, amount, frequency, categoryId, startDate);
+        if (!userId || !db || !migrationsReady) return Promise.resolve(false);
+        return addBill(db, userId, name, amount, frequency, categoryId, startDate);
       }}
       onUpdateBill={(id, data) => {
-        if (!userId) return Promise.resolve(false);
-        return updateBill(getDb(userId), userId, id, data);
+        if (!userId || !db || !migrationsReady) return Promise.resolve(false);
+        return updateBill(db, userId, id, data);
       }}
       onDone={() => router.back()}
     />

--- a/apps/mobile/app/bills-calendar.tsx
+++ b/apps/mobile/app/bills-calendar.tsx
@@ -1,8 +1,19 @@
 import { useRouter } from "expo-router";
-import { CalendarGrid, MonthNavigator, useCalendarStore } from "@/features/calendar";
+import { useCallback } from "react";
+import { useAuthStore } from "@/features/auth";
+import {
+  CalendarGrid,
+  MonthNavigator,
+  nextMonth,
+  prevMonth,
+  useCalendarStore,
+} from "@/features/calendar";
 import { ScreenLayout } from "@/shared/components";
 import { View } from "@/shared/components/rn";
+import { getDb } from "@/shared/db";
 import { useTranslation } from "@/shared/hooks";
+import { captureError } from "@/shared/lib";
+import type { UserId } from "@/shared/types/branded";
 
 export default function BillsCalendarScreen() {
   const router = useRouter();
@@ -10,13 +21,26 @@ export default function BillsCalendarScreen() {
   const currentMonth = useCalendarStore((s) => s.currentMonth);
   const bills = useCalendarStore((s) => s.bills);
   const payments = useCalendarStore((s) => s.payments);
-  const nextMonth = useCalendarStore((s) => s.nextMonth);
-  const prevMonth = useCalendarStore((s) => s.prevMonth);
+  const userId = useAuthStore((s) => s.session?.user.id ?? null) as UserId | null;
+
+  const handleNextMonth = useCallback(() => {
+    if (!userId) return;
+    void nextMonth(getDb(userId)).catch(captureError);
+  }, [userId]);
+
+  const handlePrevMonth = useCallback(() => {
+    if (!userId) return;
+    void prevMonth(getDb(userId)).catch(captureError);
+  }, [userId]);
 
   return (
     <ScreenLayout title={t("calendar.title")} variant="sub" onBack={() => router.back()}>
       <View className="flex-1 px-4">
-        <MonthNavigator currentMonth={currentMonth} onPrev={prevMonth} onNext={nextMonth} />
+        <MonthNavigator
+          currentMonth={currentMonth}
+          onPrev={handlePrevMonth}
+          onNext={handleNextMonth}
+        />
         <View className="flex-1">
           <CalendarGrid
             currentMonth={currentMonth}

--- a/apps/mobile/app/day-detail.tsx
+++ b/apps/mobile/app/day-detail.tsx
@@ -1,12 +1,21 @@
 import { format } from "date-fns";
 import { useLocalSearchParams, useRouter } from "expo-router";
-import { type BillPayment, getBillsForDate, useCalendarStore } from "@/features/calendar";
+import { useAuthStore } from "@/features/auth";
+import {
+  type BillPayment,
+  deleteBill,
+  getBillsForDate,
+  markBillPaid,
+  unmarkBillPaid,
+  useCalendarStore,
+} from "@/features/calendar";
 import { Check, Pencil, Trash2 } from "@/shared/components/icons";
 import { Alert, Pressable, ScrollView, StyleSheet, Text, View } from "@/shared/components/rn";
+import { getDb } from "@/shared/db";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { getDateFnsLocale } from "@/shared/i18n";
-import { formatMoney, toIsoDate } from "@/shared/lib";
-import type { BillId, CopAmount } from "@/shared/types/branded";
+import { captureError, formatMoney, toIsoDate } from "@/shared/lib";
+import type { BillId, CopAmount, UserId } from "@/shared/types/branded";
 
 export default function DayDetailScreen() {
   const { date } = useLocalSearchParams<{ date: string }>();
@@ -14,9 +23,7 @@ export default function DayDetailScreen() {
   const { t, locale } = useTranslation();
   const bills = useCalendarStore((s) => s.bills);
   const payments = useCalendarStore((s) => s.payments);
-  const markBillPaid = useCalendarStore((s) => s.markBillPaid);
-  const unmarkBillPaid = useCalendarStore((s) => s.unmarkBillPaid);
-  const deleteBill = useCalendarStore((s) => s.deleteBill);
+  const userId = useAuthStore((s) => s.session?.user.id ?? null) as UserId | null;
 
   const primaryColor = useThemeColor("primary");
   const secondaryColor = useThemeColor("secondary");
@@ -36,11 +43,12 @@ export default function DayDetailScreen() {
     payments.find((p) => p.billId === billId && p.dueDate === dueDateStr);
 
   const handleTogglePaid = async (billId: BillId) => {
+    if (!userId) return;
     const existing = isPaymentPaid(billId);
     if (existing) {
-      await unmarkBillPaid(billId, dueDateStr);
+      await unmarkBillPaid(getDb(userId), userId, billId, dueDateStr);
     } else {
-      await markBillPaid(billId, dueDateStr);
+      await markBillPaid(getDb(userId), userId, billId, dueDateStr);
     }
   };
 
@@ -55,7 +63,8 @@ export default function DayDetailScreen() {
         text: t("common.delete"),
         style: "destructive",
         onPress: () => {
-          void deleteBill(billId);
+          if (!userId) return;
+          void deleteBill(getDb(userId), userId, billId).catch(captureError);
         },
       },
     ]);

--- a/apps/mobile/features/calendar/index.ts
+++ b/apps/mobile/features/calendar/index.ts
@@ -3,4 +3,16 @@ export { MonthNavigator } from "./components/MonthNavigator";
 export { getBillsForDate, getNextOccurrence } from "./lib/calendar-utils";
 export type { Bill, BillFrequency, BillPayment, CreateBillInput } from "./schema";
 export { billSchema, FREQUENCIES } from "./schema";
-export { useCalendarStore } from "./store";
+export {
+  addBill,
+  deleteBill,
+  initializeCalendarSession,
+  loadBills,
+  loadPaymentsForMonth,
+  markBillPaid,
+  nextMonth,
+  prevMonth,
+  unmarkBillPaid,
+  updateBill,
+  useCalendarStore,
+} from "./store";

--- a/apps/mobile/features/calendar/services/create-calendar-query-service.ts
+++ b/apps/mobile/features/calendar/services/create-calendar-query-service.ts
@@ -1,0 +1,40 @@
+import { endOfMonth, startOfMonth } from "date-fns";
+import type { AnyDb } from "@/shared/db";
+import { toIsoDate } from "@/shared/lib";
+import type { UserId } from "@/shared/types/branded";
+import { getAllBills, getBillPaymentsForMonth } from "../lib/repository";
+import { type Bill, type BillPayment, fromBillRow } from "../schema";
+
+type LoadBillsInput = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+};
+
+type LoadPaymentsInput = {
+  readonly db: AnyDb;
+  readonly month: Date;
+};
+
+type CreateCalendarQueryServiceDeps = {
+  readonly getAllBills?: typeof getAllBills;
+  readonly getBillPaymentsForMonth?: typeof getBillPaymentsForMonth;
+};
+
+export function createCalendarQueryService({
+  getAllBills: loadBills = getAllBills,
+  getBillPaymentsForMonth: loadPayments = getBillPaymentsForMonth,
+}: CreateCalendarQueryServiceDeps = {}) {
+  return {
+    loadBills: async ({ db, userId }: LoadBillsInput): Promise<readonly Bill[]> =>
+      loadBills(db, userId).map(fromBillRow),
+
+    loadPaymentsForMonth: async ({
+      db,
+      month,
+    }: LoadPaymentsInput): Promise<readonly BillPayment[]> => {
+      const startIso = toIsoDate(startOfMonth(month));
+      const endIso = toIsoDate(endOfMonth(month));
+      return loadPayments(db, startIso, endIso) as readonly BillPayment[];
+    },
+  };
+}

--- a/apps/mobile/features/calendar/store.ts
+++ b/apps/mobile/features/calendar/store.ts
@@ -12,6 +12,7 @@ import { createCalendarQueryService } from "./services/create-calendar-query-ser
 
 let loadBillsRequestId = 0;
 let loadPaymentsRequestId = 0;
+let calendarSessionId = 0;
 
 const calendarQueryService = createCalendarQueryService();
 
@@ -87,20 +88,30 @@ export const useCalendarStore = create<CalendarState & CalendarActions>((set) =>
     })),
 }));
 
-function isCurrentBillsRequest(requestId: number, userId: UserId): boolean {
-  return loadBillsRequestId === requestId && useCalendarStore.getState().activeUserId === userId;
+function isCurrentBillsRequest(requestId: number, userId: UserId, sessionId: number): boolean {
+  return (
+    loadBillsRequestId === requestId &&
+    useCalendarStore.getState().activeUserId === userId &&
+    calendarSessionId === sessionId
+  );
 }
 
 function isCurrentPaymentsRequest(
   requestId: number,
   userId: UserId,
-  requestedMonth: Date
+  requestedMonth: Date,
+  sessionId: number
 ): boolean {
   return (
     loadPaymentsRequestId === requestId &&
     useCalendarStore.getState().activeUserId === userId &&
-    useCalendarStore.getState().currentMonth.getTime() === requestedMonth.getTime()
+    useCalendarStore.getState().currentMonth.getTime() === requestedMonth.getTime() &&
+    calendarSessionId === sessionId
   );
+}
+
+function isActiveCalendarSession(userId: UserId, sessionId: number): boolean {
+  return calendarSessionId === sessionId && useCalendarStore.getState().activeUserId === userId;
 }
 
 function createLiveCalendarBillMutations(db: AnyDb, userId: UserId) {
@@ -121,6 +132,7 @@ function createLiveCalendarBillMutations(db: AnyDb, userId: UserId) {
 }
 
 export function initializeCalendarSession(userId: UserId): void {
+  calendarSessionId += 1;
   loadBillsRequestId += 1;
   loadPaymentsRequestId += 1;
   useCalendarStore.getState().beginSession(userId);
@@ -128,11 +140,12 @@ export function initializeCalendarSession(userId: UserId): void {
 
 export async function loadBills(db: AnyDb, userId: UserId): Promise<void> {
   const requestId = ++loadBillsRequestId;
+  const sessionId = calendarSessionId;
   useCalendarStore.getState().setIsLoading(true);
 
   try {
     const bills = await calendarQueryService.loadBills({ db, userId });
-    if (!isCurrentBillsRequest(requestId, userId)) {
+    if (!isCurrentBillsRequest(requestId, userId, sessionId)) {
       if (loadBillsRequestId === requestId) {
         useCalendarStore.getState().setIsLoading(false);
       }
@@ -152,6 +165,7 @@ export async function loadPaymentsForMonth(db: AnyDb): Promise<void> {
   if (!userId) return;
 
   const requestId = ++loadPaymentsRequestId;
+  const sessionId = calendarSessionId;
   const requestedMonth = useCalendarStore.getState().currentMonth;
 
   const payments = await calendarQueryService.loadPaymentsForMonth({
@@ -159,7 +173,7 @@ export async function loadPaymentsForMonth(db: AnyDb): Promise<void> {
     month: requestedMonth,
   });
 
-  if (!isCurrentPaymentsRequest(requestId, userId, requestedMonth)) {
+  if (!isCurrentPaymentsRequest(requestId, userId, requestedMonth, sessionId)) {
     return;
   }
 
@@ -187,6 +201,7 @@ export async function addBill(
   categoryId: CategoryId,
   startDate: Date
 ): Promise<boolean> {
+  const sessionId = calendarSessionId;
   const result = await createLiveCalendarBillMutations(db, userId).addBill({
     name,
     amount,
@@ -195,6 +210,7 @@ export async function addBill(
     startDate,
   });
   if (!result.success) return false;
+  if (!isActiveCalendarSession(userId, sessionId)) return false;
 
   useCalendarStore.getState().appendBill(result.bill);
   return true;
@@ -207,16 +223,21 @@ export async function updateBill(
   fields: Partial<
     Pick<Bill, "name" | "amount" | "frequency" | "categoryId" | "startDate" | "isActive">
   >
-): Promise<void> {
+): Promise<boolean> {
+  const sessionId = calendarSessionId;
   const didUpdate = await createLiveCalendarBillMutations(db, userId).updateBill(id, fields);
-  if (!didUpdate) return;
+  if (!didUpdate) return false;
+  if (!isActiveCalendarSession(userId, sessionId)) return false;
 
   useCalendarStore.getState().replaceBill(id, fields);
+  return true;
 }
 
 export async function deleteBill(db: AnyDb, userId: UserId, id: BillId): Promise<void> {
+  const sessionId = calendarSessionId;
   const didDelete = await createLiveCalendarBillMutations(db, userId).deleteBill(id);
   if (!didDelete) return;
+  if (!isActiveCalendarSession(userId, sessionId)) return;
 
   useCalendarStore.getState().removeBill(id);
 }
@@ -227,12 +248,14 @@ export async function markBillPaid(
   billId: BillId,
   dueDate: IsoDate
 ): Promise<void> {
+  const sessionId = calendarSessionId;
   const result = await createLiveCalendarBillMutations(db, userId).markBillPaid(
     useCalendarStore.getState().bills,
     billId,
     dueDate
   );
   if (!result.success) return;
+  if (!isActiveCalendarSession(userId, sessionId)) return;
 
   useCalendarStore.getState().appendPayment(result.payment);
 }
@@ -243,12 +266,14 @@ export async function unmarkBillPaid(
   billId: BillId,
   dueDate: IsoDate
 ): Promise<void> {
+  const sessionId = calendarSessionId;
   const result = await createLiveCalendarBillMutations(db, userId).unmarkBillPaid(
     useCalendarStore.getState().payments,
     billId,
     dueDate
   );
   if (!result.success) return;
+  if (!isActiveCalendarSession(userId, sessionId)) return;
 
   useCalendarStore.getState().removePayment(billId, dueDate);
 }

--- a/apps/mobile/features/calendar/store.ts
+++ b/apps/mobile/features/calendar/store.ts
@@ -1,55 +1,114 @@
-import { addMonths, endOfMonth, startOfMonth, subMonths } from "date-fns";
+import { addMonths, subMonths } from "date-fns";
 import { create } from "zustand";
 import { useTransactionStore } from "@/features/transactions";
-import { createWriteThroughMutationModule, type WriteThroughMutationModule } from "@/mutations";
+import { createWriteThroughMutationModule } from "@/mutations";
 import type { AnyDb } from "@/shared/db";
-import { captureError, toIsoDate, trackBillCreated, trackBillPaymentRecorded } from "@/shared/lib";
+import { captureError, trackBillCreated, trackBillPaymentRecorded } from "@/shared/lib";
 import type { BillId, CategoryId, IsoDate, UserId } from "@/shared/types/branded";
 import { createCalendarBillMutationService } from "./lib/bill-mutation-service";
 import { requestNotificationPermissions, scheduleBillNotifications } from "./lib/notifications";
-import { getAllBills, getBillPaymentsForMonth } from "./lib/repository";
-import { type Bill, type BillFrequency, type BillPayment, fromBillRow } from "./schema";
+import type { Bill, BillFrequency, BillPayment } from "./schema";
+import { createCalendarQueryService } from "./services/create-calendar-query-service";
 
-// Module-level refs: Zustand doesn't serialize DB connections, so we keep them outside the store.
-let dbRef: AnyDb | null = null;
-let userIdRef: UserId | null = null;
-let mutations: WriteThroughMutationModule | null = null;
+let loadBillsRequestId = 0;
+let loadPaymentsRequestId = 0;
+
+const calendarQueryService = createCalendarQueryService();
 
 type CalendarState = {
-  currentMonth: Date;
-  bills: Bill[];
-  payments: BillPayment[];
-  isLoading: boolean;
+  readonly activeUserId: UserId | null;
+  readonly currentMonth: Date;
+  readonly bills: Bill[];
+  readonly payments: BillPayment[];
+  readonly isLoading: boolean;
 };
 
 type CalendarActions = {
-  initStore: (db: AnyDb, userId: UserId) => void;
-  nextMonth: () => void;
-  prevMonth: () => void;
-  loadBills: () => Promise<void>;
-  loadPaymentsForMonth: () => Promise<void>;
-  addBill: (
-    name: string,
-    amount: string,
-    frequency: BillFrequency,
-    category: CategoryId,
-    startDate: Date
-  ) => Promise<boolean>;
-  updateBill: (
+  beginSession: (userId: UserId) => void;
+  setCurrentMonth: (currentMonth: Date) => void;
+  setBills: (bills: readonly Bill[]) => void;
+  setPayments: (payments: readonly BillPayment[]) => void;
+  setIsLoading: (isLoading: boolean) => void;
+  appendBill: (bill: Bill) => void;
+  replaceBill: (
     id: BillId,
     fields: Partial<
       Pick<Bill, "name" | "amount" | "frequency" | "categoryId" | "startDate" | "isActive">
     >
-  ) => Promise<void>;
-  deleteBill: (id: BillId) => Promise<void>;
-  markBillPaid: (billId: BillId, dueDate: IsoDate) => Promise<void>;
-  unmarkBillPaid: (billId: BillId, dueDate: IsoDate) => Promise<void>;
+  ) => void;
+  removeBill: (id: BillId) => void;
+  appendPayment: (payment: BillPayment) => void;
+  removePayment: (billId: BillId, dueDate: IsoDate) => void;
 };
 
-export const useCalendarStore = create<CalendarState & CalendarActions>((set, get) => {
-  const billMutations = createCalendarBillMutationService({
-    getCommit: () => mutations?.commit ?? null,
-    getUserId: () => userIdRef,
+export const useCalendarStore = create<CalendarState & CalendarActions>((set) => ({
+  activeUserId: null,
+  currentMonth: new Date(),
+  bills: [],
+  payments: [],
+  isLoading: false,
+
+  beginSession: (userId) =>
+    set({
+      activeUserId: userId,
+      bills: [],
+      payments: [],
+      isLoading: false,
+    }),
+
+  setCurrentMonth: (currentMonth) => set({ currentMonth }),
+
+  setBills: (bills) => set({ bills: [...bills], isLoading: false }),
+
+  setPayments: (payments) => set({ payments: [...payments] }),
+
+  setIsLoading: (isLoading) => set({ isLoading }),
+
+  appendBill: (bill) => set((state) => ({ bills: [...state.bills, bill] })),
+
+  replaceBill: (id, fields) =>
+    set((state) => ({
+      bills: state.bills.map((bill) => (bill.id === id ? { ...bill, ...fields } : bill)),
+    })),
+
+  removeBill: (id) =>
+    set((state) => ({
+      bills: state.bills.filter((bill) => bill.id !== id),
+      payments: state.payments.filter((payment) => payment.billId !== id),
+    })),
+
+  appendPayment: (payment) => set((state) => ({ payments: [...state.payments, payment] })),
+
+  removePayment: (billId, dueDate) =>
+    set((state) => ({
+      payments: state.payments.filter(
+        (payment) => !(payment.billId === billId && payment.dueDate === dueDate)
+      ),
+    })),
+}));
+
+function isCurrentBillsRequest(requestId: number, userId: UserId): boolean {
+  return loadBillsRequestId === requestId && useCalendarStore.getState().activeUserId === userId;
+}
+
+function isCurrentPaymentsRequest(
+  requestId: number,
+  userId: UserId,
+  requestedMonth: Date
+): boolean {
+  return (
+    loadPaymentsRequestId === requestId &&
+    useCalendarStore.getState().activeUserId === userId &&
+    useCalendarStore.getState().currentMonth.getTime() === requestedMonth.getTime()
+  );
+}
+
+function createLiveCalendarBillMutations(db: AnyDb, userId: UserId) {
+  const mutations = createWriteThroughMutationModule(db);
+
+  return createCalendarBillMutationService({
+    getCommit: () => mutations.commit,
+    getUserId: () => userId,
     requestNotificationPermissions,
     scheduleBillNotifications,
     reportAsyncError: captureError,
@@ -59,96 +118,137 @@ export const useCalendarStore = create<CalendarState & CalendarActions>((set, ge
     trackCreated: trackBillCreated,
     trackPaymentRecorded: trackBillPaymentRecorded,
   });
+}
 
-  return {
-    currentMonth: new Date(),
-    bills: [],
-    payments: [],
-    isLoading: false,
+export function initializeCalendarSession(userId: UserId): void {
+  loadBillsRequestId += 1;
+  loadPaymentsRequestId += 1;
+  useCalendarStore.getState().beginSession(userId);
+}
 
-    initStore: (db, userId) => {
-      dbRef = db;
-      userIdRef = userId;
-      mutations = createWriteThroughMutationModule(db);
-    },
+export async function loadBills(db: AnyDb, userId: UserId): Promise<void> {
+  const requestId = ++loadBillsRequestId;
+  useCalendarStore.getState().setIsLoading(true);
 
-    nextMonth: () => {
-      set((s) => ({ currentMonth: addMonths(s.currentMonth, 1) }));
-      get().loadPaymentsForMonth().catch(captureError);
-    },
-
-    prevMonth: () => {
-      set((s) => ({ currentMonth: subMonths(s.currentMonth, 1) }));
-      get().loadPaymentsForMonth().catch(captureError);
-    },
-
-    loadBills: async () => {
-      if (!dbRef || !userIdRef) return;
-      set({ isLoading: true });
-      try {
-        const rows = getAllBills(dbRef, userIdRef);
-        set({ bills: rows.map(fromBillRow), isLoading: false });
-      } catch (error) {
-        set({ isLoading: false });
-        throw error;
+  try {
+    const bills = await calendarQueryService.loadBills({ db, userId });
+    if (!isCurrentBillsRequest(requestId, userId)) {
+      if (loadBillsRequestId === requestId) {
+        useCalendarStore.getState().setIsLoading(false);
       }
-    },
+      return;
+    }
+    useCalendarStore.getState().setBills(bills);
+  } catch (error) {
+    if (loadBillsRequestId === requestId) {
+      useCalendarStore.getState().setIsLoading(false);
+    }
+    throw error;
+  }
+}
 
-    loadPaymentsForMonth: async () => {
-      if (!dbRef) return;
-      const { currentMonth } = get();
-      const startIso = toIsoDate(startOfMonth(currentMonth));
-      const endIso = toIsoDate(endOfMonth(currentMonth));
-      const rows = getBillPaymentsForMonth(dbRef, startIso, endIso);
-      set({ payments: rows as BillPayment[] });
-    },
+export async function loadPaymentsForMonth(db: AnyDb): Promise<void> {
+  const userId = useCalendarStore.getState().activeUserId;
+  if (!userId) return;
 
-    addBill: async (name, amount, frequency, category, startDate) => {
-      const result = await billMutations.addBill({
-        name,
-        amount,
-        frequency,
-        categoryId: category,
-        startDate,
-      });
-      if (!result.success) return false;
+  const requestId = ++loadPaymentsRequestId;
+  const requestedMonth = useCalendarStore.getState().currentMonth;
 
-      set((s) => ({
-        bills: [...s.bills, result.bill],
-      }));
+  const payments = await calendarQueryService.loadPaymentsForMonth({
+    db,
+    month: requestedMonth,
+  });
 
-      return true;
-    },
+  if (!isCurrentPaymentsRequest(requestId, userId, requestedMonth)) {
+    return;
+  }
 
-    updateBill: async (id, fields) => {
-      const didUpdate = await billMutations.updateBill(id, fields);
-      if (!didUpdate) return;
-      set((s) => ({
-        bills: s.bills.map((b) => (b.id === id ? { ...b, ...fields } : b)),
-      }));
-    },
+  useCalendarStore.getState().setPayments(payments);
+}
 
-    deleteBill: async (id) => {
-      const didDelete = await billMutations.deleteBill(id);
-      if (!didDelete) return;
-      set((s) => ({
-        bills: s.bills.filter((b) => b.id !== id),
-        payments: s.payments.filter((p) => p.billId !== id),
-      }));
-    },
+export async function nextMonth(db: AnyDb): Promise<void> {
+  const next = addMonths(useCalendarStore.getState().currentMonth, 1);
+  useCalendarStore.getState().setCurrentMonth(next);
+  await loadPaymentsForMonth(db);
+}
 
-    markBillPaid: async (billId, dueDate) => {
-      const result = await billMutations.markBillPaid(get().bills, billId, dueDate);
-      if (!result.success) return;
-      set((s) => ({ payments: [...s.payments, result.payment] }));
-    },
+export async function prevMonth(db: AnyDb): Promise<void> {
+  const previous = subMonths(useCalendarStore.getState().currentMonth, 1);
+  useCalendarStore.getState().setCurrentMonth(previous);
+  await loadPaymentsForMonth(db);
+}
 
-    unmarkBillPaid: async (billId, dueDate) => {
-      const result = await billMutations.unmarkBillPaid(get().payments, billId, dueDate);
-      if (!result.success) return;
-      set((s) => ({
-        payments: s.payments.filter((p) => !(p.billId === billId && p.dueDate === dueDate)),
-      }));
-    },
-  };
-});
+export async function addBill(
+  db: AnyDb,
+  userId: UserId,
+  name: string,
+  amount: string,
+  frequency: BillFrequency,
+  categoryId: CategoryId,
+  startDate: Date
+): Promise<boolean> {
+  const result = await createLiveCalendarBillMutations(db, userId).addBill({
+    name,
+    amount,
+    frequency,
+    categoryId,
+    startDate,
+  });
+  if (!result.success) return false;
+
+  useCalendarStore.getState().appendBill(result.bill);
+  return true;
+}
+
+export async function updateBill(
+  db: AnyDb,
+  userId: UserId,
+  id: BillId,
+  fields: Partial<
+    Pick<Bill, "name" | "amount" | "frequency" | "categoryId" | "startDate" | "isActive">
+  >
+): Promise<void> {
+  const didUpdate = await createLiveCalendarBillMutations(db, userId).updateBill(id, fields);
+  if (!didUpdate) return;
+
+  useCalendarStore.getState().replaceBill(id, fields);
+}
+
+export async function deleteBill(db: AnyDb, userId: UserId, id: BillId): Promise<void> {
+  const didDelete = await createLiveCalendarBillMutations(db, userId).deleteBill(id);
+  if (!didDelete) return;
+
+  useCalendarStore.getState().removeBill(id);
+}
+
+export async function markBillPaid(
+  db: AnyDb,
+  userId: UserId,
+  billId: BillId,
+  dueDate: IsoDate
+): Promise<void> {
+  const result = await createLiveCalendarBillMutations(db, userId).markBillPaid(
+    useCalendarStore.getState().bills,
+    billId,
+    dueDate
+  );
+  if (!result.success) return;
+
+  useCalendarStore.getState().appendPayment(result.payment);
+}
+
+export async function unmarkBillPaid(
+  db: AnyDb,
+  userId: UserId,
+  billId: BillId,
+  dueDate: IsoDate
+): Promise<void> {
+  const result = await createLiveCalendarBillMutations(db, userId).unmarkBillPaid(
+    useCalendarStore.getState().payments,
+    billId,
+    dueDate
+  );
+  if (!result.success) return;
+
+  useCalendarStore.getState().removePayment(billId, dueDate);
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored the mobile calendar to use explicit query/mutation boundaries so the store only holds state. Adds session/request guards to drop stale results on user switches and gates calendar mutations on Drizzle migrations readiness.

- **Refactors**
  - Added `create-calendar-query-service` to load bills and month payments using calendar month bounds.
  - Store is state-only: added `activeUserId`, removed module DB refs, and added request-id/session-id guards to discard stale load and mutation results.
  - Introduced explicit APIs: `initializeCalendarSession`, `loadBills`, `loadPaymentsForMonth`, `addBill`, `updateBill`, `deleteBill`, `markBillPaid`, `unmarkBillPaid`, `nextMonth`, `prevMonth`.
  - Updated `_layout`, `bills-calendar`, `add-bill`, and `day-detail` to call the new boundaries with `getDb(userId)`; month nav reloads payments via the boundary.
  - `add-bill` now disables submit until `useMigrations` is ready and only exits edit mode after a successful update.
  - Tests: added `query-service` tests; rewrote store tests to assert stale-result guards for loads/mutations; added screen tests for migration gating and edit-close on successful update.

- **Migration**
  - After auth, call `initializeCalendarSession(userId)`.
  - Replace previous store calls:
    - `useCalendarStore().loadBills()` → `loadBills(db, userId)`
    - `useCalendarStore().loadPaymentsForMonth()` → `loadPaymentsForMonth(db)`
    - `useCalendarStore().nextMonth()` / `prevMonth()` → `nextMonth(db)` / `prevMonth(db)`
    - `add/update/delete/mark/unmark` → use exported functions with `db` and `userId` from `@/features/calendar`.
  - Gate calendar mutations behind Drizzle `useMigrations` readiness where applicable.

<sup>Written for commit ab30e59043a8cd3eac0b21d442792ad6ffb86237. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

