### PR TITLE
refactor(mobile): deepen ai chat seam

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,10 @@ Workspace wrapper scripts like `bun run --cwd apps/mobile lint` can behave diffe
 
 Fresh workspaces may not have the `.context/fidy-vault` symlink yet, even when the external vault is correctly configured. Agents that try to read `.context/fidy-vault/AGENTS.md` before running `bun run vault:doctor` can fail with "No such file or directory". Fix: run `bun run vault:doctor` first, then read `.context/fidy-vault/AGENTS.md`.
 
+### Rebased PR branches can replay already-merged slice commits (⚠️ AGENT SURPRISE)
+
+When a new slice branch is created from an older feature branch and that parent PR later merges to `main`, the standard `git pull --rebase --autostash origin main` flow can try to replay those already-merged commits and produce conflicts in unrelated files. In this repo, the safer recovery is: stash the current work, create a fresh branch from `origin/main`, then reapply the stash there before opening the next PR.
+
 ## External Fidy Vault
 
 The persistent Fidy knowledge vault lives outside the repo on the local machine.

--- a/apps/mobile/__tests__/ai-chat/callers.test.ts
+++ b/apps/mobile/__tests__/ai-chat/callers.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+
+const sessionCleanupSource = readFileSync(
+  resolve(__dirname, "../../features/ai-chat/hooks/use-session-cleanup.ts"),
+  "utf-8"
+);
+
+const chatScreenSource = readFileSync(
+  resolve(__dirname, "../../features/ai-chat/components/ChatScreen.tsx"),
+  "utf-8"
+);
+
+describe("ai chat callers", () => {
+  test("session cleanup resubscribes when auth-scoped runtime becomes available", () => {
+    expect(sessionCleanupSource).toContain("useSubscription(");
+    expect(sessionCleanupSource).toContain("[db, userId]");
+    expect(sessionCleanupSource).toContain("Boolean(db && userId)");
+    expect(sessionCleanupSource).not.toContain("useMountEffect(");
+  });
+
+  test("ChatScreen catches action-status persistence failures", () => {
+    expect(chatScreenSource).toContain("updateChatActionStatus(db, userId, messageId, status)");
+    expect(chatScreenSource).toContain(".catch(captureError)");
+    expect(chatScreenSource).toContain("persistActionStatus");
+    expect(chatScreenSource).not.toContain(
+      'void updateChatActionStatus(db, userId, messageId, "confirmed")'
+    );
+    expect(chatScreenSource).not.toContain(
+      'void updateChatActionStatus(db, userId, messageId, "dismissed")'
+    );
+  });
+});

--- a/apps/mobile/__tests__/ai-chat/store.test.ts
+++ b/apps/mobile/__tests__/ai-chat/store.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createChatSession,
+  initializeChatSession,
+  loadChatSessions,
+  selectChatSession,
+  useChatStore,
+} from "@/features/ai-chat/store";
+import type { ChatMessageId, ChatSessionId, IsoDateTime, UserId } from "@/shared/types/branded";
+
+vi.mock("@/shared/db", () => ({
+  chatMessages: {
+    id: "id",
+    sessionId: "session_id",
+    role: "role",
+    content: "content",
+    action: "action",
+    actionStatus: "action_status",
+    createdAt: "created_at",
+  },
+  chatSessions: {
+    id: "id",
+    userId: "user_id",
+    title: "title",
+    createdAt: "created_at",
+    expiresAt: "expires_at",
+    deletedAt: "deleted_at",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: vi.fn((...args: unknown[]) => ({ type: "and", args })),
+  asc: vi.fn((column: unknown) => ({ type: "asc", column })),
+  desc: vi.fn((column: unknown) => ({ type: "desc", column })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ type: "eq", left, right })),
+  isNull: vi.fn((value: unknown) => ({ type: "isNull", value })),
+}));
+
+function createDeferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function makeSession(overrides: { id?: string; title?: string } = {}) {
+  return {
+    id: (overrides.id ?? "chat-1") as ChatSessionId,
+    userId: "user-1" as UserId,
+    title: overrides.title ?? "Trip planning",
+    createdAt: "2026-04-18T10:00:00.000Z" as IsoDateTime,
+    expiresAt: "2026-05-18T10:00:00.000Z" as IsoDateTime,
+    deletedAt: null,
+  };
+}
+
+function makeMessage(
+  overrides: { id?: string; sessionId?: string; content?: string; createdAt?: IsoDateTime } = {}
+) {
+  return {
+    id: (overrides.id ?? "message-1") as ChatMessageId,
+    sessionId: (overrides.sessionId ?? "chat-1") as ChatSessionId,
+    role: "assistant",
+    content: overrides.content ?? "Here is your weekly summary",
+    action: null,
+    actionStatus: null,
+    createdAt: overrides.createdAt ?? ("2026-04-18T10:15:00.000Z" as IsoDateTime),
+  };
+}
+
+describe("ai chat store boundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useChatStore.setState({
+      activeUserId: null,
+      sessions: [],
+      currentSessionId: null,
+      messages: [],
+      isStreaming: false,
+      streamingContent: "",
+      expiredSessionCount: 0,
+    });
+  });
+
+  it("loads sessions for the active user through the explicit boundary", async () => {
+    const rows = [makeSession()];
+    const orderBy = vi.fn().mockResolvedValue(rows);
+    const where = vi.fn().mockReturnValue({ orderBy });
+    const from = vi.fn().mockReturnValue({ where });
+    const select = vi.fn().mockReturnValue({ from });
+    const db = { select } as never;
+
+    initializeChatSession("user-1" as UserId);
+    await loadChatSessions(db, "user-1" as UserId);
+
+    expect(select).toHaveBeenCalled();
+    expect(useChatStore.getState()).toMatchObject({
+      activeUserId: "user-1",
+      sessions: rows,
+    });
+  });
+
+  it("drops stale session results after the active user changes", async () => {
+    const deferred = createDeferred<readonly ReturnType<typeof makeSession>[]>();
+    const orderBy = vi.fn().mockReturnValue(deferred.promise);
+    const where = vi.fn().mockReturnValue({ orderBy });
+    const from = vi.fn().mockReturnValue({ where });
+    const select = vi.fn().mockReturnValue({ from });
+    const db = { select } as never;
+
+    initializeChatSession("user-1" as UserId);
+    const load = loadChatSessions(db, "user-1" as UserId);
+
+    initializeChatSession("user-2" as UserId);
+    deferred.resolve([makeSession()]);
+
+    await load;
+
+    expect(useChatStore.getState()).toMatchObject({
+      activeUserId: "user-2",
+      sessions: [],
+      currentSessionId: null,
+      messages: [],
+    });
+  });
+
+  it("drops stale create-session completions after the active user changes", async () => {
+    const deferred = createDeferred<void>();
+    const values = vi.fn().mockReturnValue(deferred.promise);
+    const insert = vi.fn().mockReturnValue({ values });
+    const db = { insert } as never;
+
+    initializeChatSession("user-1" as UserId);
+    const create = createChatSession(db, "user-1" as UserId, "Plan my trip budget");
+
+    initializeChatSession("user-2" as UserId);
+    deferred.resolve();
+
+    await create;
+
+    expect(useChatStore.getState()).toMatchObject({
+      activeUserId: "user-2",
+      sessions: [],
+      currentSessionId: null,
+      messages: [],
+    });
+  });
+
+  it("drops stale session-message loads after another session becomes active", async () => {
+    const deferred = createDeferred<readonly ReturnType<typeof makeMessage>[]>();
+    const orderBy = vi.fn().mockReturnValue(deferred.promise);
+    const where = vi.fn().mockReturnValue({ orderBy });
+    const from = vi.fn().mockReturnValue({ where });
+    const select = vi.fn().mockReturnValue({ from });
+    const db = { select } as never;
+
+    initializeChatSession("user-1" as UserId);
+
+    const firstSessionId = "chat-1" as ChatSessionId;
+    const secondSessionId = "chat-2" as ChatSessionId;
+
+    const firstSelect = selectChatSession(db, "user-1" as UserId, firstSessionId);
+    await Promise.resolve();
+
+    useChatStore.getState().setCurrentSessionId(secondSessionId);
+    deferred.resolve([makeMessage({ sessionId: firstSessionId })]);
+
+    await firstSelect;
+
+    expect(useChatStore.getState()).toMatchObject({
+      activeUserId: "user-1",
+      currentSessionId: secondSessionId,
+      messages: [],
+    });
+  });
+});

