### PR TITLE
refactor(mobile): deepen budget seam

### DIFF
--- a/apps/mobile/__tests__/budget/store.test.ts
+++ b/apps/mobile/__tests__/budget/store.test.ts
@@ -7,7 +7,6 @@ const mockRefreshMonth = vi.fn();
 const mockLoadAutoSuggestions = vi.fn();
 const mockAcknowledgeAlert = vi.fn();
 const mockInsertNotificationRecord = vi.fn();
-const mockSubscribe = vi.fn(() => vi.fn());
 
 vi.mock("@/features/budget/lib/monitoring", () => ({
   createBudgetMonitoringModule: mockCreateBudgetMonitoringModule.mockImplementation(() => ({
@@ -35,9 +34,6 @@ vi.mock("@/features/transactions", async (importOriginal) => {
     ...actual,
     // biome-ignore lint/style/useNamingConvention: mock matches exported constant name
     CATEGORY_MAP: {},
-    useTransactionStore: {
-      subscribe: mockSubscribe,
-    },
   };
 });
 
@@ -65,9 +61,8 @@ function createDeferred<T>() {
   return { promise, resolve, reject };
 }
 
-async function getStore() {
-  const { useBudgetStore } = await import("@/features/budget/store");
-  return useBudgetStore;
+async function getBudgetModule() {
+  return import("@/features/budget/store");
 }
 
 describe("useBudgetStore", () => {
@@ -104,23 +99,23 @@ describe("useBudgetStore", () => {
       month === ("2026-03" as Month) ? deferredMarch.promise : Promise.resolve(freshSnapshot)
     );
 
-    const store = await getStore();
-    store.getState().initStore(mockDb, USER_ID);
-    store.setState({ currentMonth: "2026-03" as Month });
+    const { initializeBudgetSession, loadBudgetsForUser, useBudgetStore } = await getBudgetModule();
+    initializeBudgetSession(USER_ID);
+    useBudgetStore.getState().setMonth("2026-03" as Month);
 
-    const staleLoad = store.getState().loadBudgets();
+    const staleLoad = loadBudgetsForUser(mockDb, USER_ID);
 
-    store.setState({ currentMonth: "2026-04" as Month });
-    const freshLoad = store.getState().loadBudgets();
+    useBudgetStore.getState().setMonth("2026-04" as Month);
+    const freshLoad = loadBudgetsForUser(mockDb, USER_ID);
 
     await freshLoad;
     deferredMarch.resolve(staleSnapshot);
     await staleLoad;
 
-    expect(store.getState().currentMonth).toBe("2026-04");
-    expect(store.getState().budgets).toEqual(freshSnapshot.budgets);
-    expect(store.getState().summary).toEqual(freshSnapshot.summary);
-    expect(store.getState().isLoading).toBe(false);
+    expect(useBudgetStore.getState().currentMonth).toBe("2026-04");
+    expect(useBudgetStore.getState().budgets).toEqual(freshSnapshot.budgets);
+    expect(useBudgetStore.getState().summary).toEqual(freshSnapshot.summary);
+    expect(useBudgetStore.getState().isLoading).toBe(false);
   });
 
   it("clears loading when context changes without starting a newer refresh", async () => {
@@ -135,13 +130,13 @@ describe("useBudgetStore", () => {
 
     mockRefreshMonth.mockReturnValueOnce(deferredSnapshot.promise);
 
-    const store = await getStore();
-    store.getState().initStore(mockDb, USER_ID);
-    store.setState({ currentMonth: "2026-03" as Month });
+    const { initializeBudgetSession, loadBudgetsForUser, useBudgetStore } = await getBudgetModule();
+    initializeBudgetSession(USER_ID);
+    useBudgetStore.getState().setMonth("2026-03" as Month);
 
-    const load = store.getState().loadBudgets();
+    const load = loadBudgetsForUser(mockDb, USER_ID);
 
-    store.getState().initStore(mockDb, "user-2" as UserId);
+    initializeBudgetSession("user-2" as UserId);
     deferredSnapshot.resolve({
       budgets: [],
       budgetProgress: [],
@@ -152,7 +147,7 @@ describe("useBudgetStore", () => {
     });
     await load;
 
-    expect(store.getState().isLoading).toBe(false);
+    expect(useBudgetStore.getState().isLoading).toBe(false);
   });
 
   it("drops stale notification side effects after the active user changes", async () => {
@@ -167,18 +162,18 @@ describe("useBudgetStore", () => {
 
     mockRefreshMonth.mockReturnValueOnce(deferredSnapshot.promise);
 
-    const store = await getStore();
-    store.getState().initStore(mockDb, USER_ID);
-    store.setState({ currentMonth: "2026-03" as Month });
+    const { initializeBudgetSession, loadBudgetsForUser, useBudgetStore } = await getBudgetModule();
+    initializeBudgetSession(USER_ID);
+    useBudgetStore.getState().setMonth("2026-03" as Month);
 
     const monitoringCallsBeforeLoad = mockCreateBudgetMonitoringModule.mock.calls.length;
-    const load = store.getState().loadBudgets();
+    const load = loadBudgetsForUser(mockDb, USER_ID);
     const initialMonitoringPorts =
       mockCreateBudgetMonitoringModule.mock.calls[monitoringCallsBeforeLoad]?.[0];
 
     expect(initialMonitoringPorts).toBeDefined();
 
-    store.getState().initStore(mockDb, "user-2" as UserId);
+    initializeBudgetSession("user-2" as UserId);
 
     initialMonitoringPorts.insertNotification({
       type: "budget_alert",
@@ -212,14 +207,15 @@ describe("useBudgetStore", () => {
     ];
     mockLoadAutoSuggestions.mockReturnValue(suggestions);
 
-    const store = await getStore();
-    store.getState().initStore(mockDb, USER_ID);
-    store.setState({
+    const { initializeBudgetSession, loadBudgetAutoSuggestions, useBudgetStore } =
+      await getBudgetModule();
+    initializeBudgetSession(USER_ID);
+    useBudgetStore.setState({
       currentMonth: "2026-03" as Month,
       budgets: [{ id: "budget-1", categoryId: "food" as CategoryId }] as any[],
     });
 
-    store.getState().loadAutoSuggestions();
+    loadBudgetAutoSuggestions(mockDb, USER_ID);
 
     expect(mockLoadAutoSuggestions).toHaveBeenCalledWith({
       db: mockDb,
@@ -228,6 +224,6 @@ describe("useBudgetStore", () => {
       existingCategoryIds: new Set(["food" as CategoryId]),
     });
     expect(mockRefreshMonth).not.toHaveBeenCalled();
-    expect(store.getState().autoSuggestions).toEqual(suggestions);
+    expect(useBudgetStore.getState().autoSuggestions).toEqual(suggestions);
   });
 });

--- a/apps/mobile/__tests__/budget/transaction-subscription.test.ts
+++ b/apps/mobile/__tests__/budget/transaction-subscription.test.ts
@@ -34,4 +34,33 @@ describe("budget transaction subscription", () => {
     cleanup();
     expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
+
+  it("preserves a revision bump until budget state has finished its first load", () => {
+    let notify: () => void = () => undefined;
+    let hasLoadedBudgetState = false;
+    let currentRevision = 0;
+
+    const reload = vi.fn();
+
+    subscribeBudgetToTransactions({
+      subscribeTransactions: (listener) => {
+        notify = listener;
+        return vi.fn();
+      },
+      getTransactionDataRevision: () => currentRevision,
+      hasLoadedBudgetState: () => hasLoadedBudgetState,
+      reload,
+    });
+
+    currentRevision = 1;
+    notify();
+    expect(reload).not.toHaveBeenCalled();
+
+    hasLoadedBudgetState = true;
+    notify();
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    notify();
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/mobile/__tests__/budget/transaction-subscription.test.ts
+++ b/apps/mobile/__tests__/budget/transaction-subscription.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+import { subscribeBudgetToTransactions } from "@/features/budget/services/subscribe-budget-to-transactions";
+
+describe("budget transaction subscription", () => {
+  it("reloads only after budget state has loaded and the transaction data revision changes", () => {
+    let notify: () => void = () => undefined;
+    let hasLoadedBudgetState = false;
+    let currentRevision = 0;
+
+    const unsubscribe = vi.fn();
+    const reload = vi.fn();
+
+    const cleanup = subscribeBudgetToTransactions({
+      subscribeTransactions: (listener) => {
+        notify = listener;
+        return unsubscribe;
+      },
+      getTransactionDataRevision: () => currentRevision,
+      hasLoadedBudgetState: () => hasLoadedBudgetState,
+      reload,
+    });
+
+    notify();
+    expect(reload).not.toHaveBeenCalled();
+
+    hasLoadedBudgetState = true;
+    notify();
+    expect(reload).not.toHaveBeenCalled();
+
+    currentRevision += 1;
+    notify();
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    cleanup();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/app/(auth)/onboarding.tsx
+++ b/apps/mobile/app/(auth)/onboarding.tsx
@@ -3,7 +3,7 @@ import * as SplashScreen from "expo-splash-screen";
 import { useState } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useOptionalUserId } from "@/features/auth";
-import { useBudgetStore } from "@/features/budget";
+import { initializeBudgetSession } from "@/features/budget";
 import { useEmailCaptureStore } from "@/features/email-capture";
 import {
   BudgetSetupStep,
@@ -53,7 +53,7 @@ function AuthenticatedOnboardingScreen({
     () => {
       useEmailCaptureStore.getState().initStore(db, userId);
       useTransactionStore.getState().initStore(db, userId);
-      useBudgetStore.getState().initStore(db, userId);
+      initializeBudgetSession(userId);
       Promise.all([
         useEmailCaptureStore.getState().loadAccounts(),
         useTransactionStore.getState().loadInitialPage(),

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -24,7 +24,12 @@ import {
 } from "@/features/analytics";
 import { useAuthStore, useOptionalUserId } from "@/features/auth";
 import { registerBackgroundTask } from "@/features/background-fetch";
-import { useBudgetStore } from "@/features/budget";
+import {
+  initializeBudgetSession,
+  loadBudgetsForUser,
+  subscribeBudgetToTransactions,
+  useBudgetStore,
+} from "@/features/budget";
 import {
   initializeCalendarSession,
   loadBills as loadCalendarBills,
@@ -94,17 +99,14 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
       useEmailCaptureStore.getState().initStore(db, userId);
       useChatStore.getState().initStore(db, userId);
       initializeCalendarSession(userId);
-      useBudgetStore.getState().initStore(db, userId);
+      initializeBudgetSession(userId);
       initializeGoalSession(userId);
       initializeAnalyticsSession(userId);
       void initializeNotificationStore(db, userId);
       Promise.all([loadCalendarBills(db, userId), loadCalendarPaymentsForMonth(db)]).catch(
         handleRecoverableError("Failed to load calendar data")
       );
-      useBudgetStore
-        .getState()
-        .loadBudgets()
-        .catch(handleRecoverableError("Failed to load budgets"));
+      loadBudgetsForUser(db, userId).catch(handleRecoverableError("Failed to load budgets"));
       loadGoalsForUser(db, userId).catch(handleRecoverableError("Failed to load goals"));
       loadAnalyticsForUser(db, userId).catch(handleRecoverableError("Failed to load analytics"));
       refreshCategories(db, userId).catch(handleRecoverableError("Failed to load user categories"));
@@ -127,6 +129,22 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
         .catch(handleRecoverableError("Failed to hydrate settings"));
       void registerBackgroundTask().catch(captureError);
     },
+    [db, userId],
+    migrationsReady
+  );
+
+  useSubscription(
+    () =>
+      subscribeBudgetToTransactions({
+        subscribeTransactions: useTransactionStore.subscribe,
+        getTransactionDataRevision: () => useTransactionStore.getState().dataRevision,
+        hasLoadedBudgetState: () => useBudgetStore.getState().hasLoadedOnce,
+        reload: () => {
+          void loadBudgetsForUser(db, userId).catch(
+            handleRecoverableError("Failed to load budgets")
+          );
+        },
+      }),
     [db, userId],
     migrationsReady
   );

--- a/apps/mobile/app/auto-suggest-budgets.tsx
+++ b/apps/mobile/app/auto-suggest-budgets.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from "expo-router";
-import { useBudgetStore, useSuggestionSelection } from "@/features/budget";
+import { useOptionalUserId } from "@/features/auth";
+import { acceptBudgetSuggestions, useBudgetStore, useSuggestionSelection } from "@/features/budget";
 import { CATEGORY_MAP } from "@/features/transactions";
 import {
   KeyboardAvoidingView,
@@ -12,6 +13,7 @@ import {
   TextInput,
   View,
 } from "@/shared/components/rn";
+import { tryGetDb } from "@/shared/db";
 import { useAsyncGuard, useThemeColor, useTranslation } from "@/shared/hooks";
 import { getCategoryLabel } from "@/shared/i18n";
 import {
@@ -23,9 +25,10 @@ import {
 export default function AutoSuggestBudgetsScreen() {
   const router = useRouter();
   const { t, locale } = useTranslation();
+  const userId = useOptionalUserId();
+  const db = userId ? tryGetDb(userId) : null;
 
   const autoSuggestions = useBudgetStore((s) => s.autoSuggestions);
-  const acceptSuggestions = useBudgetStore((s) => s.acceptSuggestions);
 
   const { selectedIds, editedAmounts, handleToggle, handleAmountChange, buildBudgetMap } =
     useSuggestionSelection(autoSuggestions);
@@ -43,7 +46,9 @@ export default function AutoSuggestBudgetsScreen() {
     void guardedRun(async () => {
       const budgets = buildBudgetMap();
       if (budgets.size > 0) {
-        await acceptSuggestions(budgets);
+        if (!userId || !db) return;
+        const success = await acceptBudgetSuggestions(db, userId, budgets);
+        if (!success) return;
         trackBudgetSuggestionAccepted({ count: budgets.size });
       } else {
         trackBudgetSuggestionRejected();
@@ -138,7 +143,7 @@ export default function AutoSuggestBudgetsScreen() {
               { backgroundColor: accentGreen, opacity: isBusy ? 0.5 : 1 },
             ]}
             onPress={handleAccept}
-            disabled={isBusy}
+            disabled={isBusy || ((userId == null || db == null) && selectedIds.size > 0)}
           >
             <Text style={styles.acceptButtonText}>{t("budgets.autoSuggest.acceptSelected")}</Text>
           </Pressable>

--- a/apps/mobile/app/create-budget.tsx
+++ b/apps/mobile/app/create-budget.tsx
@@ -1,7 +1,15 @@
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useCallback, useMemo, useState } from "react";
 import Animated from "react-native-reanimated";
-import { type Budget, type BudgetSuggestion, useBudgetStore } from "@/features/budget";
+import { useOptionalUserId } from "@/features/auth";
+import {
+  type Budget,
+  type BudgetSuggestion,
+  createBudget,
+  deleteBudget,
+  updateBudget,
+  useBudgetStore,
+} from "@/features/budget";
 import {
   CATEGORIES,
   type CategoryId,
@@ -11,6 +19,7 @@ import {
 } from "@/features/transactions";
 import { FidyNumpad } from "@/shared/components";
 import { Pressable, ScrollView, StyleSheet, Text, View } from "@/shared/components/rn";
+import { tryGetDb } from "@/shared/db";
 import { useAsyncGuard, useBlinkingCursor, useThemeColor, useTranslation } from "@/shared/hooks";
 import { getCategoryLabel } from "@/shared/i18n";
 import { formatInputDisplay, formatMoney, parseDigitsToAmount } from "@/shared/lib";
@@ -23,14 +32,16 @@ function CreateBudgetForm({
   onCreateBudget,
   onUpdateBudget,
   onDeleteBudget,
+  canMutate,
   onDone,
 }: {
   readonly existingBudget: Budget | undefined;
   readonly existingCategoryIds: ReadonlySet<string>;
   readonly autoSuggestions: readonly BudgetSuggestion[];
   readonly onCreateBudget: (categoryId: CategoryId, amount: CopAmount) => Promise<boolean>;
-  readonly onUpdateBudget: (id: BudgetId, amount: CopAmount) => Promise<void>;
-  readonly onDeleteBudget: (id: BudgetId) => Promise<void>;
+  readonly onUpdateBudget: (id: BudgetId, amount: CopAmount) => Promise<boolean>;
+  readonly onDeleteBudget: (id: BudgetId) => Promise<boolean>;
+  readonly canMutate: boolean;
   readonly onDone: () => void;
 }) {
   const { t, locale } = useTranslation();
@@ -68,8 +79,8 @@ function CreateBudgetForm({
       if (amount <= 0) return;
 
       if (existingBudget) {
-        await onUpdateBudget(existingBudget.id, amount);
-        onDone();
+        const success = await onUpdateBudget(existingBudget.id, amount);
+        if (success) onDone();
         return;
       }
 
@@ -82,8 +93,8 @@ function CreateBudgetForm({
   const handleDelete = () => {
     void guardedSave(async () => {
       if (!existingBudget) return;
-      await onDeleteBudget(existingBudget.id);
-      onDone();
+      const success = await onDeleteBudget(existingBudget.id);
+      if (success) onDone();
     });
   };
 
@@ -159,7 +170,7 @@ function CreateBudgetForm({
       <Pressable
         style={[styles.saveButton, { backgroundColor: accentGreen, opacity: isSaving ? 0.5 : 1 }]}
         onPress={handleSave}
-        disabled={isSaving}
+        disabled={isSaving || !canMutate}
       >
         <Text style={styles.saveButtonText}>{t("common.save")}</Text>
       </Pressable>
@@ -168,7 +179,7 @@ function CreateBudgetForm({
         <Pressable
           style={[styles.deleteButton, { borderColor: accentRed }]}
           onPress={handleDelete}
-          disabled={isSaving}
+          disabled={isSaving || !canMutate}
         >
           <Text style={[styles.deleteButtonText, { color: accentRed }]}>{t("common.delete")}</Text>
         </Pressable>
@@ -182,14 +193,14 @@ function CreateBudgetForm({
 export default function CreateBudgetScreen() {
   const router = useRouter();
   const { budgetId } = useLocalSearchParams<{ budgetId?: string }>();
+  const userId = useOptionalUserId();
+  const db = userId ? tryGetDb(userId) : null;
 
   const budgets = useBudgetStore((s) => s.budgets);
   const autoSuggestions = useBudgetStore((s) => s.autoSuggestions);
-  const createBudget = useBudgetStore((s) => s.createBudget);
-  const updateBudget = useBudgetStore((s) => s.updateBudget);
-  const deleteBudget = useBudgetStore((s) => s.deleteBudget);
 
   const existingBudget = budgetId ? budgets.find((b) => b.id === budgetId) : undefined;
+  const canMutate = userId != null && db != null;
 
   const existingCategoryIds = useMemo(
     () => new Set(budgets.filter((b) => b.id !== budgetId).map((b) => b.categoryId)),
@@ -202,9 +213,19 @@ export default function CreateBudgetScreen() {
       existingBudget={existingBudget}
       existingCategoryIds={existingCategoryIds}
       autoSuggestions={autoSuggestions}
-      onCreateBudget={createBudget}
-      onUpdateBudget={updateBudget}
-      onDeleteBudget={deleteBudget}
+      onCreateBudget={(categoryId, amount) => {
+        if (!userId || !db) return Promise.resolve(false);
+        return createBudget(db, userId, categoryId, amount);
+      }}
+      onUpdateBudget={(id, amount) => {
+        if (!userId || !db) return Promise.resolve(false);
+        return updateBudget(db, userId, id, amount);
+      }}
+      onDeleteBudget={(id) => {
+        if (!userId || !db) return Promise.resolve(false);
+        return deleteBudget(db, userId, id);
+      }}
+      canMutate={canMutate}
       onDone={() => router.back()}
     />
   );

--- a/apps/mobile/features/budget/components/BudgetListScreen.tsx
+++ b/apps/mobile/features/budget/components/BudgetListScreen.tsx
@@ -1,11 +1,13 @@
 import { useRouter } from "expo-router";
 import { useCallback } from "react";
+import { useOptionalUserId } from "@/features/auth";
 import { MonthNavigator } from "@/features/calendar";
 import { ScreenLayout, TAB_BAR_CLEARANCE } from "@/shared/components";
 import { Plus, Wallet } from "@/shared/components/icons";
 import { Platform, Pressable, ScrollView, StyleSheet, Text, View } from "@/shared/components/rn";
+import { tryGetDb } from "@/shared/db";
 import { useSubscription, useThemeColor, useTranslation } from "@/shared/hooks";
-import { useBudgetStore } from "../store";
+import { nextBudgetMonth, prevBudgetMonth, useBudgetStore } from "../store";
 import { BudgetCard } from "./BudgetCard";
 import { BudgetSummaryCard } from "./BudgetSummaryCard";
 import { UpcomingBillsSection } from "./UpcomingBillsSection";
@@ -28,10 +30,9 @@ export function BudgetListScreen() {
   const budgets = useBudgetStore((s) => s.budgets);
   const budgetProgress = useBudgetStore((s) => s.budgetProgress);
   const summary = useBudgetStore((s) => s.summary);
-  const nextMonth = useBudgetStore((s) => s.nextMonth);
-  const prevMonth = useBudgetStore((s) => s.prevMonth);
   const pendingPermissionRequest = useBudgetStore((s) => s.pendingPermissionRequest);
   const clearPendingPermissionRequest = useBudgetStore((s) => s.clearPendingPermissionRequest);
+  const userId = useOptionalUserId();
 
   // Navigate to pre-permission screen when store signals it.
   // Uses useSubscription because the store's refreshProgress() is async/deep in the derivation
@@ -59,6 +60,20 @@ export function BudgetListScreen() {
     router.push("/create-budget");
   };
 
+  const handleNextMonth = useCallback(() => {
+    if (!userId) return;
+    const db = tryGetDb(userId);
+    if (!db) return;
+    void nextBudgetMonth(db, userId);
+  }, [userId]);
+
+  const handlePrevMonth = useCallback(() => {
+    if (!userId) return;
+    const db = tryGetDb(userId);
+    if (!db) return;
+    void prevBudgetMonth(db, userId);
+  }, [userId]);
+
   const handleAutoSetup = () => {
     router.push("/auto-suggest-budgets");
   };
@@ -84,7 +99,11 @@ export function BudgetListScreen() {
       }
     >
       <View style={styles.content}>
-        <MonthNavigator currentMonth={monthAsDate} onPrev={prevMonth} onNext={nextMonth} />
+        <MonthNavigator
+          currentMonth={monthAsDate}
+          onPrev={handlePrevMonth}
+          onNext={handleNextMonth}
+        />
 
         <ScrollView
           contentContainerStyle={[styles.scrollContent, { paddingBottom: TAB_BAR_CLEARANCE }]}

--- a/apps/mobile/features/budget/index.ts
+++ b/apps/mobile/features/budget/index.ts
@@ -30,4 +30,17 @@ export {
 } from "./lib/repository";
 export type { Budget, CreateBudgetInput } from "./schema";
 export { createBudgetSchema } from "./schema";
-export { useBudgetStore } from "./store";
+export { subscribeBudgetToTransactions } from "./services/subscribe-budget-to-transactions";
+export {
+  acceptBudgetSuggestions,
+  copyBudgetsForward,
+  createBudget,
+  deleteBudget,
+  initializeBudgetSession,
+  loadBudgetAutoSuggestions,
+  loadBudgetsForUser,
+  nextBudgetMonth,
+  prevBudgetMonth,
+  updateBudget,
+  useBudgetStore,
+} from "./store";

--- a/apps/mobile/features/budget/services/subscribe-budget-to-transactions.ts
+++ b/apps/mobile/features/budget/services/subscribe-budget-to-transactions.ts
@@ -1,0 +1,23 @@
+type SubscribeBudgetToTransactionsInput = {
+  readonly subscribeTransactions: (listener: () => void) => () => void;
+  readonly getTransactionDataRevision: () => number;
+  readonly hasLoadedBudgetState: () => boolean;
+  readonly reload: () => void;
+};
+
+export function subscribeBudgetToTransactions({
+  subscribeTransactions,
+  getTransactionDataRevision,
+  hasLoadedBudgetState,
+  reload,
+}: SubscribeBudgetToTransactionsInput): () => void {
+  let previousRevision = getTransactionDataRevision();
+
+  return subscribeTransactions(() => {
+    const currentRevision = getTransactionDataRevision();
+    if (currentRevision === previousRevision) return;
+    previousRevision = currentRevision;
+    if (!hasLoadedBudgetState()) return;
+    reload();
+  });
+}

--- a/apps/mobile/features/budget/services/subscribe-budget-to-transactions.ts
+++ b/apps/mobile/features/budget/services/subscribe-budget-to-transactions.ts
@@ -12,12 +12,19 @@ export function subscribeBudgetToTransactions({
   reload,
 }: SubscribeBudgetToTransactionsInput): () => void {
   let previousRevision = getTransactionDataRevision();
+  let hasPendingReload = false;
 
   return subscribeTransactions(() => {
     const currentRevision = getTransactionDataRevision();
-    if (currentRevision === previousRevision) return;
-    previousRevision = currentRevision;
+    if (currentRevision !== previousRevision && !hasLoadedBudgetState()) {
+      hasPendingReload = true;
+      return;
+    }
+    if (currentRevision === previousRevision && !hasPendingReload) return;
     if (!hasLoadedBudgetState()) return;
+
+    previousRevision = currentRevision;
+    hasPendingReload = false;
     reload();
   });
 }

--- a/apps/mobile/features/budget/store.ts
+++ b/apps/mobile/features/budget/store.ts
@@ -2,33 +2,30 @@ import { addMonths, format, subMonths } from "date-fns";
 import { create } from "zustand";
 import { insertNotificationRecord } from "@/features/notifications";
 import { useSettingsStore } from "@/features/settings";
-import { CATEGORY_MAP, useTransactionStore } from "@/features/transactions";
-import { createWriteThroughMutationModule, type WriteThroughMutationModule } from "@/mutations";
+import { CATEGORY_MAP } from "@/features/transactions";
+import { createWriteThroughMutationModule } from "@/mutations";
 import type { AnyDb } from "@/shared/db";
 import { getCategoryLabel, useLocaleStore } from "@/shared/i18n";
 import { generateBudgetId, toIsoDateTime, trackBudgetCreated } from "@/shared/lib";
 import type { BudgetId, CategoryId, CopAmount, Month, UserId } from "@/shared/types/branded";
 import type { BudgetAlert, BudgetProgress, BudgetSuggestion } from "./lib/derive";
+import type { BudgetMonthSnapshot } from "./lib/monitoring";
 import { createBudgetMonitoringModule } from "./lib/monitoring";
 import { scheduleBudgetAlert } from "./lib/notifications";
 import type { Budget } from "./schema";
 import { createBudgetSchema } from "./schema";
 
-// Module-level refs: Zustand doesn't serialize DB connections, so we keep them outside the store.
-let dbRef: AnyDb | null = null;
-let userIdRef: UserId | null = null;
-let unsubscribeTxStore: (() => void) | null = null;
+let budgetSessionId = 0;
 let loadBudgetsRequestId = 0;
-let mutations: WriteThroughMutationModule | null = null;
 
 const formatMonth = (date: Date): Month => format(date, "yyyy-MM") as Month;
 
 /** Parse "YYYY-MM" to a local-time Date (1st of month). Avoids UTC date-only parsing pitfall. */
 const parseMonth = (month: Month): Date => {
   const parts = month.split("-").map(Number);
-  const y = parts[0] ?? 0;
-  const m = parts[1] ?? 1;
-  return new Date(y, m - 1, 1);
+  const year = parts[0] ?? 0;
+  const monthIndex = (parts[1] ?? 1) - 1;
+  return new Date(year, monthIndex, 1);
 };
 
 const createLiveBudgetMonitoring = (
@@ -62,35 +59,35 @@ const budgetAlertStateManager = createBudgetMonitoringModule({
 });
 
 type BudgetState = {
-  currentMonth: Month;
-  budgets: Budget[];
-  budgetProgress: BudgetProgress[];
-  summary: { totalBudget: number; totalSpent: number; percentUsed: number };
-  autoSuggestions: BudgetSuggestion[];
-  acknowledgedAlerts: Set<string>; // "budgetId:threshold" keys
-  pendingAlerts: readonly BudgetAlert[];
-  pendingPermissionRequest: boolean;
-  isLoading: boolean;
+  readonly activeUserId: UserId | null;
+  readonly currentMonth: Month;
+  readonly budgets: readonly Budget[];
+  readonly budgetProgress: readonly BudgetProgress[];
+  readonly summary: {
+    readonly totalBudget: number;
+    readonly totalSpent: number;
+    readonly percentUsed: number;
+  };
+  readonly autoSuggestions: readonly BudgetSuggestion[];
+  readonly acknowledgedAlerts: ReadonlySet<string>;
+  readonly pendingAlerts: readonly BudgetAlert[];
+  readonly pendingPermissionRequest: boolean;
+  readonly hasLoadedOnce: boolean;
+  readonly isLoading: boolean;
 };
 
 type BudgetActions = {
-  initStore: (db: AnyDb, userId: UserId) => void;
+  beginSession: (userId: UserId) => void;
   setMonth: (month: Month) => void;
-  nextMonth: () => void;
-  prevMonth: () => void;
-  loadBudgets: () => Promise<void>;
-  refreshProgress: () => void;
-  createBudget: (categoryId: CategoryId, amount: CopAmount) => Promise<boolean>;
-  updateBudget: (id: BudgetId, amount: CopAmount) => Promise<void>;
-  deleteBudget: (id: BudgetId) => Promise<void>;
-  copyBudgetsForward: (targetMonth: Month) => Promise<void>;
-  loadAutoSuggestions: () => void;
-  acceptSuggestions: (budgets: ReadonlyMap<CategoryId, CopAmount>) => Promise<void>;
+  setSnapshot: (snapshot: BudgetMonthSnapshot) => void;
+  setAutoSuggestions: (autoSuggestions: readonly BudgetSuggestion[]) => void;
+  setIsLoading: (isLoading: boolean) => void;
   acknowledgeAlert: (budgetId: BudgetId, threshold: 80 | 100) => void;
   clearPendingPermissionRequest: () => void;
 };
 
-export const useBudgetStore = create<BudgetState & BudgetActions>((set, get) => ({
+export const useBudgetStore = create<BudgetState & BudgetActions>((set) => ({
+  activeUserId: null,
   currentMonth: formatMonth(new Date()),
   budgets: [],
   budgetProgress: [],
@@ -99,237 +96,44 @@ export const useBudgetStore = create<BudgetState & BudgetActions>((set, get) => 
   acknowledgedAlerts: new Set(),
   pendingAlerts: [],
   pendingPermissionRequest: false,
+  hasLoadedOnce: false,
   isLoading: false,
 
-  initStore: (db, userId) => {
-    dbRef = db;
-    userIdRef = userId;
-    mutations = createWriteThroughMutationModule(db);
-    // Subscribe to transaction store changes to auto-refresh progress
-    if (unsubscribeTxStore) unsubscribeTxStore();
-    unsubscribeTxStore = useTransactionStore.subscribe(() => {
-      // Re-run the full month refresh so transaction changes and alert policy stay in one path.
-      void get().loadBudgets();
-    });
-  },
+  beginSession: (userId) =>
+    set((state) => ({
+      activeUserId: userId,
+      currentMonth: state.currentMonth,
+      budgets: [],
+      budgetProgress: [],
+      summary: { totalBudget: 0, totalSpent: 0, percentUsed: 0 },
+      autoSuggestions: [],
+      acknowledgedAlerts: new Set(),
+      pendingAlerts: [],
+      pendingPermissionRequest: false,
+      hasLoadedOnce: false,
+      isLoading: false,
+    })),
 
-  setMonth: (month) => {
-    set({ currentMonth: month });
-    void get().loadBudgets();
-  },
+  setMonth: (currentMonth) => set({ currentMonth }),
 
-  nextMonth: () => {
-    const current = parseMonth(get().currentMonth);
-    const next = addMonths(current, 1);
-    get().setMonth(formatMonth(next));
-  },
+  setSnapshot: (snapshot) =>
+    set((state) => ({
+      budgets: snapshot.budgets as Budget[],
+      budgetProgress: snapshot.budgetProgress as BudgetProgress[],
+      summary: snapshot.summary,
+      autoSuggestions: snapshot.autoSuggestions as BudgetSuggestion[],
+      pendingAlerts: snapshot.pendingAlerts,
+      pendingPermissionRequest: state.pendingPermissionRequest || snapshot.pendingPermissionRequest,
+      hasLoadedOnce: true,
+      isLoading: false,
+    })),
 
-  prevMonth: () => {
-    const current = parseMonth(get().currentMonth);
-    const prev = subMonths(current, 1);
-    get().setMonth(formatMonth(prev));
-  },
+  setAutoSuggestions: (autoSuggestions) =>
+    set({ autoSuggestions: [...autoSuggestions] as BudgetSuggestion[] }),
 
-  loadBudgets: async () => {
-    if (!dbRef || !userIdRef) return;
-    const requestId = ++loadBudgetsRequestId;
-    const requestedDb = dbRef;
-    const requestedUserId = userIdRef;
-    const requestedMonth = get().currentMonth;
-    const isCurrentRefresh = () =>
-      loadBudgetsRequestId === requestId &&
-      dbRef === requestedDb &&
-      userIdRef === requestedUserId &&
-      get().currentMonth === requestedMonth;
-    const previous = {
-      pendingAlerts: get().pendingAlerts,
-      acknowledgedAlerts: get().acknowledgedAlerts,
-    };
-    set({ isLoading: true });
-    try {
-      const budgetMonitoring = createLiveBudgetMonitoring(
-        requestedDb,
-        requestedUserId,
-        isCurrentRefresh
-      );
-      const snapshot = await budgetMonitoring.refreshMonth({
-        db: requestedDb,
-        userId: requestedUserId,
-        month: requestedMonth,
-        previous,
-      });
-      if (!isCurrentRefresh()) {
-        if (loadBudgetsRequestId === requestId) {
-          set({ isLoading: false });
-        }
-        return;
-      }
-      set((state) => ({
-        budgets: snapshot.budgets as Budget[],
-        budgetProgress: snapshot.budgetProgress as BudgetProgress[],
-        summary: snapshot.summary,
-        autoSuggestions: snapshot.autoSuggestions as BudgetSuggestion[],
-        pendingAlerts: snapshot.pendingAlerts,
-        pendingPermissionRequest:
-          state.pendingPermissionRequest || snapshot.pendingPermissionRequest,
-        isLoading: false,
-      }));
-    } catch {
-      if (loadBudgetsRequestId === requestId) {
-        set({ isLoading: false });
-      }
-    }
-  },
+  setIsLoading: (isLoading) => set({ isLoading }),
 
-  refreshProgress: () => {
-    void get().loadBudgets();
-  },
-
-  loadAutoSuggestions: () => {
-    if (!dbRef || !userIdRef) return;
-    const { currentMonth, budgets } = get();
-    try {
-      const budgetMonitoring = createLiveBudgetMonitoring(dbRef, userIdRef, () => true);
-      const autoSuggestions = budgetMonitoring.loadAutoSuggestions({
-        db: dbRef,
-        userId: userIdRef,
-        month: currentMonth,
-        existingCategoryIds: new Set(budgets.map((budget) => budget.categoryId)),
-      });
-      set({ autoSuggestions: autoSuggestions as BudgetSuggestion[] });
-    } catch {
-      // Query failed — keep existing suggestions
-    }
-  },
-
-  createBudget: async (categoryId, amount) => {
-    if (!dbRef || !userIdRef) return false;
-    const validation = createBudgetSchema.safeParse({
-      categoryId,
-      amount,
-      month: get().currentMonth,
-    });
-    if (!validation.success) return false;
-    const mutationModule = mutations;
-    if (!mutationModule) return false;
-    const now = toIsoDateTime(new Date());
-    const id = generateBudgetId();
-    try {
-      const result = await mutationModule.commit({
-        kind: "budget.save",
-        row: {
-          id,
-          userId: userIdRef,
-          categoryId,
-          amount,
-          month: get().currentMonth,
-          createdAt: now,
-          updatedAt: now,
-          deletedAt: null,
-        },
-      });
-      if (!result.success) return false;
-    } catch {
-      return false;
-    }
-    trackBudgetCreated({ category: String(categoryId) });
-    await get().loadBudgets();
-    return true;
-  },
-
-  updateBudget: async (id, amount) => {
-    if (!dbRef) return;
-    const mutationModule = mutations;
-    if (!mutationModule) return;
-    const now = toIsoDateTime(new Date());
-    try {
-      const result = await mutationModule.commit({
-        kind: "budget.update",
-        budgetId: id,
-        amount,
-        now,
-      });
-      if (!result.success) return;
-    } catch {
-      return;
-    }
-    await get().loadBudgets();
-  },
-
-  deleteBudget: async (id) => {
-    if (!dbRef) return;
-    const mutationModule = mutations;
-    if (!mutationModule) return;
-    const now = toIsoDateTime(new Date());
-    try {
-      const result = await mutationModule.commit({
-        kind: "budget.delete",
-        budgetId: id,
-        now,
-      });
-      if (!result.success) return;
-    } catch {
-      return;
-    }
-    await get().loadBudgets();
-  },
-
-  copyBudgetsForward: async (targetMonth) => {
-    if (!dbRef || !userIdRef) return;
-    const userId = userIdRef;
-    const now = toIsoDateTime(new Date());
-    const mutationModule = mutations;
-    if (!mutationModule) return;
-    try {
-      const result = await mutationModule.commit({
-        kind: "budget.copy",
-        sourceMonth: get().currentMonth,
-        targetMonth,
-        userId,
-        now,
-      });
-      if (!result.success) return;
-    } catch {
-      return;
-    }
-    // Navigate to target month and reload
-    set({ currentMonth: targetMonth });
-    await get().loadBudgets();
-  },
-
-  acceptSuggestions: async (budgetsByCategory) => {
-    if (!dbRef || !userIdRef) return;
-    const userId = userIdRef;
-    const { currentMonth } = get();
-    const now = toIsoDateTime(new Date());
-    const entries = Array.from(budgetsByCategory.entries());
-    if (entries.length === 0) return;
-    const mutationModule = mutations;
-    if (!mutationModule) return;
-    try {
-      const result = await mutationModule.commitBatch(
-        entries.map(([categoryId, amount]) => ({
-          kind: "budget.save",
-          row: {
-            id: generateBudgetId(),
-            userId,
-            categoryId,
-            amount,
-            month: currentMonth,
-            createdAt: now,
-            updatedAt: now,
-            deletedAt: null,
-          },
-        }))
-      );
-      if (result.some((item) => !item.success)) return;
-    } catch {
-      return;
-    }
-    await get().loadBudgets();
-  },
-
-  acknowledgeAlert: (budgetId, threshold) => {
+  acknowledgeAlert: (budgetId, threshold) =>
     set((state) => {
       const nextState = budgetAlertStateManager.acknowledgeAlert({
         budgetId,
@@ -344,10 +148,254 @@ export const useBudgetStore = create<BudgetState & BudgetActions>((set, get) => 
         acknowledgedAlerts: new Set(nextState.acknowledgedAlerts),
         pendingAlerts: nextState.pendingAlerts,
       };
-    });
-  },
+    }),
 
   clearPendingPermissionRequest: () => {
     set({ pendingPermissionRequest: false });
   },
 }));
+
+function isCurrentBudgetRequest(
+  requestId: number,
+  userId: UserId,
+  month: Month,
+  sessionId: number
+): boolean {
+  return (
+    loadBudgetsRequestId === requestId &&
+    useBudgetStore.getState().activeUserId === userId &&
+    useBudgetStore.getState().currentMonth === month &&
+    budgetSessionId === sessionId
+  );
+}
+
+function isActiveBudgetSession(userId: UserId, sessionId: number): boolean {
+  return budgetSessionId === sessionId && useBudgetStore.getState().activeUserId === userId;
+}
+
+async function refreshBudgetsForActiveSession(
+  db: AnyDb,
+  userId: UserId,
+  sessionId: number
+): Promise<boolean> {
+  if (!isActiveBudgetSession(userId, sessionId)) return false;
+  await loadBudgetsForUser(db, userId);
+  return isActiveBudgetSession(userId, sessionId);
+}
+
+export function initializeBudgetSession(userId: UserId): void {
+  budgetSessionId += 1;
+  loadBudgetsRequestId += 1;
+  useBudgetStore.getState().beginSession(userId);
+}
+
+export async function loadBudgetsForUser(db: AnyDb, userId: UserId): Promise<void> {
+  const requestId = ++loadBudgetsRequestId;
+  const sessionId = budgetSessionId;
+  const requestedMonth = useBudgetStore.getState().currentMonth;
+  const previous = {
+    pendingAlerts: useBudgetStore.getState().pendingAlerts,
+    acknowledgedAlerts: useBudgetStore.getState().acknowledgedAlerts,
+  };
+
+  useBudgetStore.getState().setIsLoading(true);
+
+  try {
+    const snapshot = await createLiveBudgetMonitoring(db, userId, () =>
+      isCurrentBudgetRequest(requestId, userId, requestedMonth, sessionId)
+    ).refreshMonth({
+      db,
+      userId,
+      month: requestedMonth,
+      previous,
+    });
+
+    if (!isCurrentBudgetRequest(requestId, userId, requestedMonth, sessionId)) {
+      if (loadBudgetsRequestId === requestId) {
+        useBudgetStore.getState().setIsLoading(false);
+      }
+      return;
+    }
+
+    useBudgetStore.getState().setSnapshot(snapshot);
+  } catch {
+    if (loadBudgetsRequestId === requestId) {
+      useBudgetStore.getState().setIsLoading(false);
+    }
+  }
+}
+
+export async function nextBudgetMonth(db: AnyDb, userId: UserId): Promise<void> {
+  const next = formatMonth(addMonths(parseMonth(useBudgetStore.getState().currentMonth), 1));
+  useBudgetStore.getState().setMonth(next);
+  await loadBudgetsForUser(db, userId);
+}
+
+export async function prevBudgetMonth(db: AnyDb, userId: UserId): Promise<void> {
+  const previous = formatMonth(subMonths(parseMonth(useBudgetStore.getState().currentMonth), 1));
+  useBudgetStore.getState().setMonth(previous);
+  await loadBudgetsForUser(db, userId);
+}
+
+export function loadBudgetAutoSuggestions(db: AnyDb, userId: UserId): void {
+  const { currentMonth, budgets, activeUserId } = useBudgetStore.getState();
+  if (activeUserId !== userId) return;
+
+  try {
+    const autoSuggestions = createLiveBudgetMonitoring(db, userId, () => true).loadAutoSuggestions({
+      db,
+      userId,
+      month: currentMonth,
+      existingCategoryIds: new Set(budgets.map((budget) => budget.categoryId)),
+    });
+    if (useBudgetStore.getState().activeUserId !== userId) return;
+    useBudgetStore.getState().setAutoSuggestions(autoSuggestions);
+  } catch {
+    // Query failed — keep existing suggestions.
+  }
+}
+
+export async function createBudget(
+  db: AnyDb,
+  userId: UserId,
+  categoryId: CategoryId,
+  amount: CopAmount
+): Promise<boolean> {
+  const currentMonth = useBudgetStore.getState().currentMonth;
+  const validation = createBudgetSchema.safeParse({
+    categoryId,
+    amount,
+    month: currentMonth,
+  });
+  if (!validation.success) return false;
+
+  const sessionId = budgetSessionId;
+  const now = toIsoDateTime(new Date());
+
+  try {
+    const result = await createWriteThroughMutationModule(db).commit({
+      kind: "budget.save",
+      row: {
+        id: generateBudgetId(),
+        userId,
+        categoryId,
+        amount,
+        month: currentMonth,
+        createdAt: now,
+        updatedAt: now,
+        deletedAt: null,
+      },
+    });
+    if (!result.success) return false;
+  } catch {
+    return false;
+  }
+
+  trackBudgetCreated({ category: String(categoryId) });
+  return refreshBudgetsForActiveSession(db, userId, sessionId);
+}
+
+export async function updateBudget(
+  db: AnyDb,
+  userId: UserId,
+  id: BudgetId,
+  amount: CopAmount
+): Promise<boolean> {
+  const sessionId = budgetSessionId;
+  const now = toIsoDateTime(new Date());
+
+  try {
+    const result = await createWriteThroughMutationModule(db).commit({
+      kind: "budget.update",
+      budgetId: id,
+      amount,
+      now,
+    });
+    if (!result.success) return false;
+  } catch {
+    return false;
+  }
+
+  return refreshBudgetsForActiveSession(db, userId, sessionId);
+}
+
+export async function deleteBudget(db: AnyDb, userId: UserId, id: BudgetId): Promise<boolean> {
+  const sessionId = budgetSessionId;
+  const now = toIsoDateTime(new Date());
+
+  try {
+    const result = await createWriteThroughMutationModule(db).commit({
+      kind: "budget.delete",
+      budgetId: id,
+      now,
+    });
+    if (!result.success) return false;
+  } catch {
+    return false;
+  }
+
+  return refreshBudgetsForActiveSession(db, userId, sessionId);
+}
+
+export async function copyBudgetsForward(
+  db: AnyDb,
+  userId: UserId,
+  targetMonth: Month
+): Promise<boolean> {
+  const sessionId = budgetSessionId;
+  const sourceMonth = useBudgetStore.getState().currentMonth;
+  const now = toIsoDateTime(new Date());
+
+  try {
+    const result = await createWriteThroughMutationModule(db).commit({
+      kind: "budget.copy",
+      sourceMonth,
+      targetMonth,
+      userId,
+      now,
+    });
+    if (!result.success) return false;
+  } catch {
+    return false;
+  }
+
+  if (!isActiveBudgetSession(userId, sessionId)) return false;
+  useBudgetStore.getState().setMonth(targetMonth);
+  return refreshBudgetsForActiveSession(db, userId, sessionId);
+}
+
+export async function acceptBudgetSuggestions(
+  db: AnyDb,
+  userId: UserId,
+  budgetsByCategory: ReadonlyMap<CategoryId, CopAmount>
+): Promise<boolean> {
+  const entries = Array.from(budgetsByCategory.entries());
+  if (entries.length === 0) return true;
+
+  const sessionId = budgetSessionId;
+  const currentMonth = useBudgetStore.getState().currentMonth;
+  const now = toIsoDateTime(new Date());
+
+  try {
+    const result = await createWriteThroughMutationModule(db).commitBatch(
+      entries.map(([categoryId, amount]) => ({
+        kind: "budget.save" as const,
+        row: {
+          id: generateBudgetId(),
+          userId,
+          categoryId,
+          amount,
+          month: currentMonth,
+          createdAt: now,
+          updatedAt: now,
+          deletedAt: null,
+        },
+      }))
+    );
+    if (result.some((item) => !item.success)) return false;
+  } catch {
+    return false;
+  }
+
+  return refreshBudgetsForActiveSession(db, userId, sessionId);
+}

--- a/apps/mobile/features/goals/store.ts
+++ b/apps/mobile/features/goals/store.ts
@@ -56,6 +56,7 @@ export const useGoalStore = create<GoalState & GoalActions>((set) => ({
       selectedGoalContributions: [],
       isLoading: false,
     }),
+
   setGoals: (goals) => set({ goals: [...goals], isLoading: false }),
 
   setSelectedGoalId: (selectedGoalId) => set({ selectedGoalId }),

--- a/apps/mobile/features/onboarding/components/BudgetSetupStep.tsx
+++ b/apps/mobile/features/onboarding/components/BudgetSetupStep.tsx
@@ -1,4 +1,10 @@
-import { useBudgetStore, useSuggestionSelection } from "@/features/budget";
+import { useOptionalUserId } from "@/features/auth";
+import {
+  acceptBudgetSuggestions,
+  loadBudgetAutoSuggestions,
+  useBudgetStore,
+  useSuggestionSelection,
+} from "@/features/budget";
 import { CATEGORY_MAP } from "@/features/transactions";
 import {
   Pressable,
@@ -9,6 +15,7 @@ import {
   TextInput,
   View,
 } from "@/shared/components/rn";
+import { tryGetDb } from "@/shared/db";
 import { useAsyncGuard, useMountEffect, useThemeColor, useTranslation } from "@/shared/hooks";
 import { getCategoryLabel } from "@/shared/i18n";
 import { formatMoney } from "@/shared/lib";
@@ -17,10 +24,10 @@ import { useOnboardingStore } from "../store";
 export function BudgetSetupStep() {
   const { t, locale } = useTranslation();
   const nextStep = useOnboardingStore((s) => s.nextStep);
+  const userId = useOptionalUserId();
+  const db = userId ? tryGetDb(userId) : null;
 
   const autoSuggestions = useBudgetStore((s) => s.autoSuggestions);
-  const acceptSuggestions = useBudgetStore((s) => s.acceptSuggestions);
-  const loadAutoSuggestions = useBudgetStore((s) => s.loadAutoSuggestions);
 
   const primaryColor = useThemeColor("primary");
   const secondaryColor = useThemeColor("secondary");
@@ -32,7 +39,8 @@ export function BudgetSetupStep() {
 
   // Load suggestions on mount
   useMountEffect(() => {
-    loadAutoSuggestions();
+    if (!userId || !db) return;
+    loadBudgetAutoSuggestions(db, userId);
   });
 
   const { selectedIds, editedAmounts, handleToggle, handleAmountChange, buildBudgetMap } =
@@ -42,7 +50,9 @@ export function BudgetSetupStep() {
     guardedRun(async () => {
       const budgets = buildBudgetMap();
       if (budgets.size > 0) {
-        await acceptSuggestions(budgets);
+        if (!userId || !db) return;
+        const success = await acceptBudgetSuggestions(db, userId, budgets);
+        if (!success) return;
       }
       nextStep();
     });
@@ -130,7 +140,7 @@ export function BudgetSetupStep() {
           onPress={() => {
             void handleSave();
           }}
-          disabled={isBusy}
+          disabled={isBusy || ((userId == null || db == null) && selectedIds.size > 0)}
         >
           <Text style={styles.primaryButtonText}>{t("onboarding.budgetSetup.saveBudgets")}</Text>
         </Pressable>


### PR DESCRIPTION
- remove budget hidden refs
- add explicit budget boundaries
- move budget reload wiring to layout

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the mobile budget feature to make the store state-only and move all DB work into explicit functions. Budgets now reload from the app shell when transaction revisions change, and we preserve a pending revision bump until the first budget load completes to avoid missed reloads.

- **Refactors**
  - Removed hidden DB/user refs from `@/features/budget` store; added `initializeBudgetSession(userId)` and snapshot-based `loadBudgetsForUser(db, userId)`.
  - Introduced `subscribeBudgetToTransactions(...)` that reloads only after the first load and preserves pre-load revision bumps; wiring moved to app `_layout`.
  - Replaced store mutation methods with exported helpers: `createBudget`, `updateBudget`, `deleteBudget`, `copyBudgetsForward`, `acceptBudgetSuggestions`, `loadBudgetAutoSuggestions`. Updated `create-budget`, `auto-suggest-budgets`, and onboarding to pass `db` and `userId`.
  - Added `nextBudgetMonth`/`prevBudgetMonth` that fetch after changing the month; `BudgetListScreen` now uses them.
  - Improved session-aware loading to drop stale side effects when switching users. Added tests for transaction subscription; updated store tests.

- **Migration**
  - Replace `useBudgetStore.getState().initStore(db, userId)` with `initializeBudgetSession(userId)`, then call `loadBudgetsForUser(db, userId)`.
  - Use `nextBudgetMonth(db, userId)` / `prevBudgetMonth(db, userId)` for month navigation.
  - Switch from store methods to function exports for mutations and suggestions, e.g., `createBudget(db, userId, ...)`, `acceptBudgetSuggestions(db, userId, ...)`, `loadBudgetAutoSuggestions(db, userId)`.
  - In the app shell, wire `subscribeBudgetToTransactions({ subscribeTransactions: useTransactionStore.subscribe, getTransactionDataRevision: () => useTransactionStore.getState().dataRevision, hasLoadedBudgetState: () => useBudgetStore.getState().hasLoadedOnce, reload: () => loadBudgetsForUser(db, userId) })`.

<sup>Written for commit f4ed9321ce666a39129e3a5ea35ba2b316e6cc7e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

