### PR TITLE
refactor(mobile): deepen branded boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,12 @@ Follow React's ["You Might Not Need an Effect"](https://react.dev/learn/you-migh
 
 All IDs, temporal strings, and money amounts use branded types from `shared/types/branded.ts`. Never use plain `string` or `number` for these in function signatures. Use typed ID generators (`generateTransactionId()`, etc.), temporal constructors (`toIsoDate()`, `toMonth()`, `toIsoDateTime()`), and `$type<>()` on Drizzle schema columns. New entities need a branded type, a typed generator, and Drizzle `$type<>()` annotations.
 
+### Branded type assertions stay at boundaries
+
+- Keep branded-type proof in boundary helpers: constructors like `toIsoDate()`, auth hooks like `useOptionalUserId()`, route/ID decoders like `requireTransactionId()`, and row mappers/decoders in `data/`, `repository/`, or `schema/`.
+- UI files (`app/**`, `features/**/components/**`, `shared/components/**`) should not use direct `as UserId`, `as TransactionId`, `as BillId`, `as CategoryId`, `as IsoDate`, or `as IsoDateTime` assertions.
+- When a component needs a branded ID/date, add or reuse a deeper helper instead of asserting locally.
+
 ## Architectural Decisions
 
 ### Calendar-month budgets only

--- a/apps/mobile/__tests__/ai-chat/user-memories.test.ts
+++ b/apps/mobile/__tests__/ai-chat/user-memories.test.ts
@@ -141,6 +141,32 @@ describe("user memories remote adapters", () => {
     ]);
   });
 
+  test("rejects invalid extract-memories payloads", async () => {
+    mockInvoke.mockResolvedValue({
+      data: {
+        success: true,
+        data: [
+          {
+            id: "memory-1",
+            user_id: "user-1",
+            fact: "Shops weekly on Sundays",
+            category: "not-a-real-category",
+            created_at: "2026-03-05T10:00:00Z",
+            updated_at: "2026-03-05T10:00:00Z",
+          },
+        ],
+      },
+      error: null,
+    });
+
+    await expect(
+      extractMemoriesFromConversation([
+        { role: "user", content: "I shop every Sunday" },
+        { role: "assistant", content: "I'll remember that" },
+      ])
+    ).rejects.toThrow("extract_memories_failed");
+  });
+
   test("throws when the remote list fetch fails", async () => {
     mockOrder.mockResolvedValue({ data: null, error: { message: "offline" } });
 

--- a/apps/mobile/__tests__/capture-sources/hooks.test.ts
+++ b/apps/mobile/__tests__/capture-sources/hooks.test.ts
@@ -1,5 +1,6 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: mock db needs flexible typing
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { requireUserId } from "@/shared/types/assertions";
 
 const mockAddLogTransactionListener = vi.fn().mockReturnValue({ remove: vi.fn() });
 const mockAddDetectBankSmsListener = vi.fn().mockReturnValue({ remove: vi.fn() });
@@ -40,7 +41,7 @@ vi.mock("@/shared/lib/generate-id", () => ({
 }));
 
 const mockDb = {} as any;
-const USER_ID = "user-1";
+const USER_ID = requireUserId("user-1");
 
 async function loadSetup() {
   return import("@/features/capture-sources/hooks/setup");

--- a/apps/mobile/__tests__/capture-sources/hooks.test.ts
+++ b/apps/mobile/__tests__/capture-sources/hooks.test.ts
@@ -136,6 +136,44 @@ describe("setupSmsDetection", () => {
       })
     );
   });