--- a/apps/mobile/__tests__/ai-chat/store.test.ts
+++ b/apps/mobile/__tests__/ai-chat/store.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatMessage } from "@/features/ai-chat/schema";
 import {
   createChatSession,
   initializeChatSession,
@@ -59,7 +60,7 @@ function makeSession(overrides: { id?: string; title?: string } = {}) {
 
 function makeMessage(
   overrides: { id?: string; sessionId?: string; content?: string; createdAt?: IsoDateTime } = {}
-) {
+): ChatMessage {
   return {
     id: (overrides.id ?? "message-1") as ChatMessageId,
     sessionId: (overrides.sessionId ?? "chat-1") as ChatSessionId,
@@ -175,5 +176,30 @@ describe("ai chat store boundary", () => {
       currentSessionId: secondSessionId,
       messages: [],
     });
+  });
+
+  it("clears the previous session messages while the next session loads", async () => {
+    const deferred = createDeferred<readonly ReturnType<typeof makeMessage>[]>();
+    const orderBy = vi.fn().mockReturnValue(deferred.promise);
+    const where = vi.fn().mockReturnValue({ orderBy });
+    const from = vi.fn().mockReturnValue({ where });
+    const select = vi.fn().mockReturnValue({ from });
+    const db = { select } as never;
+
+    initializeChatSession("user-1" as UserId);
+    useChatStore.setState({
+      currentSessionId: "chat-1" as ChatSessionId,
+      messages: [makeMessage({ sessionId: "chat-1" })],
+    });
+
+    const selectPromise = selectChatSession(db, "user-1" as UserId, "chat-2" as ChatSessionId);
+
+    expect(useChatStore.getState()).toMatchObject({
+      currentSessionId: "chat-2",
+      messages: [],
+    });
+
+    deferred.resolve([makeMessage({ sessionId: "chat-2", content: "New conversation" })]);
+    await selectPromise;
   });
 });

--- a/apps/mobile/app/(tabs)/(ai)/index.tsx
+++ b/apps/mobile/app/(tabs)/(ai)/index.tsx
@@ -3,9 +3,13 @@ import {
   ChatScreen,
   ConversationList,
   cancelActiveStream,
+  selectChatSession,
+  startNewChat,
   useChatStore,
   useExtractUserMemoriesMutation,
 } from "@/features/ai-chat";
+import { useOptionalUserId } from "@/features/auth";
+import { tryGetDb } from "@/shared/db";
 import { captureError } from "@/shared/lib";
 import type { ChatSessionId } from "@/shared/types/branded";
 
