### PR TITLE
refactor(mobile): deepen email capture seam

### DIFF
--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -12,7 +12,18 @@ import {
 } from "@/features/email-capture/lib/repository";
 import { getAdapter } from "@/features/email-capture/services/email-adapter";
 import { processEmails } from "@/features/email-capture/services/email-pipeline";
-import { useEmailCaptureStore } from "@/features/email-capture/store";
+import {
+  confirmReviewedEmail,
+  connectEmailAccount,
+  disconnectEmailAccount,
+  dismissFailedEmail,
+  fetchAndProcessEmails,
+  initializeEmailCaptureSession,
+  loadEmailAccounts,
+  loadFailedEmails,
+  loadNeedsReviewEmails,
+  useEmailCaptureStore,
+} from "@/features/email-capture/store";
 import type {
   EmailAccountId,
   IsoDateTime,
@@ -99,11 +110,6 @@ vi.mock("@/shared/db/enqueue-sync", () => ({
 }));
 
 const mockRefresh = vi.fn();
-vi.mock("@/features/transactions", () => ({
-  useTransactionStore: {
-    getState: () => ({ refresh: mockRefresh }),
-  },
-}));
 
 vi.mock("drizzle-orm", () => ({
   eq: vi.fn((...args: unknown[]) => ({ type: "eq", args })),
@@ -168,13 +174,23 @@ function makeProcessedEmail(overrides: Record<string, unknown> = {}) {
   };
 }
 
-describe("useEmailCaptureStore", () => {
+function createDeferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("email capture boundary", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockEnsureBankSenders.mockResolvedValue([
       { bank: "Bancolombia", email: "notificaciones@bancolombia.com.co" },
     ]);
-    useEmailCaptureStore.getState().initStore(mockDb, mockUserId);
+    initializeEmailCaptureSession(mockUserId as UserId);
     useEmailCaptureStore.setState({
       accounts: [],
       failedEmails: [],
@@ -199,17 +215,33 @@ describe("useEmailCaptureStore", () => {
     const mockAccounts = [makeAccount()];
     vi.mocked(getEmailAccounts).mockResolvedValueOnce(mockAccounts);
 
-    await useEmailCaptureStore.getState().loadAccounts();
+    await loadEmailAccounts(mockDb, mockUserId as UserId);
 
     expect(getEmailAccounts).toHaveBeenCalledWith(mockDb, mockUserId);
     expect(useEmailCaptureStore.getState().accounts).toEqual(mockAccounts);
+  });
+
+  it("drops stale account results after the active user changes", async () => {
+    const deferred = createDeferred<ReturnType<typeof makeAccount>[]>();
+    vi.mocked(getEmailAccounts).mockReturnValueOnce(deferred.promise);
+
+    const load = loadEmailAccounts(mockDb, mockUserId as UserId);
+    initializeEmailCaptureSession("user-2" as UserId);
+    deferred.resolve([makeAccount()]);
+
+    await load;
+
+    expect(useEmailCaptureStore.getState()).toMatchObject({
+      activeUserId: "user-2",
+      accounts: [],
+    });
   });
 
   it("loadFailedEmails fetches from DB and sets state", async () => {
     const mockFailed = [makeProcessedEmail({ failureReason: "parse error", subject: "Compra" })];
     vi.mocked(getFailedEmails).mockResolvedValueOnce(mockFailed);
 
-    await useEmailCaptureStore.getState().loadFailedEmails();
+    await loadFailedEmails(mockDb, mockUserId as UserId);
 
     expect(getFailedEmails).toHaveBeenCalledWith(mockDb);
     expect(useEmailCaptureStore.getState().failedEmails).toEqual(mockFailed);
@@ -229,7 +261,7 @@ describe("useEmailCaptureStore", () => {
     ];
     vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce(mockReview);
 
-    await useEmailCaptureStore.getState().loadNeedsReview();
+    await loadNeedsReviewEmails(mockDb, mockUserId as UserId);
 
     expect(getNeedsReviewEmails).toHaveBeenCalledWith(mockDb);
     expect(useEmailCaptureStore.getState().needsReviewEmails).toEqual(mockReview);
@@ -245,7 +277,7 @@ describe("useEmailCaptureStore", () => {
       failedEmails: [makeProcessedEmail()],
     });
 
-    await useEmailCaptureStore.getState().dismissFailedEmail("pe-1");
+    await dismissFailedEmail(mockDb, mockUserId as UserId, "pe-1");
 
     expect(dismissProcessedEmail).toHaveBeenCalledWith(mockDb, "pe-1");
     expect(useEmailCaptureStore.getState().failedEmails).toHaveLength(0);
@@ -257,7 +289,7 @@ describe("useEmailCaptureStore", () => {
       email: "user@gmail.com",
     });
 
-    await useEmailCaptureStore.getState().connectEmail("gmail", "client-id");
+    await connectEmailAccount(mockDb, mockUserId as UserId, "gmail", "client-id");
 
     expect(getAdapter).toHaveBeenCalledWith("gmail");
     expect(mockAdapter.connect).toHaveBeenCalledWith("client-id");
@@ -278,7 +310,7 @@ describe("useEmailCaptureStore", () => {
       email: "user@outlook.com",
     });
 
-    await useEmailCaptureStore.getState().connectEmail("outlook", "client-id");
+    await connectEmailAccount(mockDb, mockUserId as UserId, "outlook", "client-id");
 
     expect(getAdapter).toHaveBeenCalledWith("outlook");
     expect(mockAdapter.connect).toHaveBeenCalledWith("client-id");
@@ -292,7 +324,7 @@ describe("useEmailCaptureStore", () => {
       error: "cancelled",
     });
 
-    await useEmailCaptureStore.getState().connectEmail("gmail", "client-id");
+    await connectEmailAccount(mockDb, mockUserId as UserId, "gmail", "client-id");
 
     expect(insertEmailAccount).not.toHaveBeenCalled();
     expect(useEmailCaptureStore.getState().accounts).toHaveLength(0);
@@ -309,7 +341,7 @@ describe("useEmailCaptureStore", () => {
       email: "user@gmail.com",
     });
 
-    await useEmailCaptureStore.getState().connectEmail("gmail", "client-id");
+    await connectEmailAccount(mockDb, mockUserId as UserId, "gmail", "client-id");
 
     // Should NOT insert a duplicate account
     expect(insertEmailAccount).not.toHaveBeenCalled();
@@ -321,7 +353,7 @@ describe("useEmailCaptureStore", () => {
       accounts: [makeAccount()],
     });
 
-    await useEmailCaptureStore.getState().disconnectEmail("ea-1");
+    await disconnectEmailAccount(mockDb, mockUserId as UserId, "ea-1");
 
     expect(getAdapter).toHaveBeenCalledWith("gmail");
     expect(mockAdapter.disconnect).toHaveBeenCalled();
@@ -334,7 +366,7 @@ describe("useEmailCaptureStore", () => {
       accounts: [makeAccount({ provider: "legacy-provider" })],
     });
 
-    await useEmailCaptureStore.getState().disconnectEmail("ea-1");
+    await disconnectEmailAccount(mockDb, mockUserId as UserId, "ea-1");
 
     expect(getAdapter).not.toHaveBeenCalled();
     expect(mockAdapter.disconnect).not.toHaveBeenCalled();
@@ -370,7 +402,13 @@ describe("useEmailCaptureStore", () => {
       vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
       vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
 
-      await useEmailCaptureStore.getState().fetchAndProcess("gmail-client-id", "outlook-client-id");
+      await fetchAndProcessEmails(
+        mockDb,
+        mockUserId as UserId,
+        "gmail-client-id",
+        "outlook-client-id",
+        mockRefresh
+      );
 
       expect(mockEnsureBankSenders).toHaveBeenCalledTimes(1);
       expect(mockAdapter.fetchEmails).toHaveBeenCalled();
@@ -388,7 +426,13 @@ describe("useEmailCaptureStore", () => {
       vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
       vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
 
-      await useEmailCaptureStore.getState().fetchAndProcess("gmail-client-id", "outlook-client-id");
+      await fetchAndProcessEmails(
+        mockDb,
+        mockUserId as UserId,
+        "gmail-client-id",
+        "outlook-client-id",
+        mockRefresh
+      );
 
       expect(getAdapter).toHaveBeenCalledWith("outlook");
       expect(mockAdapter.fetchEmails).toHaveBeenCalled();
@@ -403,7 +447,7 @@ describe("useEmailCaptureStore", () => {
       vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
       vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
 
-      const promise = useEmailCaptureStore.getState().fetchAndProcess("g", "o");
+      const promise = fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
       expect(useEmailCaptureStore.getState().isFetching).toBe(true);
 
       await promise;
@@ -411,10 +455,8 @@ describe("useEmailCaptureStore", () => {
     });
 
     it("does nothing when db or userId is not set", async () => {
-      // biome-ignore lint/suspicious/noExplicitAny: mock db needs flexible typing
-      useEmailCaptureStore.getState().initStore(null as any, null as any);
-
-      await useEmailCaptureStore.getState().fetchAndProcess("g", "o");
+      initializeEmailCaptureSession("user-2" as UserId);
+      await fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
 
       expect(mockAdapter.fetchEmails).not.toHaveBeenCalled();
     });
@@ -425,7 +467,7 @@ describe("useEmailCaptureStore", () => {
         accounts: [makeAccount()],
       });
 
-      await useEmailCaptureStore.getState().fetchAndProcess("g", "o");
+      await fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
 
       expect(mockAdapter.fetchEmails).not.toHaveBeenCalled();
     });
@@ -444,7 +486,7 @@ describe("useEmailCaptureStore", () => {
       vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
       vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
 
-      await useEmailCaptureStore.getState().fetchAndProcess("g", "o");
+      await fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
 
       expect(mockAdapter.fetchEmails).toHaveBeenCalledTimes(2);
       expect(useEmailCaptureStore.getState().isFetching).toBe(false);
@@ -477,7 +519,13 @@ describe("useEmailCaptureStore", () => {
       vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
       vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
 
-      await useEmailCaptureStore.getState().fetchAndProcess("gmail-client-id", "outlook-client-id");
+      await fetchAndProcessEmails(
+        mockDb,
+        mockUserId as UserId,
+        "gmail-client-id",
+        "outlook-client-id",
+        mockRefresh
+      );
 
       expect(processEmails).toHaveBeenCalledWith(
         mockDb,
@@ -520,7 +568,7 @@ describe("useEmailCaptureStore", () => {
       vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
       vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
 
-      await useEmailCaptureStore.getState().fetchAndProcess("g", "o");
+      await fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
 
       expect(phases).toContain("processing");
       expect(useEmailCaptureStore.getState().phase).toBe("complete");
@@ -560,7 +608,7 @@ describe("useEmailCaptureStore", () => {
       vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
       vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
 
-      await useEmailCaptureStore.getState().fetchAndProcess("g", "o");
+      await fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
 
       expect(useEmailCaptureStore.getState().phase).toBeNull();
     });
@@ -574,7 +622,7 @@ describe("useEmailCaptureStore", () => {
       vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
       vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
 
-      await useEmailCaptureStore.getState().fetchAndProcess("g", "o");
+      await fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
 
       const updatedAccount = useEmailCaptureStore.getState().accounts[0]!;
       expect(updatedAccount.lastFetchedAt).not.toBeNull();
@@ -609,7 +657,7 @@ describe("useEmailCaptureStore", () => {
         vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
         vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
 
-        await useEmailCaptureStore.getState().fetchAndProcess("g", "o");
+        await fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
 
         // Phase should be "complete" immediately after
         expect(useEmailCaptureStore.getState().phase).toBe("complete");
@@ -649,7 +697,7 @@ describe("useEmailCaptureStore", () => {
       vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
       vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
 
-      await useEmailCaptureStore.getState().fetchAndProcess("g", "o");
+      await fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
 
       expect(useEmailCaptureStore.getState().phase).toBe("complete");
       expect(useEmailCaptureStore.getState().isFetching).toBe(false);
@@ -687,7 +735,7 @@ describe("useEmailCaptureStore", () => {
       vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
       vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
 
-      await useEmailCaptureStore.getState().fetchAndProcess("g", "o");
+      await fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
 
       expect(phases).toContain("processing");
     });
@@ -701,7 +749,7 @@ describe("useEmailCaptureStore", () => {
       vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
       vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
 
-      await useEmailCaptureStore.getState().fetchAndProcess("g", "o");
+      await fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
 
       expect(useEmailCaptureStore.getState().phase).toBe("complete");
       expect(useEmailCaptureStore.getState().progress).toEqual(
@@ -727,11 +775,58 @@ describe("useEmailCaptureStore", () => {
       ]);
       vi.mocked(processEmails).mockRejectedValueOnce(new Error("pipeline crash"));
 
-      await useEmailCaptureStore.getState().fetchAndProcess("g", "o");
+      await fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
 
       expect(useEmailCaptureStore.getState().phase).toBeNull();
       expect(useEmailCaptureStore.getState().progress).toBeNull();
       expect(useEmailCaptureStore.getState().isFetching).toBe(false);
+    });
+
+    it("drops stale fetch completions after the active user changes", async () => {
+      const deferred =
+        createDeferred<
+          readonly [
+            {
+              readonly externalId: string;
+              readonly from: string;
+              readonly subject: string;
+              readonly body: string;
+              readonly receivedAt: string;
+              readonly provider: "gmail";
+            },
+          ]
+        >();
+      useEmailCaptureStore.setState({
+        accounts: [makeAccount()],
+      });
+      mockAdapter.fetchEmails.mockReturnValueOnce(deferred.promise);
+
+      const fetch = fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
+      expect(useEmailCaptureStore.getState().isFetching).toBe(true);
+
+      initializeEmailCaptureSession("user-2" as UserId);
+      deferred.resolve([
+        {
+          externalId: "ext-1",
+          from: "b@b.com",
+          subject: "A",
+          body: "b",
+          receivedAt: "2026-03-10T00:00:00Z",
+          provider: "gmail",
+        },
+      ]);
+
+      await fetch;
+
+      expect(useEmailCaptureStore.getState()).toMatchObject({
+        activeUserId: "user-2",
+        accounts: [],
+        failedEmails: [],
+        needsReviewEmails: [],
+        isFetching: false,
+        phase: null,
+        progress: null,
+      });
     });
   });
 
@@ -748,7 +843,7 @@ describe("useEmailCaptureStore", () => {
         ],
       });
 
-      await useEmailCaptureStore.getState().confirmReview("pe-1", "food");
+      await confirmReviewedEmail(mockDb, mockUserId as UserId, "pe-1", "food", mockRefresh);
 
       expect(updateProcessedEmailStatus).toHaveBeenCalledWith(mockDb, "pe-1", "success", "tx-1");
       expect(useEmailCaptureStore.getState().needsReviewEmails).toHaveLength(0);
@@ -767,7 +862,7 @@ describe("useEmailCaptureStore", () => {
     it("does nothing when processed email not found", async () => {
       useEmailCaptureStore.setState({ needsReviewEmails: [] });
 
-      await useEmailCaptureStore.getState().confirmReview("nonexistent", "food");
+      await confirmReviewedEmail(mockDb, mockUserId as UserId, "nonexistent", "food");
 
       expect(updateProcessedEmailStatus).not.toHaveBeenCalled();
     });

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -32,6 +32,18 @@ import type {
   UserId,
 } from "@/shared/types/branded";
 
+const { mockCaptureWarning } = vi.hoisted(() => ({
+  mockCaptureWarning: vi.fn(),
+}));
+
+vi.mock("@/shared/lib", async () => {
+  const actual = await vi.importActual<typeof import("@/shared/lib")>("@/shared/lib");
+  return {
+    ...actual,
+    captureWarning: mockCaptureWarning,
+  };
+});
+
 vi.mock("@/features/email-capture/lib/repository", () => ({
   getEmailAccounts: vi.fn().mockResolvedValue([]),
   insertEmailAccount: vi.fn(),
@@ -454,11 +466,16 @@ describe("email capture boundary", () => {
       expect(useEmailCaptureStore.getState().isFetching).toBe(false);
     });
 
-    it("does nothing when db or userId is not set", async () => {
+    it("warns when the requested email capture session is no longer active", async () => {
       initializeEmailCaptureSession("user-2" as UserId);
       await fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
 
       expect(mockAdapter.fetchEmails).not.toHaveBeenCalled();
+      expect(mockCaptureWarning).toHaveBeenCalledWith("email_capture_fetch_missing_context", {
+        hasActiveSession: true,
+        matchesActiveSession: false,
+        activeSessionUserId: "user-2",
+      });
     });
 
     it("skips when already fetching", async () => {

--- a/apps/mobile/app/(auth)/onboarding.tsx
+++ b/apps/mobile/app/(auth)/onboarding.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useOptionalUserId } from "@/features/auth";
 import { initializeBudgetSession } from "@/features/budget";
-import { useEmailCaptureStore } from "@/features/email-capture";
+import { initializeEmailCaptureSession, loadEmailAccounts } from "@/features/email-capture";
 import {
   BudgetSetupStep,
   CompleteStep,
@@ -51,13 +51,10 @@ function AuthenticatedOnboardingScreen({
   // Initialize minimal stores needed for onboarding
   useSubscription(
     () => {
-      useEmailCaptureStore.getState().initStore(db, userId);
+      initializeEmailCaptureSession(userId);
       useTransactionStore.getState().initStore(db, userId);
       initializeBudgetSession(userId);
-      Promise.all([
-        useEmailCaptureStore.getState().loadAccounts(),
-        useTransactionStore.getState().loadInitialPage(),
-      ])
+      Promise.all([loadEmailAccounts(db, userId), useTransactionStore.getState().loadInitialPage()])
         .catch(captureError)
         .finally(() => {
           setStoresReady(true);

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -43,7 +43,11 @@ import {
   useWidgetCapture,
 } from "@/features/capture-sources";
 import { refreshCategories } from "@/features/categories";
-import { useEmailCapture, useEmailCaptureStore } from "@/features/email-capture";
+import {
+  initializeEmailCaptureSession,
+  loadEmailAccounts,
+  useEmailCapture,
+} from "@/features/email-capture";
 import {
   initializeGoalSession,
   loadGoalsForUser,
@@ -96,7 +100,7 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
   useSubscription(
     () => {
       useTransactionStore.getState().initStore(db, userId);
-      useEmailCaptureStore.getState().initStore(db, userId);
+      initializeEmailCaptureSession(userId);
       useChatStore.getState().initStore(db, userId);
       initializeCalendarSession(userId);
       initializeBudgetSession(userId);
@@ -109,6 +113,7 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
       loadBudgetsForUser(db, userId).catch(handleRecoverableError("Failed to load budgets"));
       loadGoalsForUser(db, userId).catch(handleRecoverableError("Failed to load goals"));
       loadAnalyticsForUser(db, userId).catch(handleRecoverableError("Failed to load analytics"));
+      loadEmailAccounts(db, userId).catch(handleRecoverableError("Failed to load email accounts"));
       refreshCategories(db, userId).catch(handleRecoverableError("Failed to load user categories"));
       useChatStore
         .getState()

--- a/apps/mobile/app/connected-accounts.tsx
+++ b/apps/mobile/app/connected-accounts.tsx
@@ -1,8 +1,11 @@
 import { formatDistanceToNow } from "date-fns";
 import { useRouter } from "expo-router";
 import Animated from "react-native-reanimated";
+import { useOptionalUserId } from "@/features/auth";
 import { ApplePaySetupCard, NotificationSetupCard } from "@/features/capture-sources";
 import {
+  connectEmailAccount,
+  disconnectEmailAccount,
   getGmailClientId,
   getOutlookClientId,
   useEmailCaptureStore,
@@ -10,16 +13,17 @@ import {
 import { ScreenLayout } from "@/shared/components";
 import { Mail } from "@/shared/components/icons";
 import { Platform, Pressable, ScrollView, Text, View } from "@/shared/components/rn";
+import { tryGetDb } from "@/shared/db";
 import { usePulsingOpacity, useThemeColor, useTranslation } from "@/shared/hooks";
 import { getDateFnsLocale } from "@/shared/i18n";
 
 export default function ConnectedAccountsScreen() {
   const { back } = useRouter();
   const { t } = useTranslation();
+  const userId = useOptionalUserId();
+  const db = userId ? tryGetDb(userId) : null;
   const accounts = useEmailCaptureStore((s) => s.accounts);
   const isFetching = useEmailCaptureStore((s) => s.isFetching);
-  const connectEmail = useEmailCaptureStore((s) => s.connectEmail);
-  const disconnectEmail = useEmailCaptureStore((s) => s.disconnectEmail);
 
   const gmailAccount = accounts.find((a) => a.provider === "gmail");
   const outlookAccount = accounts.find((a) => a.provider === "outlook");
@@ -42,10 +46,12 @@ export default function ConnectedAccountsScreen() {
             account={gmailAccount}
             isSyncing={isFetching && Boolean(gmailAccount)}
             onConnect={() => {
-              void connectEmail("gmail", getGmailClientId());
+              if (!db || !userId) return;
+              void connectEmailAccount(db, userId, "gmail", getGmailClientId());
             }}
             onDisconnect={() => {
-              if (gmailAccount) void disconnectEmail(gmailAccount.id);
+              if (!db || !userId || !gmailAccount) return;
+              void disconnectEmailAccount(db, userId, gmailAccount.id);
             }}
           />
 
@@ -54,10 +60,12 @@ export default function ConnectedAccountsScreen() {
             account={outlookAccount}
             isSyncing={isFetching && Boolean(outlookAccount)}
             onConnect={() => {
-              void connectEmail("outlook", getOutlookClientId());
+              if (!db || !userId) return;
+              void connectEmailAccount(db, userId, "outlook", getOutlookClientId());
             }}
             onDisconnect={() => {
-              if (outlookAccount) void disconnectEmail(outlookAccount.id);
+              if (!db || !userId || !outlookAccount) return;
+              void disconnectEmailAccount(db, userId, outlookAccount.id);
             }}
           />
 

--- a/apps/mobile/app/failed-emails.tsx
+++ b/apps/mobile/app/failed-emails.tsx
@@ -2,10 +2,16 @@ import { FlashList } from "@shopify/flash-list";
 import { format } from "date-fns";
 import { useRouter } from "expo-router";
 import { useCallback } from "react";
-import { type ProcessedEmailRow, useEmailCaptureStore } from "@/features/email-capture";
+import { useOptionalUserId } from "@/features/auth";
+import {
+  dismissFailedEmail,
+  type ProcessedEmailRow,
+  useEmailCaptureStore,
+} from "@/features/email-capture";
 import { ScreenLayout } from "@/shared/components";
 import { Info, Plus, TriangleAlert } from "@/shared/components/icons";
 import { Pressable, Text, View } from "@/shared/components/rn";
+import { tryGetDb } from "@/shared/db";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { getDateFnsLocale } from "@/shared/i18n";
 
@@ -14,8 +20,9 @@ const ItemSeparator = () => <View style={{ height: 10 }} />;
 export default function FailedEmailsScreen() {
   const { back, push } = useRouter();
   const { t } = useTranslation();
+  const userId = useOptionalUserId();
+  const db = userId ? tryGetDb(userId) : null;
   const failedEmails = useEmailCaptureStore((s) => s.failedEmails);
-  const dismissFailedEmail = useEmailCaptureStore((s) => s.dismissFailedEmail);
 
   const handleAddManually = useCallback(() => {
     push("/(tabs)/add");
@@ -26,12 +33,13 @@ export default function FailedEmailsScreen() {
       <FailedEmailCard
         email={item}
         onDismiss={() => {
-          void dismissFailedEmail(item.id);
+          if (!db || !userId) return;
+          void dismissFailedEmail(db, userId, item.id);
         }}
         onAddManually={handleAddManually}
       />
     ),
-    [dismissFailedEmail, handleAddManually]
+    [db, handleAddManually, userId]
   );
 
   return (

--- a/apps/mobile/features/background-fetch/task.ts
+++ b/apps/mobile/features/background-fetch/task.ts
@@ -1,12 +1,15 @@
 import * as BackgroundTask from "expo-background-task";
 import * as TaskManager from "expo-task-manager";
 import {
+  fetchAndProcessEmails,
   getGmailClientId,
   getOutlookClientId,
-  useEmailCaptureStore,
+  initializeEmailCaptureSession,
+  loadEmailAccounts,
 } from "@/features/email-capture";
 import { getDb, getSupabase } from "@/shared/db";
 import { captureError } from "@/shared/lib";
+import { requireUserId } from "@/shared/types/assertions";
 
 export const BACKGROUND_TASK_NAME = "FIDY_EMAIL_FETCH";
 
@@ -17,13 +20,12 @@ TaskManager.defineTask(BACKGROUND_TASK_NAME, async () => {
       return BackgroundTask.BackgroundTaskResult.Failed;
     }
 
-    const userId = data.session.user.id;
+    const userId = requireUserId(data.session.user.id);
     const db = getDb(userId);
-    const store = useEmailCaptureStore.getState();
-    store.initStore(db, userId);
-    await store.loadAccounts();
+    initializeEmailCaptureSession(userId);
+    await loadEmailAccounts(db, userId);
 
-    await store.fetchAndProcess(getGmailClientId(), getOutlookClientId());
+    await fetchAndProcessEmails(db, userId, getGmailClientId(), getOutlookClientId());
     return BackgroundTask.BackgroundTaskResult.Success;
   } catch (error) {
     captureError(error);

--- a/apps/mobile/features/dashboard/components/HomeScreen.tsx
+++ b/apps/mobile/features/dashboard/components/HomeScreen.tsx
@@ -1,7 +1,9 @@
 import { Stack, useRouter } from "expo-router";
 import { memo, useCallback, useMemo } from "react";
+import { useOptionalUserId } from "@/features/auth";
 import { DetectedTransactionsBanner } from "@/features/capture-sources";
 import {
+  connectEmailAccount,
   EmailConnectBanner,
   FailedEmailsBanner,
   getGmailClientId,
@@ -20,6 +22,7 @@ import {
 import { ScreenLayout, TAB_BAR_CLEARANCE, TransactionRow } from "@/shared/components";
 import { Ellipsis } from "@/shared/components/icons";
 import { Alert, FlatList, Platform, Text, View } from "@/shared/components/rn";
+import { tryGetDb } from "@/shared/db";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { getCategoryLabel, getDateFnsLocale } from "@/shared/i18n";
 import { formatSignedMoney, toIsoDate } from "@/shared/lib";
@@ -85,14 +88,17 @@ const ListHeader = memo(function ListHeader({
   dailySpending,
 }: ListHeaderProps) {
   const { push } = useRouter();
-  const connectEmail = useEmailCaptureStore((s) => s.connectEmail);
+  const userId = useOptionalUserId();
 
   return (
     <View className="gap-4 px-4">
       <EmailConnectBanner
         onConnect={(provider) => {
+          if (!userId) return;
+          const db = tryGetDb(userId);
+          if (!db) return;
           const clientId = provider === "gmail" ? getGmailClientId() : getOutlookClientId();
-          void connectEmail(provider, clientId);
+          void connectEmailAccount(db, userId, provider, clientId);
         }}
       />
       <FailedEmailsBanner onPress={() => push("/failed-emails" as never)} />

--- a/apps/mobile/features/email-capture/components/NeedsReviewScreen.tsx
+++ b/apps/mobile/features/email-capture/components/NeedsReviewScreen.tsx
@@ -1,19 +1,21 @@
 import { FlashList } from "@shopify/flash-list";
 import { useRouter } from "expo-router";
 import { useCallback, useMemo } from "react";
+import { useOptionalUserId } from "@/features/auth";
 import { useTransactionStore } from "@/features/transactions";
 import { ScreenLayout } from "@/shared/components";
 import { Text, View } from "@/shared/components/rn";
+import { tryGetDb } from "@/shared/db";
 import { useTranslation } from "@/shared/hooks";
 import { requireTransactionId } from "@/shared/types/assertions";
-import { useEmailCaptureStore } from "../store";
+import { confirmReviewedEmail, useEmailCaptureStore } from "../store";
 import { NeedsReviewCard } from "./NeedsReviewCard";
 
 export default function NeedsReviewScreen() {
   const { t } = useTranslation();
   const router = useRouter();
+  const userId = useOptionalUserId();
   const needsReview = useEmailCaptureStore((s) => s.needsReviewEmails);
-  const confirmReview = useEmailCaptureStore((s) => s.confirmReview);
   const getTransaction = useTransactionStore((s) => s.getTransactionById);
 
   // Pre-fetch all needed transactions once, not per-cell
@@ -30,9 +32,14 @@ export default function NeedsReviewScreen() {
 
   const handleConfirm = useCallback(
     (processedEmailId: string, categoryId: string) => {
-      void confirmReview(processedEmailId, categoryId);
+      if (!userId) return;
+      const db = tryGetDb(userId);
+      if (!db) return;
+      void confirmReviewedEmail(db, userId, processedEmailId, categoryId, () =>
+        useTransactionStore.getState().refresh()
+      );
     },
-    [confirmReview]
+    [userId]
   );
 
   const renderItem = useCallback(

--- a/apps/mobile/features/email-capture/hooks/useEmailCapture.ts
+++ b/apps/mobile/features/email-capture/hooks/useEmailCapture.ts
@@ -1,27 +1,24 @@
+import { useTransactionStore } from "@/features/transactions";
 import { AppState } from "@/shared/components/rn";
 import type { AnyDb } from "@/shared/db";
 import { useSubscription } from "@/shared/hooks";
 import { handleRecoverableError } from "@/shared/lib";
+import type { UserId } from "@/shared/types/branded";
 import { getGmailClientId, getOutlookClientId } from "../schema";
-import { useEmailCaptureStore } from "../store";
+import { fetchAndProcessEmails, loadEmailAccounts } from "../store";
 
-export function useEmailCapture(db: AnyDb | null, userId: string | null) {
+export function useEmailCapture(db: AnyDb | null, userId: UserId | null) {
   useSubscription(
     () => {
       if (!db || !userId) return;
 
-      useEmailCaptureStore.getState().initStore(db, userId);
-
       const runFetch = () => {
-        useEmailCaptureStore
-          .getState()
-          .fetchAndProcess(getGmailClientId(), getOutlookClientId())
-          .catch(handleRecoverableError("Email sync failed"));
+        fetchAndProcessEmails(db, userId, getGmailClientId(), getOutlookClientId(), () =>
+          useTransactionStore.getState().refresh()
+        ).catch(handleRecoverableError("Email sync failed"));
       };
 
-      useEmailCaptureStore
-        .getState()
-        .loadAccounts()
+      loadEmailAccounts(db, userId)
         .then(() => runFetch())
         .catch(handleRecoverableError("Email sync failed"));
 

--- a/apps/mobile/features/email-capture/index.ts
+++ b/apps/mobile/features/email-capture/index.ts
@@ -13,4 +13,15 @@ export { getGmailClientId, getOutlookClientId } from "./schema";
 export type { LlmParsedTransaction } from "./services/llm-parser";
 export { llmOutputSchema } from "./services/llm-parser";
 export { classifyMerchantApi, stripPii } from "./services/parse-email-api";
-export { useEmailCaptureStore } from "./store";
+export {
+  confirmReviewedEmail,
+  connectEmailAccount,
+  disconnectEmailAccount,
+  dismissFailedEmail,
+  fetchAndProcessEmails,
+  initializeEmailCaptureSession,
+  loadEmailAccounts,
+  loadFailedEmails,
+  loadNeedsReviewEmails,
+  useEmailCaptureStore,
+} from "./store";

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -205,9 +205,11 @@ function completeFetchLater(requestId: number, userId: UserId, sessionId: number
 }
 
 function warnFetchMissingContext(userId: UserId): void {
+  const activeUserId = useEmailCaptureStore.getState().activeUserId;
   captureWarning("email_capture_fetch_missing_context", {
-    hasDb: true,
-    hasUserId: Boolean(userId),
+    hasActiveSession: activeUserId !== null,
+    matchesActiveSession: activeUserId === userId,
+    activeSessionUserId: activeUserId ?? "none",
   });
 }
 

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -1,7 +1,6 @@
 import { eq } from "drizzle-orm";
 import { create } from "zustand";
 import { createCaptureIngestionPort } from "@/features/capture-sources/ingestion.public";
-import { useTransactionStore } from "@/features/transactions";
 import { isValidCategoryId } from "@/features/transactions/write.public";
 import type { AnyDb } from "@/shared/db";
 import { enqueueSync, transactions } from "@/shared/db";
@@ -14,8 +13,8 @@ import {
   toIsoDateTime,
 } from "@/shared/lib";
 import { queryClient } from "@/shared/query";
-import { assertEmailAccountId, assertUserId } from "@/shared/types/assertions";
-import type { UserId } from "@/shared/types/branded";
+import { assertEmailAccountId } from "@/shared/types/assertions";
+import type { EmailAccountId, IsoDateTime, UserId } from "@/shared/types/branded";
 import { insertMerchantRule } from "./lib/merchant-rules";
 import type { ProgressPhase } from "./lib/progress-phases";
 import { isFirstFetchForAny, shouldShowProgress } from "./lib/progress-phases";
@@ -36,35 +35,49 @@ import { ensureBankSenders } from "./queries/bank-senders";
 import type { EmailProvider, RawEmail } from "./schema";
 import { getAdapter } from "./services/email-adapter";
 
-let dbRef: AnyDb | null = null;
-let userIdRef: UserId | null = null;
-let autoClearTimer: ReturnType<typeof setTimeout> | null = null;
+type ProgressSnapshot = Parameters<ProgressCallback>[0];
+type RefreshTransactions = () => Promise<void> | void;
+
 const EMPTY_RAW_EMAILS: RawEmail[] = [];
+const COMPLETE_STATE_CLEAR_DELAY_MS = 2000;
+const noopRefreshTransactions: RefreshTransactions = () => undefined;
+
+let emailCaptureSessionId = 0;
+let loadAccountsRequestId = 0;
+let loadFailedEmailsRequestId = 0;
+let loadNeedsReviewRequestId = 0;
+let fetchAndProcessRequestId = 0;
+let autoClearTimer: ReturnType<typeof setTimeout> | null = null;
 
 type EmailCaptureState = {
-  accounts: EmailAccountRow[];
-  failedEmails: ProcessedEmailRow[];
-  needsReviewEmails: ProcessedEmailRow[];
-  isFetching: boolean;
-  progress: Parameters<ProgressCallback>[0] | null;
-  phase: ProgressPhase | null;
-  bannerDismissed: boolean;
+  readonly activeUserId: UserId | null;
+  readonly accounts: readonly EmailAccountRow[];
+  readonly failedEmails: readonly ProcessedEmailRow[];
+  readonly needsReviewEmails: readonly ProcessedEmailRow[];
+  readonly isFetching: boolean;
+  readonly progress: ProgressSnapshot | null;
+  readonly phase: ProgressPhase | null;
+  readonly bannerDismissed: boolean;
 };
 
 type EmailCaptureActions = {
-  initStore: (db: AnyDb, userId: string) => void;
-  loadAccounts: () => Promise<void>;
-  loadFailedEmails: () => Promise<void>;
-  loadNeedsReview: () => Promise<void>;
+  beginSession: (userId: UserId) => void;
+  setAccounts: (accounts: readonly EmailAccountRow[]) => void;
+  setFailedEmails: (failedEmails: readonly ProcessedEmailRow[]) => void;
+  setNeedsReviewEmails: (needsReviewEmails: readonly ProcessedEmailRow[]) => void;
+  setIsFetching: (isFetching: boolean) => void;
+  setProgress: (progress: ProgressSnapshot | null) => void;
+  setPhase: (phase: ProgressPhase | null) => void;
   dismissBanner: () => void;
-  dismissFailedEmail: (id: string) => Promise<void>;
-  connectEmail: (provider: EmailProvider, clientId: string) => Promise<void>;
-  disconnectEmail: (id: string) => Promise<void>;
-  fetchAndProcess: (gmailClientId: string, outlookClientId: string) => Promise<void>;
-  confirmReview: (processedEmailId: string, categoryId: string) => Promise<void>;
+  appendAccount: (account: EmailAccountRow) => void;
+  removeAccount: (accountId: string) => void;
+  removeFailedEmail: (processedEmailId: string) => void;
+  removeNeedsReviewEmail: (processedEmailId: string) => void;
+  markAccountsFetched: (accountIds: ReadonlySet<EmailAccountId>, fetchedAt: IsoDateTime) => void;
 };
 
-export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActions>((set, get) => ({
+export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActions>((set) => ({
+  activeUserId: null,
   accounts: [],
   failedEmails: [],
   needsReviewEmails: [],
@@ -73,310 +86,445 @@ export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActio
   phase: null,
   bannerDismissed: false,
 
-  initStore: (db, userId) => {
-    dbRef = db;
-    if (typeof userId !== "string" || userId.trim().length === 0) {
-      userIdRef = null;
-      return;
-    }
-    assertUserId(userId);
-    userIdRef = userId;
-  },
+  beginSession: (userId) =>
+    set({
+      activeUserId: userId,
+      accounts: [],
+      failedEmails: [],
+      needsReviewEmails: [],
+      isFetching: false,
+      progress: null,
+      phase: null,
+      bannerDismissed: false,
+    }),
 
-  loadAccounts: async () => {
-    if (!dbRef || !userIdRef) return;
-    const accounts = await getEmailAccounts(dbRef, userIdRef);
-    set({ accounts });
-  },
+  setAccounts: (accounts) => set({ accounts: [...accounts] }),
 
-  loadFailedEmails: async () => {
-    if (!dbRef) return;
-    const failedEmails = await getFailedEmails(dbRef);
-    set({ failedEmails });
-  },
+  setFailedEmails: (failedEmails) => set({ failedEmails: [...failedEmails] }),
 
-  loadNeedsReview: async () => {
-    if (!dbRef) return;
-    const needsReviewEmails = await getNeedsReviewEmails(dbRef);
-    set({ needsReviewEmails });
-  },
+  setNeedsReviewEmails: (needsReviewEmails) => set({ needsReviewEmails: [...needsReviewEmails] }),
+
+  setIsFetching: (isFetching) => set({ isFetching }),
+
+  setProgress: (progress) => set({ progress }),
+
+  setPhase: (phase) => set({ phase }),
 
   dismissBanner: () => set({ bannerDismissed: true }),
 
-  dismissFailedEmail: async (id) => {
-    if (!dbRef) return;
-    const failedEmail = get().failedEmails.find((email) => email.id === id);
-    if (!failedEmail) return;
-    await dismissProcessedEmail(dbRef, failedEmail.id);
-    const updated = get().failedEmails.filter((e) => e.id !== id);
-    set({ failedEmails: updated });
-  },
+  appendAccount: (account) => set((state) => ({ accounts: [...state.accounts, account] })),
 
-  connectEmail: async (provider, clientId) => {
-    if (!dbRef || !userIdRef) return;
+  removeAccount: (accountId) =>
+    set((state) => ({
+      accounts: state.accounts.filter((account) => account.id !== accountId),
+    })),
 
-    const result = await getAdapter(provider).connect(clientId);
+  removeFailedEmail: (processedEmailId) =>
+    set((state) => ({
+      failedEmails: state.failedEmails.filter((email) => email.id !== processedEmailId),
+    })),
 
-    if (!result.success) return;
+  removeNeedsReviewEmail: (processedEmailId) =>
+    set((state) => ({
+      needsReviewEmails: state.needsReviewEmails.filter((email) => email.id !== processedEmailId),
+    })),
 
-    // Prevent connecting the same email address twice
-    const alreadyConnected = get().accounts.some(
-      (a) => a.email.toLowerCase() === result.email.toLowerCase()
-    );
-    if (alreadyConnected) return;
+  markAccountsFetched: (accountIds, fetchedAt) =>
+    set((state) => ({
+      accounts: state.accounts.map((account) =>
+        accountIds.has(account.id) ? { ...account, lastFetchedAt: fetchedAt } : account
+      ),
+    })),
+}));
 
-    const row: EmailAccountRow = {
-      id: generateEmailAccountId(),
-      userId: userIdRef,
-      provider,
-      email: result.email,
-      lastFetchedAt: null,
-      createdAt: toIsoDateTime(new Date()),
+function clearAutoClearTimer(): void {
+  if (autoClearTimer) {
+    clearTimeout(autoClearTimer);
+    autoClearTimer = null;
+  }
+}
+
+function isActiveEmailCaptureSession(userId: UserId, sessionId: number): boolean {
+  return (
+    emailCaptureSessionId === sessionId && useEmailCaptureStore.getState().activeUserId === userId
+  );
+}
+
+function isCurrentAccountsRequest(requestId: number, userId: UserId, sessionId: number): boolean {
+  return loadAccountsRequestId === requestId && isActiveEmailCaptureSession(userId, sessionId);
+}
+
+function isCurrentFailedEmailsRequest(
+  requestId: number,
+  userId: UserId,
+  sessionId: number
+): boolean {
+  return loadFailedEmailsRequestId === requestId && isActiveEmailCaptureSession(userId, sessionId);
+}
+
+function isCurrentNeedsReviewRequest(
+  requestId: number,
+  userId: UserId,
+  sessionId: number
+): boolean {
+  return loadNeedsReviewRequestId === requestId && isActiveEmailCaptureSession(userId, sessionId);
+}
+
+function isCurrentFetchRun(requestId: number, userId: UserId, sessionId: number): boolean {
+  return fetchAndProcessRequestId === requestId && isActiveEmailCaptureSession(userId, sessionId);
+}
+
+function setFetchState(input: {
+  readonly isFetching?: boolean;
+  readonly phase?: ProgressPhase | null;
+  readonly progress?: ProgressSnapshot | null;
+}): void {
+  const state = useEmailCaptureStore.getState();
+  if (input.isFetching !== undefined) {
+    state.setIsFetching(input.isFetching);
+  }
+  if (input.phase !== undefined) {
+    state.setPhase(input.phase);
+  }
+  if (input.progress !== undefined) {
+    state.setProgress(input.progress);
+  }
+}
+
+function completeFetchLater(requestId: number, userId: UserId, sessionId: number): void {
+  clearAutoClearTimer();
+  autoClearTimer = setTimeout(() => {
+    autoClearTimer = null;
+    if (
+      isCurrentFetchRun(requestId, userId, sessionId) &&
+      useEmailCaptureStore.getState().phase === "complete"
+    ) {
+      setFetchState({ phase: null, progress: null });
+    }
+  }, COMPLETE_STATE_CLEAR_DELAY_MS);
+}
+
+function warnFetchMissingContext(userId: UserId): void {
+  captureWarning("email_capture_fetch_missing_context", {
+    hasDb: true,
+    hasUserId: Boolean(userId),
+  });
+}
+
+export function initializeEmailCaptureSession(userId: UserId): void {
+  clearAutoClearTimer();
+  emailCaptureSessionId += 1;
+  loadAccountsRequestId += 1;
+  loadFailedEmailsRequestId += 1;
+  loadNeedsReviewRequestId += 1;
+  fetchAndProcessRequestId += 1;
+  useEmailCaptureStore.getState().beginSession(userId);
+}
+
+export async function loadEmailAccounts(db: AnyDb, userId: UserId): Promise<void> {
+  const requestId = ++loadAccountsRequestId;
+  const sessionId = emailCaptureSessionId;
+
+  try {
+    const accounts = await getEmailAccounts(db, userId);
+    if (!isCurrentAccountsRequest(requestId, userId, sessionId)) return;
+    useEmailCaptureStore.getState().setAccounts(accounts);
+  } catch {
+    // Keep existing state on account load failures.
+  }
+}
+
+export async function loadFailedEmails(db: AnyDb, userId: UserId): Promise<void> {
+  const requestId = ++loadFailedEmailsRequestId;
+  const sessionId = emailCaptureSessionId;
+
+  try {
+    const failedEmails = await getFailedEmails(db);
+    if (!isCurrentFailedEmailsRequest(requestId, userId, sessionId)) return;
+    useEmailCaptureStore.getState().setFailedEmails(failedEmails);
+  } catch {
+    // Keep existing state on failed-email load failures.
+  }
+}
+
+export async function loadNeedsReviewEmails(db: AnyDb, userId: UserId): Promise<void> {
+  const requestId = ++loadNeedsReviewRequestId;
+  const sessionId = emailCaptureSessionId;
+
+  try {
+    const needsReviewEmails = await getNeedsReviewEmails(db);
+    if (!isCurrentNeedsReviewRequest(requestId, userId, sessionId)) return;
+    useEmailCaptureStore.getState().setNeedsReviewEmails(needsReviewEmails);
+  } catch {
+    // Keep existing state on needs-review load failures.
+  }
+}
+
+export async function dismissFailedEmail(
+  db: AnyDb,
+  userId: UserId,
+  processedEmailId: string
+): Promise<void> {
+  const sessionId = emailCaptureSessionId;
+  const failedEmail = useEmailCaptureStore
+    .getState()
+    .failedEmails.find((email) => email.id === processedEmailId);
+  if (!failedEmail || !isActiveEmailCaptureSession(userId, sessionId)) return;
+
+  await dismissProcessedEmail(db, failedEmail.id);
+  if (!isActiveEmailCaptureSession(userId, sessionId)) return;
+  useEmailCaptureStore.getState().removeFailedEmail(processedEmailId);
+}
+
+export async function connectEmailAccount(
+  db: AnyDb,
+  userId: UserId,
+  provider: EmailProvider,
+  clientId: string
+): Promise<void> {
+  const sessionId = emailCaptureSessionId;
+  if (!isActiveEmailCaptureSession(userId, sessionId)) return;
+
+  const result = await getAdapter(provider).connect(clientId);
+  if (!result.success || !isActiveEmailCaptureSession(userId, sessionId)) return;
+
+  const alreadyConnected = useEmailCaptureStore
+    .getState()
+    .accounts.some((account) => account.email.toLowerCase() === result.email.toLowerCase());
+  if (alreadyConnected) return;
+
+  const row: EmailAccountRow = {
+    id: generateEmailAccountId(),
+    userId,
+    provider,
+    email: result.email,
+    lastFetchedAt: null,
+    createdAt: toIsoDateTime(new Date()),
+  };
+
+  await insertEmailAccount(db, row);
+  if (!isActiveEmailCaptureSession(userId, sessionId)) return;
+  useEmailCaptureStore.getState().appendAccount(row);
+}
+
+export async function disconnectEmailAccount(
+  db: AnyDb,
+  userId: UserId,
+  emailAccountId: string
+): Promise<void> {
+  const sessionId = emailCaptureSessionId;
+  if (!isActiveEmailCaptureSession(userId, sessionId)) return;
+
+  const account = useEmailCaptureStore
+    .getState()
+    .accounts.find((candidate) => candidate.id === emailAccountId);
+  if (account) {
+    const provider = account.provider;
+    if (provider === "gmail" || provider === "outlook") {
+      await getAdapter(provider).disconnect();
+      if (!isActiveEmailCaptureSession(userId, sessionId)) return;
+    }
+
+    await deleteEmailAccount(db, account.id);
+    if (!isActiveEmailCaptureSession(userId, sessionId)) return;
+    useEmailCaptureStore.getState().removeAccount(account.id);
+    return;
+  }
+
+  assertEmailAccountId(emailAccountId);
+  await deleteEmailAccount(db, emailAccountId);
+  if (!isActiveEmailCaptureSession(userId, sessionId)) return;
+  useEmailCaptureStore.getState().removeAccount(emailAccountId);
+}
+
+export async function fetchAndProcessEmails(
+  db: AnyDb,
+  userId: UserId,
+  gmailClientId: string,
+  outlookClientId: string,
+  refreshTransactions: RefreshTransactions = noopRefreshTransactions
+): Promise<void> {
+  const sessionId = emailCaptureSessionId;
+  if (!isActiveEmailCaptureSession(userId, sessionId)) {
+    warnFetchMissingContext(userId);
+    return;
+  }
+  if (useEmailCaptureStore.getState().isFetching) {
+    captureWarning("email_capture_fetch_already_running");
+    return;
+  }
+
+  const requestId = ++fetchAndProcessRequestId;
+  clearAutoClearTimer();
+  setFetchState({ isFetching: true, phase: null, progress: null });
+
+  try {
+    const accounts = useEmailCaptureStore.getState().accounts;
+    if (accounts.length === 0) {
+      captureWarning("email_capture_fetch_no_accounts");
+      return;
+    }
+
+    const captureIngestion = createCaptureIngestionPort(db, {
+      processEmails,
+      processRetries,
+    });
+    const senders = await ensureBankSenders(queryClient);
+    const senderEmails = senders.map((sender) => sender.email);
+
+    const minSince = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+    const clientIds: Record<EmailProvider, string> = {
+      gmail: gmailClientId,
+      outlook: outlookClientId,
     };
 
-    await insertEmailAccount(dbRef, row);
-    set((state) => ({ accounts: [...state.accounts, row] }));
-  },
-
-  disconnectEmail: async (id) => {
-    if (!dbRef) return;
-    const account = get().accounts.find((a) => a.id === id);
-    if (account) {
-      const provider = account.provider;
-      if (provider === "gmail" || provider === "outlook") {
-        await getAdapter(provider).disconnect();
-      }
-      await deleteEmailAccount(dbRef, account.id);
-      set((state) => ({
-        accounts: state.accounts.filter((a) => a.id !== id),
-      }));
-      return;
-    }
-    assertEmailAccountId(id);
-    await deleteEmailAccount(dbRef, id);
-    set((state) => ({
-      accounts: state.accounts.filter((a) => a.id !== id),
-    }));
-  },
-
-  fetchAndProcess: async (gmailClientId, outlookClientId) => {
-    const db = dbRef;
-    const userId = userIdRef;
-    if (!db || !userId) {
-      captureWarning("email_capture_fetch_missing_context", {
-        hasDb: Boolean(db),
-        hasUserId: Boolean(userId),
-      });
-      return;
-    }
-    if (get().isFetching) {
-      captureWarning("email_capture_fetch_already_running");
-      return;
-    }
-
-    // Clear any stale progress/timer from a previous run
-    if (autoClearTimer) {
-      clearTimeout(autoClearTimer);
-      autoClearTimer = null;
-    }
-    set({ isFetching: true, phase: null, progress: null });
-
-    try {
-      const captureIngestion = createCaptureIngestionPort(db, {
-        processEmails,
-        processRetries,
-      });
-      const { accounts } = get();
-      if (accounts.length === 0) {
-        captureWarning("email_capture_fetch_no_accounts");
-        return;
-      }
-
-      const senders = await ensureBankSenders(queryClient);
-      const senderEmails = senders.map((s) => s.email);
-
-      // Always look back at least 30 days; dedup by externalId prevents re-processing
-      const minSince = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
-
-      const clientIds: Record<EmailProvider, string> = {
-        gmail: gmailClientId,
-        outlook: outlookClientId,
-      };
-
-      // Fetch emails from all accounts in parallel
-      const fetchResults = await Promise.all(
-        accounts.map(async (account) => {
-          try {
-            const provider = account.provider;
-            if (provider !== "gmail" && provider !== "outlook") {
-              return { account, rawEmails: EMPTY_RAW_EMAILS, fetchOk: false };
-            }
-            const since =
-              account.lastFetchedAt && account.lastFetchedAt < minSince
-                ? account.lastFetchedAt
-                : minSince;
-            const rawEmails = await getAdapter(provider).fetchEmails(
-              clientIds[provider],
-              since,
-              senderEmails
-            );
-            return { account, rawEmails, fetchOk: true };
-          } catch (err) {
-            captureWarning("email_adapter_fetch_failed", {
-              provider: account.provider,
-              errorType: err instanceof Error ? err.message : "unknown",
-            });
+    const fetchResults = await Promise.all(
+      accounts.map(async (account) => {
+        try {
+          const provider = account.provider;
+          if (provider !== "gmail" && provider !== "outlook") {
             return { account, rawEmails: EMPTY_RAW_EMAILS, fetchOk: false };
           }
-        })
-      );
-
-      const allEmails = fetchResults.flatMap((r) => r.rawEmails);
-
-      // Determine whether to show progress UI
-      const isFirst = isFirstFetchForAny(accounts);
-      const showProgress = shouldShowProgress(allEmails.length, isFirst);
-
-      // Edge case: first fetch but zero emails found
-      if (showProgress && allEmails.length === 0) {
-        set({
-          phase: "complete",
-          progress: { total: 0, completed: 0, saved: 0, failed: 0, needsReview: 0 },
-        });
-      } else if (showProgress) {
-        set({ phase: "processing" });
-
-        let lastRefreshedSaved = 0;
-        await captureIngestion.ingest({
-          kind: "email_batch",
-          userId,
-          emails: allEmails,
-          onProgress: (progress) => {
-            set({ progress });
-            if (progress.saved > lastRefreshedSaved) {
-              lastRefreshedSaved = progress.saved;
-              void useTransactionStore.getState().refresh();
-            }
-          },
-        });
-      } else if (allEmails.length > 0) {
-        // Silent processing — no progress UI
-        let lastRefreshedSaved = 0;
-        await captureIngestion.ingest({
-          kind: "email_batch",
-          userId,
-          emails: allEmails,
-          onProgress: (progress) => {
-            set({ progress });
-            if (progress.saved > lastRefreshedSaved) {
-              lastRefreshedSaved = progress.saved;
-              void useTransactionStore.getState().refresh();
-            }
-          },
-        });
-      }
-
-      await captureIngestion.ingest({
-        kind: "email_retry",
-        userId,
-      });
-
-      // Update lastFetchedAt only for accounts whose fetch succeeded
-      const now = toIsoDateTime(new Date());
-      await Promise.all(
-        fetchResults.filter((r) => r.fetchOk).map((r) => updateLastFetchedAt(db, r.account.id, now))
-      );
-
-      // Update in-memory accounts to prevent stale lastFetchedAt
-      const successIds = new Set(fetchResults.filter((r) => r.fetchOk).map((r) => r.account.id));
-      set({
-        accounts: get().accounts.map((a) =>
-          successIds.has(a.id) ? { ...a, lastFetchedAt: now } : a
-        ),
-      });
-
-      const [failedEmails, needsReviewEmails] = await Promise.all([
-        getFailedEmails(db),
-        getNeedsReviewEmails(db),
-      ]);
-
-      if (showProgress) {
-        set({ failedEmails, needsReviewEmails, phase: "complete" });
-      } else {
-        set({ failedEmails, needsReviewEmails });
-      }
-
-      // Refresh home screen transactions
-      await useTransactionStore.getState().refresh();
-    } catch (err) {
-      captureError(err);
-    } finally {
-      // On error (phase never reached 'complete'), clear immediately.
-      // On success, auto-clear after 2s so Connected Accounts can show the transition.
-      const currentPhase = get().phase;
-      if (currentPhase !== "complete") {
-        set({ isFetching: false, progress: null, phase: null });
-      } else {
-        set({ isFetching: false });
-        autoClearTimer = setTimeout(() => {
-          autoClearTimer = null;
-          if (get().phase === "complete") {
-            set({ phase: null, progress: null });
-          }
-        }, 2000);
-      }
-    }
-  },
-
-  confirmReview: async (processedEmailId, categoryId) => {
-    const db = dbRef;
-    const userId = userIdRef;
-    if (!db || !userId) return;
-
-    const processedEmail = get().needsReviewEmails.find((e) => e.id === processedEmailId);
-    if (!processedEmail?.transactionId) return;
-    if (!isValidCategoryId(categoryId)) return;
-
-    const now = toIsoDateTime(new Date());
-
-    // Update the transaction's categoryId
-    await db
-      .update(transactions)
-      .set({ categoryId, updatedAt: now })
-      .where(eq(transactions.id, processedEmail.transactionId));
-
-    // Enqueue sync for the updated transaction
-    enqueueSync(db, {
-      id: generateSyncQueueId(),
-      tableName: "transactions",
-      rowId: processedEmail.transactionId,
-      operation: "update",
-      createdAt: now,
-    });
-
-    // Cache merchant rule so future transactions from this merchant auto-categorize
-    const txRows = await db
-      .select({ description: transactions.description })
-      .from(transactions)
-      .where(eq(transactions.id, processedEmail.transactionId));
-    const description = txRows[0]?.description;
-    if (description) {
-      const merchantKey = normalizeMerchant(description);
-      await insertMerchantRule(db, userId, merchantKey, categoryId, now);
-    }
-
-    // Update the processed email status to "success"
-    await updateProcessedEmailStatus(
-      db,
-      processedEmail.id,
-      "success",
-      processedEmail.transactionId
+          const since =
+            account.lastFetchedAt && account.lastFetchedAt < minSince
+              ? account.lastFetchedAt
+              : minSince;
+          const rawEmails = await getAdapter(provider).fetchEmails(
+            clientIds[provider],
+            since,
+            senderEmails
+          );
+          return { account, rawEmails, fetchOk: true };
+        } catch (error) {
+          captureWarning("email_adapter_fetch_failed", {
+            provider: account.provider,
+            errorType: error instanceof Error ? error.message : "unknown",
+          });
+          return { account, rawEmails: EMPTY_RAW_EMAILS, fetchOk: false };
+        }
+      })
     );
 
-    // Remove from needsReviewEmails state and refresh home screen
-    set((state) => ({
-      needsReviewEmails: state.needsReviewEmails.filter((e) => e.id !== processedEmailId),
-    }));
-    await useTransactionStore.getState().refresh();
-  },
-}));
+    const allEmails = fetchResults.flatMap((result) => result.rawEmails);
+    const isFirst = isFirstFetchForAny(accounts);
+    const showProgress = shouldShowProgress(allEmails.length, isFirst);
+
+    if (showProgress && allEmails.length === 0 && isCurrentFetchRun(requestId, userId, sessionId)) {
+      setFetchState({
+        phase: "complete",
+        progress: { total: 0, completed: 0, saved: 0, failed: 0, needsReview: 0 },
+      });
+    } else if (showProgress && isCurrentFetchRun(requestId, userId, sessionId)) {
+      useEmailCaptureStore.getState().setPhase("processing");
+    }
+
+    if (allEmails.length > 0) {
+      let lastRefreshedSaved = 0;
+      await captureIngestion.ingest({
+        kind: "email_batch",
+        userId,
+        emails: allEmails,
+        onProgress: (progress) => {
+          if (!isCurrentFetchRun(requestId, userId, sessionId)) return;
+          useEmailCaptureStore.getState().setProgress(progress);
+          if (progress.saved > lastRefreshedSaved) {
+            lastRefreshedSaved = progress.saved;
+            void refreshTransactions();
+          }
+        },
+      });
+    }
+
+    await captureIngestion.ingest({
+      kind: "email_retry",
+      userId,
+    });
+
+    const fetchedAt = toIsoDateTime(new Date());
+    await Promise.all(
+      fetchResults
+        .filter((result) => result.fetchOk)
+        .map((result) => updateLastFetchedAt(db, result.account.id, fetchedAt))
+    );
+
+    const updatedAccountIds = new Set(
+      fetchResults.filter((result) => result.fetchOk).map((result) => result.account.id)
+    );
+    if (isCurrentFetchRun(requestId, userId, sessionId)) {
+      useEmailCaptureStore.getState().markAccountsFetched(updatedAccountIds, fetchedAt);
+    }
+
+    const [failedEmails, needsReviewEmails] = await Promise.all([
+      getFailedEmails(db),
+      getNeedsReviewEmails(db),
+    ]);
+
+    if (isCurrentFetchRun(requestId, userId, sessionId)) {
+      useEmailCaptureStore.getState().setFailedEmails(failedEmails);
+      useEmailCaptureStore.getState().setNeedsReviewEmails(needsReviewEmails);
+      if (showProgress) {
+        useEmailCaptureStore.getState().setPhase("complete");
+      }
+      await refreshTransactions();
+    }
+  } catch (error) {
+    captureError(error);
+  } finally {
+    if (isCurrentFetchRun(requestId, userId, sessionId)) {
+      const currentPhase = useEmailCaptureStore.getState().phase;
+      if (currentPhase !== "complete") {
+        setFetchState({ isFetching: false, progress: null, phase: null });
+      } else {
+        useEmailCaptureStore.getState().setIsFetching(false);
+        completeFetchLater(requestId, userId, sessionId);
+      }
+    }
+  }
+}
+
+export async function confirmReviewedEmail(
+  db: AnyDb,
+  userId: UserId,
+  processedEmailId: string,
+  categoryId: string,
+  refreshTransactions: RefreshTransactions = noopRefreshTransactions
+): Promise<void> {
+  const sessionId = emailCaptureSessionId;
+  if (!isActiveEmailCaptureSession(userId, sessionId)) return;
+
+  const processedEmail = useEmailCaptureStore
+    .getState()
+    .needsReviewEmails.find((email) => email.id === processedEmailId);
+  if (!processedEmail?.transactionId || !isValidCategoryId(categoryId)) return;
+
+  const now = toIsoDateTime(new Date());
+
+  await db
+    .update(transactions)
+    .set({ categoryId, updatedAt: now })
+    .where(eq(transactions.id, processedEmail.transactionId));
+
+  enqueueSync(db, {
+    id: generateSyncQueueId(),
+    tableName: "transactions",
+    rowId: processedEmail.transactionId,
+    operation: "update",
+    createdAt: now,
+  });
+
+  const txRows = await db
+    .select({ description: transactions.description })
+    .from(transactions)
+    .where(eq(transactions.id, processedEmail.transactionId));
+  const description = txRows[0]?.description;
+  if (description) {
+    const merchantKey = normalizeMerchant(description);
+    await insertMerchantRule(db, userId, merchantKey, categoryId, now);
+  }
+
+  await updateProcessedEmailStatus(db, processedEmail.id, "success", processedEmail.transactionId);
+  if (!isActiveEmailCaptureSession(userId, sessionId)) return;
+
+  useEmailCaptureStore.getState().removeNeedsReviewEmail(processedEmailId);
+  await refreshTransactions();
+}

--- a/apps/mobile/features/onboarding/components/ConnectEmailStep.tsx
+++ b/apps/mobile/features/onboarding/components/ConnectEmailStep.tsx
@@ -1,19 +1,22 @@
 import Ionicons from "@expo/vector-icons/Ionicons";
-import { GoogleIcon, MicrosoftIcon, OAuthButton } from "@/features/auth";
+import { GoogleIcon, MicrosoftIcon, OAuthButton, useOptionalUserId } from "@/features/auth";
 import {
+  connectEmailAccount,
   getGmailClientId,
   getOutlookClientId,
   useEmailCaptureStore,
 } from "@/features/email-capture";
 import { Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
+import { tryGetDb } from "@/shared/db";
 import { useAsyncGuard, useThemeColor, useTranslation } from "@/shared/hooks";
 import { useOnboardingStore } from "../store";
 
 export function ConnectEmailStep() {
   const { t } = useTranslation();
+  const userId = useOptionalUserId();
+  const db = userId ? tryGetDb(userId) : null;
   const nextStep = useOnboardingStore((s) => s.nextStep);
   const setEmailSkipped = useOnboardingStore((s) => s.setEmailSkipped);
-  const connectEmail = useEmailCaptureStore((s) => s.connectEmail);
 
   const primaryColor = useThemeColor("primary");
   const secondaryColor = useThemeColor("secondary");
@@ -24,8 +27,9 @@ export function ConnectEmailStep() {
 
   const handleConnect = (provider: "gmail" | "outlook") =>
     guardedRun(async () => {
+      if (!db || !userId) return;
       const clientId = provider === "gmail" ? getGmailClientId() : getOutlookClientId();
-      await connectEmail(provider, clientId);
+      await connectEmailAccount(db, userId, provider, clientId);
       // If accounts were added, auto-advance
       const accounts = useEmailCaptureStore.getState().accounts;
       if (accounts.length > 0) {

--- a/apps/mobile/features/onboarding/components/SyncProgressStep.tsx
+++ b/apps/mobile/features/onboarding/components/SyncProgressStep.tsx
@@ -1,6 +1,8 @@
 import { useRef } from "react";
 import { useShallow } from "zustand/react/shallow";
+import { useOptionalUserId } from "@/features/auth";
 import {
+  fetchAndProcessEmails,
   getGmailClientId,
   getOutlookClientId,
   useEmailCaptureStore,
@@ -8,16 +10,18 @@ import {
 import { useTransactionStore } from "@/features/transactions";
 import { ProgressBar } from "@/shared/components";
 import { Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
+import { tryGetDb } from "@/shared/db";
 import { useMountEffect, useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatMoney } from "@/shared/lib";
 import { useOnboardingStore } from "../store";
 
 export function SyncProgressStep() {
   const { t } = useTranslation();
+  const userId = useOptionalUserId();
+  const db = userId ? tryGetDb(userId) : null;
   const nextStep = useOnboardingStore((s) => s.nextStep);
 
   const accounts = useEmailCaptureStore((s) => s.accounts);
-  const fetchAndProcess = useEmailCaptureStore((s) => s.fetchAndProcess);
   const progress = useEmailCaptureStore((s) => s.progress);
   const isFetching = useEmailCaptureStore((s) => s.isFetching);
 
@@ -34,9 +38,11 @@ export function SyncProgressStep() {
 
   // Start fetch on mount if we have accounts
   useMountEffect(() => {
-    if (accounts.length > 0 && !fetchStarted.current) {
+    if (accounts.length > 0 && !fetchStarted.current && db && userId) {
       fetchStarted.current = true;
-      void fetchAndProcess(getGmailClientId(), getOutlookClientId());
+      void fetchAndProcessEmails(db, userId, getGmailClientId(), getOutlookClientId(), () =>
+        useTransactionStore.getState().refresh()
+      );
     }
   });
 


### PR DESCRIPTION
- remove hidden db and user refs
- add explicit email capture boundaries
- rewire callers and regressions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors email capture to use explicit session boundaries and stateless functions, removing hidden DB/user refs. Adds clearer stale-session handling and warnings to prevent cross-user or outdated updates.

- **Refactors**
  - Added `initializeEmailCaptureSession(userId)` and parameterized actions: `loadEmailAccounts`, `loadFailedEmails`, `loadNeedsReviewEmails`, `fetchAndProcessEmails`, `connectEmailAccount`, `disconnectEmailAccount`, `dismissFailedEmail`, `confirmReviewedEmail` (now accepts an optional `refreshTransactions` callback).
  - Store now tracks `activeUserId` and exposes simple setters; removed global DB/user refs and implicit side effects.
  - Updated onboarding, app layout, connected accounts, failed emails, needs review, dashboard, background task, and `useEmailCapture` hook to pass `db` and `userId`.

- **Bug Fixes**
  - Drop stale account loads and fetch completions when the active user changes using session/request IDs.
  - Improve warning context for out-of-session fetch requests with `email_capture_fetch_missing_context` (reports session presence, match, and active session user ID).
  - Prevent duplicate account inserts; only update `lastFetchedAt` for successful fetches.
  - Ensure progress clears safely after completion and `isFetching` resets on failures.

<sup>Written for commit efcdb4fa9e80ed043b4b6b827fa39ee0aa5e6603. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

