### PR TITLE
refactor(mobile): effectify sync seam

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,10 @@ Fresh workspaces may not have the `.context/fidy-vault` symlink yet, even when t
 
 When a new slice branch is created from an older feature branch and that parent PR later merges to `main`, the standard `git pull --rebase --autostash origin main` flow can try to replay those already-merged commits and produce conflicts in unrelated files. In this repo, the safer recovery is: stash the current work, create a fresh branch from `origin/main`, then reapply the stash there before opening the next PR.
 
+### Vitest: avoid dynamic imports in `beforeEach` for heavy modules (⚠️ AGENT SURPRISE)
+
+Tests that `await import(...)` a large service module inside `beforeEach` can intermittently hit the 10s hook timeout during full-suite runs, even if the file passes in isolation. We hit this in `__tests__/email-capture/email-pipeline.test.ts` because the hook imported `email-pipeline.ts`, which itself pulled broad barrels like `@/features/transactions` and `@/shared/lib`. Fix: prefer static imports (or `beforeAll`) for the module under test, and narrow production imports to deep modules when the test only needs a small subset of functionality.
+
 ## External Fidy Vault
 
 The persistent Fidy knowledge vault lives outside the repo on the local machine.

--- a/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
@@ -1,6 +1,7 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: mock db needs flexible typing
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RawEmail } from "@/features/email-capture/schema";
+import { processEmails, processRetries } from "@/features/email-capture/services/email-pipeline";
 import { requireUserId } from "@/shared/types/assertions";
 
 const mockGetProcessedExternalIds = vi.fn().mockResolvedValue(new Set<string>());