+
+  it("normalizes epoch-millisecond SMS timestamps before insert", async () => {
+    const { setupSmsDetection } = await loadSetup();
+    let capturedListener: (event: any) => void = vi.fn();
+    mockAddDetectBankSmsListener.mockImplementationOnce((listener: any) => {
+      capturedListener = listener;
+      return { remove: vi.fn() };
+    });
+
+    const epochTimestamp = String(Date.UTC(2026, 2, 7, 14, 30, 0));
+
+    await setupSmsDetection(mockDb, USER_ID, mockRefreshDetectedSms);
+    capturedListener({ senderName: "Bancolombia", timestamp: epochTimestamp });
+
+    expect(mockInsertDetectedSmsEvent).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        detectedAt: new Date(Number(epochTimestamp)).toISOString(),
+      })
+    );
+  });
+
+  it("ignores invalid SMS timestamps without throwing from the listener", async () => {
+    const { setupSmsDetection } = await loadSetup();
+    let capturedListener: (event: any) => void = vi.fn();
+    mockAddDetectBankSmsListener.mockImplementationOnce((listener: any) => {
+      capturedListener = listener;
+      return { remove: vi.fn() };
+    });
+
+    await setupSmsDetection(mockDb, USER_ID, mockRefreshDetectedSms);
+
+    expect(() =>
+      capturedListener({ senderName: "Bancolombia", timestamp: "not-a-real-date" })
+    ).not.toThrow();
+    expect(mockInsertDetectedSmsEvent).not.toHaveBeenCalled();
+    expect(mockRefreshDetectedSms).not.toHaveBeenCalled();
+  });
 });
 
 describe("setupNotificationCapture", () => {

--- a/apps/mobile/__tests__/capture-sources/repository.test.ts
+++ b/apps/mobile/__tests__/capture-sources/repository.test.ts
@@ -1,5 +1,11 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: mock db needs flexible typing
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  requireDetectedSmsEventId,
+  requireIsoDateTime,
+  requireTransactionId,
+  requireUserId,
+} from "@/shared/types/assertions";
 import type {
   DetectedSmsEventId,
   IsoDateTime,
@@ -70,6 +76,10 @@ const mockDb = {
   orderBy: mockOrderBy,
   update: mockUpdate,
 } as any;
+const USER_ID = requireUserId("user-1");
+const DETECTED_SMS_EVENT_ID = requireDetectedSmsEventId("sms-1");
+const TRANSACTION_ID = requireTransactionId("tx-123");
+const NOW = requireIsoDateTime("2026-03-07T10:00:00Z");
 
 describe("capture-sources repository", () => {
   beforeEach(() => {
@@ -163,7 +173,7 @@ describe("capture-sources repository", () => {
     mockWhere.mockResolvedValueOnce(rows);
 
     const { getNotificationSources } = await import("@/features/capture-sources/lib/repository");
-    const result = await getNotificationSources(mockDb, "user-1");
+    const result = await getNotificationSources(mockDb, USER_ID);
 
     expect(mockSelect).toHaveBeenCalled();
     expect(mockFrom).toHaveBeenCalled();
@@ -178,7 +188,7 @@ describe("capture-sources repository", () => {
     ]);
 
     const { getEnabledPackages } = await import("@/features/capture-sources/lib/repository");
-    const result = await getEnabledPackages(mockDb, "user-1");
+    const result = await getEnabledPackages(mockDb, USER_ID);
 
     expect(mockSelect).toHaveBeenCalled();
     expect(mockFrom).toHaveBeenCalled();
@@ -191,14 +201,7 @@ describe("capture-sources repository", () => {
   it("upsertNotificationSource calls db.insert with onConflictDoUpdate", async () => {
     const { upsertNotificationSource } = await import("@/features/capture-sources/lib/repository");
 
-    await upsertNotificationSource(
-      mockDb,
-      "user-1",
-      "com.bank.app",
-      "Bank App",
-      true,
-      "2026-03-07T10:00:00Z"
-    );
+    await upsertNotificationSource(mockDb, USER_ID, "com.bank.app", "Bank App", true, NOW);
 
     expect(mockInsert).toHaveBeenCalled();
     expect(mockValues).toHaveBeenCalledWith(
@@ -247,7 +250,7 @@ describe("capture-sources repository", () => {
     mockWhere.mockResolvedValueOnce([{ total: 5 }]);
 
     const { getTodaySmsEventCount } = await import("@/features/capture-sources/lib/repository");
-    const result = await getTodaySmsEventCount(mockDb, "user-1", new Date("2026-03-07T10:00:00Z"));
+    const result = await getTodaySmsEventCount(mockDb, USER_ID, new Date("2026-03-07T10:00:00Z"));
 
     expect(mockSelect).toHaveBeenCalled();
     expect(mockFrom).toHaveBeenCalled();
@@ -259,7 +262,7 @@ describe("capture-sources repository", () => {
     mockWhere.mockResolvedValueOnce([{ total: 0 }]);
 
     const { getTodaySmsEventCount } = await import("@/features/capture-sources/lib/repository");
-    const result = await getTodaySmsEventCount(mockDb, "user-1", new Date("2026-03-07T10:00:00Z"));
+    const result = await getTodaySmsEventCount(mockDb, USER_ID, new Date("2026-03-07T10:00:00Z"));
 
     expect(result).toBe(0);
   });
@@ -269,7 +272,7 @@ describe("capture-sources repository", () => {
   it("dismissSmsEvent calls db.update with correct where clause", async () => {
     const { dismissSmsEvent } = await import("@/features/capture-sources/lib/repository");
 
-    await dismissSmsEvent(mockDb, "sms-1");
+    await dismissSmsEvent(mockDb, DETECTED_SMS_EVENT_ID);
 
     expect(mockUpdate).toHaveBeenCalled();
     expect(mockSet).toHaveBeenCalledWith({ dismissed: true });
@@ -281,7 +284,7 @@ describe("capture-sources repository", () => {
   it("linkSmsEventToTransaction updates linkedTransactionId", async () => {
     const { linkSmsEventToTransaction } = await import("@/features/capture-sources/lib/repository");
 
-    await linkSmsEventToTransaction(mockDb, "sms-1", "tx-123");
+    await linkSmsEventToTransaction(mockDb, DETECTED_SMS_EVENT_ID, TRANSACTION_ID);
 
     expect(mockUpdate).toHaveBeenCalled();
     expect(mockSet).toHaveBeenCalledWith({

--- a/apps/mobile/__tests__/capture-sources/store.test.ts
+++ b/apps/mobile/__tests__/capture-sources/store.test.ts
@@ -1,6 +1,5 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: mock db needs flexible typing
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
 import {
   hydrateCaptureSources,
   refreshCaptureSourceStatus,
@@ -8,6 +7,7 @@ import {
   toggleCaptureSourcePackage,
   useCaptureSourcesStore,
 } from "@/features/capture-sources/store";
+import { requireUserId } from "@/shared/types/assertions";
 
 const mockGetEnabledPackages = vi.fn().mockResolvedValue([]);
 const mockUpsertNotificationSource = vi.fn();
@@ -27,7 +27,7 @@ vi.mock("@/shared/lib/generate-id", () => ({
 }));
 
 const mockDb = {} as any;
-const USER_ID = "user-1";
+const USER_ID = requireUserId("user-1");
 
 describe("useCaptureSourcesStore", () => {
   beforeEach(() => {

--- a/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
@@ -1,6 +1,7 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: mock db needs flexible typing
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RawEmail } from "@/features/email-capture/schema";
+import { requireUserId } from "@/shared/types/assertions";
 
 const mockGetProcessedExternalIds = vi.fn().mockResolvedValue(new Set<string>());
 const mockInsertProcessedEmail = vi.fn();
@@ -62,7 +63,7 @@ vi.mock("@/shared/lib/generate-id", () => ({
 }));
 
 const mockDb = {} as any;
-const USER_ID = "user-1";
+const USER_ID = requireUserId("user-1");
 
 let processEmails: typeof import("@/features/email-capture/services/email-pipeline").processEmails;
 let processRetries: typeof import("@/features/email-capture/services/email-pipeline").processRetries;

--- a/apps/mobile/__tests__/email-capture/merchant-rules.test.ts
+++ b/apps/mobile/__tests__/email-capture/merchant-rules.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { requireCategoryId, requireIsoDateTime, requireUserId } from "@/shared/types/assertions";
 
 import {
   insertMerchantRule,
@@ -36,18 +37,22 @@ const mockDb = {
 } as any;
 
 describe("merchant-rules", () => {
+  const UserId = requireUserId("user1");
+  const CategoryId = requireCategoryId("food");
+  const Now = requireIsoDateTime("2026-03-07T10:00:00Z");
+
   beforeEach(() => vi.clearAllMocks());
 
   describe("lookupMerchantRule", () => {
     it("returns categoryId when found", async () => {
       mockWhere.mockResolvedValue([{ categoryId: "food" }]);
-      const result = await lookupMerchantRule(mockDb, "user1", "restaurant");
+      const result = await lookupMerchantRule(mockDb, UserId, "restaurant");
       expect(result).toBe("food");
     });
 
     it("returns null when not found", async () => {
       mockWhere.mockResolvedValue([]);
-      const result = await lookupMerchantRule(mockDb, "user1", "unknown");
+      const result = await lookupMerchantRule(mockDb, UserId, "unknown");
       expect(result).toBeNull();
     });
   });
@@ -55,7 +60,7 @@ describe("merchant-rules", () => {
   describe("insertMerchantRule", () => {
     it("calls insert with correct values", async () => {
       mockOnConflictDoUpdate.mockResolvedValue(undefined);
-      await insertMerchantRule(mockDb, "user1", "restaurant", "food", "2026-03-07T10:00:00Z");
+      await insertMerchantRule(mockDb, UserId, "restaurant", CategoryId, Now);
       expect(mockDb.insert).toHaveBeenCalled();
     });
   });

--- a/apps/mobile/__tests__/email-capture/retry-integration.test.ts
+++ b/apps/mobile/__tests__/email-capture/retry-integration.test.ts
@@ -23,6 +23,7 @@ import {
 } from "@/features/email-capture/lib/repository";
 import { processRetries } from "@/features/email-capture/services/email-pipeline";
 import { processedEmails, syncQueue, transactions } from "@/shared/db/schema";
+import { requireUserId } from "@/shared/types/assertions";
 import type { IsoDateTime, ProcessedEmailId, TransactionId } from "@/shared/types/branded";
 
 const mockParseEmailApi = vi.fn();
@@ -43,6 +44,7 @@ vi.mock("@/features/capture-sources/lib/dedup", () => ({
 
 let sqlite: InstanceType<typeof Database>;
 let db: ReturnType<typeof drizzle>;
+const USER_ID = requireUserId("user-1");
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -189,7 +191,7 @@ describe("retry queue integration (real SQLite)", () => {
       confidence: 0.9,
     });
 
-    const result = await processRetries(db as any, "user-1");
+    const result = await processRetries(db as any, USER_ID);
 
     expect(result.succeeded).toBe(1);
     expect(result.retried).toBe(0);
@@ -225,7 +227,7 @@ describe("retry queue integration (real SQLite)", () => {
 
     mockParseEmailApi.mockRejectedValueOnce(new Error("Edge Function timeout"));
 
-    const result = await processRetries(db as any, "user-1");
+    const result = await processRetries(db as any, USER_ID);
 
     expect(result.retried).toBe(1);
     expect(result.succeeded).toBe(0);
@@ -250,7 +252,7 @@ describe("retry queue integration (real SQLite)", () => {
 
     mockParseEmailApi.mockRejectedValueOnce(new Error("Edge Function timeout"));
 
-    const result = await processRetries(db as any, "user-1");
+    const result = await processRetries(db as any, USER_ID);
 
     expect(result.permanentlyFailed).toBe(1);
 

--- a/apps/mobile/__tests__/error-handling/pipeline-save-error.test.ts
+++ b/apps/mobile/__tests__/error-handling/pipeline-save-error.test.ts
@@ -1,8 +1,8 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: mock db needs flexible typing
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RawEmail } from "@/features/email-capture/schema";
-
 import { processEmails } from "@/features/email-capture/services/email-pipeline";
+import { requireUserId } from "@/shared/types/assertions";
 
 const mockCaptureError = vi.fn();
 
@@ -56,7 +56,7 @@ vi.mock("@/shared/lib/generate-id", () => ({
 }));
 
 const mockDb = {} as any;
-const USER_ID = "user-1";
+const USER_ID = requireUserId("user-1");
 
 function makeRawEmail(overrides: Partial<RawEmail> = {}): RawEmail {
   return {

--- a/apps/mobile/__tests__/lib/format-date.test.ts
+++ b/apps/mobile/__tests__/lib/format-date.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { formatDateDisplay, parseIsoDate, toIsoDate } from "@/shared/lib/format-date";
+import {
+  formatDateDisplay,
+  parseIsoDate,
+  parseOptionalIsoDate,
+  toIsoDate,
+} from "@/shared/lib/format-date";
 import type { IsoDate } from "@/shared/types/branded";
 
 describe("formatDateDisplay", () => {
@@ -39,5 +44,22 @@ describe("parseIsoDate", () => {
   it("roundtrips with toIsoDate", () => {
     const iso = "2026-01-15" as IsoDate;
     expect(toIsoDate(parseIsoDate(iso))).toBe(iso);
+  });
+});
+
+describe("parseOptionalIsoDate", () => {
+  it("returns null for absent values", () => {
+    expect(parseOptionalIsoDate(null)).toBeNull();
+    expect(parseOptionalIsoDate(undefined)).toBeNull();
+  });
+
+  it("parses present ISO dates", () => {
+    expect(toIsoDate(parseOptionalIsoDate("2026-04-09") ?? new Date())).toBe("2026-04-09");
+  });
+
+  it("rejects invalid optional ISO dates", () => {
+    expect(() => parseOptionalIsoDate("2026-02-30")).toThrow(
+      "date must be a valid ISO calendar date"
+    );
   });
 });

--- a/apps/mobile/__tests__/search/repository.test.ts
+++ b/apps/mobile/__tests__/search/repository.test.ts
@@ -1,5 +1,6 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: mock db needs flexible typing
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { requireUserId } from "@/shared/types/assertions";
 import type { SearchFilters } from "../../features/search/lib/types";
 import { EMPTY_FILTERS } from "../../features/search/lib/types";
 
@@ -16,6 +17,7 @@ const mockOffset = vi.fn().mockReturnThis();
 const mockDb = {
   select: mockSelect,
 } as any;
+const USER_ID = requireUserId("user-1");
 
 const withFilters = (overrides: Partial<SearchFilters>): SearchFilters => ({
   ...EMPTY_FILTERS,
@@ -42,7 +44,7 @@ describe("search repository", () => {
   it("searchTransactionsPaginated calls db with limit+1 for hasMore detection", async () => {
     const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
 
-    searchTransactionsPaginated(mockDb, "user-1", EMPTY_FILTERS, 30, 0);
+    searchTransactionsPaginated(mockDb, USER_ID, EMPTY_FILTERS, 30, 0);
 
     expect(mockSelect).toHaveBeenCalled();
     expect(mockFrom).toHaveBeenCalled();
@@ -56,7 +58,7 @@ describe("search repository", () => {
   it("searchTransactionsPaginated passes correct offset", async () => {
     const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
 
-    searchTransactionsPaginated(mockDb, "user-1", EMPTY_FILTERS, 30, 60);
+    searchTransactionsPaginated(mockDb, USER_ID, EMPTY_FILTERS, 30, 60);
 
     expect(mockOffset).toHaveBeenCalledWith(60);
   });
@@ -66,7 +68,7 @@ describe("search repository", () => {
 
     const { searchTransactionsAggregate } = await import("../../features/search/lib/repository");
 
-    const result = searchTransactionsAggregate(mockDb, "user-1", EMPTY_FILTERS);
+    const result = searchTransactionsAggregate(mockDb, USER_ID, EMPTY_FILTERS);
 
     expect(result).toEqual({ count: 5, total: 15000 });
   });
@@ -76,7 +78,7 @@ describe("search repository", () => {
 
     const { searchTransactionsAggregate } = await import("../../features/search/lib/repository");
 
-    const result = searchTransactionsAggregate(mockDb, "user-1", EMPTY_FILTERS);
+    const result = searchTransactionsAggregate(mockDb, USER_ID, EMPTY_FILTERS);
 
     expect(result).toEqual({ count: 0, total: 0 });
   });
@@ -84,7 +86,7 @@ describe("search repository", () => {
   it("applies query filter via LIKE when query is non-empty", async () => {
     const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
 
-    searchTransactionsPaginated(mockDb, "user-1", withFilters({ query: "coffee" }), 30, 0);
+    searchTransactionsPaginated(mockDb, USER_ID, withFilters({ query: "coffee" }), 30, 0);
 
     expect(mockWhere).toHaveBeenCalled();
   });
@@ -92,7 +94,7 @@ describe("search repository", () => {
   it("does not apply LIKE filter when query is empty", async () => {
     const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
 
-    searchTransactionsPaginated(mockDb, "user-1", EMPTY_FILTERS, 30, 0);
+    searchTransactionsPaginated(mockDb, USER_ID, EMPTY_FILTERS, 30, 0);
 
     expect(mockWhere).toHaveBeenCalled();
   });
@@ -102,7 +104,7 @@ describe("search repository", () => {
 
     searchTransactionsPaginated(
       mockDb,
-      "user-1",
+      USER_ID,
       withFilters({ categoryIds: ["food", "transport"] }),
       30,
       0
@@ -116,7 +118,7 @@ describe("search repository", () => {
 
     searchTransactionsPaginated(
       mockDb,
-      "user-1",
+      USER_ID,
       withFilters({ dateFrom: "2026-03-01", dateTo: "2026-03-31" }),
       30,
       0
@@ -130,7 +132,7 @@ describe("search repository", () => {
 
     searchTransactionsPaginated(
       mockDb,
-      "user-1",
+      USER_ID,
       withFilters({ amountMin: 100, amountMax: 5000 }),
       30,
       0
@@ -142,7 +144,7 @@ describe("search repository", () => {
   it("applies type filter when not all", async () => {
     const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
 
-    searchTransactionsPaginated(mockDb, "user-1", withFilters({ type: "expense" }), 30, 0);
+    searchTransactionsPaginated(mockDb, USER_ID, withFilters({ type: "expense" }), 30, 0);
 
     expect(mockWhere).toHaveBeenCalled();
   });
@@ -150,7 +152,7 @@ describe("search repository", () => {
   it("does not apply type filter when type is all", async () => {
     const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
 
-    searchTransactionsPaginated(mockDb, "user-1", withFilters({ type: "all" }), 30, 0);
+    searchTransactionsPaginated(mockDb, USER_ID, withFilters({ type: "all" }), 30, 0);
 
     expect(mockWhere).toHaveBeenCalled();
   });
@@ -164,13 +166,7 @@ describe("search repository", () => {
 
     const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
 
-    const result = searchTransactionsPaginated(
-      mockDb,
-      "user-1",
-      withFilters({ query: "o" }),
-      30,
-      0
-    );
+    const result = searchTransactionsPaginated(mockDb, USER_ID, withFilters({ query: "o" }), 30, 0);
 
     expect(result).toEqual(mockRows);
   });

--- a/apps/mobile/__tests__/search/store.test.ts
+++ b/apps/mobile/__tests__/search/store.test.ts
@@ -7,6 +7,7 @@ import {
   updateSearchQuery,
   useSearchStore,
 } from "@/features/search/store";
+import { requireUserId } from "@/shared/types/assertions";
 
 const mockSearchTransactionsPaginated = vi.fn();
 const mockSearchTransactionsAggregate = vi.fn();
@@ -25,7 +26,7 @@ vi.mock("@/features/transactions", () => ({
 }));
 
 const mockDb = {} as any;
-const USER_ID = "user-1";
+const USER_ID = requireUserId("user-1");
 
 const makeRow = (id: string) => ({
   id,

--- a/apps/mobile/__tests__/transactions/categories.test.ts
+++ b/apps/mobile/__tests__/transactions/categories.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { getBuiltInCategoryId } from "@/features/transactions";
 import {
   CATEGORIES,
   CATEGORY_IDS,
   DEFAULT_CATEGORY_IDS,
   isValidCategoryId,
-} from "../../features/transactions/lib/categories";
+} from "@/features/transactions/lib/categories";
 
 describe("categories", () => {
   it("exports exactly 10 categories", () => {
@@ -68,5 +69,16 @@ describe("categories", () => {
     for (const id of CATEGORY_IDS) {
       expect(DEFAULT_CATEGORY_IDS.has(id)).toBe(true);
     }
+  });
+});
+
+describe("getBuiltInCategoryId", () => {
+  it("returns the branded id for known built-in categories", () => {
+    expect(getBuiltInCategoryId("services")).toBe("services");
+    expect(getBuiltInCategoryId("other")).toBe("other");
+  });
+
+  it("throws for unknown built-in category keys", () => {
+    expect(() => getBuiltInCategoryId("missing")).toThrow("Unknown built-in category: missing");
   });
 });

--- a/apps/mobile/app/(auth)/onboarding.tsx
+++ b/apps/mobile/app/(auth)/onboarding.tsx
@@ -2,7 +2,7 @@ import { useMigrations } from "drizzle-orm/expo-sqlite/migrator";
 import * as SplashScreen from "expo-splash-screen";
 import { useState } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { useAuthStore } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth";
 import { useBudgetStore } from "@/features/budget";
 import { useEmailCaptureStore } from "@/features/email-capture";
 import {
@@ -20,13 +20,11 @@ import { StyleSheet, View } from "@/shared/components/rn";
 import { getDb } from "@/shared/db";
 import { useSubscription, useThemeColor } from "@/shared/hooks";
 import { captureError } from "@/shared/lib";
-import type { UserId } from "@/shared/types/branded";
 import migrations from "../../drizzle/migrations";
 
 export default function OnboardingScreen() {
   const insets = useSafeAreaInsets();
-  const session = useAuthStore((s) => s.session);
-  const userId = session?.user.id ?? null;
+  const userId = useOptionalUserId();
   const step = useOnboardingStore((s) => s.step);
   const pageBg = useThemeColor("page");
 
@@ -42,8 +40,8 @@ export default function OnboardingScreen() {
     () => {
       if (!db || !userId) return;
       useEmailCaptureStore.getState().initStore(db, userId);
-      useTransactionStore.getState().initStore(db, userId as UserId);
-      useBudgetStore.getState().initStore(db, userId as UserId);
+      useTransactionStore.getState().initStore(db, userId);
+      useBudgetStore.getState().initStore(db, userId);
       Promise.all([
         useEmailCaptureStore.getState().loadAccounts(),
         useTransactionStore.getState().loadInitialPage(),

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -22,7 +22,7 @@ import {
   subscribeAnalyticsToTransactions,
   useAnalyticsStore,
 } from "@/features/analytics";
-import { useAuthStore } from "@/features/auth";
+import { useAuthStore, useOptionalUserId } from "@/features/auth";
 import { registerBackgroundTask } from "@/features/background-fetch";
 import { useBudgetStore } from "@/features/budget";
 import {
@@ -196,7 +196,7 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
 function RootLayout() {
   const session = useAuthStore((s) => s.session);
   const isAuthLoading = useAuthStore((s) => s.isLoading);
-  const userId = session?.user.id ?? null;
+  const userId = useOptionalUserId();
   const router = useRouter();
   const segments = useSegments();
   const colorScheme = useColorScheme();
@@ -413,9 +413,7 @@ function RootLayout() {
               }}
             />
           </Stack>
-          {db && userId && onboardingComplete && (
-            <AuthenticatedShell db={db} userId={userId as UserId} />
-          )}
+          {db && userId && onboardingComplete && <AuthenticatedShell db={db} userId={userId} />}
         </QueryProvider>
       </SentryErrorBoundary>
       <StatusBar style="auto" />

--- a/apps/mobile/app/add-bill.tsx
+++ b/apps/mobile/app/add-bill.tsx
@@ -2,7 +2,7 @@ import DateTimePicker from "@react-native-community/datetimepicker";
 import { useMigrations } from "drizzle-orm/expo-sqlite/migrator";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useRef, useState } from "react";
-import { useAuthStore } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth";
 import {
   addBill,
   type Bill,
@@ -11,7 +11,12 @@ import {
   updateBill,
   useCalendarStore,
 } from "@/features/calendar";
-import { CATEGORIES, type CategoryId, isValidCategoryId } from "@/features/transactions";
+import {
+  CATEGORIES,
+  type CategoryId,
+  getBuiltInCategoryId,
+  isValidCategoryId,
+} from "@/features/transactions";
 import {
   Keyboard,
   KeyboardAvoidingView,
@@ -27,8 +32,11 @@ import { getDb } from "@/shared/db";
 import { useAsyncGuard, useThemeColor, useTranslation } from "@/shared/hooks";
 import { getCategoryLabel } from "@/shared/i18n";
 import { parseDigitsToAmount } from "@/shared/lib";
+import { requireBillId } from "@/shared/types/assertions";
 import type { BillId, UserId } from "@/shared/types/branded";
 import migrations from "../drizzle/migrations";
+
+const DEFAULT_BILL_CATEGORY_ID = getBuiltInCategoryId("services");
 
 function AddBillForm({
   existingBill,
@@ -63,7 +71,7 @@ function AddBillForm({
   const [category, setCategory] = useState<CategoryId>(
     existingBill?.categoryId && isValidCategoryId(existingBill.categoryId)
       ? existingBill.categoryId
-      : ("services" as CategoryId)
+      : DEFAULT_BILL_CATEGORY_ID
   );
   const [startDate, setStartDate] = useState(existingBill?.startDate ?? new Date());
 
@@ -87,7 +95,7 @@ function AddBillForm({
       if (existingBill) {
         const amountValue = parseDigitsToAmount(amount);
         if (amountValue <= 0) return;
-        const success = await onUpdateBill(existingBill.id as BillId, {
+        const success = await onUpdateBill(requireBillId(existingBill.id), {
           name: trimmedName,
           amount: amountValue,
           frequency,
@@ -281,7 +289,7 @@ export default function AddBillScreen() {
   const router = useRouter();
   const { billId } = useLocalSearchParams<{ billId?: string }>();
   const bills = useCalendarStore((s) => s.bills);
-  const userId = useAuthStore((s) => s.session?.user.id ?? null) as UserId | null;
+  const userId = useOptionalUserId();
   const existingBill = billId ? bills.find((b) => b.id === billId) : undefined;
   const handleDone = () => router.back();
 

--- a/apps/mobile/app/bills-calendar.tsx
+++ b/apps/mobile/app/bills-calendar.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "expo-router";
 import { useCallback } from "react";
-import { useAuthStore } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth";
 import {
   CalendarGrid,
   MonthNavigator,
@@ -13,7 +13,6 @@ import { View } from "@/shared/components/rn";
 import { getDb } from "@/shared/db";
 import { useTranslation } from "@/shared/hooks";
 import { captureError } from "@/shared/lib";
-import type { UserId } from "@/shared/types/branded";
 
 export default function BillsCalendarScreen() {
   const router = useRouter();
@@ -21,7 +20,7 @@ export default function BillsCalendarScreen() {
   const currentMonth = useCalendarStore((s) => s.currentMonth);
   const bills = useCalendarStore((s) => s.bills);
   const payments = useCalendarStore((s) => s.payments);
-  const userId = useAuthStore((s) => s.session?.user.id ?? null) as UserId | null;
+  const userId = useOptionalUserId();
 
   const handleNextMonth = useCallback(() => {
     if (!userId) return;

--- a/apps/mobile/app/create-budget.tsx
+++ b/apps/mobile/app/create-budget.tsx
@@ -36,10 +36,10 @@ function CreateBudgetForm({
   const { t, locale } = useTranslation();
   const isEdit = Boolean(existingBudget);
 
-  const [category, setCategory] = useState<CategoryId>(
+  const [category, setCategory] = useState<CategoryId | null>(
     existingBudget?.categoryId && isValidCategoryId(existingBudget.categoryId)
       ? existingBudget.categoryId
-      : ("" as CategoryId)
+      : null
   );
   // digits = raw whole-peso string (e.g. "18900" for $18.900 COP)
   const [digits, setDigits] = useState(existingBudget ? String(existingBudget.amount) : "");

--- a/apps/mobile/app/day-detail.tsx
+++ b/apps/mobile/app/day-detail.tsx
@@ -1,6 +1,6 @@
 import { format } from "date-fns";
 import { useLocalSearchParams, useRouter } from "expo-router";
-import { useAuthStore } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth";
 import {
   type BillPayment,
   deleteBill,
@@ -15,7 +15,8 @@ import { getDb } from "@/shared/db";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { getDateFnsLocale } from "@/shared/i18n";
 import { captureError, formatMoney, toIsoDate } from "@/shared/lib";
-import type { BillId, CopAmount, UserId } from "@/shared/types/branded";
+import { requireBillId } from "@/shared/types/assertions";
+import type { BillId, CopAmount } from "@/shared/types/branded";
 
 export default function DayDetailScreen() {
   const { date } = useLocalSearchParams<{ date: string }>();
@@ -23,7 +24,7 @@ export default function DayDetailScreen() {
   const { t, locale } = useTranslation();
   const bills = useCalendarStore((s) => s.bills);
   const payments = useCalendarStore((s) => s.payments);
-  const userId = useAuthStore((s) => s.session?.user.id ?? null) as UserId | null;
+  const userId = useOptionalUserId();
 
   const primaryColor = useThemeColor("primary");
   const secondaryColor = useThemeColor("secondary");
@@ -88,10 +89,11 @@ export default function DayDetailScreen() {
       ) : (
         <View style={styles.billList}>
           {billsForDate.map((bill) => {
-            const paid = isPaymentPaid(bill.id);
+            const billId = requireBillId(bill.id);
+            const paid = isPaymentPaid(billId);
             return (
               <View
-                key={bill.id}
+                key={billId}
                 style={[
                   styles.billRow,
                   {
@@ -113,7 +115,7 @@ export default function DayDetailScreen() {
                   <Pressable
                     style={[styles.actionButton, { backgroundColor: paid ? accentGreen : peachBg }]}
                     onPress={() => {
-                      void handleTogglePaid(bill.id as BillId);
+                      void handleTogglePaid(billId);
                     }}
                     hitSlop={8}
                   >
@@ -122,7 +124,7 @@ export default function DayDetailScreen() {
 
                   <Pressable
                     style={[styles.actionButton, { backgroundColor: peachBg }]}
-                    onPress={() => handleEdit(bill.id)}
+                    onPress={() => handleEdit(billId)}
                     hitSlop={8}
                   >
                     <Pencil size={16} color={primaryColor} />
@@ -130,7 +132,7 @@ export default function DayDetailScreen() {
 
                   <Pressable
                     style={[styles.actionButton, { backgroundColor: peachBg }]}
-                    onPress={() => handleDelete(bill.id as BillId, bill.name)}
+                    onPress={() => handleDelete(billId, bill.name)}
                     hitSlop={8}
                   >
                     <Trash2 size={16} color={accentRed} />

--- a/apps/mobile/app/edit-transaction.tsx
+++ b/apps/mobile/app/edit-transaction.tsx
@@ -30,8 +30,8 @@ export default function EditTransactionScreen() {
   const [date, setDate] = useState(new Date());
   const [loaded, setLoaded] = useState(false);
   const transactionId =
-    typeof routeTransactionId === "string" && routeTransactionId.length > 0
-      ? requireTransactionId(routeTransactionId)
+    typeof routeTransactionId === "string" && routeTransactionId.trim().length > 0
+      ? requireTransactionId(routeTransactionId.trim())
       : null;
 
   useMountEffect(() => {

--- a/apps/mobile/app/edit-transaction.tsx
+++ b/apps/mobile/app/edit-transaction.tsx
@@ -6,7 +6,8 @@ import { TransactionForm, useTransactionStore } from "@/features/transactions";
 import { InteractionManager } from "@/shared/components/rn";
 import { useAsyncGuard, useMountEffect, useTranslation } from "@/shared/hooks";
 import { showErrorToast } from "@/shared/lib";
-import type { CategoryId, TransactionId } from "@/shared/types/branded";
+import { requireTransactionId } from "@/shared/types/assertions";
+import type { CategoryId } from "@/shared/types/branded";
 
 const afterDismiss = () =>
   new Promise<void>((resolve) => {
@@ -14,7 +15,7 @@ const afterDismiss = () =>
   });
 
 export default function EditTransactionScreen() {
-  const { transactionId } = useLocalSearchParams<{ transactionId: string }>();
+  const { transactionId: routeTransactionId } = useLocalSearchParams<{ transactionId?: string }>();
   const router = useRouter();
   const { t } = useTranslation();
 
@@ -28,9 +29,18 @@ export default function EditTransactionScreen() {
   const [description, setDescription] = useState("");
   const [date, setDate] = useState(new Date());
   const [loaded, setLoaded] = useState(false);
+  const transactionId =
+    typeof routeTransactionId === "string" && routeTransactionId.length > 0
+      ? requireTransactionId(routeTransactionId)
+      : null;
 
   useMountEffect(() => {
-    const tx = getTransactionById(transactionId as TransactionId);
+    if (transactionId == null) {
+      router.back();
+      return;
+    }
+
+    const tx = getTransactionById(transactionId);
     if (tx) {
       setType(tx.type);
       setDigits(String(tx.amount));
@@ -47,11 +57,12 @@ export default function EditTransactionScreen() {
 
   const handleSave = () => {
     void guardedSave(async () => {
+      if (transactionId == null) return;
       void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       router.back();
       await afterDismiss();
       try {
-        const result = await updateTransactionDirect(transactionId as TransactionId, {
+        const result = await updateTransactionDirect(transactionId, {
           type,
           digits,
           categoryId,
@@ -69,11 +80,12 @@ export default function EditTransactionScreen() {
 
   const handleDelete = () => {
     void guardedSave(async () => {
+      if (transactionId == null) return;
       void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       router.back();
       await afterDismiss();
       try {
-        await deleteTransaction(transactionId as TransactionId);
+        await deleteTransaction(transactionId);
       } catch {
         showErrorToast(t("transactions.deleteFailed"));
       }

--- a/apps/mobile/app/enable-notifications.tsx
+++ b/apps/mobile/app/enable-notifications.tsx
@@ -2,18 +2,17 @@ import * as Notifications from "expo-notifications";
 import { useRouter } from "expo-router";
 import * as SecureStore from "expo-secure-store";
 import { useState } from "react";
-import { useAuthStore } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth";
 import { PRE_PERMISSION_KEY, registerPushToken } from "@/features/notifications";
 import { Bell } from "@/shared/components/icons";
 import { ActivityIndicator, Pressable, ScrollView, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { captureError } from "@/shared/lib";
-import type { UserId } from "@/shared/types/branded";
 
 export default function EnableNotificationsSheet() {
   const { t } = useTranslation();
   const router = useRouter();
-  const userId = useAuthStore((s) => s.session?.user.id);
+  const userId = useOptionalUserId();
   const accentGreen = useThemeColor("accentGreen");
   const borderColor = useThemeColor("borderSubtle");
   const [isRequesting, setIsRequesting] = useState(false);
@@ -28,7 +27,7 @@ export default function EnableNotificationsSheet() {
       });
 
     if (status === "granted" && userId) {
-      await registerPushToken(userId as UserId).catch(captureError);
+      await registerPushToken(userId).catch(captureError);
     }
 
     // Mark pre-permission as seen regardless of outcome.

--- a/apps/mobile/eslint.config.js
+++ b/apps/mobile/eslint.config.js
@@ -273,6 +273,35 @@ module.exports = defineConfig([
     },
   },
 
+  // ── UI branded-boundary assertions ─────────────────────────────────
+  {
+    files: [
+      "app/**/*.tsx",
+      "features/**/components/**/*.tsx",
+      "shared/components/**/*.tsx",
+      "features/**/hooks/**/*.ts",
+      "features/**/hooks/**/*.tsx",
+      "features/**/store.ts",
+    ],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "TSAsExpression > TSTypeReference[typeName.name=/^(UserId|TransactionId|BudgetId|BillId|CategoryId|IsoDate|IsoDateTime)$/]",
+          message:
+            "UI code must not assert branded IDs or dates directly. Move the proof into a boundary helper such as useOptionalUserId(), requireTransactionId(), getBuiltInCategoryId(), parseOptionalIsoDate(), or a feature row mapper.",
+        },
+        {
+          selector:
+            "TSAsExpression > TSUnionType > TSTypeReference[typeName.name=/^(UserId|TransactionId|BudgetId|BillId|CategoryId|IsoDate|IsoDateTime)$/]",
+          message:
+            "UI code must not assert branded IDs or dates directly. Move the proof into a boundary helper such as useOptionalUserId(), requireTransactionId(), getBuiltInCategoryId(), parseOptionalIsoDate(), or a feature row mapper.",
+        },
+      ],
+    },
+  },
+
   // ── Test file overrides ─────────────────────────────────────────────
   {
     files: ["__tests__/**/*.ts", "__tests__/**/*.tsx"],

--- a/apps/mobile/features/ai-chat/data/user-memories.ts
+++ b/apps/mobile/features/ai-chat/data/user-memories.ts
@@ -1,37 +1,42 @@
+import { z } from "zod";
 import { getSupabase } from "@/shared/db";
-import type { IsoDateTime, UserId, UserMemoryId } from "@/shared/types/branded";
-import type { MemoryCategory, UserMemory } from "../schema";
+import { requireIsoDateTime, requireUserId, requireUserMemoryId } from "@/shared/types/assertions";
+import type { UserId, UserMemoryId } from "@/shared/types/branded";
+import { memoryCategory, type UserMemory } from "../schema";
 
-type UserMemoryRow = {
-  readonly id: string;
+const userMemoryRowSchema = z.object({
+  id: z.string().min(1),
   // biome-ignore lint/style/useNamingConvention: Supabase column name
-  readonly user_id: string;
-  readonly fact: string;
-  readonly category: string;
+  user_id: z.string().min(1),
+  fact: z.string(),
+  category: memoryCategory,
   // biome-ignore lint/style/useNamingConvention: Supabase column name
-  readonly created_at: string;
+  created_at: z.string(),
   // biome-ignore lint/style/useNamingConvention: Supabase column name
-  readonly updated_at: string | null;
-};
+  updated_at: z.string().nullable(),
+});
+
+type UserMemoryRow = z.infer<typeof userMemoryRowSchema>;
+const userMemoryRowsSchema = z.array(userMemoryRowSchema);
 
 type ConversationMessage = {
   readonly role: "user" | "assistant";
   readonly content: string;
 };
 
-type ExtractMemoriesResponse = {
-  readonly success: boolean;
-  readonly data: readonly UserMemoryRow[];
-};
+const extractMemoriesResponseSchema = z.object({
+  success: z.literal(true),
+  data: userMemoryRowsSchema,
+});
 
 export function toUserMemory(row: UserMemoryRow): UserMemory {
   return {
-    id: row.id as UserMemoryId,
-    userId: row.user_id as UserId,
+    id: requireUserMemoryId(row.id),
+    userId: requireUserId(row.user_id),
     fact: row.fact,
-    category: row.category as MemoryCategory,
-    createdAt: row.created_at as IsoDateTime,
-    updatedAt: (row.updated_at ?? row.created_at) as IsoDateTime,
+    category: row.category,
+    createdAt: requireIsoDateTime(row.created_at),
+    updatedAt: requireIsoDateTime(row.updated_at ?? row.created_at),
   };
 }
 
@@ -47,7 +52,7 @@ export async function listUserMemories(userId: UserId): Promise<readonly UserMem
     throw new Error(error.message);
   }
 
-  return (data as UserMemoryRow[] | null)?.map(toUserMemory) ?? [];
+  return userMemoryRowsSchema.parse(data ?? []).map(toUserMemory);
 }
 
 export async function softDeleteUserMemory(id: UserMemoryId): Promise<void> {
@@ -65,18 +70,16 @@ export async function softDeleteUserMemory(id: UserMemoryId): Promise<void> {
 export async function extractMemoriesFromConversation(
   messages: readonly ConversationMessage[]
 ): Promise<readonly UserMemory[]> {
-  const result = (await getSupabase().functions.invoke("ai-chat", {
+  const { data, error } = await getSupabase().functions.invoke("ai-chat", {
     body: { mode: "extract_memories", messages },
-  })) as {
-    readonly data: ExtractMemoriesResponse | null;
-    readonly error: Error | null;
-  };
+  });
 
-  if (result.error != null) {
-    throw result.error;
+  if (error != null) {
+    throw error;
   }
 
-  if (!result.data?.success || !Array.isArray(result.data.data)) {
+  const result = extractMemoriesResponseSchema.safeParse(data);
+  if (!result.success) {
     throw new Error("extract_memories_failed");
   }
 

--- a/apps/mobile/features/ai-chat/hooks/use-user-memories.ts
+++ b/apps/mobile/features/ai-chat/hooks/use-user-memories.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useAuthStore } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth";
 import type { UserId, UserMemoryId } from "@/shared/types/branded";
 import {
   extractMemoriesFromConversation,
@@ -15,18 +15,23 @@ export function userMemoriesQueryKey(userId: UserId) {
 }
 
 export function useUserMemoriesQuery() {
-  const userId = useAuthStore((state) => state.session?.user.id as UserId | undefined);
+  const userId = useOptionalUserId() ?? undefined;
 
   return useQuery({
     queryKey: userId ? userMemoriesQueryKey(userId) : (["user-memories", "anonymous"] as const),
-    queryFn: () => listUserMemories(userId as UserId),
+    queryFn: () => {
+      if (!userId) {
+        throw new Error("missing_user");
+      }
+      return listUserMemories(userId);
+    },
     enabled: userId != null,
   });
 }
 
 export function useDeleteUserMemoryMutation() {
   const queryClient = useQueryClient();
-  const userId = useAuthStore((state) => state.session?.user.id as UserId | undefined);
+  const userId = useOptionalUserId() ?? undefined;
 
   return useMutation({
     mutationFn: (id: UserMemoryId) => softDeleteUserMemory(id),
@@ -58,7 +63,7 @@ export function useDeleteUserMemoryMutation() {
 
 export function useExtractUserMemoriesMutation() {
   const queryClient = useQueryClient();
-  const userId = useAuthStore((state) => state.session?.user.id as UserId | undefined);
+  const userId = useOptionalUserId() ?? undefined;
 
   return useMutation({
     mutationFn: (messages: readonly ConversationMessage[]) =>

--- a/apps/mobile/features/analytics/components/AnalyticsScreen.tsx
+++ b/apps/mobile/features/analytics/components/AnalyticsScreen.tsx
@@ -1,11 +1,10 @@
 import { memo, useCallback } from "react";
-import { useAuthStore } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth";
 import type { ViewStyle } from "@/shared/components/rn";
 import { Pressable, ScrollView, StyleSheet, Text, View } from "@/shared/components/rn";
 import { getDb } from "@/shared/db";
 import { useMountEffect, useThemeColor, useTranslation } from "@/shared/hooks";
 import { captureError } from "@/shared/lib";
-import type { UserId } from "@/shared/types/branded";
 import type { AnalyticsPeriod } from "../lib/derive";
 import { loadAnalyticsForUser, selectAnalyticsPeriod, useAnalyticsStore } from "../store";
 import { CategoryBreakdownCard } from "./CategoryBreakdownCard";
@@ -61,7 +60,7 @@ export function AnalyticsScreen() {
   const categoryBreakdown = useAnalyticsStore((s) => s.categoryBreakdown);
   const periodDelta = useAnalyticsStore((s) => s.periodDelta);
   const isLoading = useAnalyticsStore((s) => s.isLoading);
-  const userId = useAuthStore((s) => s.session?.user.id ?? null) as UserId | null;
+  const userId = useOptionalUserId();
 
   // Load data on mount if boot-time load failed or hasn't completed
   useMountEffect(() => {

--- a/apps/mobile/features/auth/index.ts
+++ b/apps/mobile/features/auth/index.ts
@@ -2,4 +2,5 @@ export { AppleIcon } from "./components/icons/AppleIcon";
 export { GoogleIcon } from "./components/icons/GoogleIcon";
 export { MicrosoftIcon } from "./components/icons/MicrosoftIcon";
 export { OAuthButton } from "./components/OAuthButton";
+export { useAccountCreatedAt, useOptionalUserId } from "./public";
 export { useAuthStore } from "./store";

--- a/apps/mobile/features/auth/public.ts
+++ b/apps/mobile/features/auth/public.ts
@@ -1,3 +1,9 @@
+import { requireUserId } from "@/shared/types/assertions";
 import { useAuthStore } from "./store";
 
 export const useAccountCreatedAt = () => useAuthStore((s) => s.session?.user.created_at ?? "");
+
+export const useOptionalUserId = () => {
+  const userId = useAuthStore((s) => s.session?.user.id ?? null);
+  return userId == null ? null : requireUserId(userId);
+};

--- a/apps/mobile/features/calendar/data/mock-bills.ts
+++ b/apps/mobile/features/calendar/data/mock-bills.ts
@@ -1,5 +1,7 @@
-import type { CategoryId } from "@/shared/types/branded";
+import { getBuiltInCategoryId } from "@/features/transactions";
 import type { Bill } from "../schema";
+
+const SERVICES_CATEGORY_ID = getBuiltInCategoryId("services");
 
 export const MOCK_BILLS: Bill[] = [
   {
@@ -7,7 +9,7 @@ export const MOCK_BILLS: Bill[] = [
     name: "Netflix",
     amount: 17900,
     frequency: "monthly",
-    categoryId: "services" as CategoryId,
+    categoryId: SERVICES_CATEGORY_ID,
     startDate: new Date(2025, 0, 15),
     isActive: true,
   },
@@ -16,7 +18,7 @@ export const MOCK_BILLS: Bill[] = [
     name: "Spotify",
     amount: 15900,
     frequency: "monthly",
-    categoryId: "services" as CategoryId,
+    categoryId: SERVICES_CATEGORY_ID,
     startDate: new Date(2025, 1, 3),
     isActive: true,
   },
@@ -25,7 +27,7 @@ export const MOCK_BILLS: Bill[] = [
     name: "Electric",
     amount: 85000,
     frequency: "monthly",
-    categoryId: "services" as CategoryId,
+    categoryId: SERVICES_CATEGORY_ID,
     startDate: new Date(2025, 0, 20),
     isActive: true,
   },
@@ -34,7 +36,7 @@ export const MOCK_BILLS: Bill[] = [
     name: "Gym",
     amount: 120000,
     frequency: "monthly",
-    categoryId: "services" as CategoryId,
+    categoryId: SERVICES_CATEGORY_ID,
     startDate: new Date(2025, 2, 1),
     isActive: true,
   },
@@ -43,7 +45,7 @@ export const MOCK_BILLS: Bill[] = [
     name: "Cloud Storage",
     amount: 5900,
     frequency: "monthly",
-    categoryId: "services" as CategoryId,
+    categoryId: SERVICES_CATEGORY_ID,
     startDate: new Date(2025, 0, 10),
     isActive: true,
   },
@@ -52,7 +54,7 @@ export const MOCK_BILLS: Bill[] = [
     name: "Insurance",
     amount: 450000,
     frequency: "yearly",
-    categoryId: "services" as CategoryId,
+    categoryId: SERVICES_CATEGORY_ID,
     startDate: new Date(2025, 2, 22),
     isActive: true,
   },
@@ -61,7 +63,7 @@ export const MOCK_BILLS: Bill[] = [
     name: "Internet",
     amount: 75000,
     frequency: "monthly",
-    categoryId: "services" as CategoryId,
+    categoryId: SERVICES_CATEGORY_ID,
     startDate: new Date(2025, 0, 28),
     isActive: true,
   },

--- a/apps/mobile/features/calendar/schema.ts
+++ b/apps/mobile/features/calendar/schema.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { categoryIdSchema } from "@/features/transactions";
 import { toIsoDate } from "@/shared/lib";
+import { requireBillId, requireCategoryId } from "@/shared/types/assertions";
 import type {
   BillId,
   BillPaymentId,
@@ -73,7 +74,7 @@ export function toBillRow(
   updatedAt: IsoDateTime;
 } {
   return {
-    id: bill.id as BillId,
+    id: requireBillId(bill.id),
     userId,
     name: bill.name,
     amount: bill.amount as CopAmount,
@@ -101,7 +102,7 @@ export function fromBillRow(row: {
     name: row.name,
     amount: row.amount,
     frequency: row.frequency as BillFrequency,
-    categoryId: row.categoryId as CategoryId,
+    categoryId: requireCategoryId(row.categoryId),
     startDate: new Date(row.startDate),
     isActive: row.isActive,
   };

--- a/apps/mobile/features/capture-sources/components/NotificationSetupCard.tsx
+++ b/apps/mobile/features/capture-sources/components/NotificationSetupCard.tsx
@@ -1,4 +1,4 @@
-import { useAuthStore } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth";
 import { Bell, ExternalLink } from "@/shared/components/icons";
 import { Linking, Platform, Pressable, Switch, Text, View } from "@/shared/components/rn";
 import { getDb } from "@/shared/db";
@@ -18,7 +18,7 @@ const openNotificationListenerSettings = () => {
 
 export const NotificationSetupCard = () => {
   const { t } = useTranslation();
-  const userId = useAuthStore((s) => s.session?.user.id ?? null);
+  const userId = useOptionalUserId();
   const enabledPackages = useCaptureSourcesStore((s) => s.enabledPackages);
   const isPermissionGranted = useCaptureSourcesStore((s) => s.isNotificationPermissionGranted);
 

--- a/apps/mobile/features/capture-sources/hooks/setup.ts
+++ b/apps/mobile/features/capture-sources/hooks/setup.ts
@@ -4,11 +4,33 @@ import { processNotification } from "@/features/capture-sources/services/notific
 import type { AnyDb } from "@/shared/db";
 import { captureError, generateDetectedSmsEventId, toIsoDateTime } from "@/shared/lib";
 import { requireIsoDateTime } from "@/shared/types/assertions";
-import type { UserId } from "@/shared/types/branded";
+import type { IsoDateTime, UserId } from "@/shared/types/branded";
 import type { ApplePayIntentData, NotificationData } from "../schema";
 import { createCaptureIngestionPort } from "../services/capture-ingestion";
 
 const noop = () => undefined;
+const EPOCH_MILLISECONDS_PATTERN = /^\d{13}$/;
+const EPOCH_SECONDS_PATTERN = /^\d{10}$/;
+
+function parseSmsDetectedAt(timestamp: string): IsoDateTime | null {
+  const trimmedTimestamp = timestamp.trim();
+
+  if (trimmedTimestamp.length === 0) {
+    return null;
+  }
+
+  try {
+    return requireIsoDateTime(trimmedTimestamp);
+  } catch {
+    const parsedDate = EPOCH_MILLISECONDS_PATTERN.test(trimmedTimestamp)
+      ? new Date(Number(trimmedTimestamp))
+      : EPOCH_SECONDS_PATTERN.test(trimmedTimestamp)
+        ? new Date(Number(trimmedTimestamp) * 1000)
+        : new Date(trimmedTimestamp);
+
+    return Number.isNaN(parsedDate.getTime()) ? null : toIsoDateTime(parsedDate);
+  }
+}
 
 // Dynamic import to avoid Android bundle crash — this module calls
 // requireNativeModule("ExpoAppIntents") which only exists on iOS.
@@ -43,11 +65,18 @@ export async function setupSmsDetection(
   if (!mod.isAvailable()) return noop;
 
   const subscription = mod.addDetectBankSmsListener((event) => {
+    const detectedAt = parseSmsDetectedAt(event.timestamp);
+
+    if (detectedAt == null) {
+      captureError(new Error(`Invalid SMS detection timestamp: ${event.timestamp}`));
+      return;
+    }
+
     insertDetectedSmsEvent(db, {
       id: generateDetectedSmsEventId(),
       userId,
       senderLabel: event.senderName,
-      detectedAt: requireIsoDateTime(event.timestamp),
+      detectedAt,
       dismissed: false,
       linkedTransactionId: null,
       createdAt: toIsoDateTime(new Date()),

--- a/apps/mobile/features/capture-sources/hooks/setup.ts
+++ b/apps/mobile/features/capture-sources/hooks/setup.ts
@@ -3,7 +3,8 @@ import { processApplePayIntent } from "@/features/capture-sources/services/apple
 import { processNotification } from "@/features/capture-sources/services/notification-pipeline";
 import type { AnyDb } from "@/shared/db";
 import { captureError, generateDetectedSmsEventId, toIsoDateTime } from "@/shared/lib";
-import type { IsoDateTime, UserId } from "@/shared/types/branded";
+import { requireIsoDateTime } from "@/shared/types/assertions";
+import type { UserId } from "@/shared/types/branded";
 import type { ApplePayIntentData, NotificationData } from "../schema";
 import { createCaptureIngestionPort } from "../services/capture-ingestion";
 
@@ -13,7 +14,7 @@ const noop = () => undefined;
 // requireNativeModule("ExpoAppIntents") which only exists on iOS.
 const loadAppIntents = () => import("@/modules/expo-app-intents");
 
-export async function setupApplePayCapture(db: AnyDb, userId: string): Promise<() => void> {
+export async function setupApplePayCapture(db: AnyDb, userId: UserId): Promise<() => void> {
   const captureIngestion = createCaptureIngestionPort(db, {
     processApplePayIntent,
   });
@@ -24,7 +25,7 @@ export async function setupApplePayCapture(db: AnyDb, userId: string): Promise<(
     captureIngestion
       .ingest({
         kind: "apple_pay",
-        userId: userId as UserId,
+        userId,
         intent: event as ApplePayIntentData,
       })
       .catch(captureError);
@@ -35,7 +36,7 @@ export async function setupApplePayCapture(db: AnyDb, userId: string): Promise<(
 
 export async function setupSmsDetection(
   db: AnyDb,
-  userId: string,
+  userId: UserId,
   refreshDetectedSms: () => void
 ): Promise<() => void> {
   const mod = await loadAppIntents();
@@ -44,9 +45,9 @@ export async function setupSmsDetection(
   const subscription = mod.addDetectBankSmsListener((event) => {
     insertDetectedSmsEvent(db, {
       id: generateDetectedSmsEventId(),
-      userId: userId as UserId,
+      userId,
       senderLabel: event.senderName,
-      detectedAt: event.timestamp as IsoDateTime,
+      detectedAt: requireIsoDateTime(event.timestamp),
       dismissed: false,
       linkedTransactionId: null,
       createdAt: toIsoDateTime(new Date()),
@@ -60,7 +61,7 @@ export async function setupSmsDetection(
 
 export async function setupNotificationCapture(
   db: AnyDb,
-  userId: string,
+  userId: UserId,
   packages: string[]
 ): Promise<() => void> {
   const captureIngestion = createCaptureIngestionPort(db, {
@@ -80,7 +81,7 @@ export async function setupNotificationCapture(
     captureIngestion
       .ingest({
         kind: "notification",
-        userId: userId as UserId,
+        userId,
         notification: event as NotificationData,
       })
       .catch(captureError);

--- a/apps/mobile/features/capture-sources/hooks/useApplePayCapture.ts
+++ b/apps/mobile/features/capture-sources/hooks/useApplePayCapture.ts
@@ -1,9 +1,10 @@
 import { Platform } from "@/shared/components/rn";
 import type { AnyDb } from "@/shared/db";
 import { useSubscription } from "@/shared/hooks";
+import type { UserId } from "@/shared/types/branded";
 import { setupApplePayCapture } from "./setup";
 
-export function useApplePayCapture(db: AnyDb | null, userId: string | null) {
+export function useApplePayCapture(db: AnyDb | null, userId: UserId | null) {
   useSubscription(
     () => {
       if (!db || !userId) return;

--- a/apps/mobile/features/capture-sources/hooks/useNotificationCapture.ts
+++ b/apps/mobile/features/capture-sources/hooks/useNotificationCapture.ts
@@ -2,10 +2,11 @@ import { Platform } from "@/shared/components/rn";
 import type { AnyDb } from "@/shared/db";
 import { useSubscription } from "@/shared/hooks";
 import { captureError } from "@/shared/lib";
+import type { UserId } from "@/shared/types/branded";
 import { useCaptureSourcesStore } from "../store";
 import { setupNotificationCapture } from "./setup";
 
-export function useNotificationCapture(db: AnyDb | null, userId: string | null) {
+export function useNotificationCapture(db: AnyDb | null, userId: UserId | null) {
   const enabledPackages = useCaptureSourcesStore((s) => s.enabledPackages);
 
   useSubscription(

--- a/apps/mobile/features/capture-sources/hooks/useSmsDetection.ts
+++ b/apps/mobile/features/capture-sources/hooks/useSmsDetection.ts
@@ -2,10 +2,11 @@ import { Platform } from "@/shared/components/rn";
 import type { AnyDb } from "@/shared/db";
 import { useSubscription } from "@/shared/hooks";
 import { captureError } from "@/shared/lib";
+import type { UserId } from "@/shared/types/branded";
 import { refreshDetectedSmsCount } from "../store";
 import { setupSmsDetection } from "./setup";
 
-export function useSmsDetection(db: AnyDb | null, userId: string | null) {
+export function useSmsDetection(db: AnyDb | null, userId: UserId | null) {
   useSubscription(
     () => {
       if (!db || !userId) return;

--- a/apps/mobile/features/capture-sources/hooks/useWidgetCapture.ts
+++ b/apps/mobile/features/capture-sources/hooks/useWidgetCapture.ts
@@ -6,21 +6,20 @@ import type { UserId } from "@/shared/types/branded";
 import { createCaptureIngestionPort } from "../services/capture-ingestion";
 import { processWidgetTransactions } from "../services/widget-pipeline";
 
-export function useWidgetCapture(db: AnyDb | null, userId: string | null): void {
+export function useWidgetCapture(db: AnyDb | null, userId: UserId | null): void {
   useSubscription(
     () => {
       if (!db || !userId) {
         return;
       }
 
-      const uid = userId as UserId;
       const captureIngestion = createCaptureIngestionPort(db, {
         processWidgetTransactions,
       });
 
       const ingestWidgetTransactions = () => {
         captureIngestion
-          .ingest({ kind: "widget", userId: uid })
+          .ingest({ kind: "widget", userId })
           .catch(function handleWidgetCaptureError(err) {
             captureError(err);
           });

--- a/apps/mobile/features/capture-sources/lib/repository.ts
+++ b/apps/mobile/features/capture-sources/lib/repository.ts
@@ -3,6 +3,7 @@ import { and, count, desc, eq, gte, lt } from "drizzle-orm";
 import type { AnyDb } from "@/shared/db";
 import { detectedSmsEvents, notificationSources, processedCaptures } from "@/shared/db";
 import { generateNotificationSourceId, toIsoDate } from "@/shared/lib";
+import { requireIsoDateTime } from "@/shared/types/assertions";
 import type {
   DetectedSmsEventId,
   IsoDateTime,
@@ -14,40 +15,35 @@ import type {
 
 export type NotificationSourceRow = typeof notificationSources.$inferInsert;
 
-export async function getNotificationSources(db: AnyDb, userId: string) {
-  return db
-    .select()
-    .from(notificationSources)
-    .where(eq(notificationSources.userId, userId as UserId));
+export async function getNotificationSources(db: AnyDb, userId: UserId) {
+  return db.select().from(notificationSources).where(eq(notificationSources.userId, userId));
 }
 
-export async function getEnabledPackages(db: AnyDb, userId: string): Promise<string[]> {
+export async function getEnabledPackages(db: AnyDb, userId: UserId): Promise<string[]> {
   const rows = await db
     .select({ packageName: notificationSources.packageName })
     .from(notificationSources)
-    .where(
-      and(eq(notificationSources.userId, userId as UserId), eq(notificationSources.isEnabled, true))
-    );
+    .where(and(eq(notificationSources.userId, userId), eq(notificationSources.isEnabled, true)));
   return rows.map((r) => r.packageName);
 }
 
 export async function upsertNotificationSource(
   db: AnyDb,
-  userId: string,
+  userId: UserId,
   packageName: string,
   label: string,
   isEnabled: boolean,
-  now: string
+  now: IsoDateTime
 ) {
   await db
     .insert(notificationSources)
     .values({
       id: generateNotificationSourceId(),
-      userId: userId as UserId,
+      userId,
       packageName,
       label,
       isEnabled,
-      createdAt: now as IsoDateTime,
+      createdAt: now,
     })
     .onConflictDoUpdate({
       target: [notificationSources.userId, notificationSources.packageName],
@@ -88,27 +84,25 @@ export async function insertDetectedSmsEvent(db: AnyDb, row: DetectedSmsEventRow
   await db.insert(detectedSmsEvents).values(row);
 }
 
-export async function getUndismissedSmsEvents(db: AnyDb, userId: string) {
+export async function getUndismissedSmsEvents(db: AnyDb, userId: UserId) {
   return db
     .select()
     .from(detectedSmsEvents)
-    .where(
-      and(eq(detectedSmsEvents.userId, userId as UserId), eq(detectedSmsEvents.dismissed, false))
-    )
+    .where(and(eq(detectedSmsEvents.userId, userId), eq(detectedSmsEvents.dismissed, false)))
     .orderBy(desc(detectedSmsEvents.detectedAt));
 }
 
-export async function getTodaySmsEventCount(db: AnyDb, userId: string, now: Date): Promise<number> {
+export async function getTodaySmsEventCount(db: AnyDb, userId: UserId, now: Date): Promise<number> {
   const today = toIsoDate(now);
   const tomorrow = toIsoDate(addDays(now, 1));
-  const todayStart = `${today}T00:00:00.000Z` as IsoDateTime;
-  const tomorrowStart = `${tomorrow}T00:00:00.000Z` as IsoDateTime;
+  const todayStart = requireIsoDateTime(`${today}T00:00:00.000Z`);
+  const tomorrowStart = requireIsoDateTime(`${tomorrow}T00:00:00.000Z`);
   const rows = await db
     .select({ total: count() })
     .from(detectedSmsEvents)
     .where(
       and(
-        eq(detectedSmsEvents.userId, userId as UserId),
+        eq(detectedSmsEvents.userId, userId),
         eq(detectedSmsEvents.dismissed, false),
         gte(detectedSmsEvents.detectedAt, todayStart),
         lt(detectedSmsEvents.detectedAt, tomorrowStart)
@@ -117,19 +111,20 @@ export async function getTodaySmsEventCount(db: AnyDb, userId: string, now: Date
   return rows[0]?.total ?? 0;
 }
 
-export async function dismissSmsEvent(db: AnyDb, id: string) {
-  await db
-    .update(detectedSmsEvents)
-    .set({ dismissed: true })
-    .where(eq(detectedSmsEvents.id, id as DetectedSmsEventId));
+export async function dismissSmsEvent(db: AnyDb, id: DetectedSmsEventId) {
+  await db.update(detectedSmsEvents).set({ dismissed: true }).where(eq(detectedSmsEvents.id, id));
 }
 
-export async function linkSmsEventToTransaction(db: AnyDb, id: string, transactionId: string) {
+export async function linkSmsEventToTransaction(
+  db: AnyDb,
+  id: DetectedSmsEventId,
+  transactionId: TransactionId
+) {
   await db
     .update(detectedSmsEvents)
     .set({
-      linkedTransactionId: transactionId as TransactionId,
+      linkedTransactionId: transactionId,
       dismissed: true,
     })
-    .where(eq(detectedSmsEvents.id, id as DetectedSmsEventId));
+    .where(eq(detectedSmsEvents.id, id));
 }

--- a/apps/mobile/features/capture-sources/store.ts
+++ b/apps/mobile/features/capture-sources/store.ts
@@ -1,6 +1,8 @@
 import { create } from "zustand";
 import { Platform } from "@/shared/components/rn";
 import type { AnyDb } from "@/shared/db";
+import { toIsoDateTime } from "@/shared/lib";
+import type { UserId } from "@/shared/types/branded";
 import {
   getEnabledPackages,
   getTodaySmsEventCount,
@@ -41,7 +43,7 @@ export const useCaptureSourcesStore = create<CaptureSourcesState & CaptureSource
   })
 );
 
-async function loadCaptureSourceConfig(db: AnyDb, userId: string): Promise<void> {
+async function loadCaptureSourceConfig(db: AnyDb, userId: UserId): Promise<void> {
   const enabledPackages = await getEnabledPackages(db, userId);
   useCaptureSourcesStore.getState().setEnabledPackages(enabledPackages);
 }
@@ -74,7 +76,7 @@ function getUpdatedEnabledPackages(
   return enabledPackages.filter((pkg) => pkg !== packageName);
 }
 
-export async function hydrateCaptureSources(db: AnyDb, userId: string): Promise<void> {
+export async function hydrateCaptureSources(db: AnyDb, userId: UserId): Promise<void> {
   await Promise.allSettled([
     loadCaptureSourceConfig(db, userId),
     checkCaptureSourcePermissions(),
@@ -85,14 +87,21 @@ export async function hydrateCaptureSources(db: AnyDb, userId: string): Promise<
 
 export async function toggleCaptureSourcePackage(
   db: AnyDb,
-  userId: string,
+  userId: UserId,
   packageName: string,
   enabled: boolean
 ): Promise<void> {
   const knownPkg = KNOWN_BANK_PACKAGES.find((pkg) => pkg.packageName === packageName);
   const label = knownPkg?.label ?? packageName;
 
-  await upsertNotificationSource(db, userId, packageName, label, enabled, new Date().toISOString());
+  await upsertNotificationSource(
+    db,
+    userId,
+    packageName,
+    label,
+    enabled,
+    toIsoDateTime(new Date())
+  );
 
   const updated = getUpdatedEnabledPackages(
     useCaptureSourcesStore.getState().enabledPackages,
@@ -109,7 +118,7 @@ export async function refreshCaptureSourceStatus(db: AnyDb): Promise<void> {
 
 export async function refreshDetectedSmsCount(
   db: AnyDb,
-  userId: string,
+  userId: UserId,
   now: Date = new Date()
 ): Promise<void> {
   const detectedSmsCount = await getTodaySmsEventCount(db, userId, now);

--- a/apps/mobile/features/categories/components/CreateCategorySheet.tsx
+++ b/apps/mobile/features/categories/components/CreateCategorySheet.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "expo-router";
 import React, { useCallback, useState } from "react";
-import { useAuthStore } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth";
 import { Check, Ellipsis, type LucideIcon } from "@/shared/components/icons";
 import {
   FlatList,
@@ -14,7 +14,6 @@ import {
 } from "@/shared/components/rn";
 import { getDb } from "@/shared/db";
 import { useAsyncGuard, useThemeColor, useTranslation } from "@/shared/hooks";
-import type { UserId } from "@/shared/types/branded";
 import { COLOR_SWATCHES, MAX_NAME_LENGTH, MIN_NAME_LENGTH } from "../lib/constants";
 import { ICON_MAP, SELECTABLE_ICONS } from "../lib/icon-map";
 import { createCustomCategory } from "../store";
@@ -109,7 +108,7 @@ export function CreateCategorySheet() {
   const [selectedIcon, setSelectedIcon] = useState<string | null>(null);
   const [selectedColor, setSelectedColor] = useState<string | null>(null);
   const { isBusy, run: guardedCreate } = useAsyncGuard();
-  const userId = useAuthStore((state) => state.session?.user.id as UserId | undefined);
+  const userId = useOptionalUserId();
 
   const trimmedName = name.trim();
   const isFormValid =

--- a/apps/mobile/features/categories/lib/registry.ts
+++ b/apps/mobile/features/categories/lib/registry.ts
@@ -1,6 +1,6 @@
 import { CATEGORIES, CATEGORY_ROWS, type Category } from "@/features/transactions";
 import { Ellipsis } from "@/shared/components/icons";
-import type { CategoryId } from "@/shared/types/branded";
+import { requireCategoryId } from "@/shared/types/assertions";
 import { ICON_MAP } from "./icon-map";
 
 export type CategoryRegistryScope = "built_in" | "merged";
@@ -23,7 +23,7 @@ export type CategoryRegistrySnapshot = {
 };
 
 const toCustomCategory = (row: CategoryRegistryRow): Category => ({
-  id: row.id as unknown as CategoryId,
+  id: requireCategoryId(row.id),
   label: { en: row.name, es: row.name },
   icon: ICON_MAP[row.iconName] ?? Ellipsis,
   color: row.colorHex,

--- a/apps/mobile/features/email-capture/components/NeedsReviewCard.tsx
+++ b/apps/mobile/features/email-capture/components/NeedsReviewCard.tsx
@@ -3,6 +3,7 @@ import { useCallback, useState } from "react";
 import {
   CATEGORIES,
   type CategoryId,
+  getBuiltInCategoryId,
   isValidCategoryId,
   type StoredTransaction,
 } from "@/features/transactions";
@@ -18,6 +19,8 @@ type NeedsReviewCardProps = {
   readonly onConfirm: (processedEmailId: string, categoryId: string) => void;
 };
 
+const FALLBACK_CATEGORY_ID = getBuiltInCategoryId("other");
+
 export const NeedsReviewCard = ({
   processedEmail,
   transaction,
@@ -27,7 +30,7 @@ export const NeedsReviewCard = ({
   const suggestedCategory: CategoryId =
     transaction?.categoryId && isValidCategoryId(transaction.categoryId)
       ? transaction.categoryId
-      : ("other" as CategoryId);
+      : FALLBACK_CATEGORY_ID;
   const [prevSuggested, setPrevSuggested] = useState(suggestedCategory);
   const [selectedCategory, setSelectedCategory] = useState<CategoryId>(suggestedCategory);
   if (suggestedCategory !== prevSuggested) {

--- a/apps/mobile/features/email-capture/components/NeedsReviewScreen.tsx
+++ b/apps/mobile/features/email-capture/components/NeedsReviewScreen.tsx
@@ -5,7 +5,7 @@ import { useTransactionStore } from "@/features/transactions";
 import { ScreenLayout } from "@/shared/components";
 import { Text, View } from "@/shared/components/rn";
 import { useTranslation } from "@/shared/hooks";
-import type { TransactionId } from "@/shared/types/branded";
+import { requireTransactionId } from "@/shared/types/assertions";
 import { useEmailCaptureStore } from "../store";
 import { NeedsReviewCard } from "./NeedsReviewCard";
 
@@ -21,7 +21,8 @@ export default function NeedsReviewScreen() {
     const map = new Map<string, ReturnType<typeof getTransaction>>();
     needsReview.forEach((item) => {
       if (item.transactionId) {
-        map.set(item.transactionId, getTransaction(item.transactionId as TransactionId));
+        const transactionId = requireTransactionId(item.transactionId);
+        map.set(transactionId, getTransaction(transactionId));
       }
     });
     return map;

--- a/apps/mobile/features/email-capture/lib/merchant-rules.ts
+++ b/apps/mobile/features/email-capture/lib/merchant-rules.ts
@@ -6,34 +6,34 @@ import type { CategoryId, IsoDateTime, UserId } from "@/shared/types/branded";
 
 export async function lookupMerchantRule(
   db: AnyDb,
-  userId: string,
+  userId: UserId,
   keyword: string
-): Promise<string | null> {
+): Promise<CategoryId | null> {
   const rows = await db
     .select({ categoryId: merchantRules.categoryId })
     .from(merchantRules)
-    .where(and(eq(merchantRules.userId, userId as UserId), eq(merchantRules.keyword, keyword)));
+    .where(and(eq(merchantRules.userId, userId), eq(merchantRules.keyword, keyword)));
   return rows[0]?.categoryId ?? null;
 }
 
 export async function insertMerchantRule(
   db: AnyDb,
-  userId: string,
+  userId: UserId,
   keyword: string,
-  categoryId: string,
-  now: string
+  categoryId: CategoryId,
+  now: IsoDateTime
 ): Promise<void> {
   await db
     .insert(merchantRules)
     .values({
       id: generateMerchantRuleId(),
-      userId: userId as UserId,
+      userId,
       keyword,
-      categoryId: categoryId as CategoryId,
-      createdAt: now as IsoDateTime,
+      categoryId,
+      createdAt: now,
     })
     .onConflictDoUpdate({
       target: [merchantRules.userId, merchantRules.keyword],
-      set: { categoryId: categoryId as CategoryId, createdAt: now as IsoDateTime },
+      set: { categoryId, createdAt: now },
     });
 }

--- a/apps/mobile/features/email-capture/lib/retry-backoff.ts
+++ b/apps/mobile/features/email-capture/lib/retry-backoff.ts
@@ -1,12 +1,15 @@
+import { toIsoDateTime } from "@/shared/lib";
 import type { IsoDateTime } from "@/shared/types/branded";
 
 const BACKOFF_MINUTES = [1, 5, 15, 60, 240] as const;
 const MAX_RETRIES = 5;
 
 export const computeNextRetryAt = (retryCount: number, now: Date = new Date()): IsoDateTime =>
-  new Date(
-    now.getTime() +
-      (BACKOFF_MINUTES[retryCount] ?? BACKOFF_MINUTES[BACKOFF_MINUTES.length - 1] ?? 240) * 60_000
-  ).toISOString() as IsoDateTime;
+  toIsoDateTime(
+    new Date(
+      now.getTime() +
+        (BACKOFF_MINUTES[retryCount] ?? BACKOFF_MINUTES[BACKOFF_MINUTES.length - 1] ?? 240) * 60_000
+    )
+  );
 
 export const isMaxRetriesReached = (retryCount: number): boolean => retryCount >= MAX_RETRIES;

--- a/apps/mobile/features/email-capture/services/email-pipeline.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline.ts
@@ -1,5 +1,9 @@
 import { findDuplicateTransaction } from "@/features/capture-sources/dedup.public";
-import { insertTransaction, isValidCategoryId } from "@/features/transactions/write.public";
+import {
+  getBuiltInCategoryId,
+  insertTransaction,
+  isValidCategoryId,
+} from "@/features/transactions";
 import type { AnyDb } from "@/shared/db";
 import { enqueueSync } from "@/shared/db";
 import {
@@ -13,12 +17,8 @@ import {
   toIsoDateTime,
   trackTransactionCreated,
 } from "@/shared/lib";
-import {
-  assertCopAmount,
-  assertIsoDate,
-  assertIsoDateTime,
-  assertUserId,
-} from "@/shared/types/assertions";
+import { assertCopAmount, assertIsoDate, assertIsoDateTime } from "@/shared/types/assertions";
+import type { UserId } from "@/shared/types/branded";
 import { insertMerchantRule, lookupMerchantRule } from "../lib/merchant-rules";
 import {
   getPendingRetryEmails,
@@ -45,10 +45,9 @@ export type PipelineResult = {
 
 async function parseBody(
   db: AnyDb,
-  userId: string,
+  userId: UserId,
   body: string
 ): Promise<LlmParsedTransaction | null> {
-  assertUserId(userId);
   const llmResult = await parseEmailApi(body);
   if (!llmResult) return null;
 
@@ -63,19 +62,15 @@ async function parseBody(
 
 async function saveTransaction(
   db: AnyDb,
-  userId: string,
+  userId: UserId,
   validated: LlmParsedTransaction,
   email: RawEmail,
   status: "success" | "needs_review"
 ): Promise<string> {
-  assertUserId(userId);
   const source = email.provider === "gmail" ? "email_gmail" : "email_outlook";
   const txId = generateTransactionId();
   const now = toIsoDateTime(new Date());
-  const fallbackCategoryId = "other";
-  if (!isValidCategoryId(fallbackCategoryId)) {
-    throw new Error("Missing fallback category");
-  }
+  const fallbackCategoryId = getBuiltInCategoryId("other");
 
   const categoryId = isValidCategoryId(validated.categoryId)
     ? validated.categoryId
@@ -140,7 +135,7 @@ export type ProgressCallback = (progress: {
 
 export async function processEmails(
   db: AnyDb,
-  userId: string,
+  userId: UserId,
   rawEmails: RawEmail[],
   onProgress?: ProgressCallback
 ): Promise<PipelineResult> {
@@ -313,13 +308,13 @@ export async function processEmails(
         const merchantKey = normalizeMerchant(parsed.description);
         const validatedCategoryId = isValidCategoryId(parsed.categoryId)
           ? parsed.categoryId
-          : "other";
+          : getBuiltInCategoryId("other");
         await insertMerchantRule(
           db,
           userId,
           merchantKey,
           validatedCategoryId,
-          new Date().toISOString()
+          toIsoDateTime(new Date())
         );
       } catch (ruleErr) {
         captureError(ruleErr);
@@ -361,7 +356,7 @@ export type RetryResult = {
   permanentlyFailed: number;
 };
 
-export async function processRetries(db: AnyDb, userId: string): Promise<RetryResult> {
+export async function processRetries(db: AnyDb, userId: UserId): Promise<RetryResult> {
   const result: RetryResult = { retried: 0, succeeded: 0, permanentlyFailed: 0 };
   const pendingEmails = await getPendingRetryEmails(db);
 
@@ -425,14 +420,10 @@ export async function processRetries(db: AnyDb, userId: string): Promise<RetryRe
       const now = toIsoDateTime(new Date());
       const source = email.provider === "gmail" ? "email_gmail" : "email_outlook";
       const status = parsed.confidence < 0.7 ? "needs_review" : "success";
-      const fallbackCategoryId = "other";
-      if (!isValidCategoryId(fallbackCategoryId)) {
-        throw new Error("Missing fallback category");
-      }
+      const fallbackCategoryId = getBuiltInCategoryId("other");
       const retryCategoryId = isValidCategoryId(parsed.categoryId)
         ? parsed.categoryId
         : fallbackCategoryId;
-      assertUserId(userId);
 
       insertTransaction(db, {
         id: txId,

--- a/apps/mobile/features/goals/components/GoalDetail.tsx
+++ b/apps/mobile/features/goals/components/GoalDetail.tsx
@@ -5,7 +5,8 @@ import Svg, { Circle as SvgCircle } from "react-native-svg";
 import { Platform, Pressable, ScrollView, StyleSheet, Text, View } from "@/shared/components/rn";
 import { useSubscription, useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatDateDisplay, formatMoney } from "@/shared/lib";
-import type { CopAmount, IsoDate } from "@/shared/types/branded";
+import { requireIsoDate } from "@/shared/types/assertions";
+import type { CopAmount } from "@/shared/types/branded";
 import type { GoalProjection, Milestone } from "../lib/derive";
 import { deriveMonthlyMilestones } from "../lib/derive";
 import type { GoalContribution } from "../schema";
@@ -210,7 +211,7 @@ function ContributionRowInner({
     <View style={styles.contributionRow}>
       <View style={styles.contributionInfo}>
         <Text style={[styles.contributionDate, { color: primaryColor }]}>
-          {formatDateDisplay(contribution.date as IsoDate)}
+          {formatDateDisplay(requireIsoDate(contribution.date))}
         </Text>
         <Text style={[styles.contributionNote, { color: secondaryColor }]}>
           {contribution.note ?? t("goals.detail.manualPayment")}

--- a/apps/mobile/features/goals/components/GoalEditSheet.tsx
+++ b/apps/mobile/features/goals/components/GoalEditSheet.tsx
@@ -16,8 +16,12 @@ import {
   View,
 } from "@/shared/components/rn";
 import { useAsyncGuard, useBlinkingCursor, useThemeColor, useTranslation } from "@/shared/hooks";
-import { formatInputDisplay, parseDigitsToAmount, parseIsoDate, toIsoDate } from "@/shared/lib";
-import type { IsoDate } from "@/shared/types/branded";
+import {
+  formatInputDisplay,
+  parseDigitsToAmount,
+  parseOptionalIsoDate,
+  toIsoDate,
+} from "@/shared/lib";
 import { useGoalStore } from "../store";
 
 export function GoalEditSheet() {
@@ -48,9 +52,7 @@ export function GoalEditSheet() {
     goal?.interestRatePercent != null ? String(goal.interestRatePercent) : ""
   );
   const [numpadTarget, setNumpadTarget] = useState<"amount" | null>(null);
-  const [targetDate, setTargetDate] = useState<Date | null>(
-    goal?.targetDate ? parseIsoDate(goal.targetDate as IsoDate) : null
-  );
+  const [targetDate, setTargetDate] = useState<Date | null>(parseOptionalIsoDate(goal?.targetDate));
   const [showDatePicker, setShowDatePicker] = useState(false);
 
   // Blinking cursor

--- a/apps/mobile/features/goals/lib/derive.ts
+++ b/apps/mobile/features/goals/lib/derive.ts
@@ -1,6 +1,7 @@
 import { addMonths, differenceInDays } from "date-fns";
 import { parseIsoDate } from "@/shared/lib";
-import type { CopAmount, IsoDate } from "@/shared/types/branded";
+import { requireIsoDate } from "@/shared/types/assertions";
+import type { CopAmount } from "@/shared/types/branded";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -357,8 +358,8 @@ export function deriveGoalPaceGuidance(
   // createdAt is always stored as UTC ISO 8601 via toIsoDateTime(); slice(0,10) extracts the
   // UTC calendar date "YYYY-MM-DD" which is the canonical start of the goal timeline.
   // targetDate is validated as YYYY-MM-DD by Zod before storage, so the cast is safe.
-  const start = parseIsoDate(goal.createdAt.slice(0, 10) as IsoDate);
-  const end = parseIsoDate(goal.targetDate as IsoDate);
+  const start = parseIsoDate(requireIsoDate(goal.createdAt.slice(0, 10)));
+  const end = parseIsoDate(requireIsoDate(goal.targetDate));
   const totalDays = differenceInDays(end, start);
   if (totalDays <= 0) return null;
 

--- a/apps/mobile/features/goals/store.ts
+++ b/apps/mobile/features/goals/store.ts
@@ -115,11 +115,12 @@ export const useGoalStore = create<GoalState & GoalActions>((set, get) => ({
 
   loadGoals: async () => {
     const db = dbRef;
-    if (!db || !userIdRef) return;
+    const userId = userIdRef;
+    if (!db || !userId) return;
     set({ isLoading: true });
     try {
-      const goalRows = getGoalsForUser(db, userIdRef) as Goal[];
-      const monthlyTotals = getMonthlyTotalsByType(db, userIdRef as UserId, 3);
+      const goalRows = getGoalsForUser(db, userId) as Goal[];
+      const monthlyTotals = getMonthlyTotalsByType(db, userId, 3);
 
       const goalsWithProgress: GoalWithProgress[] = goalRows.map((goal) => {
         const currentAmount = getGoalCurrentAmount(db, goal.id);
@@ -370,9 +371,10 @@ export const useGoalStore = create<GoalState & GoalActions>((set, get) => ({
 
   refreshProjections: () => {
     const db = dbRef;
-    if (!db || !userIdRef) return;
+    const userId = userIdRef;
+    if (!db || !userId) return;
     try {
-      const monthlyTotals = getMonthlyTotalsByType(db, userIdRef as UserId, 3);
+      const monthlyTotals = getMonthlyTotalsByType(db, userId, 3);
       const { goals } = get();
       const updated = goals.map((g) => {
         const currentAmount = getGoalCurrentAmount(db, g.goal.id);

--- a/apps/mobile/features/notifications/components/NotificationsScreen.tsx
+++ b/apps/mobile/features/notifications/components/NotificationsScreen.tsx
@@ -1,14 +1,12 @@
 import { Stack, useRouter } from "expo-router";
 import { useCallback, useMemo } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { useAuthStore } from "@/features/auth";
-import { useAccountCreatedAt } from "@/features/auth/public";
+import { useAccountCreatedAt, useOptionalUserId } from "@/features/auth";
 import { ScreenLayout } from "@/shared/components";
 import { Platform, Pressable, SectionList, StyleSheet, Text, View } from "@/shared/components/rn";
 import { getDb } from "@/shared/db";
 import { useMountEffect, useSubscription, useThemeColor, useTranslation } from "@/shared/hooks";
 import { trackNotificationCenterOpened } from "@/shared/lib";
-import type { UserId } from "@/shared/types/branded";
 import { deriveNotificationDisplay, groupNotificationsBySection } from "../lib/display";
 import { isFirstWeek } from "../lib/first-week";
 import type { NotificationDisplay } from "../lib/types";
@@ -24,7 +22,7 @@ import { NotificationEmptyState } from "./NotificationEmptyState";
 export const NotificationsScreen = () => {
   const router = useRouter();
   const { t } = useTranslation();
-  const userId = useAuthStore((state) => state.session?.user.id as UserId | undefined);
+  const userId = useOptionalUserId();
   const notifications = useNotificationStore((s) => s.notifications);
   const isLoading = useNotificationStore((s) => s.isLoading);
   const tertiaryColor = useThemeColor("tertiary");

--- a/apps/mobile/features/notifications/store.ts
+++ b/apps/mobile/features/notifications/store.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 import { createWriteThroughMutationModule } from "@/mutations";
 import type { AnyDb } from "@/shared/db";
 import { generateNotificationId, toIsoDateTime } from "@/shared/lib";
+import { requireIsoDateTime } from "@/shared/types/assertions";
 import type { CategoryId, IsoDateTime, UserId } from "@/shared/types/branded";
 import type { NotificationType, StoredNotification } from "./lib/types";
 import { countNotificationsSince, getNotifications } from "./repository";
@@ -70,7 +71,7 @@ export async function initializeNotificationStore(db: AnyDb, userId: UserId): Pr
   let lastVisitedAt: IsoDateTime | null = null;
   try {
     const stored = await SecureStore.getItemAsync(lastVisitedKey(userId));
-    lastVisitedAt = stored ? (stored as IsoDateTime) : null;
+    lastVisitedAt = stored ? requireIsoDateTime(stored) : null;
   } catch {
     // SecureStore may fail in tests — default to null
   }

--- a/apps/mobile/features/search/components/SearchScreen.tsx
+++ b/apps/mobile/features/search/components/SearchScreen.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "expo-router";
 import { memo, useCallback, useMemo, useRef, useState } from "react";
-import { useAuthStore } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth";
 import { CATEGORY_MAP, makeDateLabel, type StoredTransaction } from "@/features/transactions";
 import { ScreenLayout, TAB_BAR_CLEARANCE, TransactionRow } from "@/shared/components";
 import { Ellipsis } from "@/shared/components/icons";
@@ -72,7 +72,7 @@ export const SearchScreen = () => {
   const primary = useThemeColor("primary");
   const secondary = useThemeColor("secondary");
   const peachLight = useThemeColor("peachLight");
-  const userId = useAuthStore((state) => state.session?.user.id ?? null);
+  const userId = useOptionalUserId();
   const db = userId ? getDb(userId) : null;
 
   const filters = useSearchStore((s) => s.filters);

--- a/apps/mobile/features/search/lib/repository.ts
+++ b/apps/mobile/features/search/lib/repository.ts
@@ -1,20 +1,24 @@
 import { and, count, desc, eq, gte, inArray, isNull, like, lte, sql } from "drizzle-orm";
 import type { AnyDb } from "@/shared/db";
 import { transactions } from "@/shared/db";
-import type { CategoryId, CopAmount, IsoDate, UserId } from "@/shared/types/branded";
+import { requireCategoryId, requireIsoDate } from "@/shared/types/assertions";
+import type { CopAmount, UserId } from "@/shared/types/branded";
 import type { SearchFilters, SearchSummary } from "./types";
 
-function buildSearchConditions(userId: string, filters: SearchFilters) {
+function buildSearchConditions(userId: UserId, filters: SearchFilters) {
   const trimmedQuery = filters.query.trim();
+  const categoryIds = filters.categoryIds
+    .filter((id) => id.trim().length > 0)
+    .map((id) => requireCategoryId(id));
   return [
-    eq(transactions.userId, userId as UserId),
+    eq(transactions.userId, userId),
     isNull(transactions.deletedAt),
     ...(trimmedQuery.length > 0 ? [like(transactions.description, `%${trimmedQuery}%`)] : []),
-    ...(filters.categoryIds.length > 0
-      ? [inArray(transactions.categoryId, [...filters.categoryIds] as CategoryId[])]
+    ...(categoryIds.length > 0 ? [inArray(transactions.categoryId, categoryIds)] : []),
+    ...(filters.dateFrom !== null
+      ? [gte(transactions.date, requireIsoDate(filters.dateFrom))]
       : []),
-    ...(filters.dateFrom !== null ? [gte(transactions.date, filters.dateFrom as IsoDate)] : []),
-    ...(filters.dateTo !== null ? [lte(transactions.date, filters.dateTo as IsoDate)] : []),
+    ...(filters.dateTo !== null ? [lte(transactions.date, requireIsoDate(filters.dateTo))] : []),
     ...(filters.amountMin !== null
       ? [gte(transactions.amount, filters.amountMin as CopAmount)]
       : []),
@@ -27,7 +31,7 @@ function buildSearchConditions(userId: string, filters: SearchFilters) {
 
 export function searchTransactionsPaginated(
   db: AnyDb,
-  userId: string,
+  userId: UserId,
   filters: SearchFilters,
   limit: number,
   offset: number
@@ -45,7 +49,7 @@ export function searchTransactionsPaginated(
 
 export function searchTransactionsAggregate(
   db: AnyDb,
-  userId: string,
+  userId: UserId,
   filters: SearchFilters
 ): SearchSummary {
   const conditions = buildSearchConditions(userId, filters);

--- a/apps/mobile/features/search/store.ts
+++ b/apps/mobile/features/search/store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import type { StoredTransaction } from "@/features/transactions";
 import { toStoredTransaction } from "@/features/transactions";
 import type { AnyDb } from "@/shared/db";
+import type { UserId } from "@/shared/types/branded";
 import { searchTransactionsAggregate, searchTransactionsPaginated } from "./lib/repository";
 import type { SearchFilters, SearchSummary } from "./lib/types";
 import { EMPTY_FILTERS } from "./lib/types";
@@ -78,7 +79,7 @@ export const useSearchStore = create<SearchState & SearchActions>((set) => ({
   },
 }));
 
-export function executeSearch(db: AnyDb, userId: string): void {
+export function executeSearch(db: AnyDb, userId: UserId): void {
   const { filters, setIsSearching, setSearchResults } = useSearchStore.getState();
   setIsSearching(true);
 
@@ -93,7 +94,7 @@ export function executeSearch(db: AnyDb, userId: string): void {
   }
 }
 
-export function loadNextSearchPage(db: AnyDb, userId: string): void {
+export function loadNextSearchPage(db: AnyDb, userId: UserId): void {
   const { hasMore, offset, filters, appendSearchResults } = useSearchStore.getState();
   if (!hasMore) return;
 
@@ -107,21 +108,21 @@ export function loadNextSearchPage(db: AnyDb, userId: string): void {
   }
 }
 
-export function updateSearchQuery(db: AnyDb, userId: string, query: string): void {
+export function updateSearchQuery(db: AnyDb, userId: UserId, query: string): void {
   useSearchStore.getState().setQuery(query);
   executeSearch(db, userId);
 }
 
 export function updateSearchFilters(
   db: AnyDb,
-  userId: string,
+  userId: UserId,
   partial: Partial<SearchFilters>
 ): void {
   useSearchStore.getState().setFilters(partial);
   executeSearch(db, userId);
 }
 
-export function clearSearchFilters(db: AnyDb, userId: string): void {
+export function clearSearchFilters(db: AnyDb, userId: UserId): void {
   useSearchStore.getState().clearFilters();
   executeSearch(db, userId);
 }

--- a/apps/mobile/features/settings/hooks/use-notification-preferences.ts
+++ b/apps/mobile/features/settings/hooks/use-notification-preferences.ts
@@ -1,11 +1,10 @@
 import { useMutation } from "@tanstack/react-query";
-import { useAuthStore } from "@/features/auth";
-import type { UserId } from "@/shared/types/branded";
+import { useOptionalUserId } from "@/features/auth";
 import { saveNotificationPreferences } from "../data/notification-preferences";
 import type { NotificationPreferences } from "../store";
 
 export function useNotificationPreferencesMutation() {
-  const userId = useAuthStore((state) => state.session?.user.id as UserId | undefined);
+  const userId = useOptionalUserId() ?? undefined;
 
   return useMutation({
     mutationFn: (preferences: NotificationPreferences) => {

--- a/apps/mobile/features/sync/services/syncEngine.ts
+++ b/apps/mobile/features/sync/services/syncEngine.ts
@@ -18,10 +18,7 @@ import {
   generateSyncConflictId,
   toIsoDateTime,
 } from "@/shared/lib";
-import {
-  requireBudgetId,
-  requireTransactionId,
-} from "@/shared/types/assertions";
+import { requireBudgetId, requireTransactionId } from "@/shared/types/assertions";
 import type { SyncQueueId } from "@/shared/types/branded";
 import { hasDataConflict } from "../lib/conflict-detection";
 import { insertConflict } from "../lib/conflict-repository";

--- a/apps/mobile/features/sync/services/syncEngine.ts
+++ b/apps/mobile/features/sync/services/syncEngine.ts
@@ -18,7 +18,11 @@ import {
   generateSyncConflictId,
   toIsoDateTime,
 } from "@/shared/lib";
-import type { BudgetId, SyncQueueId, TransactionId } from "@/shared/types/branded";
+import {
+  requireBudgetId,
+  requireTransactionId,
+} from "@/shared/types/assertions";
+import type { SyncQueueId } from "@/shared/types/branded";
 import { hasDataConflict } from "../lib/conflict-detection";
 import { insertConflict } from "../lib/conflict-repository";
 
@@ -87,7 +91,7 @@ async function processBudgetEntry(
   supabase: SupabaseClient,
   rowId: string
 ): Promise<boolean> {
-  const row = getBudgetById(db, rowId as BudgetId);
+  const row = getBudgetById(db, requireBudgetId(rowId));
   if (!row) return true;
   const { error } = await supabase.from("budgets").upsert({
     id: row.id,
@@ -150,10 +154,10 @@ async function processContributionEntry(
 async function processEntry(
   db: AnyDb,
   supabase: SupabaseClient,
-  entry: { id: string; tableName: string; rowId: string }
-): Promise<string | null> {
+  entry: { id: SyncQueueId; tableName: string; rowId: string }
+): Promise<SyncQueueId | null> {
   if (entry.tableName === "transactions") {
-    const row = await getTransactionById(db, entry.rowId as TransactionId);
+    const row = await getTransactionById(db, requireTransactionId(entry.rowId));
     if (!row) return entry.id;
     const { error } = await supabase.from("transactions").upsert(toSupabaseRow(row));
     if (error) {
@@ -200,12 +204,12 @@ export async function syncPush(
   const results = await Promise.allSettled(entries.map((e) => processEntry(db, supabase, e)));
   const processedIds = results
     .filter(
-      (r): r is PromiseFulfilledResult<string> => r.status === "fulfilled" && r.value !== null
+      (r): r is PromiseFulfilledResult<SyncQueueId> => r.status === "fulfilled" && r.value !== null
     )
     .map((r) => r.value);
 
   if (processedIds.length > 0) {
-    await clearSyncEntries(db, processedIds as SyncQueueId[]);
+    await clearSyncEntries(db, processedIds);
   }
 
   capturePipelineEvent({
@@ -243,7 +247,8 @@ export async function syncPull(
   let conflictCount = 0;
   for (const serverRow of rows) {
     try {
-      const localRow = await getTransactionById(db, serverRow.id as TransactionId);
+      const transactionId = requireTransactionId(serverRow.id);
+      const localRow = await getTransactionById(db, transactionId);
       const mappedServerRow = fromSupabaseRow(serverRow);
 
       if (shouldUpdateLocal(serverRow.updated_at, localRow?.updatedAt)) {
@@ -257,7 +262,7 @@ export async function syncPull(
           try {
             insertConflict(db, {
               id: generateSyncConflictId(),
-              transactionId: serverRow.id as TransactionId,
+              transactionId,
               localData: JSON.stringify(localRow),
               serverData: JSON.stringify(mappedServerRow),
               detectedAt: toIsoDateTime(new Date()),

--- a/apps/mobile/features/sync/store.ts
+++ b/apps/mobile/features/sync/store.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import type { AnyDb } from "@/shared/db";
 import { captureError } from "@/shared/lib";
-import type { SyncConflictId } from "@/shared/types/branded";
+import { requireSyncConflictId } from "@/shared/types/assertions";
 import {
   listConflicts,
   resolveConflict as resolveConflictBoundary,
@@ -42,7 +42,7 @@ export async function resolveSyncConflictSelection(
 ): Promise<void> {
   await resolveConflictBoundary({
     db,
-    conflictId: id as SyncConflictId,
+    conflictId: requireSyncConflictId(id),
     resolution,
   });
   await loadSyncConflicts(db);

--- a/apps/mobile/features/transactions/index.ts
+++ b/apps/mobile/features/transactions/index.ts
@@ -9,6 +9,7 @@ export {
   CATEGORY_IDS,
   CATEGORY_MAP,
   CATEGORY_ROWS,
+  getBuiltInCategoryId,
   isValidCategoryId,
 } from "./lib/categories";
 export { getDateLabel } from "./lib/format-date";

--- a/apps/mobile/features/transactions/lib/build-transaction.ts
+++ b/apps/mobile/features/transactions/lib/build-transaction.ts
@@ -1,14 +1,8 @@
-import { parseDigitsToAmount, parseIsoDate, toIsoDate } from "@/shared/lib";
-import type {
-  CategoryId,
-  CopAmount,
-  IsoDateTime,
-  TransactionId,
-  UserId,
-} from "@/shared/types/branded";
+import { parseDigitsToAmount, parseIsoDate, toIsoDate, toIsoDateTime } from "@/shared/lib";
+import type { CategoryId, CopAmount, TransactionId, UserId } from "@/shared/types/branded";
 import type { StoredTransaction, TransactionType } from "../schema";
 import { createTransactionSchema } from "../schema";
-import { isValidCategoryId } from "./categories";
+import { getBuiltInCategoryId, isValidCategoryId } from "./categories";
 import type { TransactionRow } from "./repository";
 
 type BuildInput = {
@@ -18,6 +12,8 @@ type BuildInput = {
   description: string;
   date: Date;
 };
+
+const OTHER_CATEGORY_ID = getBuiltInCategoryId("other");
 
 export function buildTransaction(
   input: BuildInput,
@@ -66,7 +62,7 @@ export function toStoredTransaction(row: TransactionRow): StoredTransaction {
     userId: row.userId,
     type: row.type as TransactionType,
     amount: row.amount,
-    categoryId: isValidCategoryId(row.categoryId) ? row.categoryId : ("other" as CategoryId),
+    categoryId: isValidCategoryId(row.categoryId) ? row.categoryId : OTHER_CATEGORY_ID,
     description: row.description ?? "",
     date: parseIsoDate(row.date),
     createdAt: new Date(row.createdAt),
@@ -84,7 +80,7 @@ export function toTransactionRow(tx: StoredTransaction): TransactionRow {
     categoryId: tx.categoryId,
     description: tx.description || null,
     date: toIsoDate(tx.date),
-    createdAt: tx.createdAt.toISOString() as IsoDateTime,
-    updatedAt: tx.updatedAt.toISOString() as IsoDateTime,
+    createdAt: toIsoDateTime(tx.createdAt),
+    updatedAt: toIsoDateTime(tx.updatedAt),
   };
 }

--- a/apps/mobile/features/transactions/lib/categories.ts
+++ b/apps/mobile/features/transactions/lib/categories.ts
@@ -88,6 +88,16 @@ export const CATEGORY_MAP: Record<string, Category | undefined> = Object.fromEnt
   CATEGORIES.map((c) => [c.id, c])
 );
 
+export const getBuiltInCategory = (id: string): Category => {
+  const category = CATEGORY_MAP[id];
+  if (!category) {
+    throw new Error(`Unknown built-in category: ${id}`);
+  }
+  return category;
+};
+
+export const getBuiltInCategoryId = (id: string): CategoryId => getBuiltInCategory(id).id;
+
 export const DEFAULT_CATEGORY_IDS: ReadonlySet<string> = new Set(CATEGORIES.map((c) => c.id));
 
 export const isValidCategoryId = (

--- a/apps/mobile/shared/lib/format-date.ts
+++ b/apps/mobile/shared/lib/format-date.ts
@@ -1,3 +1,4 @@
+import { assertIsoDate } from "@/shared/types/assertions";
 import type { IsoDate, IsoDateTime, Month } from "@/shared/types/branded";
 
 /**
@@ -28,6 +29,12 @@ export function parseIsoDate(isoDate: IsoDate): Date {
   const month = parts[1] ?? 1;
   const day = parts[2] ?? 1;
   return new Date(year, month - 1, day);
+}
+
+export function parseOptionalIsoDate(value: string | null | undefined): Date | null {
+  if (value == null) return null;
+  assertIsoDate(value);
+  return parseIsoDate(value);
 }
 
 /**

--- a/apps/mobile/shared/lib/index.ts
+++ b/apps/mobile/shared/lib/index.ts
@@ -21,7 +21,14 @@ export {
 } from "./analytics";
 export type { CurrencyConfig } from "./currency";
 export { getActiveCurrency } from "./currency";
-export { formatDateDisplay, parseIsoDate, toIsoDate, toIsoDateTime, toMonth } from "./format-date";
+export {
+  formatDateDisplay,
+  parseIsoDate,
+  parseOptionalIsoDate,
+  toIsoDate,
+  toIsoDateTime,
+  toMonth,
+} from "./format-date";
 export {
   cleanDigitInput,
   formatInputDisplay,

--- a/apps/mobile/shared/types/assertions.ts
+++ b/apps/mobile/shared/types/assertions.ts
@@ -1,11 +1,18 @@
 import type {
+  BillId,
+  BudgetId,
+  CategoryId,
   CopAmount,
+  DetectedSmsEventId,
   EmailAccountId,
   IsoDate,
   IsoDateTime,
   ProcessedEmailId,
+  SyncConflictId,
+  SyncQueueId,
   TransactionId,
   UserId,
+  UserMemoryId,
 } from "@/shared/types/branded";
 
 const ISO_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
@@ -102,12 +109,40 @@ export function assertTransactionId(value: string): asserts value is Transaction
   assertNonEmptyString(value, "transactionId");
 }
 
+export function assertBillId(value: string): asserts value is BillId {
+  assertNonEmptyString(value, "billId");
+}
+
+export function assertBudgetId(value: string): asserts value is BudgetId {
+  assertNonEmptyString(value, "budgetId");
+}
+
+export function assertCategoryId(value: string): asserts value is CategoryId {
+  assertNonEmptyString(value, "categoryId");
+}
+
+export function assertDetectedSmsEventId(value: string): asserts value is DetectedSmsEventId {
+  assertNonEmptyString(value, "detectedSmsEventId");
+}
+
 export function assertEmailAccountId(value: string): asserts value is EmailAccountId {
   assertNonEmptyString(value, "emailAccountId");
 }
 
 export function assertProcessedEmailId(value: string): asserts value is ProcessedEmailId {
   assertNonEmptyString(value, "processedEmailId");
+}
+
+export function assertSyncConflictId(value: string): asserts value is SyncConflictId {
+  assertNonEmptyString(value, "syncConflictId");
+}
+
+export function assertSyncQueueId(value: string): asserts value is SyncQueueId {
+  assertNonEmptyString(value, "syncQueueId");
+}
+
+export function assertUserMemoryId(value: string): asserts value is UserMemoryId {
+  assertNonEmptyString(value, "userMemoryId");
 }
 
 export function assertCopAmount(value: number): asserts value is CopAmount {
@@ -126,4 +161,59 @@ export function assertIsoDateTime(value: string): asserts value is IsoDateTime {
   if (!isValidIsoDateTimeValue(value)) {
     throw new Error("datetime must be a valid ISO 8601 timestamp");
   }
+}
+
+export function requireUserId(value: string): UserId {
+  assertUserId(value);
+  return value;
+}
+
+export function requireTransactionId(value: string): TransactionId {
+  assertTransactionId(value);
+  return value;
+}
+
+export function requireBillId(value: string): BillId {
+  assertBillId(value);
+  return value;
+}
+
+export function requireBudgetId(value: string): BudgetId {
+  assertBudgetId(value);
+  return value;
+}
+
+export function requireCategoryId(value: string): CategoryId {
+  assertCategoryId(value);
+  return value;
+}
+
+export function requireDetectedSmsEventId(value: string): DetectedSmsEventId {
+  assertDetectedSmsEventId(value);
+  return value;
+}
+
+export function requireIsoDate(value: string): IsoDate {
+  assertIsoDate(value);
+  return value;
+}
+
+export function requireIsoDateTime(value: string): IsoDateTime {
+  assertIsoDateTime(value);
+  return value;
+}
+
+export function requireUserMemoryId(value: string): UserMemoryId {
+  assertUserMemoryId(value);
+  return value;
+}
+
+export function requireSyncConflictId(value: string): SyncConflictId {
+  assertSyncConflictId(value);
+  return value;
+}
+
+export function requireSyncQueueId(value: string): SyncQueueId {
+  assertSyncQueueId(value);
+  return value;
 }


### PR DESCRIPTION
- scope branded lint to UI files
- add boundary helpers for ids and dates
- move UI callers to typed helpers
- deepen email and sync boundary decoding
- rerun lint, typecheck, and tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deepened branded-type boundaries and hardened parsing across mobile. IDs and dates are validated at boundaries; UI can’t cast; route `transactionId` is trimmed before branding; SMS timestamps are normalized (epoch ms/sec) or ignored if invalid.

- **Refactors**
  - Added boundary helpers for IDs and dates: `requireUserId`, `requireTransactionId`, `requireBillId`, `requireBudgetId`, `requireCategoryId`, `requireDetectedSmsEventId`, `requireSyncConflictId`, `requireSyncQueueId`, `requireIsoDate`, `requireIsoDateTime`, `requireUserMemoryId`.
  - Introduced `useOptionalUserId`, `parseOptionalIsoDate`, and `getBuiltInCategoryId`; updated screens, hooks, and stores to use them.
  - Scoped ESLint rule to UI/hooks/stores to block `as` assertions for branded IDs/dates.
  - Hardened parsing at boundaries:
    - Routes: trim and validate `transactionId` before use.
    - SMS detection: normalize epoch/ISO timestamps; ignore invalid values.
    - AI chat: Zod-validated rows and `memoryCategory`; throw on invalid `extract_memories` responses.
    - Email: typed `UserId`, fallback categories via `getBuiltInCategoryId("other")`, timestamps via `toIsoDateTime`.
    - Sync/search/notifications: guarded IDs (`requireTransactionId`, `requireBudgetId`, etc.) and validated date filters; branded datetimes in counts and “last visited”.
  - Date helpers: added `parseOptionalIsoDate`; normalized ISO datetimes via `toIsoDateTime`/`requireIsoDateTime`.
  - Docs: added boundary guidance to `AGENTS.md`.

- **Migration**
  - Replace UI casts with helpers:
    - Auth/user: `useOptionalUserId()`
    - Route/row IDs: `requireTransactionId()`, `requireBillId()`, etc.
    - Categories: `getBuiltInCategoryId("other" | "services")`
    - Optional dates: `parseOptionalIsoDate(...)`
  - Update feature APIs to pass branded `UserId`, IDs, and `IsoDateTime` where required.

<sup>Written for commit 1adbb0f2d7c8fee20b7b074f566672ade9d03f22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

