### PR TITLE
refactor(mobile): deepen transactions seam

### DIFF
--- a/apps/mobile/__tests__/sync/sync-conflict-resolution.test.ts
+++ b/apps/mobile/__tests__/sync/sync-conflict-resolution.test.ts
@@ -12,8 +12,8 @@ import { resolveConflict } from "@/features/sync/services/sync";
 import {
   getQueuedSyncEntries,
   getTransactionById,
+  initializeTransactionSession,
   insertTransaction,
-  useTransactionStore,
 } from "@/features/transactions";
 import type {
   CategoryId,
@@ -31,7 +31,7 @@ beforeEach(() => {
   sqlite = new Database(":memory:");
   db = drizzle(sqlite);
   migrate(db, { migrationsFolder: resolve(__dirname, "../../drizzle") });
-  useTransactionStore.getState().initStore(db as any, "user-1" as UserId);
+  initializeTransactionSession("user-1" as UserId);
 });
 
 afterEach(() => {

--- a/apps/mobile/__tests__/sync/sync-module.test.ts
+++ b/apps/mobile/__tests__/sync/sync-module.test.ts
@@ -1,23 +1,19 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: sync boundary test uses flexible mock ports
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const refreshMock = vi.fn();
 const mockGetSupabase = vi.fn();
 const mockIsOnline = vi.fn();
 const mockSyncPull = vi.fn();
 const mockSyncPush = vi.fn();
 const mockGetUnresolvedConflicts = vi.fn();
+const mockRefreshTransactions = vi.fn();
 
 vi.mock("@/shared/db", () => ({
   getSupabase: (...args: any[]) => mockGetSupabase(...args),
 }));
 
 vi.mock("@/features/transactions", () => ({
-  useTransactionStore: {
-    getState: () => ({
-      refresh: refreshMock,
-    }),
-  },
+  refreshTransactions: (...args: any[]) => mockRefreshTransactions(...args),
 }));
 
 vi.mock("@/features/sync/services/networkMonitor", () => ({
@@ -41,6 +37,7 @@ describe("sync module", () => {
     mockSyncPull.mockResolvedValue(true);
     mockSyncPush.mockResolvedValue(undefined);
     mockGetUnresolvedConflicts.mockReturnValue([]);
+    mockRefreshTransactions.mockResolvedValue(undefined);
   });
 
   it("syncs by pulling first, then pushing queued rows when online", async () => {
@@ -52,7 +49,7 @@ describe("sync module", () => {
     expect(mockIsOnline).toHaveBeenCalled();
     expect(mockSyncPull).toHaveBeenCalledWith(db, expect.any(Object), "user-1");
     expect(mockSyncPush).toHaveBeenCalledWith(db, expect.any(Object), "user-1");
-    expect(refreshMock).toHaveBeenCalledTimes(1);
+    expect(mockRefreshTransactions).toHaveBeenCalledTimes(1);
     expect(result.status).toBe("synced");
     expect(result.unresolvedConflicts).toBe(0);
   });
@@ -66,7 +63,7 @@ describe("sync module", () => {
 
     expect(mockSyncPull).not.toHaveBeenCalled();
     expect(mockSyncPush).not.toHaveBeenCalled();
-    expect(refreshMock).not.toHaveBeenCalled();
+    expect(mockRefreshTransactions).not.toHaveBeenCalled();
     expect(result.status).toBe("skipped_offline");
   });
 

--- a/apps/mobile/__tests__/sync/sync-module.test.ts
+++ b/apps/mobile/__tests__/sync/sync-module.test.ts
@@ -7,6 +7,7 @@ const mockSyncPull = vi.fn();
 const mockSyncPush = vi.fn();
 const mockGetUnresolvedConflicts = vi.fn();
 const mockRefreshTransactions = vi.fn();
+const mockUpsertTransaction = vi.fn();
 
 vi.mock("@/shared/db", () => ({
   getSupabase: (...args: any[]) => mockGetSupabase(...args),
@@ -14,6 +15,7 @@ vi.mock("@/shared/db", () => ({
 
 vi.mock("@/features/transactions", () => ({
   refreshTransactions: (...args: any[]) => mockRefreshTransactions(...args),
+  upsertTransaction: (...args: any[]) => mockUpsertTransaction(...args),
 }));
 
 vi.mock("@/features/sync/services/networkMonitor", () => ({
@@ -38,6 +40,7 @@ describe("sync module", () => {
     mockSyncPush.mockResolvedValue(undefined);
     mockGetUnresolvedConflicts.mockReturnValue([]);
     mockRefreshTransactions.mockResolvedValue(undefined);
+    mockUpsertTransaction.mockReset();
   });
 
   it("syncs by pulling first, then pushing queued rows when online", async () => {

--- a/apps/mobile/__tests__/sync/sync-service.test.ts
+++ b/apps/mobile/__tests__/sync/sync-service.test.ts
@@ -207,4 +207,64 @@ describe("createSyncService", () => {
     expect(refreshTransactions).toHaveBeenCalledTimes(1);
     expect(result).toEqual({ unresolvedConflicts: 0 });
   });
+
+  it("still resolves server conflicts when localData is malformed", async () => {
+    const upsertTransaction = vi.fn();
+    const enqueueTransactionSync = vi.fn();
+    const resolveConflictRow = vi.fn();
+    const refreshTransactions = vi.fn();
+    const getConflictRows = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          id: "conflict-1",
+          transactionId: "tx-1",
+          localData: "{not-json",
+          serverData: JSON.stringify({
+            id: "tx-1",
+            userId: "user-1",
+            type: "expense",
+            amount: 2000,
+            categoryId: "food",
+            description: "Server merchant",
+            date: "2026-03-10",
+            createdAt: "2026-03-10T08:00:00.000Z",
+            updatedAt: "2026-03-10T14:00:00.000Z",
+            deletedAt: null,
+            source: "email",
+          }),
+          detectedAt: "2026-03-15T10:00:00.000Z",
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const service = createSyncService({
+      isOnline: vi.fn().mockResolvedValue(true),
+      getSupabase: vi.fn(),
+      syncPull: vi.fn(),
+      syncPush: vi.fn(),
+      refreshTransactions,
+      getConflictRows,
+      upsertTransaction,
+      enqueueTransactionSync,
+      resolveConflictRow,
+    });
+
+    const result = await service.resolveConflict({
+      db: {} as never,
+      conflictId: "conflict-1" as never,
+      resolution: "server",
+    });
+
+    expect(upsertTransaction).not.toHaveBeenCalled();
+    expect(enqueueTransactionSync).not.toHaveBeenCalled();
+    expect(resolveConflictRow).toHaveBeenCalledWith(
+      {} as never,
+      "conflict-1",
+      "server",
+      expect.any(String)
+    );
+    expect(refreshTransactions).toHaveBeenCalledWith({ db: {} as never, userId: "user-1" });
+    expect(result).toEqual({ unresolvedConflicts: 0 });
+  });
 });

--- a/apps/mobile/__tests__/transactions/callers.test.ts
+++ b/apps/mobile/__tests__/transactions/callers.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+
+const editTransactionSource = readFileSync(
+  resolve(__dirname, "../../app/edit-transaction.tsx"),
+  "utf-8"
+);
+
+describe("transaction callers", () => {
+  test("edit screen surfaces save and delete failures before navigating away when auth/db is missing", () => {
+    expect(editTransactionSource).toContain(
+      'if (transactionId == null || !db || !userId) {\n        showErrorToast(t("transactions.updateFailed"));'
+    );
+    expect(editTransactionSource).toContain(
+      'if (transactionId == null || !db || !userId) {\n        showErrorToast(t("transactions.deleteFailed"));'
+    );
+  });
+});

--- a/apps/mobile/__tests__/transactions/query-service.test.ts
+++ b/apps/mobile/__tests__/transactions/query-service.test.ts
@@ -119,6 +119,28 @@ describe("transaction query service", () => {
     expect(getTransactionsPaginated).toHaveBeenCalledWith(expect.anything(), mockUserId, 30, 0);
   });
 
+  it("uses an inclusive 30-day daily-spending window", () => {
+    const getDailySpendingAggregate = vi.fn().mockReturnValue([]);
+    const service = createTransactionQueryService({
+      getTransactionsPaginated: vi.fn().mockReturnValue([]),
+      getSpendingByCategoryAggregate: vi.fn().mockReturnValue([]),
+      getDailySpendingAggregate,
+      getNow: () => new Date("2026-04-12T18:00:00.000Z"),
+    });
+
+    service.loadAggregateSnapshot({
+      db: {} as never,
+      userId: mockUserId,
+    });
+
+    expect(getDailySpendingAggregate).toHaveBeenCalledWith(
+      expect.anything(),
+      mockUserId,
+      "2026-03-14",
+      "2026-04-12"
+    );
+  });
+
   it("returns null for deleted or cross-user transaction lookups", () => {
     const getTransactionById = vi
       .fn()

--- a/apps/mobile/__tests__/transactions/query-service.test.ts
+++ b/apps/mobile/__tests__/transactions/query-service.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTransactionQueryService } from "@/features/transactions/services/create-transaction-query-service";
+import type {
+  CategoryId,
+  CopAmount,
+  IsoDate,
+  IsoDateTime,
+  TransactionId,
+  UserId,
+} from "@/shared/types/branded";
+
+const mockUserId = "user-1" as UserId;
+
+function makeRow(
+  overrides: Partial<{
+    id: TransactionId;
+    userId: UserId;
+    amount: CopAmount;
+    categoryId: CategoryId;
+    description: string | null;
+    date: IsoDate;
+    createdAt: IsoDateTime;
+    updatedAt: IsoDateTime;
+    deletedAt: IsoDateTime | null;
+  }> = {}
+) {
+  return {
+    id: "tx-1" as TransactionId,
+    userId: mockUserId,
+    type: "expense",
+    amount: 1200 as CopAmount,
+    categoryId: "food" as CategoryId,
+    description: "Lunch",
+    date: "2026-04-12" as IsoDate,
+    createdAt: "2026-04-12T10:00:00.000Z" as IsoDateTime,
+    updatedAt: "2026-04-12T10:00:00.000Z" as IsoDateTime,
+    deletedAt: null,
+    source: "manual",
+    ...overrides,
+  };
+}
+
+describe("transaction query service", () => {
+  it("loads an initial snapshot with page and aggregate data", () => {
+    const getTransactionsPaginated = vi.fn().mockReturnValue([makeRow()]);
+    const getSpendingByCategoryAggregate = vi
+      .fn()
+      .mockReturnValue([{ categoryId: "food" as CategoryId, total: 1200 as CopAmount }]);
+    const getDailySpendingAggregate = vi
+      .fn()
+      .mockReturnValue([{ date: "2026-04-12" as IsoDate, total: 1200 as CopAmount }]);
+    const service = createTransactionQueryService({
+      getTransactionsPaginated,
+      getSpendingByCategoryAggregate,
+      getDailySpendingAggregate,
+      getNow: () => new Date("2026-04-12T18:00:00.000Z"),
+    });
+
+    const snapshot = service.loadInitialSnapshot({
+      db: {} as never,
+      userId: mockUserId,
+      pageSize: 30,
+    });
+
+    expect(snapshot).toMatchObject({
+      offset: 1,
+      hasMore: false,
+      balance: 1200,
+      categorySpending: [{ categoryId: "food", total: 1200 }],
+      dailySpending: [{ date: "2026-04-12", total: 1200 }],
+    });
+    expect(snapshot.pages[0]).toMatchObject({
+      id: "tx-1",
+      description: "Lunch",
+    });
+    expect(snapshot.pages[0]?.date).toBeInstanceOf(Date);
+  });
+
+  it("marks refresh snapshots as unchanged when ids and updatedAt values match", () => {
+    const getTransactionsPaginated = vi.fn().mockReturnValue([
+      makeRow({
+        id: "tx-1" as TransactionId,
+        updatedAt: "2026-04-12T10:00:00.000Z" as IsoDateTime,
+      }),
+    ]);
+    const service = createTransactionQueryService({
+      getTransactionsPaginated,
+      getSpendingByCategoryAggregate: vi.fn().mockReturnValue([]),
+      getDailySpendingAggregate: vi.fn().mockReturnValue([]),
+      getNow: () => new Date("2026-04-12T18:00:00.000Z"),
+    });
+
+    const currentPages = [
+      {
+        id: "tx-1" as TransactionId,
+        userId: mockUserId,
+        type: "expense" as const,
+        amount: 1200 as CopAmount,
+        categoryId: "food" as CategoryId,
+        description: "Lunch",
+        date: new Date("2026-04-12T00:00:00.000Z"),
+        createdAt: new Date("2026-04-12T10:00:00.000Z"),
+        updatedAt: new Date("2026-04-12T10:00:00.000Z"),
+        deletedAt: null,
+      },
+    ];
+
+    const snapshot = service.loadRefreshSnapshot({
+      db: {} as never,
+      userId: mockUserId,
+      currentPages,
+      currentOffset: 1,
+      pageSize: 30,
+    });
+
+    expect(snapshot.sameData).toBe(true);
+    expect(snapshot.offset).toBe(1);
+    expect(snapshot.hasMore).toBe(false);
+    expect(getTransactionsPaginated).toHaveBeenCalledWith(expect.anything(), mockUserId, 30, 0);
+  });
+
+  it("returns null for deleted or cross-user transaction lookups", () => {
+    const getTransactionById = vi
+      .fn()
+      .mockReturnValueOnce(makeRow({ userId: "user-2" as UserId }))
+      .mockReturnValueOnce(makeRow({ deletedAt: "2026-04-13T08:00:00.000Z" as IsoDateTime }));
+    const service = createTransactionQueryService({ getTransactionById });
+
+    expect(
+      service.getStoredTransaction({
+        db: {} as never,
+        userId: mockUserId,
+        transactionId: "tx-1" as TransactionId,
+      })
+    ).toBeNull();
+
+    expect(
+      service.getStoredTransaction({
+        db: {} as never,
+        userId: mockUserId,
+        transactionId: "tx-1" as TransactionId,
+      })
+    ).toBeNull();
+  });
+});

--- a/apps/mobile/__tests__/transactions/store.test.ts
+++ b/apps/mobile/__tests__/transactions/store.test.ts
@@ -1,13 +1,24 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  getBalanceAggregate,
+  getDailySpendingAggregate,
   getSpendingByCategoryAggregate,
   getTransactionById,
   getTransactionsPaginated,
   insertTransaction,
   softDeleteTransaction,
 } from "@/features/transactions/lib/repository";
-import { useTransactionStore } from "@/features/transactions/store";
+import {
+  getStoredTransactionById,
+  initializeTransactionSession,
+  loadInitialTransactions,
+  loadNextTransactions,
+  loadTransactionAggregates,
+  loadTransactionIntoForm,
+  refreshTransactions,
+  removeTransaction,
+  saveCurrentTransaction,
+  useTransactionStore,
+} from "@/features/transactions/store";
 import type { AnyDb } from "@/shared/db";
 import { enqueueSync } from "@/shared/db/enqueue-sync";
 import type {
@@ -22,12 +33,12 @@ import type {
 vi.mock("@/features/transactions/lib/repository", () => ({
   insertTransaction: vi.fn(),
   getTransactionsPaginated: vi.fn().mockReturnValue([]),
-  getBalanceAggregate: vi.fn().mockReturnValue(0),
   getSpendingByCategoryAggregate: vi.fn().mockReturnValue([]),
   getDailySpendingAggregate: vi.fn().mockReturnValue([]),
   getRecentTransactions: vi.fn().mockReturnValue([]),
   getTransactionById: vi.fn().mockReturnValue(null),
   softDeleteTransaction: vi.fn(),
+  upsertTransaction: vi.fn(),
 }));
 
 vi.mock("@/shared/db/enqueue-sync", () => ({
@@ -39,38 +50,60 @@ const mockDb = {
 } as unknown as AnyDb;
 const mockUserId = "user-1" as UserId;
 
-describe("useTransactionStore", () => {
+function makeStoredTransaction(overrides: Partial<{ id: TransactionId; updatedAt: Date }> = {}) {
+  return {
+    id: "tx-1" as TransactionId,
+    userId: mockUserId,
+    type: "expense" as const,
+    amount: 1000 as CopAmount,
+    categoryId: "food" as CategoryId,
+    description: "Lunch",
+    date: new Date("2026-03-04T00:00:00.000Z"),
+    createdAt: new Date("2026-03-04T10:00:00.000Z"),
+    updatedAt: new Date("2026-03-04T10:00:00.000Z"),
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+function makeRow(
+  overrides: Partial<{
+    id: TransactionId;
+    type: "expense" | "income";
+    amount: CopAmount;
+    categoryId: CategoryId;
+    description: string | null;
+    date: IsoDate;
+    createdAt: IsoDateTime;
+    updatedAt: IsoDateTime;
+    deletedAt: IsoDateTime | null;
+  }> = {}
+) {
+  return {
+    id: "tx-1" as TransactionId,
+    userId: mockUserId,
+    type: "expense",
+    amount: 1000 as CopAmount,
+    categoryId: "food" as CategoryId,
+    description: "Lunch",
+    date: "2026-03-04" as IsoDate,
+    createdAt: "2026-03-04T10:00:00.000Z" as IsoDateTime,
+    updatedAt: "2026-03-04T10:00:00.000Z" as IsoDateTime,
+    deletedAt: null,
+    source: "manual",
+    ...overrides,
+  };
+}
+
+describe("transaction boundaries", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useTransactionStore.getState().initStore(mockDb, mockUserId);
-    useTransactionStore.setState({
-      step: 1,
-      type: "expense",
-      digits: "",
-      categoryId: null,
-      description: "",
-      date: new Date(),
-      pages: [],
-      offset: 0,
-      hasMore: true,
-
-      balance: 0,
-      categorySpending: [],
-      dailySpending: [],
-      dataRevision: 0,
-      editingId: null,
-    });
+    initializeTransactionSession(mockUserId);
   });
 
-  it("saveTransaction returns error when store is not initialized", async () => {
-    // biome-ignore lint/suspicious/noExplicitAny: testing uninitialized store guard
-    useTransactionStore.getState().initStore(null as any, null as any);
-    const result = await useTransactionStore.getState().saveTransaction();
-    expect(result).toEqual({ success: false, error: "Store not initialized" });
-  });
-
-  it("starts with default form values", () => {
+  it("starts with default form values after session initialization", () => {
     const state = useTransactionStore.getState();
+    expect(state.activeUserId).toBe(mockUserId);
     expect(state.step).toBe(1);
     expect(state.type).toBe("expense");
     expect(state.digits).toBe("");
@@ -79,72 +112,59 @@ describe("useTransactionStore", () => {
     expect(state.pages).toEqual([]);
   });
 
-  it("setType toggles between expense and income", () => {
-    const store = useTransactionStore.getState();
-    store.setType("income");
-    expect(useTransactionStore.getState().type).toBe("income");
-    store.setType("expense");
-    expect(useTransactionStore.getState().type).toBe("expense");
-  });
-
-  it("setDigits updates digit string", () => {
+  it("updates form state through setters and resetForm keeps loaded pages", () => {
+    useTransactionStore.getState().setType("income");
     useTransactionStore.getState().setDigits("4520");
-    expect(useTransactionStore.getState().digits).toBe("4520");
-  });
-
-  it("setCategoryId updates category", () => {
     useTransactionStore.getState().setCategoryId("food" as CategoryId);
-    expect(useTransactionStore.getState().categoryId).toBe("food");
-  });
-
-  it("setDescription updates description", () => {
     useTransactionStore.getState().setDescription("Lunch");
-    expect(useTransactionStore.getState().description).toBe("Lunch");
+    useTransactionStore.getState().setDate(new Date("2026-06-15T00:00:00.000Z"));
+    useTransactionStore.setState({ pages: [makeStoredTransaction()] });
+
+    useTransactionStore.getState().resetForm();
+
+    expect(useTransactionStore.getState()).toMatchObject({
+      type: "expense",
+      digits: "",
+      categoryId: null,
+      description: "",
+    });
+    expect(useTransactionStore.getState().pages).toHaveLength(1);
   });
 
-  it("setDate updates date", () => {
-    const newDate = new Date("2026-06-15");
-    useTransactionStore.getState().setDate(newDate);
-    expect(useTransactionStore.getState().date).toEqual(newDate);
+  it("saveCurrentTransaction returns store-not-initialized when the active session changed", async () => {
+    initializeTransactionSession("user-2" as UserId);
+
+    const result = await saveCurrentTransaction(mockDb, mockUserId);
+
+    expect(result).toEqual({ success: false, error: "Store not initialized" });
   });
 
-  it("saveTransaction succeeds with valid data and persists to DB", async () => {
-    const store = useTransactionStore.getState();
-    store.setDigits("4520");
-    store.setCategoryId("food" as CategoryId);
-    store.setDescription("Groceries");
+  it("saves valid transactions and refreshes read models", async () => {
+    vi.mocked(getSpendingByCategoryAggregate).mockReturnValueOnce([
+      { categoryId: "food" as CategoryId, total: 4520 as CopAmount },
+    ]);
+    vi.mocked(getDailySpendingAggregate).mockReturnValueOnce([
+      { date: "2026-03-04" as IsoDate, total: 4520 as CopAmount },
+    ]);
 
-    const result = await store.saveTransaction();
+    useTransactionStore.getState().setDigits("4520");
+    useTransactionStore.getState().setCategoryId("food" as CategoryId);
+    useTransactionStore.getState().setDescription("Groceries");
+
+    const result = await saveCurrentTransaction(mockDb, mockUserId);
+
     expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.transaction.amount).toBe(4520);
-      expect(result.transaction.categoryId).toBe("food");
-      expect(result.transaction.description).toBe("Groceries");
-      expect(result.transaction.type).toBe("expense");
-      expect(result.transaction.userId).toBe(mockUserId);
-      expect(result.transaction.updatedAt).toBeInstanceOf(Date);
-      expect(result.transaction.deletedAt).toBeNull();
-    }
-
+    if (!result.success) return;
+    expect(result.transaction.amount).toBe(4520);
     expect(insertTransaction).toHaveBeenCalledWith(
       mockDb,
       expect.objectContaining({
         amount: 4520,
         categoryId: "food",
-        type: "expense",
         userId: mockUserId,
         updatedAt: expect.any(String),
       })
     );
-  });
-
-  it("saveTransaction enqueues sync entry after insert", async () => {
-    const store = useTransactionStore.getState();
-    store.setDigits("1000");
-    store.setCategoryId("food" as CategoryId);
-
-    await store.saveTransaction();
-
     expect(enqueueSync).toHaveBeenCalledWith(
       mockDb,
       expect.objectContaining({
@@ -152,338 +172,101 @@ describe("useTransactionStore", () => {
         operation: "insert",
       })
     );
-  });
-
-  it("saveTransaction calls refresh after successful save", async () => {
-    const store = useTransactionStore.getState();
-    store.setDigits("1000");
-    store.setCategoryId("food" as CategoryId);
-
-    await store.saveTransaction();
-
-    // refresh calls getTransactionsPaginated and aggregate functions
     expect(getTransactionsPaginated).toHaveBeenCalled();
     expect(getSpendingByCategoryAggregate).toHaveBeenCalled();
   });
 
-  it("saveTransaction fails with zero amount", async () => {
-    const store = useTransactionStore.getState();
-    store.setCategoryId("food" as CategoryId);
+  it("defaults to the other category when saving without a selection", async () => {
+    useTransactionStore.getState().setDigits("1000");
 
-    const result = await store.saveTransaction();
-    expect(result.success).toBe(false);
-    expect(insertTransaction).not.toHaveBeenCalled();
-  });
+    const result = await saveCurrentTransaction(mockDb, mockUserId);
 
-  it("saveTransaction defaults to 'other' when no category selected", async () => {
-    const store = useTransactionStore.getState();
-    store.setDigits("1000");
-
-    const result = await store.saveTransaction();
     expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.transaction.categoryId).toBe("other");
-    }
+    if (!result.success) return;
+    expect(result.transaction.categoryId).toBe("other");
   });
 
-  it("resetForm clears form but keeps pages", async () => {
-    useTransactionStore.setState({
-      digits: "4520",
-      categoryId: "food" as CategoryId,
-      step: 2,
-      pages: [
-        {
-          id: "tx-1" as TransactionId,
-          userId: mockUserId,
-          type: "expense",
-          amount: 100 as CopAmount,
-          categoryId: "food" as CategoryId,
-          description: "Test",
-          date: new Date(),
-          createdAt: new Date(),
-          updatedAt: new Date(),
-          deletedAt: null,
-        },
-      ],
-    });
-
-    useTransactionStore.getState().resetForm();
-    const state = useTransactionStore.getState();
-    expect(state.digits).toBe("");
-    expect(state.step).toBe(1);
-    expect(state.categoryId).toBeNull();
-    expect(state.pages).toHaveLength(1);
-  });
-
-  it("loadInitialPage reads paginated data from DB", async () => {
-    vi.mocked(getTransactionsPaginated).mockReturnValueOnce([
-      {
-        id: "tx-1" as TransactionId,
-        userId: mockUserId,
-        type: "expense",
-        amount: 1000 as CopAmount,
-        categoryId: "food" as CategoryId,
-        description: "Lunch",
-        date: "2026-03-04" as IsoDate,
-        createdAt: "2026-03-04T10:00:00.000Z" as IsoDateTime,
-        updatedAt: "2026-03-04T10:00:00.000Z" as IsoDateTime,
-        deletedAt: null,
-        source: "manual",
-      },
+  it("loads the initial transaction snapshot with aggregates", async () => {
+    vi.mocked(getTransactionsPaginated).mockReturnValueOnce([makeRow()]);
+    vi.mocked(getSpendingByCategoryAggregate).mockReturnValueOnce([
+      { categoryId: "food" as CategoryId, total: 1000 as CopAmount },
+    ]);
+    vi.mocked(getDailySpendingAggregate).mockReturnValueOnce([
+      { date: "2026-03-04" as IsoDate, total: 1000 as CopAmount },
     ]);
 
-    await useTransactionStore.getState().loadInitialPage();
+    await loadInitialTransactions(mockDb, mockUserId);
 
-    const state = useTransactionStore.getState();
-    expect(state.pages).toHaveLength(1);
-    expect(state.pages[0]?.id).toBe("tx-1");
-    expect(state.pages[0]?.date).toBeInstanceOf(Date);
-    expect(state.hasMore).toBe(false);
-    expect(state.offset).toBe(1);
-    expect(getTransactionsPaginated).toHaveBeenCalledWith(mockDb, mockUserId, 30, 0);
+    expect(useTransactionStore.getState()).toMatchObject({
+      offset: 1,
+      hasMore: false,
+      balance: 1000,
+      categorySpending: [{ categoryId: "food", total: 1000 }],
+      dailySpending: [{ date: "2026-03-04", total: 1000 }],
+    });
+    expect(useTransactionStore.getState().pages[0]?.id).toBe("tx-1");
   });
 
-  it("loadInitialPage sets hasMore when more rows exist", async () => {
-    // Return 31 rows (PAGE_SIZE + 1) to indicate more exist
-    const rows = Array.from({ length: 31 }, (_, i) => ({
-      id: `tx-${i}` as TransactionId,
-      userId: mockUserId,
-      type: "expense",
-      amount: 1000 as CopAmount,
-      categoryId: "food" as CategoryId,
-      description: `Item ${i}`,
-      date: "2026-03-04" as IsoDate,
-      createdAt: "2026-03-04T10:00:00.000Z" as IsoDateTime,
-      updatedAt: "2026-03-04T10:00:00.000Z" as IsoDateTime,
-      deletedAt: null,
-      source: "manual",
-    }));
-    vi.mocked(getTransactionsPaginated).mockReturnValueOnce(rows);
-
-    await useTransactionStore.getState().loadInitialPage();
-
-    const state = useTransactionStore.getState();
-    expect(state.pages).toHaveLength(30);
-    expect(state.hasMore).toBe(true);
-    expect(state.offset).toBe(30);
-  });
-
-  it("loadNextPage appends more transactions", async () => {
-    // Set up initial state with first page loaded
+  it("loads the next page when more rows are available", async () => {
     useTransactionStore.setState({
-      pages: [
-        {
-          id: "tx-0" as TransactionId,
-          userId: mockUserId,
-          type: "expense",
-          amount: 100 as CopAmount,
-          categoryId: "food" as CategoryId,
-          description: "First",
-          date: new Date(),
-          createdAt: new Date(),
-          updatedAt: new Date(),
-          deletedAt: null,
-        },
-      ],
+      pages: [makeStoredTransaction({ id: "tx-0" as TransactionId })],
       offset: 1,
       hasMore: true,
     });
-
     vi.mocked(getTransactionsPaginated).mockReturnValueOnce([
-      {
-        id: "tx-1" as TransactionId,
-        userId: mockUserId,
-        type: "expense",
-        amount: 200 as CopAmount,
-        categoryId: "food" as CategoryId,
-        description: "Second",
-        date: "2026-03-03" as IsoDate,
-        createdAt: "2026-03-03T10:00:00.000Z" as IsoDateTime,
-        updatedAt: "2026-03-03T10:00:00.000Z" as IsoDateTime,
-        deletedAt: null,
-        source: "manual",
-      },
+      makeRow({ id: "tx-1" as TransactionId }),
     ]);
 
-    await useTransactionStore.getState().loadNextPage();
+    await loadNextTransactions(mockDb, mockUserId);
 
-    const state = useTransactionStore.getState();
-    expect(state.pages).toHaveLength(2);
-    expect(state.pages[1]?.id).toBe("tx-1");
-    expect(state.hasMore).toBe(false);
-  });
-
-  it("loadNextPage does nothing when hasMore is false", async () => {
-    useTransactionStore.setState({ hasMore: false });
-
-    await useTransactionStore.getState().loadNextPage();
-
-    expect(getTransactionsPaginated).not.toHaveBeenCalled();
-  });
-
-  it("refresh updates pagination metadata even when transaction rows are unchanged", async () => {
-    useTransactionStore.setState({
-      pages: [
-        {
-          id: "tx-1" as TransactionId,
-          userId: mockUserId,
-          type: "expense",
-          amount: 1000 as CopAmount,
-          categoryId: "food" as CategoryId,
-          description: "Lunch",
-          date: new Date("2026-03-04T00:00:00.000Z"),
-          createdAt: new Date("2026-03-04T10:00:00.000Z"),
-          updatedAt: new Date("2026-03-04T10:00:00.000Z"),
-          deletedAt: null,
-        },
-      ],
-      offset: 1,
-      hasMore: true,
-    });
-
-    vi.mocked(getTransactionsPaginated).mockReturnValueOnce([
-      {
-        id: "tx-1" as TransactionId,
-        userId: mockUserId,
-        type: "expense",
-        amount: 1000 as CopAmount,
-        categoryId: "food" as CategoryId,
-        description: "Lunch",
-        date: "2026-03-04" as IsoDate,
-        createdAt: "2026-03-04T10:00:00.000Z" as IsoDateTime,
-        updatedAt: "2026-03-04T10:00:00.000Z" as IsoDateTime,
-        deletedAt: null,
-        source: "manual",
-      },
-    ]);
-
-    await useTransactionStore.getState().refresh();
-
+    expect(useTransactionStore.getState().pages).toHaveLength(2);
+    expect(useTransactionStore.getState().pages[1]?.id).toBe("tx-1");
     expect(useTransactionStore.getState().hasMore).toBe(false);
   });
 
-  it("refresh keeps existing pages and aggregates when the DB read fails", async () => {
-    const existingDate = new Date("2026-03-04T00:00:00.000Z");
-    const existingUpdatedAt = new Date("2026-03-04T10:00:00.000Z");
-    const existingCategorySpending = [
-      { categoryId: "food" as CategoryId, total: 42000 as CopAmount },
-    ];
-    const existingDailySpending = [{ date: "2026-03-04" as IsoDate, total: 42000 as CopAmount }];
-
+  it("refreshTransactions increments dataRevision even when page identity is unchanged", async () => {
     useTransactionStore.setState({
-      pages: [
-        {
-          id: "tx-1" as TransactionId,
-          userId: mockUserId,
-          type: "expense",
-          amount: 42000 as CopAmount,
-          categoryId: "food" as CategoryId,
-          description: "Existing lunch",
-          date: existingDate,
-          createdAt: existingUpdatedAt,
-          updatedAt: existingUpdatedAt,
-          deletedAt: null,
-        },
-      ],
-      offset: 1,
-      hasMore: true,
-      balance: 42000,
-      categorySpending: existingCategorySpending,
-      dailySpending: existingDailySpending,
-    });
-
-    vi.mocked(getTransactionsPaginated).mockImplementationOnce(() => {
-      throw new Error("db read failed");
-    });
-
-    await useTransactionStore.getState().refresh();
-
-    const state = useTransactionStore.getState();
-    expect(state.pages).toHaveLength(1);
-    expect(state.pages[0]?.id).toBe("tx-1");
-    expect(state.offset).toBe(1);
-    expect(state.hasMore).toBe(true);
-    expect(state.balance).toBe(42000);
-    expect(state.categorySpending).toEqual(existingCategorySpending);
-    expect(state.dailySpending).toEqual(existingDailySpending);
-    expect(getSpendingByCategoryAggregate).not.toHaveBeenCalled();
-  });
-
-  it("refresh increments dataRevision even when page identity is unchanged", async () => {
-    useTransactionStore.setState({
-      pages: [
-        {
-          id: "tx-1" as TransactionId,
-          userId: mockUserId,
-          type: "expense",
-          amount: 1000 as CopAmount,
-          categoryId: "food" as CategoryId,
-          description: "Lunch",
-          date: new Date("2026-03-04T00:00:00.000Z"),
-          createdAt: new Date("2026-03-04T10:00:00.000Z"),
-          updatedAt: new Date("2026-03-04T10:00:00.000Z"),
-          deletedAt: null,
-        },
-      ],
+      pages: [makeStoredTransaction()],
       offset: 1,
       hasMore: true,
       dataRevision: 2,
     });
+    vi.mocked(getTransactionsPaginated).mockReturnValueOnce([makeRow()]);
 
-    vi.mocked(getTransactionsPaginated).mockReturnValueOnce([
-      {
-        id: "tx-1" as TransactionId,
-        userId: mockUserId,
-        type: "expense",
-        amount: 1000 as CopAmount,
-        categoryId: "food" as CategoryId,
-        description: "Lunch",
-        date: "2026-03-04" as IsoDate,
-        createdAt: "2026-03-04T10:00:00.000Z" as IsoDateTime,
-        updatedAt: "2026-03-04T10:00:00.000Z" as IsoDateTime,
-        deletedAt: null,
-        source: "manual",
-      },
-    ]);
-
-    await useTransactionStore.getState().refresh();
+    await refreshTransactions(mockDb, mockUserId);
 
     expect(useTransactionStore.getState()).toMatchObject({
       dataRevision: 3,
       offset: 1,
       hasMore: false,
     });
+    expect(useTransactionStore.getState().pages[0]?.id).toBe("tx-1");
   });
 
-  it("editTransaction hydrates edit mode from the stored transaction row", () => {
-    vi.mocked(getTransactionById).mockReturnValueOnce({
-      id: "tx-1" as TransactionId,
-      userId: mockUserId,
+  it("loadTransactionIntoForm hydrates edit state from the stored row", () => {
+    vi.mocked(getTransactionById).mockReturnValueOnce(
+      makeRow({
+        id: "tx-1" as TransactionId,
+        type: "income",
+        amount: 235000 as CopAmount,
+        description: "Payroll correction",
+        date: "2026-04-12" as IsoDate,
+      })
+    );
+
+    const loaded = loadTransactionIntoForm(mockDb, mockUserId, "tx-1" as TransactionId);
+
+    expect(loaded).toBe(true);
+    expect(useTransactionStore.getState()).toMatchObject({
+      editingId: "tx-1",
       type: "income",
-      amount: 235000 as CopAmount,
-      categoryId: "food" as CategoryId,
+      digits: "235000",
+      categoryId: "food",
       description: "Payroll correction",
-      date: "2026-04-12" as IsoDate,
-      createdAt: "2026-04-12T08:00:00.000Z" as IsoDateTime,
-      updatedAt: "2026-04-13T09:00:00.000Z" as IsoDateTime,
-      deletedAt: null,
-      source: "manual",
     });
-
-    useTransactionStore.getState().editTransaction("tx-1" as TransactionId);
-
-    const state = useTransactionStore.getState();
-    expect(state.editingId).toBe("tx-1");
-    expect(state.type).toBe("income");
-    expect(state.digits).toBe("235000");
-    expect(state.categoryId).toBe("food");
-    expect(state.description).toBe("Payroll correction");
-    expect(state.date.getFullYear()).toBe(2026);
-    expect(state.date.getMonth()).toBe(3);
-    expect(state.date.getDate()).toBe(12);
   });
 
-  it("editTransaction clears stale edit state when the requested row is missing", () => {
+  it("loadTransactionIntoForm resets stale edit state when the row is missing", () => {
     useTransactionStore.setState({
       editingId: "tx-stale" as TransactionId,
       step: 2,
@@ -493,77 +276,31 @@ describe("useTransactionStore", () => {
       description: "Stale draft",
       date: new Date("2026-04-12T00:00:00.000Z"),
     });
-
     vi.mocked(getTransactionById).mockReturnValueOnce(null);
 
-    useTransactionStore.getState().editTransaction("tx-missing" as TransactionId);
+    const loaded = loadTransactionIntoForm(mockDb, mockUserId, "tx-missing" as TransactionId);
 
-    const state = useTransactionStore.getState();
-    expect(state.editingId).toBeNull();
-    expect(state.step).toBe(1);
-    expect(state.type).toBe("expense");
-    expect(state.digits).toBe("");
-    expect(state.categoryId).toBeNull();
-    expect(state.description).toBe("");
+    expect(loaded).toBe(false);
+    expect(useTransactionStore.getState()).toMatchObject({
+      editingId: null,
+      step: 1,
+      type: "expense",
+      digits: "",
+      categoryId: null,
+      description: "",
+    });
   });
 
-  it("editTransaction clears stale edit state when the DB read throws", () => {
-    useTransactionStore.setState({
-      editingId: "tx-stale" as TransactionId,
-      step: 2,
-      type: "income",
-      digits: "235000",
-      categoryId: "food" as CategoryId,
-      description: "Stale draft",
-      date: new Date("2026-04-12T00:00:00.000Z"),
-    });
-
+  it("getStoredTransactionById returns null when the underlying read throws", () => {
     vi.mocked(getTransactionById).mockImplementationOnce(() => {
       throw new Error("db read failed");
     });
 
-    expect(() =>
-      useTransactionStore.getState().editTransaction("tx-broken" as TransactionId)
-    ).not.toThrow();
-
-    const state = useTransactionStore.getState();
-    expect(state.editingId).toBeNull();
-    expect(state.step).toBe(1);
-    expect(state.type).toBe("expense");
-    expect(state.digits).toBe("");
-    expect(state.categoryId).toBeNull();
-    expect(state.description).toBe("");
+    expect(getStoredTransactionById(mockDb, mockUserId, "tx-1" as TransactionId)).toBeNull();
   });
 
-  it("getTransactionById returns null when the DB read throws", () => {
-    vi.mocked(getTransactionById).mockImplementationOnce(() => {
-      throw new Error("db read failed");
-    });
-
-    const result = useTransactionStore.getState().getTransactionById("tx-1" as TransactionId);
-
-    expect(result).toBeNull();
-  });
-
-  it("removeTransaction soft-deletes from DB, enqueues sync, and refreshes", async () => {
-    useTransactionStore.setState({
-      pages: [
-        {
-          id: "tx-1" as TransactionId,
-          userId: mockUserId,
-          type: "expense",
-          amount: 100 as CopAmount,
-          categoryId: "food" as CategoryId,
-          description: "Test",
-          date: new Date(),
-          createdAt: new Date(),
-          updatedAt: new Date(),
-          deletedAt: null,
-        },
-      ],
-    });
-
-    await useTransactionStore.getState().removeTransaction("tx-1" as TransactionId);
+  it("removeTransaction soft-deletes, enqueues sync, and refreshes", async () => {
+    await removeTransaction(mockDb, mockUserId, "tx-1" as TransactionId);
 
     expect(softDeleteTransaction).toHaveBeenCalledWith(mockDb, "tx-1", expect.any(String));
     expect(enqueueSync).toHaveBeenCalledWith(
@@ -574,106 +311,37 @@ describe("useTransactionStore", () => {
         operation: "delete",
       })
     );
-    // refresh was called
     expect(getTransactionsPaginated).toHaveBeenCalled();
   });
 
-  it("saveTransaction returns error when DB insert fails", async () => {
-    vi.mocked(insertTransaction).mockImplementationOnce(() => {
-      throw new Error("disk full");
-    });
-
-    const store = useTransactionStore.getState();
-    store.setDigits("500");
-    store.setCategoryId("food" as CategoryId);
-
-    const result = await store.saveTransaction();
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error).toBe("Failed to save transaction");
-    }
-  });
-
-  it("removeTransaction keeps UI state when DB operation fails", async () => {
-    useTransactionStore.setState({
-      pages: [
-        {
-          id: "tx-1" as TransactionId,
-          userId: mockUserId,
-          type: "expense",
-          amount: 100 as CopAmount,
-          categoryId: "food" as CategoryId,
-          description: "Test",
-          date: new Date(),
-          createdAt: new Date(),
-          updatedAt: new Date(),
-          deletedAt: null,
-        },
-      ],
-    });
-
-    vi.mocked(softDeleteTransaction).mockImplementationOnce(() => {
-      throw new Error("db error");
-    });
-    await expect(
-      useTransactionStore.getState().removeTransaction("tx-1" as TransactionId)
-    ).rejects.toThrow("db error");
-
-    expect(useTransactionStore.getState().pages).toHaveLength(1);
-  });
-
-  it("addToCache prepends to pages", () => {
-    const tx = {
-      id: "tx-new" as TransactionId,
-      userId: mockUserId,
-      type: "expense" as const,
-      amount: 500 as CopAmount,
-      categoryId: "food" as CategoryId,
-      description: "New",
-      date: new Date(),
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      deletedAt: null,
-    };
-
-    useTransactionStore.getState().addToCache(tx);
-
-    expect(useTransactionStore.getState().pages[0]?.id).toBe("tx-new");
-  });
-
-  it("removeFromCache filters from pages", () => {
-    useTransactionStore.setState({
-      pages: [
-        {
-          id: "tx-1" as TransactionId,
-          userId: mockUserId,
-          type: "expense",
-          amount: 100 as CopAmount,
-          categoryId: "food" as CategoryId,
-          description: "Test",
-          date: new Date(),
-          createdAt: new Date(),
-          updatedAt: new Date(),
-          deletedAt: null,
-        },
-      ],
-    });
-
-    useTransactionStore.getState().removeFromCache("tx-1" as TransactionId);
-
-    expect(useTransactionStore.getState().pages).toHaveLength(0);
-  });
-
-  it("loadAggregates derives balance from current month category spending totals", () => {
+  it("loadTransactionAggregates updates aggregate state without disturbing pages", () => {
+    useTransactionStore.setState({ pages: [makeStoredTransaction()] });
     vi.mocked(getSpendingByCategoryAggregate).mockReturnValueOnce([
       { categoryId: "food" as CategoryId, total: 50000 as CopAmount },
       { categoryId: "transport" as CategoryId, total: 30000 as CopAmount },
     ]);
 
-    useTransactionStore.getState().loadAggregates();
+    loadTransactionAggregates(mockDb, mockUserId);
 
-    const state = useTransactionStore.getState();
-    expect(state.balance).toBe(80000);
-    expect(getBalanceAggregate).not.toHaveBeenCalled();
+    expect(useTransactionStore.getState().balance).toBe(80000);
+    expect(useTransactionStore.getState().pages).toHaveLength(1);
+  });
+
+  it("addToCache and removeFromCache maintain page state and dataRevision", () => {
+    useTransactionStore
+      .getState()
+      .addToCache(makeStoredTransaction({ id: "tx-new" as TransactionId }));
+    expect(useTransactionStore.getState()).toMatchObject({
+      offset: 1,
+      dataRevision: 1,
+    });
+    expect(useTransactionStore.getState().pages[0]?.id).toBe("tx-new");
+
+    useTransactionStore.getState().removeFromCache("tx-new" as TransactionId);
+    expect(useTransactionStore.getState()).toMatchObject({
+      offset: 0,
+      dataRevision: 2,
+    });
+    expect(useTransactionStore.getState().pages).toHaveLength(0);
   });
 });

--- a/apps/mobile/__tests__/transactions/store.test.ts
+++ b/apps/mobile/__tests__/transactions/store.test.ts
@@ -266,6 +266,33 @@ describe("transaction boundaries", () => {
     });
   });
 
+  it("loadTransactionIntoForm ignores stale session loads without mutating the current form", () => {
+    initializeTransactionSession("user-2" as UserId);
+    useTransactionStore.setState({
+      editingId: "tx-current" as TransactionId,
+      step: 2,
+      type: "income",
+      digits: "999999",
+      categoryId: "transport" as CategoryId,
+      description: "Current draft",
+      date: new Date("2026-05-01T00:00:00.000Z"),
+    });
+
+    const loaded = loadTransactionIntoForm(mockDb, mockUserId, "tx-1" as TransactionId);
+
+    expect(loaded).toBe(false);
+    expect(getTransactionById).not.toHaveBeenCalled();
+    expect(useTransactionStore.getState()).toMatchObject({
+      activeUserId: "user-2",
+      editingId: "tx-current",
+      step: 2,
+      type: "income",
+      digits: "999999",
+      categoryId: "transport",
+      description: "Current draft",
+    });
+  });
+
   it("loadTransactionIntoForm resets stale edit state when the row is missing", () => {
     useTransactionStore.setState({
       editingId: "tx-stale" as TransactionId,

--- a/apps/mobile/app/(auth)/onboarding.tsx
+++ b/apps/mobile/app/(auth)/onboarding.tsx
@@ -15,7 +15,7 @@ import {
   useOnboardingStore,
   WelcomeStep,
 } from "@/features/onboarding";
-import { useTransactionStore } from "@/features/transactions";
+import { initializeTransactionSession, loadInitialTransactions } from "@/features/transactions";
 import { StyleSheet, View } from "@/shared/components/rn";
 import { getDb } from "@/shared/db";
 import { useSubscription, useThemeColor } from "@/shared/hooks";
@@ -52,9 +52,9 @@ function AuthenticatedOnboardingScreen({
   useSubscription(
     () => {
       initializeEmailCaptureSession(userId);
-      useTransactionStore.getState().initStore(db, userId);
+      initializeTransactionSession(userId);
       initializeBudgetSession(userId);
-      Promise.all([loadEmailAccounts(db, userId), useTransactionStore.getState().loadInitialPage()])
+      Promise.all([loadEmailAccounts(db, userId), loadInitialTransactions(db, userId)])
         .catch(captureError)
         .finally(() => {
           setStoresReady(true);

--- a/apps/mobile/app/(tabs)/add.tsx
+++ b/apps/mobile/app/(tabs)/add.tsx
@@ -4,17 +4,21 @@ import { useCallback, useMemo, useRef } from "react";
 import Animated from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useShallow } from "zustand/react/shallow";
+import { useOptionalUserId } from "@/features/auth";
 import {
   CATEGORIES,
   CategoryPill,
   getDateLabel,
   handleNumpadPress,
+  saveCurrentTransaction,
   TypeToggle,
+  updateCurrentTransaction,
   useTransactionStore,
 } from "@/features/transactions";
 import { FidyNumpad } from "@/shared/components";
 import { Calendar } from "@/shared/components/icons";
 import { Platform, Pressable, Text, TextInput, View } from "@/shared/components/rn";
+import { tryGetDb } from "@/shared/db";
 import { useAsyncGuard, useBlinkingCursor, useThemeColor, useTranslation } from "@/shared/hooks";
 import { getDateFnsLocale } from "@/shared/i18n";
 import { formatInputDisplay, parseDigitsToAmount, trackTransactionCreated } from "@/shared/lib";
@@ -22,6 +26,8 @@ import { formatInputDisplay, parseDigitsToAmount, trackTransactionCreated } from
 export default function AddTransactionScreen() {
   const { navigate } = useRouter();
   const { t, locale } = useTranslation();
+  const userId = useOptionalUserId();
+  const db = userId ? tryGetDb(userId) : null;
   const { bottom: safeBottom } = useSafeAreaInsets();
   const {
     type,
@@ -34,8 +40,6 @@ export default function AddTransactionScreen() {
     setDigits,
     setCategoryId,
     setDescription,
-    saveTransaction,
-    updateTransaction,
     resetForm,
   } = useTransactionStore(
     useShallow((s) => ({
@@ -49,8 +53,6 @@ export default function AddTransactionScreen() {
       setDigits: s.setDigits,
       setCategoryId: s.setCategoryId,
       setDescription: s.setDescription,
-      saveTransaction: s.saveTransaction,
-      updateTransaction: s.updateTransaction,
       resetForm: s.resetForm,
     }))
   );
@@ -82,7 +84,10 @@ export default function AddTransactionScreen() {
 
   const handleSave = () => {
     void guardedSave(async () => {
-      const result = isEditing ? await updateTransaction(editingId) : await saveTransaction();
+      if (!db || !userId) return;
+      const result = isEditing
+        ? await updateCurrentTransaction(db, userId, editingId)
+        : await saveCurrentTransaction(db, userId);
       if (result.success) {
         void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
         if (!isEditing) {

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -66,7 +66,11 @@ import {
 } from "@/features/onboarding";
 import { useSettingsStore } from "@/features/settings";
 import { loadSyncConflicts, useSync } from "@/features/sync";
-import { useTransactionStore } from "@/features/transactions";
+import {
+  initializeTransactionSession,
+  loadInitialTransactions,
+  useTransactionStore,
+} from "@/features/transactions";
 import { ErrorFallback } from "@/shared/components";
 import { Platform, useColorScheme } from "@/shared/components/rn";
 import { Colors } from "@/shared/constants/theme";
@@ -103,7 +107,7 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
 
   useSubscription(
     () => {
-      useTransactionStore.getState().initStore(db, userId);
+      initializeTransactionSession(userId);
       initializeEmailCaptureSession(userId);
       initializeChatSession(userId);
       initializeCalendarSession(userId);
@@ -125,10 +129,9 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
       hydrateCaptureSources(db, userId).catch(
         handleRecoverableError("Failed to load capture sources")
       );
-      useTransactionStore
-        .getState()
-        .loadInitialPage()
-        .catch(handleRecoverableError("Failed to load transactions"));
+      loadInitialTransactions(db, userId).catch(
+        handleRecoverableError("Failed to load transactions")
+      );
       void loadSyncConflicts(db);
       useSettingsStore
         .getState()

--- a/apps/mobile/app/edit-transaction.tsx
+++ b/apps/mobile/app/edit-transaction.tsx
@@ -1,9 +1,16 @@
 import * as Haptics from "expo-haptics";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useState } from "react";
+import { useOptionalUserId } from "@/features/auth";
 import type { TransactionType } from "@/features/transactions";
-import { TransactionForm, useTransactionStore } from "@/features/transactions";
+import {
+  deleteTransaction,
+  getStoredTransactionById,
+  TransactionForm,
+  updateTransactionDirect,
+} from "@/features/transactions";
 import { InteractionManager } from "@/shared/components/rn";
+import { tryGetDb } from "@/shared/db";
 import { useAsyncGuard, useMountEffect, useTranslation } from "@/shared/hooks";
 import { showErrorToast } from "@/shared/lib";
 import { requireTransactionId } from "@/shared/types/assertions";
@@ -18,10 +25,8 @@ export default function EditTransactionScreen() {
   const { transactionId: routeTransactionId } = useLocalSearchParams<{ transactionId?: string }>();
   const router = useRouter();
   const { t } = useTranslation();
-
-  const getTransactionById = useTransactionStore((s) => s.getTransactionById);
-  const updateTransactionDirect = useTransactionStore((s) => s.updateTransactionDirect);
-  const deleteTransaction = useTransactionStore((s) => s.deleteTransaction);
+  const userId = useOptionalUserId();
+  const db = userId ? tryGetDb(userId) : null;
 
   const [type, setType] = useState<TransactionType>("expense");
   const [digits, setDigits] = useState("");
@@ -35,12 +40,12 @@ export default function EditTransactionScreen() {
       : null;
 
   useMountEffect(() => {
-    if (transactionId == null) {
+    if (transactionId == null || !db || !userId) {
       router.back();
       return;
     }
 
-    const tx = getTransactionById(transactionId);
+    const tx = getStoredTransactionById(db, userId, transactionId);
     if (tx) {
       setType(tx.type);
       setDigits(String(tx.amount));
@@ -62,7 +67,8 @@ export default function EditTransactionScreen() {
       router.back();
       await afterDismiss();
       try {
-        const result = await updateTransactionDirect(transactionId, {
+        if (!db || !userId) return;
+        const result = await updateTransactionDirect(db, userId, transactionId, {
           type,
           digits,
           categoryId,
@@ -85,7 +91,8 @@ export default function EditTransactionScreen() {
       router.back();
       await afterDismiss();
       try {
-        await deleteTransaction(transactionId);
+        if (!db || !userId) return;
+        await deleteTransaction(db, userId, transactionId);
       } catch {
         showErrorToast(t("transactions.deleteFailed"));
       }

--- a/apps/mobile/app/edit-transaction.tsx
+++ b/apps/mobile/app/edit-transaction.tsx
@@ -62,12 +62,14 @@ export default function EditTransactionScreen() {
 
   const handleSave = () => {
     void guardedSave(async () => {
-      if (transactionId == null) return;
+      if (transactionId == null || !db || !userId) {
+        showErrorToast(t("transactions.updateFailed"));
+        return;
+      }
       void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       router.back();
       await afterDismiss();
       try {
-        if (!db || !userId) return;
         const result = await updateTransactionDirect(db, userId, transactionId, {
           type,
           digits,
@@ -86,12 +88,14 @@ export default function EditTransactionScreen() {
 
   const handleDelete = () => {
     void guardedSave(async () => {
-      if (transactionId == null) return;
+      if (transactionId == null || !db || !userId) {
+        showErrorToast(t("transactions.deleteFailed"));
+        return;
+      }
       void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       router.back();
       await afterDismiss();
       try {
-        if (!db || !userId) return;
         await deleteTransaction(db, userId, transactionId);
       } catch {
         showErrorToast(t("transactions.deleteFailed"));

--- a/apps/mobile/features/ai-chat/components/ChatScreen.tsx
+++ b/apps/mobile/features/ai-chat/components/ChatScreen.tsx
@@ -3,7 +3,7 @@ import { FlashList } from "@shopify/flash-list";
 import { memo, useCallback, useRef } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useOptionalUserId } from "@/features/auth";
-import { useTransactionStore } from "@/features/transactions";
+import { removeTransaction } from "@/features/transactions";
 import { HEADER_HEIGHT, ScreenLayout } from "@/shared/components";
 import { Keyboard, KeyboardAvoidingView, Platform, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
@@ -68,7 +68,8 @@ export function ChatScreen({ onBack }: ChatScreenProps) {
       const msg = messages.find((m) => m.id === messageId);
       if (msg?.action?.type === "delete") {
         try {
-          await useTransactionStore.getState().removeTransaction(msg.action.transactionId);
+          if (!db || !userId) return;
+          await removeTransaction(db, userId, msg.action.transactionId);
         } catch {
           persistActionStatus(messageId, "dismissed");
           return;
@@ -76,7 +77,7 @@ export function ChatScreen({ onBack }: ChatScreenProps) {
       }
       persistActionStatus(messageId, "confirmed");
     },
-    [messages, persistActionStatus]
+    [db, messages, persistActionStatus, userId]
   );
 
   const handleDismissAction = useCallback(

--- a/apps/mobile/features/ai-chat/hooks/use-streaming-chat.ts
+++ b/apps/mobile/features/ai-chat/hooks/use-streaming-chat.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { useOptionalUserId } from "@/features/auth";
-import { useTransactionStore } from "@/features/transactions";
+import { saveCurrentTransaction, useTransactionStore } from "@/features/transactions";
 import { tryGetDb } from "@/shared/db";
 import {
   captureWarning,
@@ -37,39 +37,43 @@ export function useStreamingChat() {
   const isStreaming = useChatStore((s) => s.isStreaming);
   const streamingContent = useChatStore((s) => s.streamingContent);
 
-  const executeAction = useCallback(async (action: ChatAction) => {
-    switch (action.type) {
-      case "add": {
-        const store = useTransactionStore.getState();
-        store.setType(action.data.type);
-        store.setDigits(String(action.data.amount));
-        store.setCategoryId(action.data.categoryId);
-        store.setDescription(action.data.description);
-        store.setDate(parseIsoDate(action.data.date));
-        try {
-          const result = await store.saveTransaction();
-          if (result.success) {
-            trackTransactionCreated({
-              type: action.data.type,
-              category: String(action.data.categoryId),
-              source: "ai_chat",
-            });
+  const executeAction = useCallback(
+    async (action: ChatAction) => {
+      switch (action.type) {
+        case "add": {
+          const store = useTransactionStore.getState();
+          if (!db || !userId) return;
+          store.setType(action.data.type);
+          store.setDigits(String(action.data.amount));
+          store.setCategoryId(action.data.categoryId);
+          store.setDescription(action.data.description);
+          store.setDate(parseIsoDate(action.data.date));
+          try {
+            const result = await saveCurrentTransaction(db, userId);
+            if (result.success) {
+              trackTransactionCreated({
+                type: action.data.type,
+                category: String(action.data.categoryId),
+                source: "ai_chat",
+              });
+            }
+          } finally {
+            store.resetForm();
           }
-        } finally {
-          store.resetForm();
+          break;
         }
-        break;
+        case "edit": {
+          // Edit not yet fully wired
+          break;
+        }
+        case "delete": {
+          // Delete handled via updateActionStatus flow in ChatScreen
+          break;
+        }
       }
-      case "edit": {
-        // Edit not yet fully wired
-        break;
-      }
-      case "delete": {
-        // Delete handled via updateActionStatus flow in ChatScreen
-        break;
-      }
-    }
-  }, []);
+    },
+    [db, userId]
+  );
 
   const sendMessage = useCallback(
     async (text: string) => {

--- a/apps/mobile/features/dashboard/components/HomeScreen.tsx
+++ b/apps/mobile/features/dashboard/components/HomeScreen.tsx
@@ -15,6 +15,9 @@ import { SearchAction } from "@/features/search";
 import { SyncConflictBanner } from "@/features/sync";
 import {
   CATEGORY_MAP,
+  deleteTransaction,
+  loadNextTransactions,
+  loadTransactionIntoForm,
   makeDateLabel,
   type StoredTransaction,
   useTransactionStore,
@@ -121,14 +124,13 @@ const ListHeader = memo(function ListHeader({
 export const HomeScreen = () => {
   const { push } = useRouter();
   const { t } = useTranslation();
+  const userId = useOptionalUserId();
+  const db = userId ? tryGetDb(userId) : null;
   const pages = useTransactionStore((s) => s.pages);
   const hasMore = useTransactionStore((s) => s.hasMore);
-  const loadNextPage = useTransactionStore((s) => s.loadNextPage);
   const balance = useTransactionStore((s) => s.balance);
   const categorySpending = useTransactionStore((s) => s.categorySpending);
   const dailySpending = useTransactionStore((s) => s.dailySpending);
-  const editTransaction = useTransactionStore((s) => s.editTransaction);
-  const deleteTransaction = useTransactionStore((s) => s.deleteTransaction);
   // phase gates ListEmptyComponent — suppresses "No transactions" during first sync
   const phase = useEmailCaptureStore((s) => s.phase);
   const primaryColor = useThemeColor("primary");
@@ -148,17 +150,18 @@ export const HomeScreen = () => {
   }, [pages]);
 
   const handleEndReached = useCallback(() => {
-    if (hasMore) {
-      void loadNextPage();
-    }
-  }, [hasMore, loadNextPage]);
+    if (!db || !userId || !hasMore) return;
+    void loadNextTransactions(db, userId);
+  }, [db, hasMore, userId]);
 
   const handleEdit = useCallback(
     (id: TransactionId) => {
-      editTransaction(id);
+      if (!db || !userId) return;
+      const didLoad = loadTransactionIntoForm(db, userId, id);
+      if (!didLoad) return;
       push("/(tabs)/add" as never);
     },
-    [editTransaction, push]
+    [db, push, userId]
   );
 
   const handleDelete = useCallback(
@@ -169,12 +172,13 @@ export const HomeScreen = () => {
           text: t("common.delete"),
           style: "destructive",
           onPress: () => {
-            void deleteTransaction(id);
+            if (!db || !userId) return;
+            void deleteTransaction(db, userId, id);
           },
         },
       ]);
     },
-    [t, deleteTransaction]
+    [db, t, userId]
   );
 
   const renderItem = useCallback(

--- a/apps/mobile/features/email-capture/components/NeedsReviewScreen.tsx
+++ b/apps/mobile/features/email-capture/components/NeedsReviewScreen.tsx
@@ -2,7 +2,7 @@ import { FlashList } from "@shopify/flash-list";
 import { useRouter } from "expo-router";
 import { useCallback, useMemo } from "react";
 import { useOptionalUserId } from "@/features/auth";
-import { useTransactionStore } from "@/features/transactions";
+import { getStoredTransactionById, refreshTransactions } from "@/features/transactions";
 import { ScreenLayout } from "@/shared/components";
 import { Text, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
@@ -15,31 +15,34 @@ export default function NeedsReviewScreen() {
   const { t } = useTranslation();
   const router = useRouter();
   const userId = useOptionalUserId();
+  const db = userId ? tryGetDb(userId) : null;
   const needsReview = useEmailCaptureStore((s) => s.needsReviewEmails);
-  const getTransaction = useTransactionStore((s) => s.getTransactionById);
 
   // Pre-fetch all needed transactions once, not per-cell
   const txMap = useMemo(() => {
-    const map = new Map<string, ReturnType<typeof getTransaction>>();
+    const map = new Map<string, ReturnType<typeof getStoredTransactionById>>();
+    if (!db || !userId) {
+      return map;
+    }
+
     needsReview.forEach((item) => {
       if (item.transactionId) {
         const transactionId = requireTransactionId(item.transactionId);
-        map.set(transactionId, getTransaction(transactionId));
+        map.set(transactionId, getStoredTransactionById(db, userId, transactionId));
       }
     });
     return map;
-  }, [needsReview, getTransaction]);
+  }, [db, needsReview, userId]);
 
   const handleConfirm = useCallback(
     (processedEmailId: string, categoryId: string) => {
       if (!userId) return;
-      const db = tryGetDb(userId);
       if (!db) return;
       void confirmReviewedEmail(db, userId, processedEmailId, categoryId, () =>
-        useTransactionStore.getState().refresh()
+        refreshTransactions(db, userId)
       );
     },
-    [userId]
+    [db, userId]
   );
 
   const renderItem = useCallback(

--- a/apps/mobile/features/email-capture/hooks/useEmailCapture.ts
+++ b/apps/mobile/features/email-capture/hooks/useEmailCapture.ts
@@ -1,4 +1,4 @@
-import { useTransactionStore } from "@/features/transactions";
+import { refreshTransactions } from "@/features/transactions";
 import { AppState } from "@/shared/components/rn";
 import type { AnyDb } from "@/shared/db";
 import { useSubscription } from "@/shared/hooks";
@@ -14,7 +14,7 @@ export function useEmailCapture(db: AnyDb | null, userId: UserId | null) {
 
       const runFetch = () => {
         fetchAndProcessEmails(db, userId, getGmailClientId(), getOutlookClientId(), () =>
-          useTransactionStore.getState().refresh()
+          refreshTransactions(db, userId)
         ).catch(handleRecoverableError("Email sync failed"));
       };
 

--- a/apps/mobile/features/onboarding/components/SyncProgressStep.tsx
+++ b/apps/mobile/features/onboarding/components/SyncProgressStep.tsx
@@ -7,7 +7,7 @@ import {
   getOutlookClientId,
   useEmailCaptureStore,
 } from "@/features/email-capture";
-import { useTransactionStore } from "@/features/transactions";
+import { refreshTransactions, useTransactionStore } from "@/features/transactions";
 import { ProgressBar } from "@/shared/components";
 import { Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
@@ -41,7 +41,7 @@ export function SyncProgressStep() {
     if (accounts.length > 0 && !fetchStarted.current && db && userId) {
       fetchStarted.current = true;
       void fetchAndProcessEmails(db, userId, getGmailClientId(), getOutlookClientId(), () =>
-        useTransactionStore.getState().refresh()
+        refreshTransactions(db, userId)
       );
     }
   });

--- a/apps/mobile/features/sync/services/create-sync-service.ts
+++ b/apps/mobile/features/sync/services/create-sync-service.ts
@@ -60,6 +60,14 @@ export type SyncService = {
   ) => Promise<ResolveConflictResult>;
 };
 
+function tryParseTransactionSnapshot(value: string): TransactionSnapshot | null {
+  try {
+    return JSON.parse(value) as TransactionSnapshot;
+  } catch {
+    return null;
+  }
+}
+
 export function createSyncService({
   isOnline,
   getSupabase,
@@ -100,17 +108,20 @@ export function createSyncService({
           }
 
           const resolvedAt = toIsoDateTime(new Date());
+          const serverData = tryParseTransactionSnapshot(row.serverData);
+          const localData =
+            resolution === "local" ? (JSON.parse(row.localData) as TransactionSnapshot) : null;
+          const refreshUserId = localData?.userId ?? serverData?.userId ?? null;
 
-          const localData = JSON.parse(row.localData) as TransactionSnapshot;
-          const refreshUserId = localData.userId;
-
-          if (resolution === "local") {
+          if (resolution === "local" && localData) {
             yield* fromThunk(() => upsertTransaction(db, { ...localData, updatedAt: resolvedAt }));
             yield* fromThunk(() => enqueueTransactionSync(db, row.transactionId, resolvedAt));
           }
 
           yield* fromThunk(() => resolveConflictRow(db, conflictId, resolution, resolvedAt));
-          yield* fromThunk(() => refreshTransactions({ db, userId: refreshUserId }));
+          if (refreshUserId != null) {
+            yield* fromThunk(() => refreshTransactions({ db, userId: refreshUserId }));
+          }
 
           return {
             unresolvedConflicts: (yield* fromThunk(() => listConflicts({ db }))).length,

--- a/apps/mobile/features/sync/services/create-sync-service.ts
+++ b/apps/mobile/features/sync/services/create-sync-service.ts
@@ -29,6 +29,10 @@ type EnqueueTransactionSync = (
   transactionId: string,
   createdAt: IsoDateTime
 ) => void | Promise<void>;
+type RefreshTransactions = (input: {
+  readonly db: SyncContext["db"];
+  readonly userId: string;
+}) => Promise<void>;
 type ResolveConflictRow = (
   db: SyncContext["db"],
   conflictId: ResolveTransactionConflictInput["conflictId"],
@@ -41,7 +45,7 @@ type CreateSyncServiceDeps = {
   readonly getSupabase: () => SupabaseClient;
   readonly syncPull: SyncPull;
   readonly syncPush: SyncPush;
-  readonly refreshTransactions: () => Promise<void>;
+  readonly refreshTransactions: RefreshTransactions;
   readonly getConflictRows: (input: SyncContext) => Promise<readonly ConflictRow[]>;
   readonly upsertTransaction: UpsertTransaction;
   readonly enqueueTransactionSync: EnqueueTransactionSync;
@@ -97,14 +101,16 @@ export function createSyncService({
 
           const resolvedAt = toIsoDateTime(new Date());
 
+          const localData = JSON.parse(row.localData) as TransactionSnapshot;
+          const refreshUserId = localData.userId;
+
           if (resolution === "local") {
-            const localData = JSON.parse(row.localData) as TransactionSnapshot;
             yield* fromThunk(() => upsertTransaction(db, { ...localData, updatedAt: resolvedAt }));
             yield* fromThunk(() => enqueueTransactionSync(db, row.transactionId, resolvedAt));
           }
 
           yield* fromThunk(() => resolveConflictRow(db, conflictId, resolution, resolvedAt));
-          yield* fromThunk(refreshTransactions);
+          yield* fromThunk(() => refreshTransactions({ db, userId: refreshUserId }));
 
           return {
             unresolvedConflicts: (yield* fromThunk(() => listConflicts({ db }))).length,
@@ -128,7 +134,7 @@ export function createSyncService({
           const pullOk = yield* fromThunk(() => syncPull(db, supabase, userId));
           if (pullOk) {
             yield* fromThunk(() => syncPush(db, supabase, userId));
-            yield* fromThunk(refreshTransactions);
+            yield* fromThunk(() => refreshTransactions({ db, userId }));
           }
 
           return {

--- a/apps/mobile/features/sync/services/sync.ts
+++ b/apps/mobile/features/sync/services/sync.ts
@@ -1,7 +1,8 @@
 // biome-ignore-all lint/style/useNamingConvention: snake_case matches Supabase Postgres column names
-import { upsertTransaction, useTransactionStore } from "@/features/transactions";
+import { refreshTransactions, upsertTransaction } from "@/features/transactions";
 import { enqueueSync, getSupabase } from "@/shared/db";
 import { generateSyncQueueId } from "@/shared/lib";
+import type { UserId } from "@/shared/types/branded";
 import {
   getUnresolvedConflicts,
   resolveConflict as resolveConflictDb,
@@ -23,8 +24,8 @@ const syncService = createSyncService({
   getSupabase,
   syncPull,
   syncPush,
-  refreshTransactions: async () => {
-    await useTransactionStore.getState().refresh();
+  refreshTransactions: async ({ db, userId }) => {
+    await refreshTransactions(db, userId as UserId);
   },
   getConflictRows: async ({ db }) => getUnresolvedConflicts(db),
   upsertTransaction: async (db, row) => {

--- a/apps/mobile/features/transactions/components/TransactionDetails.tsx
+++ b/apps/mobile/features/transactions/components/TransactionDetails.tsx
@@ -1,19 +1,23 @@
 import * as Haptics from "expo-haptics";
 import { useRouter } from "expo-router";
 import { useShallow } from "zustand/react/shallow";
+import { useOptionalUserId } from "@/features/auth";
 import { Calendar, ChevronLeft } from "@/shared/components/icons";
 import { Pressable, Text, TextInput, View } from "@/shared/components/rn";
+import { tryGetDb } from "@/shared/db";
 import { useAsyncGuard, useThemeColor, useTranslation } from "@/shared/hooks";
 import { getDateFnsLocale } from "@/shared/i18n";
 import { formatInputDisplay, trackTransactionCreated } from "@/shared/lib";
 import { CATEGORIES } from "../lib/categories";
 import { getDateLabel } from "../lib/format-date";
-import { useTransactionStore } from "../store";
+import { saveCurrentTransaction, useTransactionStore } from "../store";
 import { CategoryPill } from "./CategoryPill";
 
 export const TransactionDetails = () => {
   const { back } = useRouter();
   const { t, locale } = useTranslation();
+  const userId = useOptionalUserId();
+  const db = userId ? tryGetDb(userId) : null;
   const {
     type,
     digits,
@@ -23,7 +27,6 @@ export const TransactionDetails = () => {
     setStep,
     setCategoryId,
     setDescription,
-    saveTransaction,
     resetForm,
   } = useTransactionStore(
     useShallow((s) => ({
@@ -35,7 +38,6 @@ export const TransactionDetails = () => {
       setStep: s.setStep,
       setCategoryId: s.setCategoryId,
       setDescription: s.setDescription,
-      saveTransaction: s.saveTransaction,
       resetForm: s.resetForm,
     }))
   );
@@ -55,7 +57,8 @@ export const TransactionDetails = () => {
 
   const handleSave = () =>
     guardedSave(async () => {
-      const result = await saveTransaction();
+      if (!db || !userId) return;
+      const result = await saveCurrentTransaction(db, userId);
       if (result.success) {
         trackTransactionCreated({
           type,

--- a/apps/mobile/features/transactions/index.ts
+++ b/apps/mobile/features/transactions/index.ts
@@ -30,4 +30,18 @@ export {
 } from "./lib/repository";
 export type { CreateTransactionInput, StoredTransaction, TransactionType } from "./schema";
 export { categoryIdSchema } from "./schema";
-export { useTransactionStore } from "./store";
+export {
+  deleteTransaction,
+  getStoredTransactionById,
+  initializeTransactionSession,
+  loadInitialTransactions,
+  loadNextTransactions,
+  loadTransactionAggregates,
+  loadTransactionIntoForm,
+  refreshTransactions,
+  removeTransaction,
+  saveCurrentTransaction,
+  updateCurrentTransaction,
+  updateTransactionDirect,
+  useTransactionStore,
+} from "./store";

--- a/apps/mobile/features/transactions/services/create-transaction-query-service.ts
+++ b/apps/mobile/features/transactions/services/create-transaction-query-service.ts
@@ -1,0 +1,183 @@
+import type { AnyDb } from "@/shared/db";
+import { toIsoDate, toMonth } from "@/shared/lib";
+import type { CategoryId, CopAmount, IsoDate, TransactionId, UserId } from "@/shared/types/branded";
+import { toStoredTransaction } from "../lib/build-transaction";
+import {
+  getDailySpendingAggregate,
+  getSpendingByCategoryAggregate,
+  getTransactionById,
+  getTransactionsPaginated,
+} from "../lib/repository";
+import type { StoredTransaction } from "../schema";
+
+export type CategorySpendingItem = {
+  readonly categoryId: CategoryId;
+  readonly total: CopAmount;
+};
+
+export type DailySpendingItem = {
+  readonly date: IsoDate;
+  readonly total: CopAmount;
+};
+
+export type TransactionPageSnapshot = {
+  readonly pages: readonly StoredTransaction[];
+  readonly offset: number;
+  readonly hasMore: boolean;
+};
+
+export type TransactionAggregateSnapshot = {
+  readonly balance: number;
+  readonly categorySpending: readonly CategorySpendingItem[];
+  readonly dailySpending: readonly DailySpendingItem[];
+};
+
+export type TransactionRefreshSnapshot = TransactionPageSnapshot &
+  TransactionAggregateSnapshot & {
+    readonly sameData: boolean;
+  };
+
+type LoadPageInput = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly pageSize: number;
+  readonly offset: number;
+};
+
+type LoadInitialSnapshotInput = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly pageSize: number;
+};
+
+type LoadRefreshSnapshotInput = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly currentPages: readonly StoredTransaction[];
+  readonly currentOffset: number;
+  readonly pageSize: number;
+};
+
+type GetStoredTransactionInput = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly transactionId: TransactionId;
+};
+
+type CreateTransactionQueryServiceDeps = {
+  readonly getTransactionsPaginated?: typeof getTransactionsPaginated;
+  readonly getSpendingByCategoryAggregate?: typeof getSpendingByCategoryAggregate;
+  readonly getDailySpendingAggregate?: typeof getDailySpendingAggregate;
+  readonly getTransactionById?: typeof getTransactionById;
+  readonly getNow?: () => Date;
+};
+
+function toPageSnapshot(
+  rows: ReturnType<typeof getTransactionsPaginated>,
+  pageSize: number
+): TransactionPageSnapshot {
+  const hasMore = rows.length > pageSize;
+  const pageRows = hasMore ? rows.slice(0, pageSize) : rows;
+  return {
+    pages: pageRows.map(toStoredTransaction),
+    offset: pageRows.length,
+    hasMore,
+  };
+}
+
+function toPageKey(pages: readonly StoredTransaction[]): string {
+  return pages.map((page) => `${page.id}:${page.updatedAt.getTime()}`).join(",");
+}
+
+function loadAggregateSnapshot(
+  db: AnyDb,
+  userId: UserId,
+  getNow: () => Date,
+  loadSpendingByCategory: typeof getSpendingByCategoryAggregate,
+  loadDailySpending: typeof getDailySpendingAggregate
+): TransactionAggregateSnapshot {
+  const now = getNow();
+  const currentMonth = toMonth(now);
+  const thirtyDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30);
+  const startDate = toIsoDate(thirtyDaysAgo);
+  const endDate = toIsoDate(now);
+  const categorySpending = loadSpendingByCategory(db, userId, currentMonth);
+  const balance = categorySpending.reduce((sum, category) => sum + category.total, 0);
+  const dailySpending = loadDailySpending(db, userId, startDate, endDate);
+
+  return {
+    balance,
+    categorySpending,
+    dailySpending,
+  };
+}
+
+export function createTransactionQueryService({
+  getTransactionsPaginated: loadTransactionsPaginated = getTransactionsPaginated,
+  getSpendingByCategoryAggregate: loadSpendingByCategory = getSpendingByCategoryAggregate,
+  getDailySpendingAggregate: loadDailySpending = getDailySpendingAggregate,
+  getTransactionById: loadTransactionById = getTransactionById,
+  getNow = () => new Date(),
+}: CreateTransactionQueryServiceDeps = {}) {
+  const loadAggregateOnlySnapshot = (db: AnyDb, userId: UserId): TransactionAggregateSnapshot =>
+    loadAggregateSnapshot(db, userId, getNow, loadSpendingByCategory, loadDailySpending);
+
+  return {
+    loadInitialSnapshot({
+      db,
+      userId,
+      pageSize,
+    }: LoadInitialSnapshotInput): TransactionPageSnapshot & TransactionAggregateSnapshot {
+      const pageSnapshot = toPageSnapshot(
+        loadTransactionsPaginated(db, userId, pageSize, 0),
+        pageSize
+      );
+      return {
+        ...pageSnapshot,
+        ...loadAggregateOnlySnapshot(db, userId),
+      };
+    },
+
+    loadNextPage({ db, userId, pageSize, offset }: LoadPageInput): TransactionPageSnapshot {
+      return toPageSnapshot(loadTransactionsPaginated(db, userId, pageSize, offset), pageSize);
+    },
+
+    loadRefreshSnapshot({
+      db,
+      userId,
+      currentPages,
+      currentOffset,
+      pageSize,
+    }: LoadRefreshSnapshotInput): TransactionRefreshSnapshot {
+      const reloadSize = Math.max(currentOffset, pageSize);
+      const pageSnapshot = toPageSnapshot(
+        loadTransactionsPaginated(db, userId, reloadSize, 0),
+        reloadSize
+      );
+      return {
+        ...pageSnapshot,
+        ...loadAggregateOnlySnapshot(db, userId),
+        sameData: toPageKey(currentPages) === toPageKey(pageSnapshot.pages),
+      };
+    },
+
+    loadAggregateSnapshot({
+      db,
+      userId,
+    }: Pick<LoadInitialSnapshotInput, "db" | "userId">): TransactionAggregateSnapshot {
+      return loadAggregateOnlySnapshot(db, userId);
+    },
+
+    getStoredTransaction({
+      db,
+      userId,
+      transactionId,
+    }: GetStoredTransactionInput): StoredTransaction | null {
+      const row = loadTransactionById(db, transactionId);
+      if (!row || row.userId !== userId || row.deletedAt != null) {
+        return null;
+      }
+      return toStoredTransaction(row);
+    },
+  };
+}

--- a/apps/mobile/features/transactions/services/create-transaction-query-service.ts
+++ b/apps/mobile/features/transactions/services/create-transaction-query-service.ts
@@ -98,8 +98,8 @@ function loadAggregateSnapshot(
 ): TransactionAggregateSnapshot {
   const now = getNow();
   const currentMonth = toMonth(now);
-  const thirtyDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30);
-  const startDate = toIsoDate(thirtyDaysAgo);
+  const inclusiveThirtyDayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 29);
+  const startDate = toIsoDate(inclusiveThirtyDayStart);
   const endDate = toIsoDate(now);
   const categorySpending = loadSpendingByCategory(db, userId, currentMonth);
   const balance = categorySpending.reduce((sum, category) => sum + category.total, 0);

--- a/apps/mobile/features/transactions/store.ts
+++ b/apps/mobile/features/transactions/store.ts
@@ -323,12 +323,18 @@ export async function removeTransaction(
 }
 
 export function loadTransactionIntoForm(db: AnyDb, userId: UserId, id: TransactionId): boolean {
+  const sessionId = transactionsSessionId;
+  if (!isActiveTransactionSession(userId, sessionId)) return false;
+
   try {
     const transaction = createTransactionQueryService().getStoredTransaction({
       db,
       userId,
       transactionId: id,
     });
+
+    if (!isActiveTransactionSession(userId, sessionId)) return false;
+
     if (!transaction) {
       useTransactionStore.getState().resetForm();
       return false;

--- a/apps/mobile/features/transactions/store.ts
+++ b/apps/mobile/features/transactions/store.ts
@@ -1,106 +1,67 @@
 import { create } from "zustand";
-import { createWriteThroughMutationModule, type WriteThroughMutationModule } from "@/mutations";
+import { createWriteThroughMutationModule } from "@/mutations";
 import type { AnyDb } from "@/shared/db";
 import {
   generateTransactionId,
-  toIsoDate,
-  toMonth,
   trackTransactionDeleted,
   trackTransactionEdited,
 } from "@/shared/lib";
-import type { CategoryId, CopAmount, IsoDate, TransactionId, UserId } from "@/shared/types/branded";
-import { toStoredTransaction } from "./lib/build-transaction";
-import { createTransactionMutationService } from "./lib/mutation-service";
+import type { CategoryId, TransactionId, UserId } from "@/shared/types/branded";
 import {
-  getDailySpendingAggregate,
-  getSpendingByCategoryAggregate,
-  getTransactionById,
-  getTransactionsPaginated,
-} from "./lib/repository";
+  createTransactionMutationService,
+  type TransactionMutationResult,
+} from "./lib/mutation-service";
 import type { StoredTransaction, TransactionType } from "./schema";
+import {
+  type CategorySpendingItem,
+  createTransactionQueryService,
+  type DailySpendingItem,
+  type TransactionAggregateSnapshot,
+  type TransactionPageSnapshot,
+  type TransactionRefreshSnapshot,
+} from "./services/create-transaction-query-service";
 
 type FormStep = 1 | 2;
 
 const PAGE_SIZE = 30;
 
-// Module-level refs: Zustand doesn't serialize DB connections, so we keep them outside the store.
-let dbRef: AnyDb | null = null;
-let userIdRef: UserId | null = null;
-let mutations: WriteThroughMutationModule | null = null;
-
-type CategorySpendingItem = {
-  readonly categoryId: CategoryId;
-  readonly total: CopAmount;
-};
-
-type DailySpendingItem = {
-  readonly date: IsoDate;
-  readonly total: CopAmount;
-};
+let transactionsSessionId = 0;
+let loadTransactionsRequestId = 0;
 
 type TransactionState = {
-  // Form fields
-  step: FormStep;
-  type: TransactionType;
-  digits: string;
-  categoryId: CategoryId | null;
-  description: string;
-  date: Date;
-
-  // Paginated transactions
-  pages: StoredTransaction[];
-  offset: number;
-  hasMore: boolean;
-
-  // Aggregate data (from SQL)
-  balance: number;
-  categorySpending: CategorySpendingItem[];
-  dailySpending: DailySpendingItem[];
-  dataRevision: number;
+  readonly activeUserId: UserId | null;
+  readonly step: FormStep;
+  readonly type: TransactionType;
+  readonly digits: string;
+  readonly categoryId: CategoryId | null;
+  readonly description: string;
+  readonly date: Date;
+  readonly pages: readonly StoredTransaction[];
+  readonly offset: number;
+  readonly hasMore: boolean;
+  readonly balance: number;
+  readonly categorySpending: readonly CategorySpendingItem[];
+  readonly dailySpending: readonly DailySpendingItem[];
+  readonly dataRevision: number;
+  readonly editingId: TransactionId | null;
 };
 
 type TransactionActions = {
-  initStore: (db: AnyDb, userId: UserId) => void;
+  beginSession: (userId: UserId) => void;
   setStep: (step: FormStep) => void;
   setType: (type: TransactionType) => void;
   setDigits: (digits: string) => void;
   setCategoryId: (id: CategoryId) => void;
   setDescription: (desc: string) => void;
   setDate: (date: Date) => void;
-  saveTransaction: () => Promise<
-    { success: true; transaction: StoredTransaction } | { success: false; error: string }
-  >;
-  loadInitialPage: () => Promise<void>;
-  loadNextPage: () => Promise<void>;
-  loadAggregates: () => void;
-  refresh: () => Promise<void>;
-  removeTransaction: (id: TransactionId) => Promise<void>;
-  editTransaction: (id: TransactionId) => void;
-  updateTransaction: (
-    id: TransactionId
-  ) => Promise<
-    { success: true; transaction: StoredTransaction } | { success: false; error: string }
-  >;
-  updateTransactionDirect: (
-    id: TransactionId,
-    fields: {
-      type: TransactionType;
-      digits: string;
-      categoryId: CategoryId | null;
-      description: string;
-      date: Date;
-    }
-  ) => Promise<
-    { success: true; transaction: StoredTransaction } | { success: false; error: string }
-  >;
-  deleteTransaction: (id: TransactionId) => Promise<void>;
+  setPageSnapshot: (snapshot: TransactionPageSnapshot) => void;
+  appendPageSnapshot: (snapshot: TransactionPageSnapshot) => void;
+  setAggregateSnapshot: (snapshot: TransactionAggregateSnapshot) => void;
+  applyRefreshSnapshot: (snapshot: TransactionRefreshSnapshot) => void;
+  hydrateEditingTransaction: (id: TransactionId, transaction: StoredTransaction) => void;
   addToCache: (tx: StoredTransaction) => void;
   removeFromCache: (id: TransactionId) => void;
   resetForm: () => void;
-  getTransactionById: (id: TransactionId) => StoredTransaction | null;
-
-  // Edit mode
-  editingId: TransactionId | null;
 };
 
 const INITIAL_FORM: Pick<
@@ -114,6 +75,22 @@ const INITIAL_FORM: Pick<
   description: "",
 };
 
+function createInitialState(activeUserId: UserId | null): TransactionState {
+  return {
+    activeUserId,
+    ...INITIAL_FORM,
+    date: new Date(),
+    pages: [],
+    offset: 0,
+    hasMore: true,
+    balance: 0,
+    categorySpending: [],
+    dailySpending: [],
+    dataRevision: 0,
+    editingId: null,
+  };
+}
+
 function toTransactionFormInput(
   state: Pick<TransactionState, "type" | "digits" | "categoryId" | "description" | "date">
 ) {
@@ -126,197 +103,301 @@ function toTransactionFormInput(
   };
 }
 
-export const useTransactionStore = create<TransactionState & TransactionActions>((set, get) => {
-  const mutationService = createTransactionMutationService({
-    getCommit: () => mutations?.commit ?? null,
-    getUserId: () => userIdRef,
-    refresh: () => get().refresh(),
-    resetForm: () => get().resetForm(),
+function isActiveTransactionSession(userId: UserId, sessionId: number): boolean {
+  return (
+    transactionsSessionId === sessionId && useTransactionStore.getState().activeUserId === userId
+  );
+}
+
+function isCurrentTransactionsRequest(
+  requestId: number,
+  userId: UserId,
+  sessionId: number
+): boolean {
+  return loadTransactionsRequestId === requestId && isActiveTransactionSession(userId, sessionId);
+}
+
+function createLiveTransactionMutationService(db: AnyDb, userId: UserId, sessionId: number) {
+  const mutations = createWriteThroughMutationModule(db);
+
+  return createTransactionMutationService({
+    getCommit: () => mutations.commit,
+    getUserId: () => userId,
+    refresh: async () => {
+      if (!isActiveTransactionSession(userId, sessionId)) return;
+      await refreshTransactions(db, userId);
+    },
+    resetForm: () => {
+      if (!isActiveTransactionSession(userId, sessionId)) return;
+      useTransactionStore.getState().resetForm();
+    },
     trackDeleted: trackTransactionDeleted,
     trackEdited: trackTransactionEdited,
     createId: generateTransactionId,
   });
+}
 
-  return {
-    ...INITIAL_FORM,
-    date: new Date(),
-    pages: [],
-    offset: 0,
-    hasMore: true,
-    balance: 0,
-    categorySpending: [],
-    dailySpending: [],
-    dataRevision: 0,
-    editingId: null,
+export const useTransactionStore = create<TransactionState & TransactionActions>((set) => ({
+  ...createInitialState(null),
 
-    initStore: (db, userId) => {
-      dbRef = db;
-      userIdRef = userId;
-      mutations = createWriteThroughMutationModule(db);
-    },
+  beginSession: (userId) => set(createInitialState(userId)),
+  setStep: (step) => set({ step }),
+  setType: (type) => set({ type }),
+  setDigits: (digits) => set({ digits }),
+  setCategoryId: (categoryId) => set({ categoryId }),
+  setDescription: (description) => set({ description }),
+  setDate: (date) => set({ date }),
 
-    setStep: (step) => set({ step }),
-    setType: (type) => set({ type }),
-    setDigits: (digits) => set({ digits }),
-    setCategoryId: (categoryId) => set({ categoryId }),
-    setDescription: (description) => set({ description }),
-    setDate: (date) => set({ date }),
+  setPageSnapshot: (snapshot) =>
+    set({
+      pages: [...snapshot.pages],
+      offset: snapshot.offset,
+      hasMore: snapshot.hasMore,
+    }),
 
-    loadInitialPage: async () => {
-      if (!dbRef || !userIdRef) return;
-      try {
-        const rows = getTransactionsPaginated(dbRef, userIdRef, PAGE_SIZE, 0);
-        const hasMore = rows.length > PAGE_SIZE;
-        const pageData = hasMore ? rows.slice(0, PAGE_SIZE) : rows;
-        set({
-          pages: pageData.map(toStoredTransaction),
-          offset: pageData.length,
-          hasMore,
-        });
-        get().loadAggregates();
-      } catch {
-        // DB read failed — keep existing state
-      }
-    },
+  appendPageSnapshot: (snapshot) =>
+    set((state) => ({
+      pages: [...state.pages, ...snapshot.pages],
+      offset: state.offset + snapshot.pages.length,
+      hasMore: snapshot.hasMore,
+    })),
 
-    loadNextPage: async () => {
-      if (!dbRef || !userIdRef) return;
-      const { hasMore, offset } = get();
-      if (!hasMore) return;
+  setAggregateSnapshot: (snapshot) =>
+    set({
+      balance: snapshot.balance,
+      categorySpending: [...snapshot.categorySpending],
+      dailySpending: [...snapshot.dailySpending],
+    }),
 
-      try {
-        const rows = getTransactionsPaginated(dbRef, userIdRef, PAGE_SIZE, offset);
-        const moreAvailable = rows.length > PAGE_SIZE;
-        const pageData = moreAvailable ? rows.slice(0, PAGE_SIZE) : rows;
-        set((s) => ({
-          pages: [...s.pages, ...pageData.map(toStoredTransaction)],
-          offset: s.offset + pageData.length,
-          hasMore: moreAvailable,
-        }));
-      } catch {
-        // DB read failed — keep existing state
-      }
-    },
+  applyRefreshSnapshot: (snapshot) =>
+    set((state) => ({
+      ...(snapshot.sameData ? null : { pages: [...snapshot.pages] }),
+      offset: snapshot.offset,
+      hasMore: snapshot.hasMore,
+      balance: snapshot.balance,
+      categorySpending: [...snapshot.categorySpending],
+      dailySpending: [...snapshot.dailySpending],
+      dataRevision: state.dataRevision + 1,
+    })),
 
-    loadAggregates: () => {
-      if (!dbRef || !userIdRef) return;
-      try {
-        const now = new Date();
-        const currentMonth = toMonth(now);
-        const thirtyDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30);
-        const startDate = toIsoDate(thirtyDaysAgo);
-        const endDate = toIsoDate(now);
+  hydrateEditingTransaction: (id, transaction) =>
+    set({
+      editingId: id,
+      type: transaction.type,
+      digits: String(transaction.amount),
+      categoryId: transaction.categoryId,
+      description: transaction.description,
+      date: transaction.date,
+    }),
 
-        const categorySpending = getSpendingByCategoryAggregate(dbRef, userIdRef, currentMonth);
-        const balance = categorySpending.reduce((sum, c) => sum + c.total, 0) as CopAmount;
-        const dailySpending = getDailySpendingAggregate(dbRef, userIdRef, startDate, endDate);
+  addToCache: (transaction) =>
+    set((state) => ({
+      pages: [transaction, ...state.pages],
+      offset: state.offset + 1,
+      dataRevision: state.dataRevision + 1,
+    })),
 
-        set({ balance, categorySpending, dailySpending });
-      } catch {
-        // Aggregate query failed — keep existing state
-      }
-    },
+  removeFromCache: (id) =>
+    set((state) => {
+      const pages = state.pages.filter((transaction) => transaction.id !== id);
+      const removed = pages.length < state.pages.length;
 
-    refresh: async () => {
-      if (!dbRef || !userIdRef) return;
-      try {
-        const currentOffset = get().offset;
-        const reloadSize = Math.max(currentOffset, PAGE_SIZE);
-        const rows = getTransactionsPaginated(dbRef, userIdRef, reloadSize, 0);
-        const hasMore = rows.length > reloadSize;
-        const pageData = hasMore ? rows.slice(0, reloadSize) : rows;
+      return {
+        pages,
+        offset: removed ? Math.max(0, state.offset - 1) : state.offset,
+        dataRevision: removed ? state.dataRevision + 1 : state.dataRevision,
+      };
+    }),
 
-        // Skip pages update if data hasn't changed — avoids FlatList re-layout
-        const currentPages = get().pages;
-        const currentKey = currentPages.map((p) => `${p.id}:${p.updatedAt.getTime()}`).join(",");
-        const newKey = pageData.map((r) => `${r.id}:${new Date(r.updatedAt).getTime()}`).join(",");
-        const sameData = currentKey === newKey;
+  resetForm: () =>
+    set({
+      ...INITIAL_FORM,
+      date: new Date(),
+      editingId: null,
+    }),
+}));
 
-        if (!sameData) {
-          set({
-            pages: pageData.map(toStoredTransaction),
-            offset: pageData.length,
-            hasMore,
-            dataRevision: get().dataRevision + 1,
-          });
-        } else {
-          set({
-            offset: pageData.length,
-            hasMore,
-            dataRevision: get().dataRevision + 1,
-          });
-        }
-        get().loadAggregates();
-      } catch {
-        // Refresh failed — keep existing state
-      }
-    },
+export function initializeTransactionSession(userId: UserId): void {
+  transactionsSessionId += 1;
+  loadTransactionsRequestId += 1;
+  useTransactionStore.getState().beginSession(userId);
+}
 
-    saveTransaction: async () => mutationService.save(toTransactionFormInput(get())),
+export async function loadInitialTransactions(db: AnyDb, userId: UserId): Promise<void> {
+  const requestId = ++loadTransactionsRequestId;
+  const sessionId = transactionsSessionId;
 
-    removeTransaction: async (id) => {
-      await mutationService.remove(id);
-    },
+  try {
+    const snapshot = createTransactionQueryService().loadInitialSnapshot({
+      db,
+      userId,
+      pageSize: PAGE_SIZE,
+    });
+    if (!isCurrentTransactionsRequest(requestId, userId, sessionId)) return;
+    useTransactionStore.getState().setPageSnapshot(snapshot);
+    useTransactionStore.getState().setAggregateSnapshot(snapshot);
+  } catch {
+    // DB read failed — keep existing state
+  }
+}
 
-    editTransaction: (id) => {
-      if (!dbRef) return;
-      try {
-        const row = getTransactionById(dbRef, id);
-        if (!row) {
-          get().resetForm();
-          return;
-        }
+export async function loadNextTransactions(db: AnyDb, userId: UserId): Promise<void> {
+  const sessionId = transactionsSessionId;
+  if (!isActiveTransactionSession(userId, sessionId)) return;
 
-        const tx = toStoredTransaction(row);
-        set({
-          editingId: id,
-          type: tx.type,
-          digits: String(tx.amount),
-          categoryId: tx.categoryId,
-          description: tx.description,
-          date: tx.date,
-        });
-      } catch {
-        get().resetForm();
-      }
-    },
+  const { hasMore, offset } = useTransactionStore.getState();
+  if (!hasMore) return;
 
-    updateTransaction: async (id) => mutationService.update(id, toTransactionFormInput(get())),
+  try {
+    const snapshot = createTransactionQueryService().loadNextPage({
+      db,
+      userId,
+      pageSize: PAGE_SIZE,
+      offset,
+    });
+    if (!isActiveTransactionSession(userId, sessionId)) return;
+    useTransactionStore.getState().appendPageSnapshot(snapshot);
+  } catch {
+    // DB read failed — keep existing state
+  }
+}
 
-    updateTransactionDirect: async (id, fields) => mutationService.updateDirect(id, fields),
+export function loadTransactionAggregates(db: AnyDb, userId: UserId): void {
+  const sessionId = transactionsSessionId;
+  if (!isActiveTransactionSession(userId, sessionId)) return;
 
-    deleteTransaction: async (id) => {
-      await get().removeTransaction(id);
-    },
+  try {
+    const snapshot = createTransactionQueryService().loadAggregateSnapshot({
+      db,
+      userId,
+    });
+    if (!isActiveTransactionSession(userId, sessionId)) return;
+    useTransactionStore.getState().setAggregateSnapshot(snapshot);
+  } catch {
+    // Aggregate query failed — keep existing state
+  }
+}
 
-    addToCache: (tx) =>
-      set((s) => ({
-        pages: [tx, ...s.pages],
-        offset: s.offset + 1,
-        dataRevision: s.dataRevision + 1,
-      })),
+export async function refreshTransactions(db: AnyDb, userId: UserId): Promise<void> {
+  const requestId = ++loadTransactionsRequestId;
+  const sessionId = transactionsSessionId;
 
-    removeFromCache: (id) =>
-      set((s) => {
-        const filtered = s.pages.filter((t) => t.id !== id);
-        const removed = filtered.length < s.pages.length;
-        return {
-          pages: filtered,
-          offset: removed ? Math.max(0, s.offset - 1) : s.offset,
-          dataRevision: removed ? s.dataRevision + 1 : s.dataRevision,
-        };
-      }),
+  try {
+    const { pages, offset } = useTransactionStore.getState();
+    const snapshot = createTransactionQueryService().loadRefreshSnapshot({
+      db,
+      userId,
+      currentPages: pages,
+      currentOffset: offset,
+      pageSize: PAGE_SIZE,
+    });
+    if (!isCurrentTransactionsRequest(requestId, userId, sessionId)) return;
+    useTransactionStore.getState().applyRefreshSnapshot(snapshot);
+  } catch {
+    // Refresh failed — keep existing state
+  }
+}
 
-    resetForm: () => set({ ...INITIAL_FORM, date: new Date(), editingId: null }),
+export async function saveCurrentTransaction(
+  db: AnyDb,
+  userId: UserId
+): Promise<TransactionMutationResult> {
+  const sessionId = transactionsSessionId;
+  if (!isActiveTransactionSession(userId, sessionId)) {
+    return { success: false, error: "Store not initialized" };
+  }
 
-    getTransactionById: (id) => {
-      if (!dbRef) return null;
-      try {
-        const row = getTransactionById(dbRef, id);
-        return row ? toStoredTransaction(row) : null;
-      } catch {
-        return null;
-      }
-    },
-  };
-});
+  return createLiveTransactionMutationService(db, userId, sessionId).save(
+    toTransactionFormInput(useTransactionStore.getState())
+  );
+}
+
+export async function removeTransaction(
+  db: AnyDb,
+  userId: UserId,
+  id: TransactionId
+): Promise<void> {
+  const sessionId = transactionsSessionId;
+  if (!isActiveTransactionSession(userId, sessionId)) return;
+  await createLiveTransactionMutationService(db, userId, sessionId).remove(id);
+}
+
+export function loadTransactionIntoForm(db: AnyDb, userId: UserId, id: TransactionId): boolean {
+  try {
+    const transaction = createTransactionQueryService().getStoredTransaction({
+      db,
+      userId,
+      transactionId: id,
+    });
+    if (!transaction) {
+      useTransactionStore.getState().resetForm();
+      return false;
+    }
+
+    useTransactionStore.getState().hydrateEditingTransaction(id, transaction);
+    return true;
+  } catch {
+    useTransactionStore.getState().resetForm();
+    return false;
+  }
+}
+
+export async function updateCurrentTransaction(
+  db: AnyDb,
+  userId: UserId,
+  id: TransactionId
+): Promise<TransactionMutationResult> {
+  const sessionId = transactionsSessionId;
+  if (!isActiveTransactionSession(userId, sessionId)) {
+    return { success: false, error: "Store not initialized" };
+  }
+
+  return createLiveTransactionMutationService(db, userId, sessionId).update(
+    id,
+    toTransactionFormInput(useTransactionStore.getState())
+  );
+}
+
+export async function updateTransactionDirect(
+  db: AnyDb,
+  userId: UserId,
+  id: TransactionId,
+  fields: {
+    readonly type: TransactionType;
+    readonly digits: string;
+    readonly categoryId: CategoryId | null;
+    readonly description: string;
+    readonly date: Date;
+  }
+): Promise<TransactionMutationResult> {
+  const sessionId = transactionsSessionId;
+  if (!isActiveTransactionSession(userId, sessionId)) {
+    return { success: false, error: "Store not initialized" };
+  }
+
+  return createLiveTransactionMutationService(db, userId, sessionId).updateDirect(id, fields);
+}
+
+export async function deleteTransaction(
+  db: AnyDb,
+  userId: UserId,
+  id: TransactionId
+): Promise<void> {
+  await removeTransaction(db, userId, id);
+}
+
+export function getStoredTransactionById(
+  db: AnyDb,
+  userId: UserId,
+  id: TransactionId
+): StoredTransaction | null {
+  try {
+    return createTransactionQueryService().getStoredTransaction({
+      db,
+      userId,
+      transactionId: id,
+    });
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
- extract transaction query service
- remove hidden db and user refs
- rewire callers to explicit boundaries
- expand transaction boundary coverage

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deepened the transactions boundary by extracting a read-side query service and removing implicit DB/user state from the store. Also hardened sync conflict resolution, guarded stale form loads, and surfaced missing auth/db errors; daily spending now uses an inclusive 30‑day window.

- **Refactors**
  - Added `createTransactionQueryService` for reads (pagination, aggregates, lookups) with an inclusive 30‑day daily-spending window.
  - Store now holds only UI state; writes go through session-aware helpers; `refreshTransactions` now takes `{ db, userId }`.
  - Replaced hidden refs with explicit params across dashboard, add/edit, chat, email-capture, onboarding, and sync.
  - Safety: guard against stale session loads when hydrating edit forms; edit screen surfaces save/delete failures when `db`/`userId` are missing.
  - Sync: conflict resolution tolerates malformed `localData` and refreshes the correct user’s views.
  - New helpers: `initializeTransactionSession`, `loadInitialTransactions`, `loadNextTransactions`, `loadTransactionAggregates`, `refreshTransactions`, `saveCurrentTransaction`, `updateCurrentTransaction`, `updateTransactionDirect`, `removeTransaction`/`deleteTransaction`, `loadTransactionIntoForm`, `getStoredTransactionById`.

- **Migration**
  - Init: call `initializeTransactionSession(userId)` before using the store.
  - Initial load: `loadInitialTransactions(db, userId)`; pagination via `loadNextTransactions(db, userId)`.
  - Write ops: `saveCurrentTransaction(db, userId)`, `updateCurrentTransaction(db, userId, id)`, `removeTransaction(db, userId, id)`.
  - Reads/refresh: `loadTransactionIntoForm(db, userId, id)`, `getStoredTransactionById(db, userId, id)`, `refreshTransactions(db, userId)`.

<sup>Written for commit 4e74e7331c00fae3c3b736c4acfa42eba1ba3a6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