@@ -13,20 +17,22 @@ type AiView = "list" | "chat";
 
 export default function AiTab() {
   const [view, setView] = useState<AiView>("list");
-  const selectSession = useChatStore((s) => s.selectSession);
+  const userId = useOptionalUserId();
+  const db = userId ? tryGetDb(userId) : null;
   const messages = useChatStore((s) => s.messages);
   const extractUserMemories = useExtractUserMemoriesMutation();
 
   const handleSelectSession = useCallback(
     async (id: ChatSessionId) => {
-      await selectSession(id);
+      if (!db || !userId) return;
+      await selectChatSession(db, userId, id);
       setView("chat");
     },
-    [selectSession]
+    [db, userId]
   );
 
   const handleNewChat = useCallback(() => {
-    useChatStore.setState({ currentSessionId: null, messages: [] });
+    startNewChat();
     setView("chat");
   }, []);
 

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -15,7 +15,11 @@ import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
 import { useMemo } from "react";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
-import { useChatStore } from "@/features/ai-chat";
+import {
+  cleanupExpiredChatSessions,
+  initializeChatSession,
+  loadChatSessions,
+} from "@/features/ai-chat";
 import {
   initializeAnalyticsSession,
   loadAnalyticsForUser,
@@ -101,7 +105,7 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
     () => {
       useTransactionStore.getState().initStore(db, userId);
       initializeEmailCaptureSession(userId);
-      useChatStore.getState().initStore(db, userId);
+      initializeChatSession(userId);
       initializeCalendarSession(userId);
       initializeBudgetSession(userId);
       initializeGoalSession(userId);
@@ -115,10 +119,8 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
       loadAnalyticsForUser(db, userId).catch(handleRecoverableError("Failed to load analytics"));
       loadEmailAccounts(db, userId).catch(handleRecoverableError("Failed to load email accounts"));
       refreshCategories(db, userId).catch(handleRecoverableError("Failed to load user categories"));
-      useChatStore
-        .getState()
-        .loadSessions()
-        .then(() => useChatStore.getState().cleanupExpiredSessions())
+      loadChatSessions(db, userId)
+        .then(() => cleanupExpiredChatSessions(db, userId))
         .catch(handleRecoverableError("Failed to load chat sessions"));
       hydrateCaptureSources(db, userId).catch(
         handleRecoverableError("Failed to load capture sources")

--- a/apps/mobile/features/ai-chat/components/ChatScreen.tsx
+++ b/apps/mobile/features/ai-chat/components/ChatScreen.tsx
@@ -2,15 +2,17 @@ import type { FlashListRef } from "@shopify/flash-list";
 import { FlashList } from "@shopify/flash-list";
 import { memo, useCallback, useRef } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useOptionalUserId } from "@/features/auth";
 import { useTransactionStore } from "@/features/transactions";
 import { HEADER_HEIGHT, ScreenLayout } from "@/shared/components";
 import { Keyboard, KeyboardAvoidingView, Platform, View } from "@/shared/components/rn";
+import { tryGetDb } from "@/shared/db";
 import { useMountEffect, useTranslation } from "@/shared/hooks";
 import { trackAiChatOpened } from "@/shared/lib";
 import type { ChatMessageId } from "@/shared/types/branded";
 import { useStreamingChat } from "../hooks/use-streaming-chat";
 import type { ChatMessage } from "../schema";
-import { useChatStore } from "../store";
+import { updateChatActionStatus, useChatStore } from "../store";
 import { ChatInput } from "./ChatInput";
 import { MessageBubble } from "./MessageBubble";
 import { StarterSuggestions } from "./StarterSuggestions";
@@ -39,13 +41,14 @@ const MemoizedMessageBubble = memo(function MemoizedBubble({
 export function ChatScreen({ onBack }: ChatScreenProps) {
   const { t } = useTranslation();
   useMountEffect(() => trackAiChatOpened());
+  const userId = useOptionalUserId();
   const listRef = useRef<FlashListRef<ChatMessage>>(null);
   const { top: safeTop } = useSafeAreaInsets();
+  const db = userId ? tryGetDb(userId) : null;
 
   const messages = useChatStore((s) => s.messages);
   const sessions = useChatStore((s) => s.sessions);
   const currentSessionId = useChatStore((s) => s.currentSessionId);
-  const updateActionStatus = useChatStore((s) => s.updateActionStatus);
 
   const { sendMessage, isStreaming, streamingContent } = useStreamingChat();
 
@@ -59,20 +62,23 @@ export function ChatScreen({ onBack }: ChatScreenProps) {
         try {
           await useTransactionStore.getState().removeTransaction(msg.action.transactionId);
         } catch {
-          void updateActionStatus(messageId, "dismissed");
+          if (!db || !userId) return;
+          void updateChatActionStatus(db, userId, messageId, "dismissed");
           return;
         }
       }
-      void updateActionStatus(messageId, "confirmed");
+      if (!db || !userId) return;
+      void updateChatActionStatus(db, userId, messageId, "confirmed");
     },
-    [messages, updateActionStatus]
+    [db, messages, userId]
   );
 
   const handleDismissAction = useCallback(
     (messageId: ChatMessageId) => {
-      void updateActionStatus(messageId, "dismissed");
+      if (!db || !userId) return;
+      void updateChatActionStatus(db, userId, messageId, "dismissed");
     },
-    [updateActionStatus]
+    [db, userId]
   );
 
   const renderItem = useCallback(

--- a/apps/mobile/features/ai-chat/components/ChatScreen.tsx
+++ b/apps/mobile/features/ai-chat/components/ChatScreen.tsx
@@ -8,10 +8,10 @@ import { HEADER_HEIGHT, ScreenLayout } from "@/shared/components";
 import { Keyboard, KeyboardAvoidingView, Platform, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
 import { useMountEffect, useTranslation } from "@/shared/hooks";
-import { trackAiChatOpened } from "@/shared/lib";
+import { captureError, trackAiChatOpened } from "@/shared/lib";
 import type { ChatMessageId } from "@/shared/types/branded";
 import { useStreamingChat } from "../hooks/use-streaming-chat";
-import type { ChatMessage } from "../schema";
+import type { ActionStatus, ChatMessage } from "../schema";
 import { updateChatActionStatus, useChatStore } from "../store";
 import { ChatInput } from "./ChatInput";
 import { MessageBubble } from "./MessageBubble";
@@ -55,6 +55,14 @@ export function ChatScreen({ onBack }: ChatScreenProps) {
   const currentSession = sessions.find((s) => s.id === currentSessionId);
   const title = currentSession?.title ?? t("aiChat.fidyAi");
 
+  const persistActionStatus = useCallback(
+    (messageId: ChatMessageId, status: ActionStatus) => {
+      if (!db || !userId) return;
+      void updateChatActionStatus(db, userId, messageId, status).catch(captureError);
+    },
+    [db, userId]
+  );
+
   const handleConfirmAction = useCallback(
     async (messageId: ChatMessageId) => {
       const msg = messages.find((m) => m.id === messageId);
@@ -62,23 +70,20 @@ export function ChatScreen({ onBack }: ChatScreenProps) {
         try {
           await useTransactionStore.getState().removeTransaction(msg.action.transactionId);
         } catch {
-          if (!db || !userId) return;
-          void updateChatActionStatus(db, userId, messageId, "dismissed");
+          persistActionStatus(messageId, "dismissed");
           return;
         }
       }
-      if (!db || !userId) return;
-      void updateChatActionStatus(db, userId, messageId, "confirmed");
+      persistActionStatus(messageId, "confirmed");
     },
-    [db, messages, userId]
+    [messages, persistActionStatus]
   );
 
   const handleDismissAction = useCallback(
     (messageId: ChatMessageId) => {
-      if (!db || !userId) return;
-      void updateChatActionStatus(db, userId, messageId, "dismissed");
+      persistActionStatus(messageId, "dismissed");
     },
-    [db, userId]
+    [persistActionStatus]
   );
 
   const renderItem = useCallback(

--- a/apps/mobile/features/ai-chat/components/ConversationList.tsx
+++ b/apps/mobile/features/ai-chat/components/ConversationList.tsx
@@ -2,15 +2,17 @@ import { FlashList } from "@shopify/flash-list";
 import { format } from "date-fns";
 import { Stack } from "expo-router";
 import { memo, useCallback } from "react";
+import { useOptionalUserId } from "@/features/auth";
 import { ScreenLayout, TAB_BAR_CLEARANCE } from "@/shared/components";
 import { MessageSquare, Plus, Trash2, X } from "@/shared/components/icons";
 import { Platform, Pressable, Text, View } from "@/shared/components/rn";
+import { tryGetDb } from "@/shared/db";
 import { useMountEffect, useThemeColor, useTranslation } from "@/shared/hooks";
 import { getDateFnsLocale } from "@/shared/i18n";
 import type { ChatSessionId } from "@/shared/types/branded";
 import { useSessionCleanup } from "../hooks/use-session-cleanup";
 import type { ChatSession } from "../schema";
-import { useChatStore } from "../store";
+import { deleteChatSession, loadChatSessions, useChatStore } from "../store";
 
 type ConversationListProps = {
   readonly onSelectSession: (id: ChatSessionId) => void;
@@ -80,22 +82,24 @@ function NewChatButton({ onPress }: { readonly onPress: () => void }) {
 
 export function ConversationList({ onSelectSession, onNewChat }: ConversationListProps) {
   const { t } = useTranslation();
+  const userId = useOptionalUserId();
+  const db = userId ? tryGetDb(userId) : null;
   const sessions = useChatStore((s) => s.sessions);
-  const loadSessions = useChatStore((s) => s.loadSessions);
-  const deleteSession = useChatStore((s) => s.deleteSession);
 
   const tertiary = useThemeColor("tertiary");
   const { message: cleanupMessage, dismiss: dismissCleanup } = useSessionCleanup();
 
   useMountEffect(() => {
-    void loadSessions();
+    if (!db || !userId) return;
+    void loadChatSessions(db, userId);
   });
 
   const handleDelete = useCallback(
     (id: ChatSessionId) => {
-      void deleteSession(id);
+      if (!db || !userId) return;
+      void deleteChatSession(db, userId, id);
     },
-    [deleteSession]
+    [db, userId]
   );
 
   const renderItem = useCallback(

--- a/apps/mobile/features/ai-chat/hooks/use-session-cleanup.ts
+++ b/apps/mobile/features/ai-chat/hooks/use-session-cleanup.ts
@@ -1,15 +1,19 @@
 import { useCallback, useState } from "react";
+import { useOptionalUserId } from "@/features/auth";
+import { tryGetDb } from "@/shared/db";
 import { useMountEffect } from "@/shared/hooks";
 import { useLocaleStore } from "@/shared/i18n/store";
 import { formatCleanupMessage } from "../lib/sessions";
-import { useChatStore } from "../store";
+import { cleanupExpiredChatSessions } from "../store";
 
 export function useSessionCleanup() {
   const [message, setMessage] = useState<string | null>(null);
-  const cleanupExpiredSessions = useChatStore((s) => s.cleanupExpiredSessions);
+  const userId = useOptionalUserId();
+  const db = userId ? tryGetDb(userId) : null;
 
   useMountEffect(() => {
-    void cleanupExpiredSessions().then((expired) => {
+    if (!db || !userId) return;
+    void cleanupExpiredChatSessions(db, userId).then((expired) => {
       setMessage(formatCleanupMessage(expired.length, useLocaleStore.getState().t));
     });
   });

--- a/apps/mobile/features/ai-chat/hooks/use-session-cleanup.ts
+++ b/apps/mobile/features/ai-chat/hooks/use-session-cleanup.ts
@@ -1,8 +1,9 @@
 import { useCallback, useState } from "react";
 import { useOptionalUserId } from "@/features/auth";
 import { tryGetDb } from "@/shared/db";
-import { useMountEffect } from "@/shared/hooks";
+import { useSubscription } from "@/shared/hooks";
 import { useLocaleStore } from "@/shared/i18n/store";
+import { captureError } from "@/shared/lib";
 import { formatCleanupMessage } from "../lib/sessions";
 import { cleanupExpiredChatSessions } from "../store";
 
@@ -11,12 +12,26 @@ export function useSessionCleanup() {
   const userId = useOptionalUserId();
   const db = userId ? tryGetDb(userId) : null;
 
-  useMountEffect(() => {
-    if (!db || !userId) return;
-    void cleanupExpiredChatSessions(db, userId).then((expired) => {
-      setMessage(formatCleanupMessage(expired.length, useLocaleStore.getState().t));
-    });
-  });
+  useSubscription(
+    () => {
+      if (!db || !userId) return;
+
+      let active = true;
+
+      void cleanupExpiredChatSessions(db, userId)
+        .then((expired) => {
+          if (!active) return;
+          setMessage(formatCleanupMessage(expired.length, useLocaleStore.getState().t));
+        })
+        .catch(captureError);
+
+      return () => {
+        active = false;
+      };
+    },
+    [db, userId],
+    Boolean(db && userId)
+  );
 
   const dismiss = useCallback(() => setMessage(null), []);
 

--- a/apps/mobile/features/ai-chat/hooks/use-streaming-chat.ts
+++ b/apps/mobile/features/ai-chat/hooks/use-streaming-chat.ts
@@ -1,5 +1,7 @@
 import { useCallback } from "react";
+import { useOptionalUserId } from "@/features/auth";
 import { useTransactionStore } from "@/features/transactions";
+import { tryGetDb } from "@/shared/db";
 import {
   captureWarning,
   parseIsoDate,
@@ -9,7 +11,12 @@ import {
 import { parseActionFromResponse } from "../lib/parse-action";
 import type { ChatAction } from "../schema";
 import { streamChat } from "../services/ai-chat-api";
-import { useChatStore } from "../store";
+import {
+  addAssistantChatMessage,
+  addUserChatMessage,
+  createChatSession,
+  useChatStore,
+} from "../store";
 
 let activeController: AbortController | null = null;
 
@@ -25,6 +32,8 @@ export function cancelActiveStream(): void {
 }
 
 export function useStreamingChat() {
+  const userId = useOptionalUserId();
+  const db = userId ? tryGetDb(userId) : null;
   const isStreaming = useChatStore((s) => s.isStreaming);
   const streamingContent = useChatStore((s) => s.streamingContent);
 
@@ -64,15 +73,19 @@ export function useStreamingChat() {
 
   const sendMessage = useCallback(
     async (text: string) => {
-      if (isStreaming || !text.trim()) return;
+      if (isStreaming || !text.trim() || !db || !userId) return;
 
       const store = useChatStore.getState();
 
       if (!store.currentSessionId) {
-        await store.createSession(text);
+        await createChatSession(db, userId, text);
       }
 
-      await store.addUserMessage(text);
+      if (!useChatStore.getState().currentSessionId) {
+        return;
+      }
+
+      await addUserChatMessage(db, userId, text);
       trackAiMessageSent();
 
       const allMessages = [
@@ -102,7 +115,7 @@ export function useStreamingChat() {
             onDone: () => {
               void (async () => {
                 const action = parseActionFromResponse(accumulated);
-                await useChatStore.getState().addAssistantMessage(accumulated, action);
+                await addAssistantChatMessage(db, userId, accumulated, action);
 
                 if (action?.type === "add") {
                   try {
@@ -122,7 +135,7 @@ export function useStreamingChat() {
               void (async () => {
                 const errorMessage =
                   accumulated || `I'm sorry, something went wrong. Please try again. (${error})`;
-                await useChatStore.getState().addAssistantMessage(errorMessage);
+                await addAssistantChatMessage(db, userId, errorMessage);
                 resetStreamState();
               })();
             },
@@ -134,12 +147,12 @@ export function useStreamingChat() {
           const errorMessage =
             accumulated ||
             `I'm sorry, something went wrong. Please try again. (${err instanceof Error ? err.message : "Unknown error"})`;
-          await useChatStore.getState().addAssistantMessage(errorMessage);
+          await addAssistantChatMessage(db, userId, errorMessage);
         }
         resetStreamState();
       }
     },
-    [isStreaming, executeAction]
+    [db, executeAction, isStreaming, userId]
   );
 
   return { sendMessage, cancelStream: cancelActiveStream, isStreaming, streamingContent };

--- a/apps/mobile/features/ai-chat/index.ts
+++ b/apps/mobile/features/ai-chat/index.ts
@@ -7,4 +7,17 @@ export {
   useExtractUserMemoriesMutation,
   useUserMemoriesQuery,
 } from "./hooks/use-user-memories";
-export { useChatStore } from "./store";
+export {
+  addAssistantChatMessage,
+  addUserChatMessage,
+  cleanupExpiredChatSessions,
+  createChatSession,
+  deleteChatSession,
+  dismissExpiredChatBanner,
+  initializeChatSession,
+  loadChatSessions,
+  selectChatSession,
+  startNewChat,
+  updateChatActionStatus,
+  useChatStore,
+} from "./store";

--- a/apps/mobile/features/ai-chat/store.ts
+++ b/apps/mobile/features/ai-chat/store.ts
@@ -2,40 +2,45 @@ import { and, asc, desc, eq, isNull } from "drizzle-orm";
 import { create } from "zustand";
 import { type AnyDb, chatMessages, chatSessions } from "@/shared/db";
 import { generateChatMessageId, generateChatSessionId, toIsoDateTime } from "@/shared/lib";
+import { requireIsoDateTime } from "@/shared/types/assertions";
 import type { ChatMessageId, ChatSessionId, UserId } from "@/shared/types/branded";
 import { deriveConversationTitle, findExpiredSessions } from "./lib/sessions";
 import type { ActionStatus, ChatAction, ChatMessage, ChatSession } from "./schema";
 
-let dbRef: AnyDb | null = null;
-let userIdRef: UserId | null = null;
-
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 
+let chatStoreSessionId = 0;
+let loadChatSessionsRequestId = 0;
+let selectChatSessionRequestId = 0;
+
 type ChatState = {
-  sessions: ChatSession[];
-  currentSessionId: ChatSessionId | null;
-  messages: ChatMessage[];
-  isStreaming: boolean;
-  streamingContent: string;
-  expiredSessionCount: number;
+  readonly activeUserId: UserId | null;
+  readonly sessions: readonly ChatSession[];
+  readonly currentSessionId: ChatSessionId | null;
+  readonly messages: readonly ChatMessage[];
+  readonly isStreaming: boolean;
+  readonly streamingContent: string;
+  readonly expiredSessionCount: number;
 };
 
 type ChatActions = {
-  initStore: (db: AnyDb, userId: UserId) => void;
-  loadSessions: () => Promise<void>;
-  createSession: (firstMessage: string) => Promise<ChatSessionId>;
-  deleteSession: (id: ChatSessionId) => Promise<void>;
-  selectSession: (id: ChatSessionId) => Promise<void>;
-  addUserMessage: (content: string) => Promise<ChatMessage>;
-  addAssistantMessage: (content: string, action?: ChatAction | null) => Promise<ChatMessage>;
-  updateActionStatus: (messageId: ChatMessageId, status: ActionStatus) => Promise<void>;
+  beginSession: (userId: UserId) => void;
+  setSessions: (sessions: readonly ChatSession[]) => void;
+  prependSession: (session: ChatSession) => void;
+  removeSession: (sessionId: ChatSessionId) => void;
+  setCurrentSessionId: (sessionId: ChatSessionId | null) => void;
+  setMessages: (messages: readonly ChatMessage[]) => void;
+  appendMessage: (message: ChatMessage) => void;
+  setMessageActionStatus: (messageId: ChatMessageId, status: ActionStatus) => void;
   setStreaming: (isStreaming: boolean) => void;
   setStreamingContent: (content: string) => void;
-  cleanupExpiredSessions: () => Promise<readonly ChatSession[]>;
+  setExpiredSessionCount: (count: number) => void;
+  clearCurrentConversation: () => void;
   dismissExpiredBanner: () => void;
 };
 
-export const useChatStore = create<ChatState & ChatActions>((set, get) => ({
+export const useChatStore = create<ChatState & ChatActions>((set) => ({
+  activeUserId: null,
   sessions: [],
   currentSessionId: null,
   messages: [],
@@ -43,215 +48,365 @@ export const useChatStore = create<ChatState & ChatActions>((set, get) => ({
   streamingContent: "",
   expiredSessionCount: 0,
 
-  initStore: (db, userId) => {
-    dbRef = db;
-    userIdRef = userId;
+  beginSession: (userId) =>
     set({
+      activeUserId: userId,
       sessions: [],
       currentSessionId: null,
       messages: [],
+      isStreaming: false,
+      streamingContent: "",
       expiredSessionCount: 0,
-    });
-  },
+    }),
 
-  loadSessions: async () => {
-    if (!dbRef || !userIdRef) return;
-    const rows = await dbRef
-      .select()
-      .from(chatSessions)
-      .where(and(eq(chatSessions.userId, userIdRef), isNull(chatSessions.deletedAt)))
-      .orderBy(desc(chatSessions.createdAt));
+  setSessions: (sessions) => set({ sessions: [...sessions] }),
 
-    set({
-      sessions: rows.map((r) => ({
-        id: r.id,
-        userId: r.userId,
-        title: r.title,
-        createdAt: r.createdAt,
-        expiresAt: r.expiresAt,
-        deletedAt: r.deletedAt,
-      })),
-    });
-  },
-
-  createSession: async (firstMessage) => {
-    if (!dbRef || !userIdRef) throw new Error("Store not initialized");
-    const id = generateChatSessionId();
-    const now = new Date();
-    const nowIso = toIsoDateTime(now);
-    const expiresIso = toIsoDateTime(new Date(now.getTime() + THIRTY_DAYS_MS));
-    const session: ChatSession = {
-      id,
-      userId: userIdRef,
-      title: deriveConversationTitle(firstMessage),
-      createdAt: nowIso,
-      expiresAt: expiresIso,
-      deletedAt: null,
-    };
-
-    await dbRef.insert(chatSessions).values({
-      id: session.id,
-      userId: session.userId,
-      title: session.title,
-      createdAt: session.createdAt,
-      expiresAt: session.expiresAt,
-      deletedAt: null,
-    });
-
+  prependSession: (session) =>
     set((state) => ({
       sessions: [session, ...state.sessions],
-      currentSessionId: id,
+      currentSessionId: session.id,
       messages: [],
-    }));
-    return id;
-  },
+    })),
 
-  deleteSession: async (id) => {
-    if (!dbRef) return;
-    const now = toIsoDateTime(new Date());
-    await dbRef.update(chatSessions).set({ deletedAt: now }).where(eq(chatSessions.id, id));
-
+  removeSession: (sessionId) =>
     set((state) => ({
-      sessions: state.sessions.filter((s) => s.id !== id),
-      currentSessionId: state.currentSessionId === id ? null : state.currentSessionId,
-      messages: state.currentSessionId === id ? [] : state.messages,
-    }));
-  },
+      sessions: state.sessions.filter((session) => session.id !== sessionId),
+      currentSessionId: state.currentSessionId === sessionId ? null : state.currentSessionId,
+      messages: state.currentSessionId === sessionId ? [] : state.messages,
+    })),
 
-  selectSession: async (id) => {
-    if (!dbRef) return;
-    const rows = await dbRef
-      .select()
-      .from(chatMessages)
-      .where(eq(chatMessages.sessionId, id))
-      .orderBy(asc(chatMessages.createdAt));
+  setCurrentSessionId: (currentSessionId) => set({ currentSessionId }),
 
-    set({
-      currentSessionId: id,
-      messages: rows.map((r) => ({
-        id: r.id,
-        sessionId: r.sessionId,
-        role: r.role as "user" | "assistant",
-        content: r.content,
-        action: r.action ? (JSON.parse(r.action) as ChatAction) : null,
-        actionStatus: r.actionStatus as ActionStatus | null,
-        createdAt: r.createdAt,
-      })),
-    });
-  },
+  setMessages: (messages) => set({ messages: [...messages] }),
 
-  addUserMessage: async (content) => {
-    if (!dbRef) throw new Error("Store not initialized");
-    const { currentSessionId } = get();
-    if (!currentSessionId) throw new Error("No active session");
-
-    const msg: ChatMessage = {
-      id: generateChatMessageId(),
-      sessionId: currentSessionId,
-      role: "user",
-      content,
-      action: null,
-      actionStatus: null,
-      createdAt: toIsoDateTime(new Date()),
-    };
-
-    await dbRef.insert(chatMessages).values({
-      id: msg.id,
-      sessionId: msg.sessionId,
-      role: msg.role,
-      content: msg.content,
-      action: null,
-      actionStatus: null,
-      createdAt: msg.createdAt,
-    });
-
-    set((state) => ({ messages: [...state.messages, msg] }));
-    return msg;
-  },
-
-  addAssistantMessage: async (content, action = null) => {
-    if (!dbRef) throw new Error("Store not initialized");
-    const { currentSessionId } = get();
-    if (!currentSessionId) throw new Error("No active session");
-
-    const actionStatus: ActionStatus | null = action
-      ? action.type === "add"
-        ? "confirmed"
-        : action.type === "delete"
-          ? "pending"
-          : null
-      : null;
-
-    const msg: ChatMessage = {
-      id: generateChatMessageId(),
-      sessionId: currentSessionId,
-      role: "assistant",
-      content,
-      action,
-      actionStatus,
-      createdAt: toIsoDateTime(new Date()),
-    };
-
-    await dbRef.insert(chatMessages).values({
-      id: msg.id,
-      sessionId: msg.sessionId,
-      role: msg.role,
-      content: msg.content,
-      action: action ? JSON.stringify(action) : null,
-      actionStatus: msg.actionStatus,
-      createdAt: msg.createdAt,
-    });
-
-    set((state) => ({ messages: [...state.messages, msg] }));
-    return msg;
-  },
-
-  updateActionStatus: async (messageId, status) => {
-    if (!dbRef) return;
-    await dbRef
-      .update(chatMessages)
-      .set({ actionStatus: status })
-      .where(eq(chatMessages.id, messageId));
-
+  appendMessage: (message) =>
     set((state) => ({
-      messages: state.messages.map((m) =>
-        m.id === messageId ? { ...m, actionStatus: status } : m
+      messages: [...state.messages, message],
+    })),
+
+  setMessageActionStatus: (messageId, status) =>
+    set((state) => ({
+      messages: state.messages.map((message) =>
+        message.id === messageId ? { ...message, actionStatus: status } : message
       ),
-    }));
-  },
+    })),
 
   setStreaming: (isStreaming) => set({ isStreaming }),
+
   setStreamingContent: (streamingContent) => set({ streamingContent }),
 
-  cleanupExpiredSessions: async () => {
-    if (!dbRef) return [];
-    const db = dbRef;
-    const { sessions } = get();
-    const now = toIsoDateTime(new Date());
-    const expired = findExpiredSessions(sessions, now);
+  setExpiredSessionCount: (expiredSessionCount) => set({ expiredSessionCount }),
 
-    await Promise.all(
-      expired.map((s) =>
-        db.update(chatSessions).set({ deletedAt: now }).where(eq(chatSessions.id, s.id))
-      )
-    );
-
-    if (expired.length > 0) {
-      const expiredIds = new Set(expired.map((s) => s.id));
-      set((state) => {
-        const isActiveExpired = state.currentSessionId
-          ? expiredIds.has(state.currentSessionId)
-          : false;
-        return {
-          sessions: state.sessions.filter((s) => !expiredIds.has(s.id)),
-          expiredSessionCount: expired.length,
-          ...(isActiveExpired ? { currentSessionId: null, messages: [] } : {}),
-        };
-      });
-    }
-
-    return expired;
-  },
+  clearCurrentConversation: () =>
+    set({
+      currentSessionId: null,
+      messages: [],
+      isStreaming: false,
+      streamingContent: "",
+    }),
 
   dismissExpiredBanner: () => set({ expiredSessionCount: 0 }),
 }));
+
+function isActiveChatSession(userId: UserId, sessionId: number): boolean {
+  return chatStoreSessionId === sessionId && useChatStore.getState().activeUserId === userId;
+}
+
+function isCurrentLoadSessionsRequest(
+  requestId: number,
+  userId: UserId,
+  sessionId: number
+): boolean {
+  return loadChatSessionsRequestId === requestId && isActiveChatSession(userId, sessionId);
+}
+
+function isCurrentSelectSessionRequest(
+  requestId: number,
+  userId: UserId,
+  sessionId: number,
+  chatSessionId: ChatSessionId
+): boolean {
+  return (
+    selectChatSessionRequestId === requestId &&
+    isActiveChatSession(userId, sessionId) &&
+    useChatStore.getState().currentSessionId === chatSessionId
+  );
+}
+
+function mapChatSessionRow(row: {
+  id: ChatSessionId;
+  userId: UserId;
+  title: string;
+  createdAt: string;
+  expiresAt: string;
+  deletedAt: string | null;
+}): ChatSession {
+  return {
+    id: row.id,
+    userId: row.userId,
+    title: row.title,
+    createdAt: requireIsoDateTime(row.createdAt),
+    expiresAt: requireIsoDateTime(row.expiresAt),
+    deletedAt: row.deletedAt ? requireIsoDateTime(row.deletedAt) : null,
+  };
+}
+
+function mapChatMessageRow(row: {
+  id: ChatMessageId;
+  sessionId: ChatSessionId;
+  role: string;
+  content: string;
+  action: string | null;
+  actionStatus: string | null;
+  createdAt: string;
+}): ChatMessage {
+  return {
+    id: row.id,
+    sessionId: row.sessionId,
+    role: row.role as "user" | "assistant",
+    content: row.content,
+    action: row.action ? (JSON.parse(row.action) as ChatAction) : null,
+    actionStatus: row.actionStatus as ActionStatus | null,
+    createdAt: requireIsoDateTime(row.createdAt),
+  };
+}
+
+export function initializeChatSession(userId: UserId): void {
+  chatStoreSessionId += 1;
+  loadChatSessionsRequestId += 1;
+  selectChatSessionRequestId += 1;
+  useChatStore.getState().beginSession(userId);
+}
+
+export function startNewChat(): void {
+  useChatStore.getState().clearCurrentConversation();
+}
+
+export async function loadChatSessions(db: AnyDb, userId: UserId): Promise<void> {
+  const requestId = ++loadChatSessionsRequestId;
+  const sessionId = chatStoreSessionId;
+  const rows = await db
+    .select()
+    .from(chatSessions)
+    .where(and(eq(chatSessions.userId, userId), isNull(chatSessions.deletedAt)))
+    .orderBy(desc(chatSessions.createdAt));
+
+  if (!isCurrentLoadSessionsRequest(requestId, userId, sessionId)) return;
+  useChatStore.getState().setSessions(rows.map(mapChatSessionRow));
+}
+
+export async function createChatSession(
+  db: AnyDb,
+  userId: UserId,
+  firstMessage: string
+): Promise<ChatSessionId> {
+  const sessionId = chatStoreSessionId;
+  if (!isActiveChatSession(userId, sessionId)) {
+    throw new Error("Chat store not initialized");
+  }
+
+  const id = generateChatSessionId();
+  const now = new Date();
+  const nowIso = toIsoDateTime(now);
+  const expiresIso = toIsoDateTime(new Date(now.getTime() + THIRTY_DAYS_MS));
+  const session: ChatSession = {
+    id,
+    userId,
+    title: deriveConversationTitle(firstMessage),
+    createdAt: nowIso,
+    expiresAt: expiresIso,
+    deletedAt: null,
+  };
+
+  if (!isActiveChatSession(userId, sessionId)) return id;
+
+  await db.insert(chatSessions).values({
+    id: session.id,
+    userId: session.userId,
+    title: session.title,
+    createdAt: session.createdAt,
+    expiresAt: session.expiresAt,
+    deletedAt: null,
+  });
+
+  if (isActiveChatSession(userId, sessionId)) {
+    useChatStore.getState().prependSession(session);
+  }
+  return id;
+}
+
+export async function deleteChatSession(
+  db: AnyDb,
+  userId: UserId,
+  id: ChatSessionId
+): Promise<void> {
+  const sessionId = chatStoreSessionId;
+  if (!isActiveChatSession(userId, sessionId)) return;
+
+  const now = toIsoDateTime(new Date());
+  await db.update(chatSessions).set({ deletedAt: now }).where(eq(chatSessions.id, id));
+
+  if (!isActiveChatSession(userId, sessionId)) return;
+  useChatStore.getState().removeSession(id);
+}
+
+export async function selectChatSession(
+  db: AnyDb,
+  userId: UserId,
+  id: ChatSessionId
+): Promise<void> {
+  const requestId = ++selectChatSessionRequestId;
+  const sessionId = chatStoreSessionId;
+  useChatStore.getState().setCurrentSessionId(id);
+
+  const rows = await db
+    .select()
+    .from(chatMessages)
+    .where(eq(chatMessages.sessionId, id))
+    .orderBy(asc(chatMessages.createdAt));
+
+  if (!isCurrentSelectSessionRequest(requestId, userId, sessionId, id)) return;
+  useChatStore.getState().setMessages(rows.map(mapChatMessageRow));
+}
+
+export async function addUserChatMessage(
+  db: AnyDb,
+  userId: UserId,
+  content: string
+): Promise<ChatMessage> {
+  const sessionId = chatStoreSessionId;
+  if (!isActiveChatSession(userId, sessionId)) {
+    throw new Error("Chat store not initialized");
+  }
+  const currentSessionId = useChatStore.getState().currentSessionId;
+  if (!currentSessionId) throw new Error("No active session");
+
+  const message: ChatMessage = {
+    id: generateChatMessageId(),
+    sessionId: currentSessionId,
+    role: "user",
+    content,
+    action: null,
+    actionStatus: null,
+    createdAt: toIsoDateTime(new Date()),
+  };
+
+  if (!isActiveChatSession(userId, sessionId)) return message;
+
+  await db.insert(chatMessages).values({
+    id: message.id,
+    sessionId: message.sessionId,
+    role: message.role,
+    content: message.content,
+    action: null,
+    actionStatus: null,
+    createdAt: message.createdAt,
+  });
+
+  if (isActiveChatSession(userId, sessionId)) {
+    useChatStore.getState().appendMessage(message);
+  }
+  return message;
+}
+
+export async function addAssistantChatMessage(
+  db: AnyDb,
+  userId: UserId,
+  content: string,
+  action: ChatAction | null = null
+): Promise<ChatMessage> {
+  const sessionId = chatStoreSessionId;
+  if (!isActiveChatSession(userId, sessionId)) {
+    throw new Error("Chat store not initialized");
+  }
+  const currentSessionId = useChatStore.getState().currentSessionId;
+  if (!currentSessionId) throw new Error("No active session");
+
+  const actionStatus: ActionStatus | null = action
+    ? action.type === "add"
+      ? "confirmed"
+      : action.type === "delete"
+        ? "pending"
+        : null
+    : null;
+
+  const message: ChatMessage = {
+    id: generateChatMessageId(),
+    sessionId: currentSessionId,
+    role: "assistant",
+    content,
+    action,
+    actionStatus,
+    createdAt: toIsoDateTime(new Date()),
+  };
+
+  if (!isActiveChatSession(userId, sessionId)) return message;
+
+  await db.insert(chatMessages).values({
+    id: message.id,
+    sessionId: message.sessionId,
+    role: message.role,
+    content: message.content,
+    action: action ? JSON.stringify(action) : null,
+    actionStatus: message.actionStatus,
+    createdAt: message.createdAt,
+  });
+
+  if (isActiveChatSession(userId, sessionId)) {
+    useChatStore.getState().appendMessage(message);
+  }
+  return message;
+}
+
+export async function updateChatActionStatus(
+  db: AnyDb,
+  userId: UserId,
+  messageId: ChatMessageId,
+  status: ActionStatus
+): Promise<void> {
+  const sessionId = chatStoreSessionId;
+  if (!isActiveChatSession(userId, sessionId)) return;
+
+  await db.update(chatMessages).set({ actionStatus: status }).where(eq(chatMessages.id, messageId));
+
+  if (!isActiveChatSession(userId, sessionId)) return;
+  useChatStore.getState().setMessageActionStatus(messageId, status);
+}
+
+export async function cleanupExpiredChatSessions(
+  db: AnyDb,
+  userId: UserId
+): Promise<readonly ChatSession[]> {
+  const sessionId = chatStoreSessionId;
+  if (!isActiveChatSession(userId, sessionId)) return [];
+
+  const sessions = useChatStore.getState().sessions;
+  const now = toIsoDateTime(new Date());
+  const expired = findExpiredSessions(sessions, now);
+
+  await Promise.all(
+    expired.map((session) =>
+      db.update(chatSessions).set({ deletedAt: now }).where(eq(chatSessions.id, session.id))
+    )
+  );
+
+  if (!isActiveChatSession(userId, sessionId) || expired.length === 0) {
+    return expired;
+  }
+
+  const expiredIds = new Set(expired.map((session) => session.id));
+  useChatStore.setState((state) => {
+    const isActiveExpired = state.currentSessionId ? expiredIds.has(state.currentSessionId) : false;
+    return {
+      sessions: state.sessions.filter((session) => !expiredIds.has(session.id)),
+      expiredSessionCount: expired.length,
+      ...(isActiveExpired ? { currentSessionId: null, messages: [] } : {}),
+    };
+  });
+
+  return expired;
+}
+
+export function dismissExpiredChatBanner(): void {
+  useChatStore.getState().dismissExpiredBanner();
+}

--- a/apps/mobile/features/ai-chat/store.ts
+++ b/apps/mobile/features/ai-chat/store.ts
@@ -75,7 +75,7 @@ export const useChatStore = create<ChatState & ChatActions>((set) => ({
       messages: state.currentSessionId === sessionId ? [] : state.messages,
     })),
 
-  setCurrentSessionId: (currentSessionId) => set({ currentSessionId }),
+  setCurrentSessionId: (currentSessionId) => set({ currentSessionId, messages: [] }),
 
   setMessages: (messages) => set({ messages: [...messages] }),
 


### PR DESCRIPTION
- explicit chat boundaries\n- state-only streaming store\n- note stacked-branch rebase surprise

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the mobile AI chat into a state-only store with explicit, per-user DB functions and guardrails to drop stale results. Follow-up fixes clear messages on session switch, rerun expired-session cleanup after auth hydrate, and catch action-status write failures.

- **Refactors**
  - Store now holds state only; DB work moved to functions: initialize/load/select/create/delete sessions, add user/assistant messages, update action status, cleanup expired, start a new chat.
  - Added request guards to ignore stale loads/selects; clear messages immediately when switching sessions.
  - Updated screens, list, layout, and streaming hook to pass `db` and `userId` and call the new functions; `use-session-cleanup` now resubscribes on `[db, userId]`; `ChatScreen` catches action-status persistence errors.
  - Added tests for boundaries, stale-result drops, message clearing on switch, cleanup resubscription, and action-status error handling.
  - Documented stacked-branch rebase gotcha in `AGENTS.md`.

- **Migration**
  - On auth: call initializeChatSession(userId), then loadChatSessions(db, userId) and cleanupExpiredChatSessions(db, userId).
  - Replace store method calls with functions:
    - selectChatSession(db, userId, id); createChatSession(db, userId, title); deleteChatSession(db, userId, id).
    - addUserChatMessage(db, userId, text); addAssistantChatMessage(db, userId, text, action); updateChatActionStatus(db, userId, id, status).
  - For new chats: call startNewChat() before rendering the composer.

<sup>Written for commit 60fb6c5e5c7cf6b52410e62d912b6b0961a9f7df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