@@ -65,9 +66,6 @@ vi.mock("@/shared/lib/generate-id", () => ({
 const mockDb = {} as any;
 const USER_ID = requireUserId("user-1");
 
-let processEmails: typeof import("@/features/email-capture/services/email-pipeline").processEmails;
-let processRetries: typeof import("@/features/email-capture/services/email-pipeline").processRetries;
-
 function makeRawEmail(overrides: Partial<RawEmail> = {}): RawEmail {
   return {
     externalId: "ext-1",
@@ -83,10 +81,7 @@ function makeRawEmail(overrides: Partial<RawEmail> = {}): RawEmail {
 describe("email processing pipeline", () => {
   let idCounter: number;
 
-  beforeEach(async () => {
-    ({ processEmails, processRetries } = await import(
-      "@/features/email-capture/services/email-pipeline"
-    ));
+  beforeEach(() => {
     vi.clearAllMocks();
     idCounter = 0;
     mockGenerateId.mockImplementation((prefix: string) => {

--- a/apps/mobile/features/email-capture/services/email-pipeline.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline.ts
@@ -1,22 +1,17 @@
-import { findDuplicateTransaction } from "@/features/capture-sources/dedup.public";
-import {
-  getBuiltInCategoryId,
-  insertTransaction,
-  isValidCategoryId,
-} from "@/features/transactions";
+import { findDuplicateTransaction } from "@/features/capture-sources/lib/dedup";
+import { getBuiltInCategoryId, isValidCategoryId } from "@/features/transactions/lib/categories";
+import { insertTransaction } from "@/features/transactions/lib/repository";
 import type { AnyDb } from "@/shared/db";
 import { enqueueSync } from "@/shared/db";
+import { trackTransactionCreated } from "@/shared/lib/analytics";
+import { toIsoDateTime } from "@/shared/lib/format-date";
 import {
-  captureError,
-  capturePipelineEvent,
-  captureWarning,
   generateProcessedEmailId,
   generateSyncQueueId,
   generateTransactionId,
-  normalizeMerchant,
-  toIsoDateTime,
-  trackTransactionCreated,
-} from "@/shared/lib";
+} from "@/shared/lib/generate-id";
+import { normalizeMerchant } from "@/shared/lib/normalize-merchant";
+import { captureError, capturePipelineEvent, captureWarning } from "@/shared/lib/sentry";
 import { assertCopAmount, assertIsoDate, assertIsoDateTime } from "@/shared/types/assertions";
 import type { UserId } from "@/shared/types/branded";
 import { insertMerchantRule, lookupMerchantRule } from "../lib/merchant-rules";

--- a/apps/mobile/features/sync/services/create-sync-service.ts
+++ b/apps/mobile/features/sync/services/create-sync-service.ts
@@ -1,6 +1,12 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { Effect } from "effect";
-import { fromThunk, runAppEffect } from "@/shared/effect/runtime";
+import {
+  fromPromise,
+  fromSync,
+  fromThunk,
+  makeAppTag,
+  runWithService,
+} from "@/shared/effect/runtime";
 import { toIsoDateTime } from "@/shared/lib";
 import type { IsoDateTime } from "@/shared/types/branded";
 import type {
@@ -60,12 +66,95 @@ export type SyncService = {
   ) => Promise<ResolveConflictResult>;
 };
 
+const SyncDeps = makeAppTag<CreateSyncServiceDeps>("@/features/sync/SyncDeps");
+
 function tryParseTransactionSnapshot(value: string): TransactionSnapshot | null {
   try {
     return JSON.parse(value) as TransactionSnapshot;
   } catch {
     return null;
   }
+}
+
+const getConflictRowsEffect = (db: SyncContext["db"]) =>
+  Effect.flatMap(SyncDeps, ({ getConflictRows }) => fromPromise(() => getConflictRows({ db })));
+
+const unresolvedConflictCountEffect = (db: SyncContext["db"]) =>
+  Effect.map(listConflictsEffect({ db }), (conflicts) => conflicts.length);
+
+function listConflictsEffect({ db }: SyncContext) {
+  return Effect.flatMap(getConflictRowsEffect(db), (rows) =>
+    Effect.forEach(rows, (row) =>
+      fromSync(() => ({
+        id: row.id,
+        transactionId: row.transactionId,
+        localData: JSON.parse(row.localData) as TransactionSnapshot,
+        serverData: JSON.parse(row.serverData) as TransactionSnapshot,
+        detectedAt: row.detectedAt,
+      }))
+    )
+  );
+}
+
+function resolveConflictEffect({ db, conflictId, resolution }: ResolveTransactionConflictInput) {
+  return Effect.gen(function* () {
+    const rows = yield* getConflictRowsEffect(db);
+    const row = rows.find((conflict) => conflict.id === conflictId);
+    if (!row) {
+      return {
+        unresolvedConflicts: yield* unresolvedConflictCountEffect(db),
+      };
+    }
+
+    const { upsertTransaction, enqueueTransactionSync, resolveConflictRow, refreshTransactions } =
+      yield* SyncDeps;
+    const resolvedAt = toIsoDateTime(new Date());
+    const serverData = tryParseTransactionSnapshot(row.serverData);
+    const localData =
+      resolution === "local" ? (JSON.parse(row.localData) as TransactionSnapshot) : null;
+    const refreshUserId = localData?.userId ?? serverData?.userId ?? null;
+
+    if (resolution === "local" && localData) {
+      yield* fromThunk(() => upsertTransaction(db, { ...localData, updatedAt: resolvedAt }));
+      yield* fromThunk(() => enqueueTransactionSync(db, row.transactionId, resolvedAt));
+    }
+
+    yield* fromThunk(() => resolveConflictRow(db, conflictId, resolution, resolvedAt));
+    if (refreshUserId != null) {
+      yield* fromThunk(() => refreshTransactions({ db, userId: refreshUserId }));
+    }
+
+    return {
+      unresolvedConflicts: yield* unresolvedConflictCountEffect(db),
+    };
+  });
+}
+
+function runSyncEffect({ db, userId, reason: _reason = "foreground" }: SyncInput) {
+  return Effect.gen(function* () {
+    void _reason;
+
+    const { isOnline, getSupabase, syncPull, syncPush, refreshTransactions } = yield* SyncDeps;
+    const online = yield* fromPromise(isOnline);
+    if (!online) {
+      return {
+        status: "skipped_offline" as const,
+        unresolvedConflicts: yield* unresolvedConflictCountEffect(db),
+      };
+    }
+
+    const supabase = yield* fromSync(getSupabase);
+    const pullOk = yield* fromPromise(() => syncPull(db, supabase, userId));
+    if (pullOk) {
+      yield* fromPromise(() => syncPush(db, supabase, userId));
+      yield* fromThunk(() => refreshTransactions({ db, userId }));
+    }
+
+    return {
+      status: pullOk ? ("synced" as const) : ("failed_pull" as const),
+      unresolvedConflicts: yield* unresolvedConflictCountEffect(db),
+    };
+  });
 }
 
 export function createSyncService({
@@ -79,81 +168,21 @@ export function createSyncService({
   enqueueTransactionSync,
   resolveConflictRow,
 }: CreateSyncServiceDeps): SyncService {
-  const listConflicts = async ({ db }: SyncContext): Promise<readonly SyncConflict[]> =>
-    runAppEffect(
-      fromThunk(() => getConflictRows({ db })).pipe(
-        Effect.map((rows) =>
-          rows.map((row) => ({
-            id: row.id,
-            transactionId: row.transactionId,
-            localData: JSON.parse(row.localData) as TransactionSnapshot,
-            serverData: JSON.parse(row.serverData) as TransactionSnapshot,
-            detectedAt: row.detectedAt,
-          }))
-        )
-      )
-    );
+  const deps = {
+    isOnline,
+    getSupabase,
+    syncPull,
+    syncPush,
+    refreshTransactions,
+    getConflictRows,
+    upsertTransaction,
+    enqueueTransactionSync,
+    resolveConflictRow,
+  } satisfies CreateSyncServiceDeps;
 
   return {
-    listConflicts,
-    resolveConflict: async ({ db, conflictId, resolution }) => {
-      return runAppEffect(
-        Effect.gen(function* () {
-          const rows = yield* fromThunk(() => getConflictRows({ db }));
-          const row = rows.find((conflict) => conflict.id === conflictId);
-          if (!row) {
-            return {
-              unresolvedConflicts: (yield* fromThunk(() => listConflicts({ db }))).length,
-            };
-          }
-
-          const resolvedAt = toIsoDateTime(new Date());
-          const serverData = tryParseTransactionSnapshot(row.serverData);
-          const localData =
-            resolution === "local" ? (JSON.parse(row.localData) as TransactionSnapshot) : null;
-          const refreshUserId = localData?.userId ?? serverData?.userId ?? null;
-
-          if (resolution === "local" && localData) {
-            yield* fromThunk(() => upsertTransaction(db, { ...localData, updatedAt: resolvedAt }));
-            yield* fromThunk(() => enqueueTransactionSync(db, row.transactionId, resolvedAt));
-          }
-
-          yield* fromThunk(() => resolveConflictRow(db, conflictId, resolution, resolvedAt));
-          if (refreshUserId != null) {
-            yield* fromThunk(() => refreshTransactions({ db, userId: refreshUserId }));
-          }
-
-          return {
-            unresolvedConflicts: (yield* fromThunk(() => listConflicts({ db }))).length,
-          };
-        })
-      );
-    },
-    run: async ({ db, userId, reason: _reason = "foreground" }) => {
-      return runAppEffect(
-        Effect.gen(function* () {
-          void _reason;
-          const online = yield* fromThunk(isOnline);
-          if (!online) {
-            return {
-              status: "skipped_offline" as const,
-              unresolvedConflicts: (yield* fromThunk(() => listConflicts({ db }))).length,
-            };
-          }
-
-          const supabase = yield* fromThunk(getSupabase);
-          const pullOk = yield* fromThunk(() => syncPull(db, supabase, userId));
-          if (pullOk) {
-            yield* fromThunk(() => syncPush(db, supabase, userId));
-            yield* fromThunk(() => refreshTransactions({ db, userId }));
-          }
-
-          return {
-            status: pullOk ? ("synced" as const) : ("failed_pull" as const),
-            unresolvedConflicts: (yield* fromThunk(() => listConflicts({ db }))).length,
-          };
-        })
-      );
-    },
+    listConflicts: (input) => runWithService(listConflictsEffect(input), SyncDeps, deps),
+    resolveConflict: (input) => runWithService(resolveConflictEffect(input), SyncDeps, deps),
+    run: (input) => runWithService(runSyncEffect(input), SyncDeps, deps),
   };
 }

--- a/apps/mobile/shared/effect/runtime.ts
+++ b/apps/mobile/shared/effect/runtime.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Context, Effect } from "effect";
 
 export type AppEffect<A, E = unknown, R = never> = Effect.Effect<A, E, R>;
 
@@ -6,6 +6,26 @@ export function runAppEffect<A, E>(effect: AppEffect<A, E>): Promise<A> {
   return Effect.runPromise(effect);
 }
 
-export function fromThunk<A>(thunk: () => A | Promise<A>): AppEffect<A> {
-  return Effect.promise(() => Promise.resolve().then(thunk));
+export function makeAppTag<Service>(key: string): Context.Tag<Service, Service> {
+  return Context.GenericTag<Service>(key);
+}
+
+export function runWithService<A, E, I, S>(
+  effect: AppEffect<A, E, I>,
+  tag: Context.Tag<I, S>,
+  service: S
+): Promise<A> {
+  return runAppEffect(Effect.provideService(effect, tag, service));
+}
+
+export function fromSync<A>(thunk: () => A): AppEffect<A> {
+  return Effect.try({ try: thunk, catch: (error) => error });
+}
+
+export function fromPromise<A>(thunk: () => Promise<A>): AppEffect<A> {
+  return Effect.tryPromise({ try: thunk, catch: (error) => error });
+}
+
+export function fromThunk<A>(thunk: () => A | Promise<A>): AppEffect<Awaited<A>> {
+  return fromPromise(() => Promise.resolve(thunk()));
 }


### PR DESCRIPTION
- add typed effect runtime helpers
- move sync orchestration behind effect programs
- keep public sync api unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored mobile sync to use typed `effect` programs with a dependency tag and new runtime helpers, and reduced email pipeline test flakiness by removing dynamic imports and narrowing to deep module imports. The `SyncService` public API remains unchanged.

- **Refactors**
  - Added runtime helpers: `makeAppTag`, `runWithService`, `fromSync`, `fromPromise`; refined `fromThunk`.
  - Introduced `SyncDeps` and moved sync orchestration to `listConflictsEffect`, `resolveConflictEffect`, `runSyncEffect`.
  - Reduced Vitest flake in the email pipeline by using static imports and deep module imports; documented the pattern in AGENTS.md.

<sup>Written for commit e173c2d009f1069f87f7517956c5c502f2376055. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

