### PR TITLE
refactor(mobile): deepen goals seam

### DIFF
--- a/apps/mobile/__tests__/analytics/transaction-subscription.test.ts
+++ b/apps/mobile/__tests__/analytics/transaction-subscription.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 import { subscribeAnalyticsToTransactions } from "@/features/analytics/services/subscribe-analytics-to-transactions";
 
 describe("analytics transaction subscription", () => {
-  it("reloads only after analytics has loaded and the transaction pages reference changes", () => {
+  it("reloads only after analytics has loaded and the transaction data revision changes", () => {
     let notify: () => void = () => undefined;
     let hasLoadedAnalytics = false;
-    let currentPages: readonly string[] = ["tx-1"];
+    let currentRevision = 0;
 
     const unsubscribe = vi.fn();
     const reload = vi.fn();
@@ -15,7 +15,7 @@ describe("analytics transaction subscription", () => {
         notify = listener;
         return unsubscribe;
       },
-      getTransactionPages: () => currentPages,
+      getTransactionDataRevision: () => currentRevision,
       hasLoadedAnalytics: () => hasLoadedAnalytics,
       reload,
     });
@@ -27,7 +27,7 @@ describe("analytics transaction subscription", () => {
     notify();
     expect(reload).not.toHaveBeenCalled();
 
-    currentPages = ["tx-1", "tx-2"];
+    currentRevision += 1;
     notify();
     expect(reload).toHaveBeenCalledTimes(1);
 

--- a/apps/mobile/__tests__/db/client.test.ts
+++ b/apps/mobile/__tests__/db/client.test.ts
@@ -2,7 +2,7 @@ import { getRandomBytes } from "expo-crypto";
 import { deleteItemAsync, getItem, setItem } from "expo-secure-store";
 import { openDatabaseSync } from "expo-sqlite";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getDb, resetDb } from "@/shared/db/client";
+import { getDb, resetDb, tryGetDb } from "@/shared/db/client";
 
 vi.mock("expo-sqlite", () => ({
   openDatabaseSync: vi.fn(() => ({ execSync: vi.fn(), closeSync: vi.fn() })),
@@ -125,5 +125,13 @@ describe("getDb", () => {
     expect(mockCloseSync).toHaveBeenCalled();
     expect(db2).toBeDefined();
     expect(openDatabaseSync).toHaveBeenCalledWith("fidy-user-456.db");
+  });
+
+  it("tryGetDb returns null instead of throwing when initialization fails", () => {
+    vi.mocked(openDatabaseSync).mockImplementationOnce(() => {
+      throw new Error("SQLite open failed");
+    });
+
+    expect(tryGetDb("user-123")).toBeNull();
   });
 });

--- a/apps/mobile/__tests__/goals/service.test.ts
+++ b/apps/mobile/__tests__/goals/service.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+import { createGoalQueryService } from "@/features/goals/services/create-goal-query-service";
+import type { UserId } from "@/shared/types/branded";
+
+const mockGetGoalsForUser = vi.fn();
+const mockGetGoalCurrentAmount = vi.fn();
+const mockGetMonthlyTotalsByType = vi.fn();
+const mockGetContributionMonthCount = vi.fn();
+const mockGetContributionsForGoal = vi.fn();
+
+describe("goal query service", () => {
+  it("builds goal progress snapshots for the active user", async () => {
+    mockGetGoalsForUser.mockReturnValue([
+      {
+        id: "goal-1",
+        userId: "user-1",
+        name: "Trip",
+        type: "savings",
+        targetAmount: 900000,
+        targetDate: "2026-12-31",
+        interestRatePercent: null,
+        iconName: null,
+        colorHex: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        deletedAt: null,
+      },
+    ]);
+    mockGetGoalCurrentAmount.mockReturnValue(300000);
+    mockGetMonthlyTotalsByType.mockReturnValue([
+      { month: "2026-03", type: "income", total: 1200000 },
+      { month: "2026-03", type: "expense", total: 300000 },
+      { month: "2026-02", type: "income", total: 1100000 },
+      { month: "2026-02", type: "expense", total: 400000 },
+      { month: "2026-01", type: "income", total: 1000000 },
+      { month: "2026-01", type: "expense", total: 350000 },
+    ]);
+    mockGetContributionMonthCount.mockReturnValue(2);
+
+    const service = createGoalQueryService({
+      getGoalsForUser: mockGetGoalsForUser,
+      getGoalCurrentAmount: mockGetGoalCurrentAmount,
+      getMonthlyTotalsByType: mockGetMonthlyTotalsByType,
+      getContributionMonthCount: mockGetContributionMonthCount,
+      getContributionsForGoal: mockGetContributionsForGoal,
+      getToday: () => new Date("2026-03-15T00:00:00.000Z"),
+    });
+
+    const snapshot = await service.loadGoals({
+      db: {} as never,
+      userId: "user-1" as UserId,
+    });
+
+    expect(mockGetGoalsForUser).toHaveBeenCalledWith(expect.anything(), "user-1");
+    expect(mockGetMonthlyTotalsByType).toHaveBeenCalledWith(expect.anything(), "user-1", 3);
+    expect(snapshot).toEqual([
+      expect.objectContaining({
+        goal: expect.objectContaining({ id: "goal-1", name: "Trip" }),
+        currentAmount: 300000,
+        progress: expect.objectContaining({
+          percentComplete: 33,
+          remaining: 600000,
+          isComplete: false,
+        }),
+        projection: expect.objectContaining({
+          confidence: "high",
+          monthsToGo: 1,
+          netMonthlySavings: 750000,
+          projectedDate: expect.any(Date),
+        }),
+        installments: {
+          current: 2,
+          total: 2,
+        },
+      }),
+    ]);
+  });
+
+  it("loads contribution history for the selected goal", async () => {
+    mockGetContributionsForGoal.mockReturnValue([
+      {
+        id: "contrib-1",
+        goalId: "goal-1",
+        userId: "user-1",
+        amount: 50000,
+        note: "bonus",
+        date: "2026-03-10",
+        createdAt: "2026-03-10T00:00:00.000Z",
+        updatedAt: "2026-03-10T00:00:00.000Z",
+        deletedAt: null,
+      },
+    ]);
+
+    const service = createGoalQueryService({
+      getGoalsForUser: mockGetGoalsForUser,
+      getGoalCurrentAmount: mockGetGoalCurrentAmount,
+      getMonthlyTotalsByType: mockGetMonthlyTotalsByType,
+      getContributionMonthCount: mockGetContributionMonthCount,
+      getContributionsForGoal: mockGetContributionsForGoal,
+    });
+
+    const contributions = await service.loadGoalContributions({
+      db: {} as never,
+      goalId: "goal-1",
+    });
+
+    expect(mockGetContributionsForGoal).toHaveBeenCalledWith(expect.anything(), "goal-1");
+    expect(contributions).toEqual([expect.objectContaining({ id: "contrib-1", note: "bonus" })]);
+  });
+});

--- a/apps/mobile/__tests__/goals/store.test.ts
+++ b/apps/mobile/__tests__/goals/store.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createGoal,
+  initializeGoalSession,
+  loadGoalsForUser,
+  selectGoal,
+  useGoalStore,
+} from "@/features/goals/store";
+import type { UserId } from "@/shared/types/branded";
+
+const mockLoadGoals = vi.fn();
+const mockLoadGoalContributions = vi.fn();
+const mockCommit = vi.fn();
+
+vi.mock("@/features/goals/services/create-goal-query-service", () => ({
+  createGoalQueryService: () => ({
+    loadGoals: (...args: unknown[]) => mockLoadGoals(...args),
+    loadGoalContributions: (...args: unknown[]) => mockLoadGoalContributions(...args),
+  }),
+}));
+
+vi.mock("@/mutations", () => ({
+  createWriteThroughMutationModule: () => ({
+    commit: mockCommit,
+  }),
+}));
+
+vi.mock("@/features/notifications", () => ({
+  insertNotificationRecord: vi.fn(),
+  scheduleLocalPush: vi.fn(),
+}));
+
+vi.mock("@/shared/lib", async () => {
+  const actual = await vi.importActual<typeof import("@/shared/lib")>("@/shared/lib");
+  return {
+    ...actual,
+    captureError: vi.fn(),
+    generateId: vi.fn(() => "goal-generated"),
+    toIsoDateTime: vi.fn(() => "2026-04-18T10:00:00.000Z"),
+    trackGoalContributionAdded: vi.fn(),
+    trackGoalCreated: vi.fn(),
+    trackGoalMilestoneReached: vi.fn(),
+  };
+});
+
+function createDeferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("goal store boundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useGoalStore.setState({
+      activeUserId: null,
+      goals: [],
+      selectedGoalId: null,
+      selectedGoalContributions: [],
+      isLoading: false,
+    });
+  });
+
+  it("drops stale goal results after the active user changes", async () => {
+    const deferred =
+      createDeferred<
+        readonly [
+          {
+            readonly goal: {
+              readonly id: string;
+              readonly name: string;
+            };
+            readonly currentAmount: number;
+            readonly progress: {
+              readonly percentComplete: number;
+              readonly remaining: number;
+              readonly isComplete: boolean;
+            };
+            readonly projection: {
+              readonly monthsToGo: number | null;
+              readonly projectedDate: Date | null;
+              readonly confidence: "none" | "low" | "medium" | "high";
+              readonly netMonthlySavings: number;
+            };
+            readonly installments: {
+              readonly current: number;
+              readonly total: number;
+            };
+            readonly paceGuidance: null;
+          },
+        ]
+      >();
+    mockLoadGoals.mockReturnValueOnce(deferred.promise);
+
+    initializeGoalSession("user-1" as UserId);
+    const load = loadGoalsForUser({} as never, "user-1" as UserId);
+
+    initializeGoalSession("user-2" as UserId);
+    deferred.resolve([
+      {
+        goal: { id: "goal-1", name: "Trip" },
+        currentAmount: 250000,
+        progress: { percentComplete: 25, remaining: 750000, isComplete: false },
+        projection: {
+          monthsToGo: 2,
+          projectedDate: new Date("2026-06-01T00:00:00.000Z"),
+          confidence: "high",
+          netMonthlySavings: 400000,
+        },
+        installments: { current: 1, total: 3 },
+        paceGuidance: null,
+      },
+    ]);
+
+    await load;
+
+    expect(useGoalStore.getState()).toMatchObject({
+      activeUserId: "user-2",
+      goals: [],
+      isLoading: false,
+    });
+  });
+
+  it("loads contributions for the selected goal through the explicit boundary", async () => {
+    mockLoadGoalContributions.mockResolvedValueOnce([
+      {
+        id: "contrib-1",
+        goalId: "goal-1",
+        userId: "user-1",
+        amount: 50000,
+        note: "bonus",
+        date: "2026-04-10",
+        createdAt: "2026-04-10T00:00:00.000Z",
+        updatedAt: "2026-04-10T00:00:00.000Z",
+        deletedAt: null,
+      },
+    ]);
+
+    initializeGoalSession("user-1" as UserId);
+    await selectGoal({} as never, "user-1" as UserId, "goal-1");
+
+    expect(mockLoadGoalContributions).toHaveBeenCalledWith({
+      db: expect.anything(),
+      goalId: "goal-1",
+    });
+    expect(useGoalStore.getState()).toMatchObject({
+      activeUserId: "user-1",
+      selectedGoalId: "goal-1",
+      selectedGoalContributions: [expect.objectContaining({ id: "contrib-1", note: "bonus" })],
+    });
+  });
+
+  it("drops stale create-goal completions after the active user changes", async () => {
+    const deferredCommit = createDeferred<{ success: true }>();
+    mockCommit.mockReturnValueOnce(deferredCommit.promise);
+
+    initializeGoalSession("user-1" as UserId);
+    const create = createGoal({} as never, "user-1" as UserId, {
+      name: "Trip",
+      type: "savings",
+      targetAmount: 900000,
+    });
+
+    initializeGoalSession("user-2" as UserId);
+    deferredCommit.resolve({ success: true });
+
+    await expect(create).resolves.toBe(false);
+    expect(useGoalStore.getState()).toMatchObject({
+      activeUserId: "user-2",
+      goals: [],
+    });
+  });
+});

--- a/apps/mobile/__tests__/goals/transaction-subscription.test.ts
+++ b/apps/mobile/__tests__/goals/transaction-subscription.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+import { subscribeGoalsToTransactions } from "@/features/goals/services/subscribe-goals-to-transactions";
+
+describe("goal transaction subscription", () => {
+  it("reloads only after goals have loaded and the transaction pages reference changes", () => {
+    let notify: () => void = () => undefined;
+    let hasLoadedGoals = false;
+    let currentPages: readonly string[] = ["tx-1"];
+
+    const unsubscribe = vi.fn();
+    const reload = vi.fn();
+
+    const cleanup = subscribeGoalsToTransactions({
+      subscribeTransactions: (listener) => {
+        notify = listener;
+        return unsubscribe;
+      },
+      getTransactionPages: () => currentPages,
+      hasLoadedGoals: () => hasLoadedGoals,
+      reload,
+    });
+
+    notify();
+    expect(reload).not.toHaveBeenCalled();
+
+    hasLoadedGoals = true;
+    notify();
+    expect(reload).not.toHaveBeenCalled();
+
+    currentPages = ["tx-1", "tx-2"];
+    notify();
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    cleanup();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/__tests__/goals/transaction-subscription.test.ts
+++ b/apps/mobile/__tests__/goals/transaction-subscription.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 import { subscribeGoalsToTransactions } from "@/features/goals/services/subscribe-goals-to-transactions";
 
 describe("goal transaction subscription", () => {
-  it("reloads only after goals have loaded and the transaction pages reference changes", () => {
+  it("reloads only after goals have loaded and the transaction data revision changes", () => {
     let notify: () => void = () => undefined;
     let hasLoadedGoals = false;
-    let currentPages: readonly string[] = ["tx-1"];
+    let currentRevision = 0;
 
     const unsubscribe = vi.fn();
     const reload = vi.fn();
@@ -15,7 +15,7 @@ describe("goal transaction subscription", () => {
         notify = listener;
         return unsubscribe;
       },
-      getTransactionPages: () => currentPages,
+      getTransactionDataRevision: () => currentRevision,
       hasLoadedGoals: () => hasLoadedGoals,
       reload,
     });
@@ -27,7 +27,7 @@ describe("goal transaction subscription", () => {
     notify();
     expect(reload).not.toHaveBeenCalled();
 
-    currentPages = ["tx-1", "tx-2"];
+    currentRevision += 1;
     notify();
     expect(reload).toHaveBeenCalledTimes(1);
 

--- a/apps/mobile/__tests__/transactions/store.test.ts
+++ b/apps/mobile/__tests__/transactions/store.test.ts
@@ -57,6 +57,7 @@ describe("useTransactionStore", () => {
       balance: 0,
       categorySpending: [],
       dailySpending: [],
+      dataRevision: 0,
       editingId: null,
     });
   });
@@ -406,6 +407,52 @@ describe("useTransactionStore", () => {
     expect(state.categorySpending).toEqual(existingCategorySpending);
     expect(state.dailySpending).toEqual(existingDailySpending);
     expect(getSpendingByCategoryAggregate).not.toHaveBeenCalled();
+  });
+
+  it("refresh increments dataRevision even when page identity is unchanged", async () => {
+    useTransactionStore.setState({
+      pages: [
+        {
+          id: "tx-1" as TransactionId,
+          userId: mockUserId,
+          type: "expense",
+          amount: 1000 as CopAmount,
+          categoryId: "food" as CategoryId,
+          description: "Lunch",
+          date: new Date("2026-03-04T00:00:00.000Z"),
+          createdAt: new Date("2026-03-04T10:00:00.000Z"),
+          updatedAt: new Date("2026-03-04T10:00:00.000Z"),
+          deletedAt: null,
+        },
+      ],
+      offset: 1,
+      hasMore: true,
+      dataRevision: 2,
+    });
+
+    vi.mocked(getTransactionsPaginated).mockReturnValueOnce([
+      {
+        id: "tx-1" as TransactionId,
+        userId: mockUserId,
+        type: "expense",
+        amount: 1000 as CopAmount,
+        categoryId: "food" as CategoryId,
+        description: "Lunch",
+        date: "2026-03-04" as IsoDate,
+        createdAt: "2026-03-04T10:00:00.000Z" as IsoDateTime,
+        updatedAt: "2026-03-04T10:00:00.000Z" as IsoDateTime,
+        deletedAt: null,
+        source: "manual",
+      },
+    ]);
+
+    await useTransactionStore.getState().refresh();
+
+    expect(useTransactionStore.getState()).toMatchObject({
+      dataRevision: 3,
+      offset: 1,
+      hasMore: false,
+    });
   });
 
   it("editTransaction hydrates edit mode from the stored transaction row", () => {

--- a/apps/mobile/app/(auth)/onboarding.tsx
+++ b/apps/mobile/app/(auth)/onboarding.tsx
@@ -27,23 +27,34 @@ export default function OnboardingScreen() {
   const insets = useSafeAreaInsets();
   const session = useAuthStore((s) => s.session);
   const userId = session?.user.id ?? null;
-  const step = useOnboardingStore((s) => s.step);
   const pageBg = useThemeColor("page");
 
-  const [storesReady, setStoresReady] = useState(false);
+  if (!userId) {
+    return <View style={[styles.container, { backgroundColor: pageBg }]} />;
+  }
 
-  // Create DB for this user — useMigrations requires a non-null db,
-  // but this screen only renders when userId is set (routed from _layout.tsx)
-  const db = userId ? getDb(userId) : null;
-  const { success: migrationsReady } = useMigrations(db ?? (undefined as never), migrations);
+  return <AuthenticatedOnboardingScreen insets={insets} userId={userId as UserId} />;
+}
+
+function AuthenticatedOnboardingScreen({
+  insets,
+  userId,
+}: {
+  readonly insets: { top: number; bottom: number };
+  readonly userId: UserId;
+}) {
+  const step = useOnboardingStore((s) => s.step);
+  const pageBg = useThemeColor("page");
+  const [storesReady, setStoresReady] = useState(false);
+  const db = getDb(userId);
+  const { success: migrationsReady } = useMigrations(db, migrations);
 
   // Initialize minimal stores needed for onboarding
   useSubscription(
     () => {
-      if (!db || !userId) return;
       useEmailCaptureStore.getState().initStore(db, userId);
-      useTransactionStore.getState().initStore(db, userId as UserId);
-      useBudgetStore.getState().initStore(db, userId as UserId);
+      useTransactionStore.getState().initStore(db, userId);
+      useBudgetStore.getState().initStore(db, userId);
       Promise.all([
         useEmailCaptureStore.getState().loadAccounts(),
         useTransactionStore.getState().loadInitialPage(),
@@ -54,7 +65,7 @@ export default function OnboardingScreen() {
         });
     },
     [db, userId],
-    migrationsReady && db != null && userId != null && !storesReady
+    migrationsReady && !storesReady
   );
 
   // Hide splash once ready

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -39,7 +39,12 @@ import {
 } from "@/features/capture-sources";
 import { refreshCategories } from "@/features/categories";
 import { useEmailCapture, useEmailCaptureStore } from "@/features/email-capture";
-import { useGoalStore } from "@/features/goals";
+import {
+  initializeGoalSession,
+  loadGoalsForUser,
+  subscribeGoalsToTransactions,
+  useGoalStore,
+} from "@/features/goals";
 import { initializeNotificationStore, registerPushToken } from "@/features/notifications";
 import {
   clearOnboardingFromStore,
@@ -90,7 +95,7 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
       useChatStore.getState().initStore(db, userId);
       initializeCalendarSession(userId);
       useBudgetStore.getState().initStore(db, userId);
-      useGoalStore.getState().initStore(db, userId);
+      initializeGoalSession(userId);
       initializeAnalyticsSession(userId);
       void initializeNotificationStore(db, userId);
       Promise.all([loadCalendarBills(db, userId), loadCalendarPaymentsForMonth(db)]).catch(
@@ -100,7 +105,7 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
         .getState()
         .loadBudgets()
         .catch(handleRecoverableError("Failed to load budgets"));
-      useGoalStore.getState().loadGoals().catch(handleRecoverableError("Failed to load goals"));
+      loadGoalsForUser(db, userId).catch(handleRecoverableError("Failed to load goals"));
       loadAnalyticsForUser(db, userId).catch(handleRecoverableError("Failed to load analytics"));
       refreshCategories(db, userId).catch(handleRecoverableError("Failed to load user categories"));
       useChatStore
@@ -122,6 +127,20 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
         .catch(handleRecoverableError("Failed to hydrate settings"));
       void registerBackgroundTask().catch(captureError);
     },
+    [db, userId],
+    migrationsReady
+  );
+
+  useSubscription(
+    () =>
+      subscribeGoalsToTransactions({
+        subscribeTransactions: useTransactionStore.subscribe,
+        getTransactionPages: () => useTransactionStore.getState().pages,
+        hasLoadedGoals: () => useGoalStore.getState().goals.length > 0,
+        reload: () => {
+          void loadGoalsForUser(db, userId).catch(handleRecoverableError("Failed to load goals"));
+        },
+      }),
     [db, userId],
     migrationsReady
   );

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -135,7 +135,7 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
     () =>
       subscribeGoalsToTransactions({
         subscribeTransactions: useTransactionStore.subscribe,
-        getTransactionPages: () => useTransactionStore.getState().pages,
+        getTransactionDataRevision: () => useTransactionStore.getState().dataRevision,
         hasLoadedGoals: () => useGoalStore.getState().goals.length > 0,
         reload: () => {
           void loadGoalsForUser(db, userId).catch(handleRecoverableError("Failed to load goals"));
@@ -149,7 +149,7 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
     () =>
       subscribeAnalyticsToTransactions({
         subscribeTransactions: useTransactionStore.subscribe,
-        getTransactionPages: () => useTransactionStore.getState().pages,
+        getTransactionDataRevision: () => useTransactionStore.getState().dataRevision,
         hasLoadedAnalytics: () => useAnalyticsStore.getState().incomeExpense !== null,
         reload: () => {
           void loadAnalyticsForUser(db, userId).catch(

--- a/apps/mobile/features/analytics/services/subscribe-analytics-to-transactions.ts
+++ b/apps/mobile/features/analytics/services/subscribe-analytics-to-transactions.ts
@@ -1,22 +1,22 @@
 type SubscribeAnalyticsToTransactionsInput = {
   readonly subscribeTransactions: (listener: () => void) => () => void;
-  readonly getTransactionPages: () => unknown;
+  readonly getTransactionDataRevision: () => number;
   readonly hasLoadedAnalytics: () => boolean;
   readonly reload: () => void;
 };
 
 export function subscribeAnalyticsToTransactions({
   subscribeTransactions,
-  getTransactionPages,
+  getTransactionDataRevision,
   hasLoadedAnalytics,
   reload,
 }: SubscribeAnalyticsToTransactionsInput): () => void {
-  let previousPages = getTransactionPages();
+  let previousRevision = getTransactionDataRevision();
 
   return subscribeTransactions(() => {
-    const currentPages = getTransactionPages();
-    if (currentPages === previousPages) return;
-    previousPages = currentPages;
+    const currentRevision = getTransactionDataRevision();
+    if (currentRevision === previousRevision) return;
+    previousRevision = currentRevision;
     if (!hasLoadedAnalytics()) return;
     reload();
   });

--- a/apps/mobile/features/goals/components/AddPaymentSheet.tsx
+++ b/apps/mobile/features/goals/components/AddPaymentSheet.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from "expo-router";
 import { useCallback, useRef, useState } from "react";
 import Animated from "react-native-reanimated";
+import { useAuthStore } from "@/features/auth";
 import { handleNumpadPress } from "@/features/transactions";
 import { FidyNumpad } from "@/shared/components";
 import {
@@ -12,16 +13,18 @@ import {
   TextInput,
   View,
 } from "@/shared/components/rn";
+import { getDb } from "@/shared/db";
 import { useAsyncGuard, useBlinkingCursor, useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatInputDisplay, parseDigitsToAmount, toIsoDate } from "@/shared/lib";
-import { useGoalStore } from "../store";
+import type { UserId } from "@/shared/types/branded";
+import { addContribution, useGoalStore } from "../store";
 
 export function AddPaymentSheet() {
   const { back } = useRouter();
   const { t } = useTranslation();
 
   const selectedGoalId = useGoalStore((s) => s.selectedGoalId);
-  const addContribution = useGoalStore((s) => s.addContribution);
+  const userId = useAuthStore((s) => s.session?.user.id ?? null) as UserId | null;
 
   const cardBg = useThemeColor("card");
   const primaryColor = useThemeColor("primary");
@@ -51,10 +54,11 @@ export function AddPaymentSheet() {
     () =>
       guardedAdd(async () => {
         if (selectedGoalId == null) return;
+        if (!userId) return;
         const amount = parseDigitsToAmount(digits);
         if (amount <= 0) return;
 
-        const success = await addContribution({
+        const success = await addContribution(getDb(userId), userId, {
           goalId: selectedGoalId,
           amount,
           note: note.trim() || undefined,
@@ -65,7 +69,7 @@ export function AddPaymentSheet() {
           back();
         }
       }),
-    [selectedGoalId, digits, note, date, addContribution, back, guardedAdd]
+    [selectedGoalId, digits, note, date, back, guardedAdd, userId]
   );
 
   return (
@@ -142,7 +146,7 @@ export function AddPaymentSheet() {
         onPress={() => {
           void handleAddPayment();
         }}
-        disabled={isAdding}
+        disabled={isAdding || userId == null}
       >
         <Text style={styles.ctaButtonText}>{t("goals.payment.addPaymentCta")}</Text>
       </Pressable>

--- a/apps/mobile/features/goals/components/AddPaymentSheet.tsx
+++ b/apps/mobile/features/goals/components/AddPaymentSheet.tsx
@@ -13,7 +13,7 @@ import {
   TextInput,
   View,
 } from "@/shared/components/rn";
-import { getDb } from "@/shared/db";
+import { tryGetDb } from "@/shared/db";
 import { useAsyncGuard, useBlinkingCursor, useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatInputDisplay, parseDigitsToAmount, toIsoDate } from "@/shared/lib";
 import type { UserId } from "@/shared/types/branded";
@@ -55,10 +55,12 @@ export function AddPaymentSheet() {
       guardedAdd(async () => {
         if (selectedGoalId == null) return;
         if (!userId) return;
+        const db = tryGetDb(userId);
+        if (!db) return;
         const amount = parseDigitsToAmount(digits);
         if (amount <= 0) return;
 
-        const success = await addContribution(getDb(userId), userId, {
+        const success = await addContribution(db, userId, {
           goalId: selectedGoalId,
           amount,
           note: note.trim() || undefined,

--- a/apps/mobile/features/goals/components/GoalCard.tsx
+++ b/apps/mobile/features/goals/components/GoalCard.tsx
@@ -4,7 +4,7 @@ import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatMoney } from "@/shared/lib";
 import type { CopAmount } from "@/shared/types/branded";
 import { deriveGoalCardStatus } from "../lib/derive";
-import type { GoalWithProgress } from "../store";
+import type { GoalWithProgress } from "../types";
 
 type GoalCardProps = {
   readonly goalWithProgress: GoalWithProgress;

--- a/apps/mobile/features/goals/components/GoalCreateSheet.tsx
+++ b/apps/mobile/features/goals/components/GoalCreateSheet.tsx
@@ -15,7 +15,7 @@ import {
   TextInput,
   View,
 } from "@/shared/components/rn";
-import { getDb } from "@/shared/db";
+import { tryGetDb } from "@/shared/db";
 import { useAsyncGuard, useBlinkingCursor, useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatInputDisplay, parseDigitsToAmount, toIsoDate } from "@/shared/lib";
 import type { UserId } from "@/shared/types/branded";
@@ -78,7 +78,9 @@ export function GoalCreateSheet() {
         const isValidRate = /^\d+(\.\d+)?$/.test(normalizedRate);
         const parsedRate = isValidRate ? Number.parseFloat(normalizedRate) : undefined;
         if (!userId) return;
-        const success = await createGoal(getDb(userId), userId, {
+        const db = tryGetDb(userId);
+        if (!db) return;
+        const success = await createGoal(db, userId, {
           name: name.trim(),
           type: goalType,
           targetAmount: parsedAmount,

--- a/apps/mobile/features/goals/components/GoalCreateSheet.tsx
+++ b/apps/mobile/features/goals/components/GoalCreateSheet.tsx
@@ -2,6 +2,7 @@ import DateTimePicker from "@react-native-community/datetimepicker";
 import { useRouter } from "expo-router";
 import { useCallback, useRef, useState } from "react";
 import Animated from "react-native-reanimated";
+import { useAuthStore } from "@/features/auth";
 import { handleNumpadPress } from "@/features/transactions";
 import { FidyNumpad } from "@/shared/components";
 import {
@@ -14,16 +15,18 @@ import {
   TextInput,
   View,
 } from "@/shared/components/rn";
+import { getDb } from "@/shared/db";
 import { useAsyncGuard, useBlinkingCursor, useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatInputDisplay, parseDigitsToAmount, toIsoDate } from "@/shared/lib";
+import type { UserId } from "@/shared/types/branded";
 import type { GoalType } from "../schema";
-import { useGoalStore } from "../store";
+import { createGoal, useGoalStore } from "../store";
 
 export function GoalCreateSheet() {
   const { back } = useRouter();
   const { t, locale } = useTranslation();
-  const createGoal = useGoalStore((s) => s.createGoal);
   const goals = useGoalStore((s) => s.goals);
+  const userId = useAuthStore((s) => s.session?.user.id ?? null) as UserId | null;
 
   const cardBg = useThemeColor("card");
   const primaryColor = useThemeColor("primary");
@@ -74,7 +77,8 @@ export function GoalCreateSheet() {
         const normalizedRate = interestRate.replace(",", ".");
         const isValidRate = /^\d+(\.\d+)?$/.test(normalizedRate);
         const parsedRate = isValidRate ? Number.parseFloat(normalizedRate) : undefined;
-        const success = await createGoal({
+        if (!userId) return;
+        const success = await createGoal(getDb(userId), userId, {
           name: name.trim(),
           type: goalType,
           targetAmount: parsedAmount,
@@ -89,7 +93,7 @@ export function GoalCreateSheet() {
           back();
         }
       }),
-    [name, digits, goalType, targetDate, interestRate, createGoal, back, guardedCreate]
+    [name, digits, goalType, targetDate, interestRate, back, guardedCreate, userId]
   );
 
   const handleDateChange = useCallback((_event: unknown, date?: Date) => {
@@ -278,7 +282,7 @@ export function GoalCreateSheet() {
         onPress={() => {
           void handleCreate();
         }}
-        disabled={isCreating}
+        disabled={isCreating || userId == null}
       >
         <Text style={styles.createButtonText}>{t("goals.create.title")}</Text>
       </Pressable>

--- a/apps/mobile/features/goals/components/GoalEditSheet.tsx
+++ b/apps/mobile/features/goals/components/GoalEditSheet.tsx
@@ -2,6 +2,7 @@ import DateTimePicker from "@react-native-community/datetimepicker";
 import { useRouter } from "expo-router";
 import { useCallback, useRef, useState } from "react";
 import Animated from "react-native-reanimated";
+import { useAuthStore } from "@/features/auth";
 import { handleNumpadPress } from "@/features/transactions";
 import { FidyNumpad } from "@/shared/components";
 import {
@@ -15,10 +16,11 @@ import {
   TextInput,
   View,
 } from "@/shared/components/rn";
+import { getDb } from "@/shared/db";
 import { useAsyncGuard, useBlinkingCursor, useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatInputDisplay, parseDigitsToAmount, parseIsoDate, toIsoDate } from "@/shared/lib";
-import type { IsoDate } from "@/shared/types/branded";
-import { useGoalStore } from "../store";
+import type { IsoDate, UserId } from "@/shared/types/branded";
+import { deleteGoal, updateGoal, useGoalStore } from "../store";
 
 export function GoalEditSheet() {
   const { back } = useRouter();
@@ -26,8 +28,7 @@ export function GoalEditSheet() {
 
   const selectedGoalId = useGoalStore((s) => s.selectedGoalId);
   const goals = useGoalStore((s) => s.goals);
-  const updateGoal = useGoalStore((s) => s.updateGoal);
-  const deleteGoal = useGoalStore((s) => s.deleteGoal);
+  const userId = useAuthStore((s) => s.session?.user.id ?? null) as UserId | null;
 
   const cardBg = useThemeColor("card");
   const primaryColor = useThemeColor("primary");
@@ -73,14 +74,14 @@ export function GoalEditSheet() {
   const handleSave = useCallback(
     () =>
       guardedSave(async () => {
-        if (selectedGoalId == null) return;
+        if (selectedGoalId == null || !userId) return;
         const parsedAmount = parseDigitsToAmount(digits);
         if (!name.trim() || parsedAmount <= 0) return;
 
         const normalizedRate = interestRate.replace(",", ".");
         const isValidRate = /^\d+(\.\d+)?$/.test(normalizedRate);
         const parsedRate = isValidRate ? Number.parseFloat(normalizedRate) : null;
-        await updateGoal(selectedGoalId, {
+        const success = await updateGoal(getDb(userId), userId, selectedGoalId, {
           name: name.trim(),
           targetAmount: parsedAmount,
           targetDate: targetDate ? toIsoDate(targetDate) : null,
@@ -89,23 +90,13 @@ export function GoalEditSheet() {
               ? parsedRate
               : null,
         });
-        back();
+        if (success) back();
       }),
-    [
-      selectedGoalId,
-      name,
-      digits,
-      goalType,
-      targetDate,
-      interestRate,
-      updateGoal,
-      back,
-      guardedSave,
-    ]
+    [selectedGoalId, name, digits, goalType, targetDate, interestRate, back, guardedSave, userId]
   );
 
   const handleDelete = useCallback(() => {
-    if (selectedGoalId == null || goal == null) return;
+    if (selectedGoalId == null || goal == null || !userId) return;
     Alert.alert(
       t("goals.edit.deleteConfirmTitle"),
       t("goals.edit.deleteConfirmMessage", { goalName: goal.name }),
@@ -116,14 +107,14 @@ export function GoalEditSheet() {
           style: "destructive",
           onPress: () => {
             void guardedDelete(async () => {
-              await deleteGoal(selectedGoalId);
-              back();
+              const success = await deleteGoal(getDb(userId), userId, selectedGoalId);
+              if (success) back();
             });
           },
         },
       ]
     );
-  }, [selectedGoalId, goal, deleteGoal, back, guardedDelete, t]);
+  }, [selectedGoalId, goal, back, guardedDelete, t, userId]);
 
   const handleDateChange = useCallback((_event: unknown, date?: Date) => {
     if (Platform.OS === "android") setShowDatePicker(false);
@@ -263,7 +254,7 @@ export function GoalEditSheet() {
         onPress={() => {
           void handleSave();
         }}
-        disabled={isSaving}
+        disabled={isSaving || userId == null}
       >
         <Text style={styles.saveButtonText}>{t("goals.edit.saveChanges")}</Text>
       </Pressable>
@@ -272,7 +263,7 @@ export function GoalEditSheet() {
       <Pressable
         style={[styles.deleteButton, { borderColor: accentRed, opacity: isDeleting ? 0.5 : 1 }]}
         onPress={handleDelete}
-        disabled={isDeleting}
+        disabled={isDeleting || userId == null}
       >
         <Text style={[styles.deleteButtonText, { color: accentRed }]}>
           {t("goals.edit.deleteGoal")}

--- a/apps/mobile/features/goals/components/GoalEditSheet.tsx
+++ b/apps/mobile/features/goals/components/GoalEditSheet.tsx
@@ -16,7 +16,7 @@ import {
   TextInput,
   View,
 } from "@/shared/components/rn";
-import { getDb } from "@/shared/db";
+import { tryGetDb } from "@/shared/db";
 import { useAsyncGuard, useBlinkingCursor, useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatInputDisplay, parseDigitsToAmount, parseIsoDate, toIsoDate } from "@/shared/lib";
 import type { IsoDate, UserId } from "@/shared/types/branded";
@@ -75,13 +75,15 @@ export function GoalEditSheet() {
     () =>
       guardedSave(async () => {
         if (selectedGoalId == null || !userId) return;
+        const db = tryGetDb(userId);
+        if (!db) return;
         const parsedAmount = parseDigitsToAmount(digits);
         if (!name.trim() || parsedAmount <= 0) return;
 
         const normalizedRate = interestRate.replace(",", ".");
         const isValidRate = /^\d+(\.\d+)?$/.test(normalizedRate);
         const parsedRate = isValidRate ? Number.parseFloat(normalizedRate) : null;
-        const success = await updateGoal(getDb(userId), userId, selectedGoalId, {
+        const success = await updateGoal(db, userId, selectedGoalId, {
           name: name.trim(),
           targetAmount: parsedAmount,
           targetDate: targetDate ? toIsoDate(targetDate) : null,
@@ -107,7 +109,9 @@ export function GoalEditSheet() {
           style: "destructive",
           onPress: () => {
             void guardedDelete(async () => {
-              const success = await deleteGoal(getDb(userId), userId, selectedGoalId);
+              const db = tryGetDb(userId);
+              if (!db) return;
+              const success = await deleteGoal(db, userId, selectedGoalId);
               if (success) back();
             });
           },

--- a/apps/mobile/features/goals/components/GoalSmartCard.tsx
+++ b/apps/mobile/features/goals/components/GoalSmartCard.tsx
@@ -1,16 +1,19 @@
 import { useRouter } from "expo-router";
 import { memo, useCallback, useMemo } from "react";
+import { useAuthStore } from "@/features/auth";
 import { Pressable, Text, View } from "@/shared/components/rn";
+import { getDb } from "@/shared/db";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatMoney } from "@/shared/lib";
-import type { CopAmount } from "@/shared/types/branded";
-import { useGoalStore } from "../store";
+import type { CopAmount, UserId } from "@/shared/types/branded";
+import { selectGoal, useGoalStore } from "../store";
 
 export const GoalSmartCard = memo(function GoalSmartCard() {
   const { push } = useRouter();
   const { t } = useTranslation();
   const goals = useGoalStore((s) => s.goals);
   const accentGreen = useThemeColor("accentGreen");
+  const userId = useAuthStore((s) => s.session?.user.id ?? null) as UserId | null;
 
   // Find best goal to display: highest progress % among active (non-complete) goals
   // Fallback: most recently created
@@ -30,11 +33,10 @@ export const GoalSmartCard = memo(function GoalSmartCard() {
   }, [goals]);
 
   const handlePress = useCallback(() => {
-    if (displayData) {
-      useGoalStore.getState().selectGoal(displayData.topGoal.goal.id);
-      push("/goal-detail" as never);
-    }
-  }, [displayData, push]);
+    if (!displayData || !userId) return;
+    void selectGoal(getDb(userId), userId, displayData.topGoal.goal.id);
+    push("/goal-detail" as never);
+  }, [displayData, push, userId]);
 
   if (!displayData) return null;
 

--- a/apps/mobile/features/goals/components/GoalSmartCard.tsx
+++ b/apps/mobile/features/goals/components/GoalSmartCard.tsx
@@ -2,7 +2,7 @@ import { useRouter } from "expo-router";
 import { memo, useCallback, useMemo } from "react";
 import { useAuthStore } from "@/features/auth";
 import { Pressable, Text, View } from "@/shared/components/rn";
-import { getDb } from "@/shared/db";
+import { tryGetDb } from "@/shared/db";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatMoney } from "@/shared/lib";
 import type { CopAmount, UserId } from "@/shared/types/branded";
@@ -34,7 +34,9 @@ export const GoalSmartCard = memo(function GoalSmartCard() {
 
   const handlePress = useCallback(() => {
     if (!displayData || !userId) return;
-    void selectGoal(getDb(userId), userId, displayData.topGoal.goal.id);
+    const db = tryGetDb(userId);
+    if (!db) return;
+    void selectGoal(db, userId, displayData.topGoal.goal.id);
     push("/goal-detail" as never);
   }, [displayData, push, userId]);
 

--- a/apps/mobile/features/goals/components/GoalsListScreen.tsx
+++ b/apps/mobile/features/goals/components/GoalsListScreen.tsx
@@ -4,7 +4,7 @@ import { useAuthStore } from "@/features/auth";
 import { ScreenLayout, TAB_BAR_CLEARANCE } from "@/shared/components";
 import { Plus, Target } from "@/shared/components/icons";
 import { FlatList, Platform, Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
-import { getDb } from "@/shared/db";
+import { tryGetDb } from "@/shared/db";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import type { UserId } from "@/shared/types/branded";
 import { selectGoal, useGoalStore } from "../store";
@@ -71,7 +71,9 @@ export function GoalsListScreen() {
   const handleGoalPress = useCallback(
     (goalId: string) => {
       if (!userId) return;
-      void selectGoal(getDb(userId), userId, goalId);
+      const db = tryGetDb(userId);
+      if (!db) return;
+      void selectGoal(db, userId, goalId);
       router.push("/goal-detail");
     },
     [router, userId]
@@ -80,7 +82,9 @@ export function GoalsListScreen() {
   const handleAddPayment = useCallback(
     (goalId: string) => {
       if (!userId) return;
-      void selectGoal(getDb(userId), userId, goalId);
+      const db = tryGetDb(userId);
+      if (!db) return;
+      void selectGoal(db, userId, goalId);
       router.push("/add-payment");
     },
     [router, userId]

--- a/apps/mobile/features/goals/components/GoalsListScreen.tsx
+++ b/apps/mobile/features/goals/components/GoalsListScreen.tsx
@@ -1,10 +1,13 @@
 import { useRouter } from "expo-router";
 import { useCallback } from "react";
+import { useAuthStore } from "@/features/auth";
 import { ScreenLayout, TAB_BAR_CLEARANCE } from "@/shared/components";
 import { Plus, Target } from "@/shared/components/icons";
 import { FlatList, Platform, Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
+import { getDb } from "@/shared/db";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
-import { useGoalStore } from "../store";
+import type { UserId } from "@/shared/types/branded";
+import { selectGoal, useGoalStore } from "../store";
 import { GoalCard } from "./GoalCard";
 
 // ---------------------------------------------------------------------------
@@ -59,6 +62,7 @@ export function GoalsListScreen() {
   const { t } = useTranslation();
   const goals = useGoalStore((s) => s.goals);
   const isLoading = useGoalStore((s) => s.isLoading);
+  const userId = useAuthStore((s) => s.session?.user.id ?? null) as UserId | null;
 
   const handleCreateGoal = useCallback(() => {
     router.push("/create-goal");
@@ -66,18 +70,20 @@ export function GoalsListScreen() {
 
   const handleGoalPress = useCallback(
     (goalId: string) => {
-      useGoalStore.getState().selectGoal(goalId);
+      if (!userId) return;
+      void selectGoal(getDb(userId), userId, goalId);
       router.push("/goal-detail");
     },
-    [router]
+    [router, userId]
   );
 
   const handleAddPayment = useCallback(
     (goalId: string) => {
-      useGoalStore.getState().selectGoal(goalId);
+      if (!userId) return;
+      void selectGoal(getDb(userId), userId, goalId);
       router.push("/add-payment");
     },
-    [router]
+    [router, userId]
   );
 
   const renderItem = useCallback(

--- a/apps/mobile/features/goals/index.ts
+++ b/apps/mobile/features/goals/index.ts
@@ -51,5 +51,12 @@ export type {
   GoalType,
 } from "./schema";
 export { addContributionSchema, createGoalSchema } from "./schema";
-export type { GoalWithProgress } from "./store";
-export { useGoalStore } from "./store";
+export { createGoalQueryService } from "./services/create-goal-query-service";
+export { subscribeGoalsToTransactions } from "./services/subscribe-goals-to-transactions";
+export {
+  initializeGoalSession,
+  loadGoalsForUser,
+  selectGoal,
+  useGoalStore,
+} from "./store";
+export type { GoalWithProgress } from "./types";

--- a/apps/mobile/features/goals/services/create-goal-query-service.ts
+++ b/apps/mobile/features/goals/services/create-goal-query-service.ts
@@ -1,0 +1,124 @@
+import { getMonthlyTotalsByType } from "@/features/transactions";
+import type { AnyDb } from "@/shared/db";
+import type { UserId } from "@/shared/types/branded";
+import {
+  deriveDebtProjection,
+  deriveGoalPaceGuidance,
+  deriveGoalProgress,
+  deriveGoalProjection,
+  deriveInstallmentProgress,
+  type MonthlyTotal,
+} from "../lib/derive";
+import {
+  getContributionMonthCount,
+  getContributionsForGoal,
+  getGoalCurrentAmount,
+  getGoalsForUser,
+} from "../lib/repository";
+import type { Goal, GoalContribution } from "../schema";
+import type { GoalWithProgress } from "../types";
+
+type LoadGoalsInput = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+};
+
+type LoadGoalContributionsInput = {
+  readonly db: AnyDb;
+  readonly goalId: string;
+};
+
+type GoalQueryServiceDeps = {
+  readonly getGoalsForUser?: typeof getGoalsForUser;
+  readonly getGoalCurrentAmount?: typeof getGoalCurrentAmount;
+  readonly getMonthlyTotalsByType?: typeof getMonthlyTotalsByType;
+  readonly getContributionMonthCount?: typeof getContributionMonthCount;
+  readonly getContributionsForGoal?: typeof getContributionsForGoal;
+  readonly getToday?: () => Date;
+};
+
+function toGoalWithProgress(
+  goal: Goal,
+  currentAmount: number,
+  monthlyTotals: readonly MonthlyTotal[],
+  contributionMonths: number,
+  today: Date
+): GoalWithProgress {
+  const progress = deriveGoalProgress(goal, currentAmount);
+  const savingsProjection = deriveGoalProjection(goal, currentAmount, monthlyTotals);
+  const projection =
+    goal.type === "debt" &&
+    goal.interestRatePercent != null &&
+    savingsProjection.netMonthlySavings > 0
+      ? (() => {
+          const debtProjection = deriveDebtProjection(
+            goal,
+            currentAmount,
+            savingsProjection.netMonthlySavings
+          );
+          if (debtProjection.status === "ok" || debtProjection.status === "zero_rate") {
+            return {
+              projectedDate: debtProjection.projectedDate,
+              monthsToGo: debtProjection.monthsToGo,
+              confidence: savingsProjection.confidence,
+              netMonthlySavings: savingsProjection.netMonthlySavings,
+            };
+          }
+          if (debtProjection.status === "payment_too_low") {
+            return {
+              projectedDate: null,
+              monthsToGo: null,
+              confidence: savingsProjection.confidence,
+              netMonthlySavings: savingsProjection.netMonthlySavings,
+            };
+          }
+          return savingsProjection;
+        })()
+      : savingsProjection;
+
+  return {
+    goal,
+    currentAmount,
+    progress,
+    projection,
+    installments: deriveInstallmentProgress(
+      goal.targetAmount,
+      projection.netMonthlySavings,
+      contributionMonths
+    ),
+    paceGuidance: deriveGoalPaceGuidance(goal, currentAmount, contributionMonths > 0, today),
+  };
+}
+
+export function createGoalQueryService({
+  getGoalsForUser: loadGoals = getGoalsForUser,
+  getGoalCurrentAmount: loadGoalCurrentAmount = getGoalCurrentAmount,
+  getMonthlyTotalsByType: loadMonthlyTotals = getMonthlyTotalsByType,
+  getContributionMonthCount: countContributionMonths = getContributionMonthCount,
+  getContributionsForGoal: loadContributions = getContributionsForGoal,
+  getToday = () => new Date(),
+}: GoalQueryServiceDeps = {}) {
+  return {
+    loadGoals: async ({ db, userId }: LoadGoalsInput): Promise<readonly GoalWithProgress[]> => {
+      const goals = loadGoals(db, userId) as Goal[];
+      const monthlyTotals = loadMonthlyTotals(db, userId, 3) as readonly MonthlyTotal[];
+      const today = getToday();
+
+      return goals.map((goal) =>
+        toGoalWithProgress(
+          goal,
+          loadGoalCurrentAmount(db, goal.id),
+          monthlyTotals,
+          countContributionMonths(db, goal.id),
+          today
+        )
+      );
+    },
+
+    loadGoalContributions: async ({
+      db,
+      goalId,
+    }: LoadGoalContributionsInput): Promise<readonly GoalContribution[]> =>
+      loadContributions(db, goalId) as GoalContribution[],
+  };
+}

--- a/apps/mobile/features/goals/services/subscribe-goals-to-transactions.ts
+++ b/apps/mobile/features/goals/services/subscribe-goals-to-transactions.ts
@@ -1,0 +1,23 @@
+type SubscribeGoalsToTransactionsInput = {
+  readonly subscribeTransactions: (listener: () => void) => () => void;
+  readonly getTransactionPages: () => unknown;
+  readonly hasLoadedGoals: () => boolean;
+  readonly reload: () => void;
+};
+
+export function subscribeGoalsToTransactions({
+  subscribeTransactions,
+  getTransactionPages,
+  hasLoadedGoals,
+  reload,
+}: SubscribeGoalsToTransactionsInput): () => void {
+  let previousPages = getTransactionPages();
+
+  return subscribeTransactions(() => {
+    const currentPages = getTransactionPages();
+    if (currentPages === previousPages) return;
+    previousPages = currentPages;
+    if (!hasLoadedGoals()) return;
+    reload();
+  });
+}

--- a/apps/mobile/features/goals/services/subscribe-goals-to-transactions.ts
+++ b/apps/mobile/features/goals/services/subscribe-goals-to-transactions.ts
@@ -1,22 +1,22 @@
 type SubscribeGoalsToTransactionsInput = {
   readonly subscribeTransactions: (listener: () => void) => () => void;
-  readonly getTransactionPages: () => unknown;
+  readonly getTransactionDataRevision: () => number;
   readonly hasLoadedGoals: () => boolean;
   readonly reload: () => void;
 };
 
 export function subscribeGoalsToTransactions({
   subscribeTransactions,
-  getTransactionPages,
+  getTransactionDataRevision,
   hasLoadedGoals,
   reload,
 }: SubscribeGoalsToTransactionsInput): () => void {
-  let previousPages = getTransactionPages();
+  let previousRevision = getTransactionDataRevision();
 
   return subscribeTransactions(() => {
-    const currentPages = getTransactionPages();
-    if (currentPages === previousPages) return;
-    previousPages = currentPages;
+    const currentRevision = getTransactionDataRevision();
+    if (currentRevision === previousRevision) return;
+    previousRevision = currentRevision;
     if (!hasLoadedGoals()) return;
     reload();
   });

--- a/apps/mobile/features/goals/store.ts
+++ b/apps/mobile/features/goals/store.ts
@@ -1,7 +1,6 @@
 import { create } from "zustand";
 import { insertNotificationRecord, scheduleLocalPush } from "@/features/notifications";
-import { getMonthlyTotalsByType, useTransactionStore } from "@/features/transactions";
-import { createWriteThroughMutationModule, type WriteThroughMutationModule } from "@/mutations";
+import { createWriteThroughMutationModule } from "@/mutations";
 import type { AnyDb } from "@/shared/db";
 import { i18n } from "@/shared/i18n";
 import {
@@ -11,416 +10,360 @@ import {
   trackGoalCreated,
   trackGoalMilestoneReached,
 } from "@/shared/lib";
+import type { MutationCommand } from "@/shared/mutations/write-through";
 import type { UserId } from "@/shared/types/branded";
-
-// Import from goals feature
-import type {
-  GoalPaceGuidance,
-  GoalProgress,
-  GoalProjection,
-  InstallmentProgress,
-} from "./lib/derive";
-import {
-  deriveDebtProjection,
-  deriveGoalPaceGuidance,
-  deriveGoalProgress,
-  deriveGoalProjection,
-  deriveInstallmentProgress,
-} from "./lib/derive";
-import {
-  getContributionMonthCount,
-  getContributionsForGoal,
-  getGoalCurrentAmount,
-  getGoalsForUser,
-} from "./lib/repository";
-import type { Goal, GoalContribution } from "./schema";
+import type { GoalContribution } from "./schema";
 import { addContributionSchema, createGoalSchema } from "./schema";
+import { createGoalQueryService } from "./services/create-goal-query-service";
+import type { GoalWithProgress } from "./types";
 
-// Module-level refs: Zustand doesn't serialize DB connections, so we keep them outside the store.
-let dbRef: AnyDb | null = null;
-let userIdRef: UserId | null = null;
-let unsubscribeTxStore: (() => void) | null = null;
-let mutations: WriteThroughMutationModule | null = null;
+let goalsSessionId = 0;
+let loadGoalsRequestId = 0;
+let loadGoalContributionsRequestId = 0;
 
-export type GoalWithProgress = {
-  readonly goal: Goal;
-  readonly currentAmount: number;
-  readonly progress: GoalProgress;
-  readonly projection: GoalProjection;
-  readonly installments: InstallmentProgress;
-  readonly paceGuidance: GoalPaceGuidance | null;
-};
+const goalQueryService = createGoalQueryService();
+const GOAL_MILESTONES = [25, 50, 75, 100] as const;
 
 type GoalState = {
-  goals: GoalWithProgress[];
-  selectedGoalId: string | null;
-  selectedGoalContributions: GoalContribution[];
-  isLoading: boolean;
+  readonly activeUserId: UserId | null;
+  readonly goals: readonly GoalWithProgress[];
+  readonly selectedGoalId: string | null;
+  readonly selectedGoalContributions: readonly GoalContribution[];
+  readonly isLoading: boolean;
 };
 
 type GoalActions = {
-  initStore: (db: AnyDb, userId: UserId) => void;
-  loadGoals: () => Promise<void>;
-  loadGoalContributions: (goalId: string) => void;
-  createGoal: (input: {
-    name: string;
-    type: "savings" | "debt";
-    targetAmount: number;
-    targetDate?: string;
-    interestRatePercent?: number;
-    iconName?: string;
-    colorHex?: string;
-  }) => Promise<boolean>;
-  updateGoal: (
-    id: string,
-    data: {
-      name?: string;
-      targetAmount?: number;
-      targetDate?: string | null;
-      interestRatePercent?: number | null;
-      iconName?: string | null;
-      colorHex?: string | null;
-    }
-  ) => Promise<void>;
-  deleteGoal: (id: string) => Promise<void>;
-  addContribution: (input: {
-    goalId: string;
-    amount: number;
-    note?: string;
-    date: string;
-  }) => Promise<boolean>;
-  deleteContribution: (id: string) => Promise<void>;
-  selectGoal: (goalId: string | null) => void;
-  refreshProjections: () => void;
+  beginSession: (userId: UserId) => void;
+  setGoals: (goals: readonly GoalWithProgress[]) => void;
+  setSelectedGoalId: (goalId: string | null) => void;
+  setSelectedGoalContributions: (contributions: readonly GoalContribution[]) => void;
+  clearSelectedGoal: () => void;
+  setIsLoading: (isLoading: boolean) => void;
 };
 
-export const useGoalStore = create<GoalState & GoalActions>((set, get) => ({
+export const useGoalStore = create<GoalState & GoalActions>((set) => ({
+  activeUserId: null,
   goals: [],
   selectedGoalId: null,
   selectedGoalContributions: [],
   isLoading: false,
 
-  initStore: (db, userId) => {
-    dbRef = db;
-    userIdRef = userId;
-    mutations = createWriteThroughMutationModule(db);
-    // Subscribe to transaction store changes to auto-refresh projections
-    if (unsubscribeTxStore) unsubscribeTxStore();
-    unsubscribeTxStore = useTransactionStore.subscribe(() => {
-      if (get().goals.length > 0) {
-        get().refreshProjections();
-      }
-    });
-  },
+  beginSession: (userId) =>
+    set({
+      activeUserId: userId,
+      goals: [],
+      selectedGoalId: null,
+      selectedGoalContributions: [],
+      isLoading: false,
+    }),
 
-  loadGoals: async () => {
-    const db = dbRef;
-    if (!db || !userIdRef) return;
-    set({ isLoading: true });
-    try {
-      const goalRows = getGoalsForUser(db, userIdRef) as Goal[];
-      const monthlyTotals = getMonthlyTotalsByType(db, userIdRef as UserId, 3);
+  setGoals: (goals) => set({ goals: [...goals], isLoading: false }),
 
-      const goalsWithProgress: GoalWithProgress[] = goalRows.map((goal) => {
-        const currentAmount = getGoalCurrentAmount(db, goal.id);
-        const progress = deriveGoalProgress(goal, currentAmount);
-        const savingsProjection = deriveGoalProjection(goal, currentAmount, monthlyTotals);
+  setSelectedGoalId: (selectedGoalId) => set({ selectedGoalId }),
 
-        // For debt goals with interest, use amortization-based projection
-        const projection: GoalProjection =
-          goal.type === "debt" &&
-          goal.interestRatePercent != null &&
-          savingsProjection.netMonthlySavings > 0
-            ? (() => {
-                const debtResult = deriveDebtProjection(
-                  goal,
-                  currentAmount,
-                  savingsProjection.netMonthlySavings
-                );
-                if (debtResult.status === "ok" || debtResult.status === "zero_rate") {
-                  return {
-                    projectedDate: debtResult.projectedDate,
-                    monthsToGo: debtResult.monthsToGo,
-                    confidence: savingsProjection.confidence,
-                    netMonthlySavings: savingsProjection.netMonthlySavings,
-                  };
-                }
-                if (debtResult.status === "payment_too_low") {
-                  return {
-                    projectedDate: null,
-                    monthsToGo: null,
-                    confidence: savingsProjection.confidence,
-                    netMonthlySavings: savingsProjection.netMonthlySavings,
-                  };
-                }
-                // complete — fall back to savings projection
-                return savingsProjection;
-              })()
-            : savingsProjection;
+  setSelectedGoalContributions: (selectedGoalContributions) =>
+    set({ selectedGoalContributions: [...selectedGoalContributions] }),
 
-        const contributionMonths = getContributionMonthCount(db, goal.id);
-        const installments = deriveInstallmentProgress(
-          goal.targetAmount,
-          projection.netMonthlySavings,
-          contributionMonths
-        );
-        const paceGuidance = deriveGoalPaceGuidance(goal, currentAmount, contributionMonths > 0);
-        return { goal, currentAmount, progress, projection, installments, paceGuidance };
-      });
+  clearSelectedGoal: () => set({ selectedGoalId: null, selectedGoalContributions: [] }),
 
-      set({ goals: goalsWithProgress, isLoading: false });
-    } catch {
-      set({ isLoading: false });
-    }
-  },
-
-  loadGoalContributions: (goalId) => {
-    if (!dbRef) return;
-    try {
-      const contributions = getContributionsForGoal(dbRef, goalId) as GoalContribution[];
-      set({ selectedGoalContributions: contributions, selectedGoalId: goalId });
-    } catch {
-      // keep existing state
-    }
-  },
-
-  createGoal: async (input) => {
-    if (!dbRef || !userIdRef) return false;
-    const validation = createGoalSchema.safeParse(input);
-    if (!validation.success) return false;
-    const mutationModule = mutations;
-    if (!mutationModule) return false;
-    const now = toIsoDateTime(new Date());
-    const id = generateId("gl");
-    try {
-      const result = await mutationModule.commit({
-        kind: "goal.save",
-        row: {
-          id,
-          userId: userIdRef,
-          name: input.name,
-          type: input.type,
-          targetAmount: input.targetAmount,
-          targetDate: input.targetDate ?? null,
-          interestRatePercent: input.interestRatePercent ?? null,
-          iconName: input.iconName ?? null,
-          colorHex: input.colorHex ?? null,
-          createdAt: now,
-          updatedAt: now,
-          deletedAt: null,
-        },
-      });
-      if (!result.success) return false;
-    } catch {
-      return false;
-    }
-    trackGoalCreated();
-    await get().loadGoals();
-    return true;
-  },
-
-  updateGoal: async (id, data) => {
-    if (!dbRef) return;
-    const mutationModule = mutations;
-    if (!mutationModule) return;
-    const now = toIsoDateTime(new Date());
-    try {
-      const result = await mutationModule.commit({
-        kind: "goal.update",
-        goalId: id,
-        data,
-        now,
-      });
-      if (!result.success) return;
-    } catch {
-      return;
-    }
-    await get().loadGoals();
-  },
-
-  deleteGoal: async (id) => {
-    if (!dbRef) return;
-    const mutationModule = mutations;
-    if (!mutationModule) return;
-    const now = toIsoDateTime(new Date());
-    try {
-      const result = await mutationModule.commit({
-        kind: "goal.delete",
-        goalId: id,
-        now,
-      });
-      if (!result.success) return;
-    } catch {
-      return;
-    }
-    if (get().selectedGoalId === id) {
-      set({ selectedGoalId: null, selectedGoalContributions: [] });
-    }
-    await get().loadGoals();
-  },
-
-  addContribution: async (input) => {
-    if (!dbRef || !userIdRef) return false;
-    const db = dbRef;
-    const userId = userIdRef;
-    const validation = addContributionSchema.safeParse(input);
-    if (!validation.success) return false;
-    const mutationModule = mutations;
-    if (!mutationModule) return false;
-    const now = toIsoDateTime(new Date());
-    const id = generateId("gc");
-    try {
-      const result = await mutationModule.commit({
-        kind: "goalContribution.save",
-        row: {
-          id,
-          goalId: input.goalId,
-          userId,
-          amount: input.amount,
-          note: input.note ?? null,
-          date: input.date,
-          createdAt: now,
-          updatedAt: now,
-          deletedAt: null,
-        },
-      });
-      if (!result.success) return false;
-    } catch {
-      return false;
-    }
-    trackGoalContributionAdded();
-    const goalBefore = get().goals.find((g) => g.goal.id === input.goalId);
-    const percentBefore = goalBefore?.progress.percentComplete ?? 0;
-
-    await get().loadGoals();
-
-    // Detect goal milestone crossings — only fire for NEWLY crossed milestones
-    const goalAfter = get().goals.find((g) => g.goal.id === input.goalId);
-    if (goalAfter) {
-      const percentAfter = goalAfter.progress.percentComplete;
-      const milestones = [25, 50, 75, 100] as const;
-      milestones.forEach((milestone) => {
-        if (percentBefore < milestone && percentAfter >= milestone) {
-          void insertNotificationRecord(db, userId, {
-            type: "goal_milestone",
-            dedupKey: `goal_milestone:${input.goalId}:${milestone}`,
-            categoryId: null,
-            goalId: input.goalId,
-            titleKey: "notifications.goalMilestone",
-            messageKey: "notifications.goalMilestoneMsg",
-            params: JSON.stringify({
-              goalName: goalAfter.goal.name,
-              percent: milestone,
-            }),
-          });
-          trackGoalMilestoneReached();
-
-          // Best-effort local push (preference guard inside scheduleLocalPush)
-          void scheduleLocalPush({
-            title: i18n.t("notifications.goalMilestone", {
-              goalName: goalAfter.goal.name,
-              percent: milestone,
-            }),
-            body: i18n.t("notifications.goalMilestoneMsg", { percent: milestone }),
-            data: { route: `/goal-detail?id=${input.goalId}` },
-            preferenceKey: "goalMilestones",
-          });
-        }
-      });
-    }
-
-    // Refresh contributions if viewing this goal
-    if (get().selectedGoalId === input.goalId) {
-      get().loadGoalContributions(input.goalId);
-    }
-    return true;
-  },
-
-  deleteContribution: async (id) => {
-    if (!dbRef) return;
-    const mutationModule = mutations;
-    if (!mutationModule) return;
-    const now = toIsoDateTime(new Date());
-    try {
-      const result = await mutationModule.commit({
-        kind: "goalContribution.delete",
-        contributionId: id,
-        now,
-      });
-      if (!result.success) return;
-    } catch {
-      return;
-    }
-    await get().loadGoals();
-    // Refresh contributions if a goal is selected
-    const selectedId = get().selectedGoalId;
-    if (selectedId) {
-      get().loadGoalContributions(selectedId);
-    }
-  },
-
-  selectGoal: (goalId) => {
-    set({ selectedGoalId: goalId });
-    if (goalId && dbRef) {
-      get().loadGoalContributions(goalId);
-    } else {
-      set({ selectedGoalContributions: [] });
-    }
-  },
-
-  refreshProjections: () => {
-    const db = dbRef;
-    if (!db || !userIdRef) return;
-    try {
-      const monthlyTotals = getMonthlyTotalsByType(db, userIdRef as UserId, 3);
-      const { goals } = get();
-      const updated = goals.map((g) => {
-        const currentAmount = getGoalCurrentAmount(db, g.goal.id);
-        const progress = deriveGoalProgress(g.goal, currentAmount);
-        const savingsProj = deriveGoalProjection(g.goal, currentAmount, monthlyTotals);
-
-        const projection: GoalProjection =
-          g.goal.type === "debt" &&
-          g.goal.interestRatePercent != null &&
-          savingsProj.netMonthlySavings > 0
-            ? (() => {
-                const dr = deriveDebtProjection(
-                  g.goal,
-                  currentAmount,
-                  savingsProj.netMonthlySavings
-                );
-                if (dr.status === "ok" || dr.status === "zero_rate") {
-                  return {
-                    projectedDate: dr.projectedDate,
-                    monthsToGo: dr.monthsToGo,
-                    confidence: savingsProj.confidence,
-                    netMonthlySavings: savingsProj.netMonthlySavings,
-                  };
-                }
-                if (dr.status === "payment_too_low") {
-                  return {
-                    projectedDate: null,
-                    monthsToGo: null,
-                    confidence: savingsProj.confidence,
-                    netMonthlySavings: savingsProj.netMonthlySavings,
-                  };
-                }
-                return savingsProj;
-              })()
-            : savingsProj;
-
-        const contributionMonths = getContributionMonthCount(db, g.goal.id);
-        const installments = deriveInstallmentProgress(
-          g.goal.targetAmount,
-          projection.netMonthlySavings,
-          contributionMonths
-        );
-        const paceGuidance = deriveGoalPaceGuidance(g.goal, currentAmount, contributionMonths > 0);
-        return { goal: g.goal, currentAmount, progress, projection, installments, paceGuidance };
-      });
-      set({ goals: updated });
-    } catch {
-      // keep existing state
-    }
-  },
+  setIsLoading: (isLoading) => set({ isLoading }),
 }));
+
+function isCurrentGoalsRequest(requestId: number, userId: UserId, sessionId: number): boolean {
+  return (
+    loadGoalsRequestId === requestId &&
+    useGoalStore.getState().activeUserId === userId &&
+    goalsSessionId === sessionId
+  );
+}
+
+function isCurrentGoalSelection(
+  requestId: number,
+  userId: UserId,
+  goalId: string,
+  sessionId: number
+): boolean {
+  return (
+    loadGoalContributionsRequestId === requestId &&
+    useGoalStore.getState().activeUserId === userId &&
+    useGoalStore.getState().selectedGoalId === goalId &&
+    goalsSessionId === sessionId
+  );
+}
+
+function isActiveGoalSession(userId: UserId, sessionId: number): boolean {
+  return goalsSessionId === sessionId && useGoalStore.getState().activeUserId === userId;
+}
+
+function getCrossedMilestones(percentBefore: number, percentAfter: number) {
+  return GOAL_MILESTONES.filter(
+    (milestone) => percentBefore < milestone && percentAfter >= milestone
+  );
+}
+
+async function commitGoalMutation(db: AnyDb, command: MutationCommand): Promise<boolean> {
+  const mutations = createWriteThroughMutationModule(db);
+
+  try {
+    const result = await mutations.commit(command);
+    return result.success;
+  } catch {
+    return false;
+  }
+}
+
+async function refreshGoalsForActiveSession(
+  db: AnyDb,
+  userId: UserId,
+  sessionId: number
+): Promise<boolean> {
+  if (!isActiveGoalSession(userId, sessionId)) return false;
+  await loadGoalsForUser(db, userId);
+  return isActiveGoalSession(userId, sessionId);
+}
+
+async function refreshSelectedGoalContributions(
+  db: AnyDb,
+  userId: UserId,
+  goalId: string,
+  sessionId: number
+): Promise<boolean> {
+  if (!isActiveGoalSession(userId, sessionId)) return false;
+  await selectGoal(db, userId, goalId);
+  return isActiveGoalSession(userId, sessionId);
+}
+
+function buildGoalMilestoneNotification(goalName: string, goalId: string, milestone: number) {
+  return {
+    type: "goal_milestone" as const,
+    dedupKey: `goal_milestone:${goalId}:${milestone}`,
+    categoryId: null,
+    goalId,
+    titleKey: "notifications.goalMilestone",
+    messageKey: "notifications.goalMilestoneMsg",
+    params: JSON.stringify({
+      goalName,
+      percent: milestone,
+    }),
+  };
+}
+
+export function initializeGoalSession(userId: UserId): void {
+  goalsSessionId += 1;
+  loadGoalsRequestId += 1;
+  loadGoalContributionsRequestId += 1;
+  useGoalStore.getState().beginSession(userId);
+}
+
+export async function loadGoalsForUser(db: AnyDb, userId: UserId): Promise<void> {
+  const requestId = ++loadGoalsRequestId;
+  const sessionId = goalsSessionId;
+  useGoalStore.getState().setIsLoading(true);
+
+  try {
+    const goals = await goalQueryService.loadGoals({ db, userId });
+    if (!isCurrentGoalsRequest(requestId, userId, sessionId)) {
+      if (loadGoalsRequestId === requestId) {
+        useGoalStore.getState().setIsLoading(false);
+      }
+      return;
+    }
+    useGoalStore.getState().setGoals(goals);
+  } catch {
+    if (loadGoalsRequestId === requestId) {
+      useGoalStore.getState().setIsLoading(false);
+    }
+  }
+}
+
+export async function selectGoal(db: AnyDb, userId: UserId, goalId: string | null): Promise<void> {
+  const requestId = ++loadGoalContributionsRequestId;
+  const sessionId = goalsSessionId;
+  useGoalStore.getState().setSelectedGoalId(goalId);
+
+  if (goalId == null) {
+    useGoalStore.getState().setSelectedGoalContributions([]);
+    return;
+  }
+
+  try {
+    const contributions = await goalQueryService.loadGoalContributions({ db, goalId });
+    if (!isCurrentGoalSelection(requestId, userId, goalId, sessionId)) {
+      return;
+    }
+    useGoalStore.getState().setSelectedGoalContributions(contributions);
+  } catch {
+    // Keep existing selection state on read failures.
+  }
+}
+
+export async function createGoal(
+  db: AnyDb,
+  userId: UserId,
+  input: {
+    readonly name: string;
+    readonly type: "savings" | "debt";
+    readonly targetAmount: number;
+    readonly targetDate?: string;
+    readonly interestRatePercent?: number;
+    readonly iconName?: string;
+    readonly colorHex?: string;
+  }
+): Promise<boolean> {
+  const validation = createGoalSchema.safeParse(input);
+  if (!validation.success) return false;
+
+  const sessionId = goalsSessionId;
+  const now = toIsoDateTime(new Date());
+  const didCommit = await commitGoalMutation(db, {
+    kind: "goal.save",
+    row: {
+      id: generateId("gl"),
+      userId,
+      name: input.name,
+      type: input.type,
+      targetAmount: input.targetAmount,
+      targetDate: input.targetDate ?? null,
+      interestRatePercent: input.interestRatePercent ?? null,
+      iconName: input.iconName ?? null,
+      colorHex: input.colorHex ?? null,
+      createdAt: now,
+      updatedAt: now,
+      deletedAt: null,
+    },
+  });
+  if (!didCommit) return false;
+  trackGoalCreated();
+
+  return refreshGoalsForActiveSession(db, userId, sessionId);
+}
+
+export async function updateGoal(
+  db: AnyDb,
+  userId: UserId,
+  id: string,
+  data: {
+    readonly name?: string;
+    readonly targetAmount?: number;
+    readonly targetDate?: string | null;
+    readonly interestRatePercent?: number | null;
+    readonly iconName?: string | null;
+    readonly colorHex?: string | null;
+  }
+): Promise<boolean> {
+  const sessionId = goalsSessionId;
+  const didCommit = await commitGoalMutation(db, {
+    kind: "goal.update",
+    goalId: id,
+    data,
+    now: toIsoDateTime(new Date()),
+  });
+  if (!didCommit) return false;
+
+  return refreshGoalsForActiveSession(db, userId, sessionId);
+}
+
+export async function deleteGoal(db: AnyDb, userId: UserId, id: string): Promise<boolean> {
+  const sessionId = goalsSessionId;
+  const didCommit = await commitGoalMutation(db, {
+    kind: "goal.delete",
+    goalId: id,
+    now: toIsoDateTime(new Date()),
+  });
+  if (!didCommit) return false;
+  if (!isActiveGoalSession(userId, sessionId)) return false;
+
+  if (useGoalStore.getState().selectedGoalId === id) {
+    useGoalStore.getState().clearSelectedGoal();
+  }
+
+  return refreshGoalsForActiveSession(db, userId, sessionId);
+}
+
+export async function addContribution(
+  db: AnyDb,
+  userId: UserId,
+  input: {
+    readonly goalId: string;
+    readonly amount: number;
+    readonly note?: string;
+    readonly date: string;
+  }
+): Promise<boolean> {
+  const validation = addContributionSchema.safeParse(input);
+  if (!validation.success) return false;
+
+  const sessionId = goalsSessionId;
+  const now = toIsoDateTime(new Date());
+  const percentBefore =
+    useGoalStore.getState().goals.find((goal) => goal.goal.id === input.goalId)?.progress
+      .percentComplete ?? 0;
+  const didCommit = await commitGoalMutation(db, {
+    kind: "goalContribution.save",
+    row: {
+      id: generateId("gc"),
+      goalId: input.goalId,
+      userId,
+      amount: input.amount,
+      note: input.note ?? null,
+      date: input.date,
+      createdAt: now,
+      updatedAt: now,
+      deletedAt: null,
+    },
+  });
+  if (!didCommit) return false;
+  trackGoalContributionAdded();
+
+  const didRefreshGoals = await refreshGoalsForActiveSession(db, userId, sessionId);
+  if (!didRefreshGoals) return false;
+
+  const selectedGoal = useGoalStore.getState().goals.find((goal) => goal.goal.id === input.goalId);
+  if (selectedGoal == null) return true;
+
+  getCrossedMilestones(percentBefore, selectedGoal.progress.percentComplete).forEach(
+    (milestone) => {
+      void insertNotificationRecord(
+        db,
+        userId,
+        buildGoalMilestoneNotification(selectedGoal.goal.name, input.goalId, milestone)
+      );
+      trackGoalMilestoneReached();
+      void scheduleLocalPush({
+        title: i18n.t("notifications.goalMilestone", {
+          goalName: selectedGoal.goal.name,
+          percent: milestone,
+        }),
+        body: i18n.t("notifications.goalMilestoneMsg", { percent: milestone }),
+        data: { route: `/goal-detail?id=${input.goalId}` },
+        preferenceKey: "goalMilestones",
+      });
+    }
+  );
+
+  if (useGoalStore.getState().selectedGoalId !== input.goalId) {
+    return true;
+  }
+
+  return refreshSelectedGoalContributions(db, userId, input.goalId, sessionId);
+}
+
+export async function deleteContribution(db: AnyDb, userId: UserId, id: string): Promise<boolean> {
+  const sessionId = goalsSessionId;
+  const didCommit = await commitGoalMutation(db, {
+    kind: "goalContribution.delete",
+    contributionId: id,
+    now: toIsoDateTime(new Date()),
+  });
+  if (!didCommit) return false;
+
+  const didRefreshGoals = await refreshGoalsForActiveSession(db, userId, sessionId);
+  if (!didRefreshGoals) return false;
+
+  const selectedGoalId = useGoalStore.getState().selectedGoalId;
+  if (selectedGoalId == null) {
+    return true;
+  }
+
+  return refreshSelectedGoalContributions(db, userId, selectedGoalId, sessionId);
+}

--- a/apps/mobile/features/goals/types.ts
+++ b/apps/mobile/features/goals/types.ts
@@ -1,0 +1,16 @@
+import type {
+  GoalPaceGuidance,
+  GoalProgress,
+  GoalProjection,
+  InstallmentProgress,
+} from "./lib/derive";
+import type { Goal } from "./schema";
+
+export type GoalWithProgress = {
+  readonly goal: Goal;
+  readonly currentAmount: number;
+  readonly progress: GoalProgress;
+  readonly projection: GoalProjection;
+  readonly installments: InstallmentProgress;
+  readonly paceGuidance: GoalPaceGuidance | null;
+};

--- a/apps/mobile/features/transactions/store.ts
+++ b/apps/mobile/features/transactions/store.ts
@@ -56,6 +56,7 @@ type TransactionState = {
   balance: number;
   categorySpending: CategorySpendingItem[];
   dailySpending: DailySpendingItem[];
+  dataRevision: number;
 };
 
 type TransactionActions = {
@@ -145,6 +146,7 @@ export const useTransactionStore = create<TransactionState & TransactionActions>
     balance: 0,
     categorySpending: [],
     dailySpending: [],
+    dataRevision: 0,
     editingId: null,
 
     initStore: (db, userId) => {
@@ -235,11 +237,13 @@ export const useTransactionStore = create<TransactionState & TransactionActions>
             pages: pageData.map(toStoredTransaction),
             offset: pageData.length,
             hasMore,
+            dataRevision: get().dataRevision + 1,
           });
         } else {
           set({
             offset: pageData.length,
             hasMore,
+            dataRevision: get().dataRevision + 1,
           });
         }
         get().loadAggregates();
@@ -285,13 +289,22 @@ export const useTransactionStore = create<TransactionState & TransactionActions>
       await get().removeTransaction(id);
     },
 
-    addToCache: (tx) => set((s) => ({ pages: [tx, ...s.pages], offset: s.offset + 1 })),
+    addToCache: (tx) =>
+      set((s) => ({
+        pages: [tx, ...s.pages],
+        offset: s.offset + 1,
+        dataRevision: s.dataRevision + 1,
+      })),
 
     removeFromCache: (id) =>
       set((s) => {
         const filtered = s.pages.filter((t) => t.id !== id);
         const removed = filtered.length < s.pages.length;
-        return { pages: filtered, offset: removed ? Math.max(0, s.offset - 1) : s.offset };
+        return {
+          pages: filtered,
+          offset: removed ? Math.max(0, s.offset - 1) : s.offset,
+          dataRevision: removed ? s.dataRevision + 1 : s.dataRevision,
+        };
       }),
 
     resetForm: () => set({ ...INITIAL_FORM, date: new Date(), editingId: null }),

--- a/apps/mobile/shared/db/client.ts
+++ b/apps/mobile/shared/db/client.ts
@@ -46,6 +46,14 @@ export function getDb(userId: string) {
   return db;
 }
 
+export function tryGetDb(userId: string) {
+  try {
+    return getDb(userId);
+  } catch {
+    return null;
+  }
+}
+
 export function resetDb() {
   try {
     sqliteRef?.closeSync();

--- a/apps/mobile/shared/db/index.ts
+++ b/apps/mobile/shared/db/index.ts
@@ -1,5 +1,5 @@
 export type { AnyDb } from "./client";
-export { getDb, resetDb } from "./client";
+export { getDb, resetDb, tryGetDb } from "./client";
 export type { SyncOperation, SyncQueueEntry, SyncTableName } from "./enqueue-sync";
 export { enqueueSync } from "./enqueue-sync";
 export {


### PR DESCRIPTION
- state-only goals store
- safe onboarding migrations
- update goal seam tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the goals feature into a state-only store with session-bound APIs and a query service. Subscriptions now use a transaction `dataRevision` signal to reliably reload goals and analytics after changes.

- **Refactors**
  - Added `create-goal-query-service`; moved `GoalWithProgress` to `types.ts`; the store no longer holds DB refs.
  - Introduced session-bound APIs (`initializeGoalSession`, `loadGoalsForUser`, `selectGoal`, plus create/update/delete/contribution helpers) that require `db` and `userId`.
  - Switched subscriptions to use transaction `dataRevision`; added `subscribe-goals-to-transactions` and wired `_layout.tsx`; updated analytics subscription accordingly.
  - Updated UI to call new APIs and gate on `userId`; added `tryGetDb` to safely open DBs.
  - `useTransactionStore` now increments `dataRevision` on refresh/add/remove.
  - Added tests for the query service, store boundary (stale drops), and transaction-linked reloads.

- **Bug Fixes**
  - Drop stale goal loads and create-goal completions after the active user changes.
  - Onboarding now runs migrations and initializes stores only when a real user DB is available.
  - Goals and analytics reload only after their data has loaded and when transaction `dataRevision` changes.

<sup>Written for commit c56f9c0492ac44aeb43cad6331980f752305d0ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

