### PR TITLE
refactor(mobile): effectify email pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,10 @@ Workspace wrapper scripts like `bun run --cwd apps/mobile lint` can behave diffe
 
 Fresh workspaces may not have the `.context/fidy-vault` symlink yet, even when the external vault is correctly configured. Agents that try to read `.context/fidy-vault/AGENTS.md` before running `bun run vault:doctor` can fail with "No such file or directory". Fix: run `bun run vault:doctor` first, then read `.context/fidy-vault/AGENTS.md`.
 
+### Effect runners should squash failures at the boundary (⚠️ AGENT SURPRISE)
+
+`Effect.runPromise(...)` rejects with Effect's `FiberFailure` wrapper, not the original thrown error. In this repo that changes observable behavior in tests and error reporting paths that expect the original `Error` instance. Fix: shared runners like `shared/effect/runtime.ts` should use `Effect.runPromiseExit(...)` and `Cause.squash(...)` before rethrowing so module boundaries preserve the original failure.
+
 ### Rebased PR branches can replay already-merged slice commits (⚠️ AGENT SURPRISE)
 
 When a new slice branch is created from an older feature branch and that parent PR later merges to `main`, the standard `git pull --rebase --autostash origin main` flow can try to replay those already-merged commits and produce conflicts in unrelated files. In this repo, the safer recovery is: stash the current work, create a fresh branch from `origin/main`, then reapply the stash there before opening the next PR.

--- a/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
@@ -306,6 +306,34 @@ describe("email processing pipeline", () => {
     expect(call.nextRetryAt).toBeTruthy();
   });
 
+  it("continues the batch when parsed output is malformed", async () => {
+    const emails = [makeRawEmail({ externalId: "ext-1" }), makeRawEmail({ externalId: "ext-2" })];
+    mockParseEmailApi
+      .mockResolvedValueOnce({
+        type: "expense",
+        amount: -1,
+        categoryId: "other",
+        description: "Compra 1",
+        date: "2026-03-05",
+        confidence: 0.9,
+      } as never)
+      .mockResolvedValueOnce({
+        type: "expense",
+        amount: 30000,
+        categoryId: "food",
+        description: "Compra 2",
+        date: "2026-03-05",
+        confidence: 0.9,
+      });
+
+    const result = await processEmails(mockDb, USER_ID, emails);
+
+    expect(result.failed).toBe(1);
+    expect(result.saved).toBe(1);
+    expect(mockParseEmailApi).toHaveBeenCalledTimes(2);
+    expect(mockInsertTransaction).toHaveBeenCalledTimes(1);
+  });
+
   it("marks email as skipped (not pending_retry) when LLM returns null", async () => {
     const emails = [makeRawEmail()];
     mockParseEmailApi.mockResolvedValueOnce(null);
@@ -534,6 +562,25 @@ describe("processRetries", () => {
     const result = await processRetries(mockDb, USER_ID);
 
     expect(mockMarkForRetry).toHaveBeenCalledWith(mockDb, "pe-retry-1", 3, expect.any(String));
+    expect(result.retried).toBe(1);
+    expect(result.succeeded).toBe(0);
+  });
+
+  it("reschedules retry when parsed output is malformed", async () => {
+    const row = makePendingRetryRow({ retryCount: 1 });
+    mockGetPendingRetryEmails.mockResolvedValueOnce([row]);
+    mockParseEmailApi.mockResolvedValueOnce({
+      type: "expense",
+      amount: -1,
+      categoryId: "other",
+      description: "Compra en Exito",
+      date: "2026-03-05",
+      confidence: 0.9,
+    } as never);
+
+    const result = await processRetries(mockDb, USER_ID);
+
+    expect(mockMarkForRetry).toHaveBeenCalledWith(mockDb, "pe-retry-1", 2, expect.any(String));
     expect(result.retried).toBe(1);
     expect(result.succeeded).toBe(0);
   });

--- a/apps/mobile/__tests__/error-handling/pipeline-save-error.test.ts
+++ b/apps/mobile/__tests__/error-handling/pipeline-save-error.test.ts
@@ -20,6 +20,11 @@ const mockLookupMerchantRule = vi.fn().mockResolvedValue(null);
 const mockInsertMerchantRule = vi.fn();
 const mockParseEmailApi = vi.fn().mockResolvedValue(null);
 const mockFindDuplicateTransaction = vi.fn().mockResolvedValue(null);
+const mockGetPendingRetryEmails = vi.fn().mockResolvedValue([]);
+const mockMarkForRetry = vi.fn();
+const mockMarkPermanentlyFailed = vi.fn();
+const mockMarkRetrySuccess = vi.fn();
+const mockUpdateProcessedEmailStatus = vi.fn();
 
 vi.mock("@/features/capture-sources/lib/dedup", () => ({
   findDuplicateTransaction: (...args: unknown[]) => mockFindDuplicateTransaction(...args),
@@ -28,6 +33,11 @@ vi.mock("@/features/capture-sources/lib/dedup", () => ({
 vi.mock("@/features/email-capture/lib/repository", () => ({
   getProcessedExternalIds: (...args: unknown[]) => mockGetProcessedExternalIds(...args),
   insertProcessedEmail: (...args: unknown[]) => mockInsertProcessedEmail(...args),
+  getPendingRetryEmails: (...args: unknown[]) => mockGetPendingRetryEmails(...args),
+  markForRetry: (...args: unknown[]) => mockMarkForRetry(...args),
+  markPermanentlyFailed: (...args: unknown[]) => mockMarkPermanentlyFailed(...args),
+  markRetrySuccess: (...args: unknown[]) => mockMarkRetrySuccess(...args),
+  updateProcessedEmailStatus: (...args: unknown[]) => mockUpdateProcessedEmailStatus(...args),
 }));
 
 vi.mock("@/features/transactions/lib/repository", () => ({
@@ -88,6 +98,11 @@ describe("pipeline worker save error path", () => {
     mockInsertMerchantRule.mockResolvedValue(undefined);
     mockParseEmailApi.mockResolvedValue(null);
     mockFindDuplicateTransaction.mockResolvedValue(null);
+    mockGetPendingRetryEmails.mockResolvedValue([]);
+    mockMarkForRetry.mockResolvedValue(undefined);
+    mockMarkPermanentlyFailed.mockResolvedValue(undefined);
+    mockMarkRetrySuccess.mockResolvedValue(undefined);
+    mockUpdateProcessedEmailStatus.mockResolvedValue(undefined);
   });
 
   it("calls captureError and continues processing when saveTransaction throws", async () => {

--- a/apps/mobile/__tests__/sync/syncEngine.test.ts
+++ b/apps/mobile/__tests__/sync/syncEngine.test.ts
@@ -8,6 +8,7 @@ const mockGetTransactionById = vi.fn().mockReturnValue(null);
 const mockGetSyncMeta = vi.fn().mockReturnValue(null);
 const mockSetSyncMeta = vi.fn();
 const mockUpsertTransaction = vi.fn();
+const mockInsertTransaction = vi.fn();
 
 const mockInsertConflict = vi.fn();
 vi.mock("@/features/sync/lib/conflict-repository", () => ({
@@ -20,6 +21,7 @@ vi.mock("@/features/transactions/lib/repository", () => ({
   getTransactionById: (...args: any[]) => mockGetTransactionById(...args),
   getSyncMeta: (...args: any[]) => mockGetSyncMeta(...args),
   setSyncMeta: (...args: any[]) => mockSetSyncMeta(...args),
+  insertTransaction: (...args: any[]) => mockInsertTransaction(...args),
   upsertTransaction: (...args: any[]) => mockUpsertTransaction(...args),
 }));
 

--- a/apps/mobile/features/email-capture/services/create-email-pipeline-service.ts
+++ b/apps/mobile/features/email-capture/services/create-email-pipeline-service.ts
@@ -1,0 +1,687 @@
+import { Effect } from "effect";
+import type { ProcessedEmailRow } from "@/features/email-capture/lib/repository";
+import { getBuiltInCategoryId, isValidCategoryId } from "@/features/transactions/lib/categories";
+import type { TransactionRow } from "@/features/transactions/lib/repository";
+import type { AnyDb, SyncQueueEntry } from "@/shared/db";
+import { fromPromise, fromThunk, makeAppTag, runWithService } from "@/shared/effect/runtime";
+import { toIsoDateTime } from "@/shared/lib/format-date";
+import {
+  generateProcessedEmailId,
+  generateSyncQueueId,
+  generateTransactionId,
+} from "@/shared/lib/generate-id";
+import { normalizeMerchant } from "@/shared/lib/normalize-merchant";
+import { assertCopAmount, assertIsoDate, assertIsoDateTime } from "@/shared/types/assertions";
+import type {
+  CategoryId,
+  IsoDateTime,
+  ProcessedEmailId,
+  TransactionId,
+  UserId,
+} from "@/shared/types/branded";
+import { computeNextRetryAt, isMaxRetriesReached } from "../lib/retry-backoff";
+import type { RawEmail } from "../schema";
+import type { LlmParsedTransaction } from "./llm-parser";
+
+export type PipelineResult = {
+  filtered: number;
+  skippedDuplicate: number;
+  skippedCrossSource: number;
+  saved: number;
+  failed: number;
+  needsReview: number;
+};
+
+export type ProgressCallback = (progress: {
+  total: number;
+  completed: number;
+  saved: number;
+  failed: number;
+  needsReview: number;
+}) => void;
+
+export type RetryResult = {
+  retried: number;
+  succeeded: number;
+  permanentlyFailed: number;
+};
+
+type CaptureWarning = (
+  name: "email_parse_exception" | "email_retry_parse_exception",
+  tags: {
+    provider: RawEmail["provider"] | ProcessedEmailRow["provider"];
+    errorType: string;
+  }
+) => void | Promise<void>;
+
+type CapturePipelineEvent = (input: {
+  source: "email";
+  batchSize: number;
+  uniqueProviders: number;
+  dedupedInBatch: number;
+  skippedAlreadyProcessed: number;
+  skippedCrossSource: number;
+  saved: number;
+  failed: number;
+  needsReview: number;
+}) => void | Promise<void>;
+
+type CreateEmailPipelineServiceDeps = {
+  readonly parseEmailApi: (body: string) => Promise<LlmParsedTransaction | null>;
+  readonly lookupMerchantRule: (
+    db: AnyDb,
+    userId: UserId,
+    merchantKey: string
+  ) => Promise<CategoryId | null>;
+  readonly findDuplicateTransaction: (
+    db: AnyDb,
+    userId: UserId,
+    amount: LlmParsedTransaction["amount"],
+    date: LlmParsedTransaction["date"],
+    description: string
+  ) => Promise<TransactionId | null>;
+  readonly getProcessedExternalIds: (db: AnyDb, externalIds: string[]) => Promise<Set<string>>;
+  readonly getPendingRetryEmails: (db: AnyDb) => Promise<readonly ProcessedEmailRow[]>;
+  readonly insertProcessedEmail: (db: AnyDb, row: ProcessedEmailRow) => Promise<void>;
+  readonly markForRetry: (
+    db: AnyDb,
+    id: ProcessedEmailId,
+    retryCount: number,
+    nextRetryAt: IsoDateTime
+  ) => Promise<void>;
+  readonly markPermanentlyFailed: (db: AnyDb, id: ProcessedEmailId) => Promise<void>;
+  readonly markRetrySuccess: (
+    db: AnyDb,
+    id: ProcessedEmailId,
+    status: "success" | "needs_review",
+    transactionId: TransactionId,
+    confidence: number
+  ) => Promise<void>;
+  readonly updateProcessedEmailStatus: (
+    db: AnyDb,
+    id: ProcessedEmailId,
+    status: string,
+    transactionId: TransactionId | null
+  ) => Promise<void>;
+  readonly insertTransaction: (db: AnyDb, row: TransactionRow) => void | Promise<void>;
+  readonly enqueueSync: (db: AnyDb, input: SyncQueueEntry) => void | Promise<void>;
+  readonly insertMerchantRule: (
+    db: AnyDb,
+    userId: UserId,
+    merchantKey: string,
+    categoryId: CategoryId,
+    createdAt: IsoDateTime
+  ) => Promise<void>;
+  readonly trackTransactionCreated: (input: {
+    type: LlmParsedTransaction["type"];
+    category: string;
+    source: "email";
+  }) => void | Promise<void>;
+  readonly captureError: (error: unknown) => void | Promise<void>;
+  readonly captureWarning: CaptureWarning;
+  readonly capturePipelineEvent: CapturePipelineEvent;
+};
+
+export type EmailPipelineService = {
+  readonly processEmails: (
+    db: AnyDb,
+    userId: UserId,
+    rawEmails: RawEmail[],
+    onProgress?: ProgressCallback
+  ) => Promise<PipelineResult>;
+  readonly processRetries: (db: AnyDb, userId: UserId) => Promise<RetryResult>;
+};
+
+const EmailPipelineDeps = makeAppTag<CreateEmailPipelineServiceDeps>(
+  "@/features/email-capture/EmailPipelineDeps"
+);
+
+function getTransactionSource(provider: RawEmail["provider"] | ProcessedEmailRow["provider"]) {
+  return provider === "gmail" ? "email_gmail" : "email_outlook";
+}
+
+function getPersistedCategoryId(categoryId: string): CategoryId {
+  return isValidCategoryId(categoryId) ? categoryId : getBuiltInCategoryId("other");
+}
+
+function getProgressSnapshot(
+  total: number,
+  completed: number,
+  result: PipelineResult
+): Parameters<ProgressCallback>[0] {
+  return {
+    total,
+    completed,
+    saved: result.saved,
+    failed: result.failed,
+    needsReview: result.needsReview,
+  };
+}
+
+function parseBodyEffect(db: AnyDb, userId: UserId, body: string) {
+  return Effect.gen(function* () {
+    const { parseEmailApi, lookupMerchantRule } = yield* EmailPipelineDeps;
+    const llmResult = yield* fromPromise(() => parseEmailApi(body));
+    if (!llmResult) return null;
+
+    const merchantKey = normalizeMerchant(llmResult.description);
+    const cachedCategoryId = yield* fromPromise(() => lookupMerchantRule(db, userId, merchantKey));
+
+    return cachedCategoryId
+      ? { ...llmResult, categoryId: cachedCategoryId, confidence: 1.0 }
+      : llmResult;
+  });
+}
+
+function getProcessedExternalIdsEffect(db: AnyDb, externalIds: string[]) {
+  return Effect.flatMap(EmailPipelineDeps, ({ getProcessedExternalIds }) =>
+    fromPromise(() => getProcessedExternalIds(db, externalIds))
+  );
+}
+
+function getPendingRetryEmailsEffect(db: AnyDb) {
+  return Effect.flatMap(EmailPipelineDeps, ({ getPendingRetryEmails }) =>
+    fromPromise(() => getPendingRetryEmails(db))
+  );
+}
+
+function findDuplicateTransactionEffect(db: AnyDb, userId: UserId, parsed: LlmParsedTransaction) {
+  return Effect.flatMap(EmailPipelineDeps, ({ findDuplicateTransaction }) =>
+    fromPromise(() =>
+      findDuplicateTransaction(db, userId, parsed.amount, parsed.date, parsed.description)
+    )
+  );
+}
+
+function insertProcessedEmailEffect(db: AnyDb, row: ProcessedEmailRow) {
+  return Effect.flatMap(EmailPipelineDeps, ({ insertProcessedEmail }) =>
+    fromPromise(() => insertProcessedEmail(db, row))
+  );
+}
+
+function saveTransactionEffect(
+  db: AnyDb,
+  userId: UserId,
+  validated: LlmParsedTransaction,
+  email: RawEmail,
+  status: "success" | "needs_review"
+) {
+  return Effect.gen(function* () {
+    const { insertTransaction, enqueueSync, insertProcessedEmail, trackTransactionCreated } =
+      yield* EmailPipelineDeps;
+    const source = getTransactionSource(email.provider);
+    const txId = generateTransactionId();
+    const now = toIsoDateTime(new Date());
+    const amount = validated.amount;
+    const date = validated.date;
+    const receivedAt = email.receivedAt;
+    const categoryId = getPersistedCategoryId(validated.categoryId);
+
+    assertCopAmount(amount);
+    assertIsoDate(date);
+    assertIsoDateTime(receivedAt);
+
+    yield* fromThunk(() =>
+      insertTransaction(db, {
+        id: txId,
+        userId,
+        type: validated.type,
+        amount,
+        categoryId,
+        description: validated.description,
+        date,
+        source,
+        createdAt: now,
+        updatedAt: now,
+      })
+    );
+
+    yield* fromThunk(() =>
+      enqueueSync(db, {
+        id: generateSyncQueueId(),
+        tableName: "transactions",
+        rowId: txId,
+        operation: "insert",
+        createdAt: now,
+      })
+    );
+
+    yield* fromPromise(() =>
+      insertProcessedEmail(db, {
+        id: generateProcessedEmailId(),
+        externalId: email.externalId,
+        provider: email.provider,
+        status,
+        failureReason: null,
+        subject: email.subject,
+        rawBodyPreview: email.body.slice(0, 500),
+        receivedAt,
+        transactionId: txId,
+        confidence: validated.confidence,
+        createdAt: now,
+      })
+    );
+
+    if (status === "success") {
+      yield* fromThunk(() =>
+        trackTransactionCreated({
+          type: validated.type,
+          category: String(categoryId),
+          source: "email",
+        })
+      );
+    }
+
+    return txId;
+  });
+}
+
+function insertMerchantRuleEffect(
+  db: AnyDb,
+  userId: UserId,
+  merchantKey: string,
+  categoryId: CategoryId,
+  createdAt: IsoDateTime
+) {
+  return Effect.flatMap(EmailPipelineDeps, ({ insertMerchantRule }) =>
+    fromPromise(() => insertMerchantRule(db, userId, merchantKey, categoryId, createdAt))
+  );
+}
+
+function captureErrorEffect(error: unknown) {
+  return Effect.flatMap(EmailPipelineDeps, ({ captureError }) =>
+    fromThunk(() => captureError(error))
+  );
+}
+
+function captureWarningEffect(
+  name: "email_parse_exception" | "email_retry_parse_exception",
+  tags: {
+    provider: RawEmail["provider"] | ProcessedEmailRow["provider"];
+    errorType: string;
+  }
+) {
+  return Effect.flatMap(EmailPipelineDeps, ({ captureWarning }) =>
+    fromThunk(() => captureWarning(name, tags))
+  );
+}
+
+function capturePipelineEventEffect(input: Parameters<CapturePipelineEvent>[0]) {
+  return Effect.flatMap(EmailPipelineDeps, ({ capturePipelineEvent }) =>
+    fromThunk(() => capturePipelineEvent(input))
+  );
+}
+
+function markForRetryEffect(
+  db: AnyDb,
+  id: ProcessedEmailId,
+  retryCount: number,
+  nextRetryAt: IsoDateTime
+) {
+  return Effect.flatMap(EmailPipelineDeps, ({ markForRetry }) =>
+    fromPromise(() => markForRetry(db, id, retryCount, nextRetryAt))
+  );
+}
+
+function markPermanentlyFailedEffect(db: AnyDb, id: ProcessedEmailId) {
+  return Effect.flatMap(EmailPipelineDeps, ({ markPermanentlyFailed }) =>
+    fromPromise(() => markPermanentlyFailed(db, id))
+  );
+}
+
+function markRetrySuccessEffect(
+  db: AnyDb,
+  id: ProcessedEmailId,
+  status: "success" | "needs_review",
+  transactionId: TransactionId,
+  confidence: number
+) {
+  return Effect.flatMap(EmailPipelineDeps, ({ markRetrySuccess }) =>
+    fromPromise(() => markRetrySuccess(db, id, status, transactionId, confidence))
+  );
+}
+
+function updateProcessedEmailStatusEffect(
+  db: AnyDb,
+  id: ProcessedEmailId,
+  status: string,
+  transactionId: TransactionId | null
+) {
+  return Effect.flatMap(EmailPipelineDeps, ({ updateProcessedEmailStatus }) =>
+    fromPromise(() => updateProcessedEmailStatus(db, id, status, transactionId))
+  );
+}
+
+function saveRetryTransactionEffect(
+  db: AnyDb,
+  userId: UserId,
+  parsed: LlmParsedTransaction,
+  email: ProcessedEmailRow
+) {
+  return Effect.gen(function* () {
+    const { insertTransaction, enqueueSync, insertMerchantRule, trackTransactionCreated } =
+      yield* EmailPipelineDeps;
+    const txId = generateTransactionId();
+    const now = toIsoDateTime(new Date());
+    const source = getTransactionSource(email.provider);
+    const amount = parsed.amount;
+    const date = parsed.date;
+    const status: "success" | "needs_review" = parsed.confidence < 0.7 ? "needs_review" : "success";
+    const categoryId = getPersistedCategoryId(parsed.categoryId);
+
+    assertCopAmount(amount);
+    assertIsoDate(date);
+
+    yield* fromThunk(() =>
+      insertTransaction(db, {
+        id: txId,
+        userId,
+        type: parsed.type,
+        amount,
+        categoryId,
+        description: parsed.description,
+        date,
+        source,
+        createdAt: now,
+        updatedAt: now,
+      })
+    );
+
+    yield* fromThunk(() =>
+      enqueueSync(db, {
+        id: generateSyncQueueId(),
+        tableName: "transactions",
+        rowId: txId,
+        operation: "insert",
+        createdAt: now,
+      })
+    );
+
+    if (status === "success") {
+      const merchantKey = normalizeMerchant(parsed.description);
+      yield* fromPromise(() => insertMerchantRule(db, userId, merchantKey, categoryId, now));
+      yield* fromThunk(() =>
+        trackTransactionCreated({
+          type: parsed.type,
+          category: String(categoryId),
+          source: "email",
+        })
+      );
+    }
+
+    return { txId, status };
+  });
+}
+
+export function createEmailPipelineService(
+  deps: CreateEmailPipelineServiceDeps
+): EmailPipelineService {
+  const runEmailPipelineEffect = <A>(
+    effect: Effect.Effect<A, unknown, CreateEmailPipelineServiceDeps>
+  ): Promise<A> => runWithService(effect, EmailPipelineDeps, deps);
+
+  return {
+    async processEmails(db, userId, rawEmails, onProgress) {
+      const uniqueEmails = Array.from(
+        new Map(rawEmails.map((email) => [email.externalId, email])).values()
+      );
+      const dedupedInBatch = rawEmails.length - uniqueEmails.length;
+      const allExternalIds = uniqueEmails.map((email) => email.externalId);
+      const processedIds = await runEmailPipelineEffect(
+        getProcessedExternalIdsEffect(db, allExternalIds)
+      );
+      const toProcess = uniqueEmails.filter((email) => !processedIds.has(email.externalId));
+      const skippedAlreadyProcessed = uniqueEmails.length - toProcess.length;
+
+      const result: PipelineResult = {
+        filtered: 0,
+        skippedDuplicate: dedupedInBatch + skippedAlreadyProcessed,
+        skippedCrossSource: 0,
+        saved: 0,
+        failed: 0,
+        needsReview: 0,
+      };
+
+      const total = toProcess.length;
+      onProgress?.(getProgressSnapshot(total, 0, result));
+
+      // FP exemption: worker pool requires shared mutable state for real-time onProgress across workers.
+      const Concurrency = 5;
+      let completed = 0;
+      let nextIdx = 0;
+
+      async function worker(): Promise<void> {
+        while (nextIdx < toProcess.length) {
+          const email = toProcess[nextIdx++];
+          if (email == null) break;
+
+          let parsed: LlmParsedTransaction | null = null;
+          let parseError = false;
+
+          try {
+            parsed = await runEmailPipelineEffect(parseBodyEffect(db, userId, email.body));
+          } catch (err) {
+            await runEmailPipelineEffect(
+              captureWarningEffect("email_parse_exception", {
+                provider: email.provider,
+                errorType: err instanceof Error ? err.message : "unknown",
+              })
+            );
+            parseError = true;
+          }
+
+          if (!parsed) {
+            const status = parseError ? "pending_retry" : "skipped";
+            const failureReason = parseError ? "parse_error" : null;
+
+            if (parseError) {
+              result.failed++;
+            } else {
+              result.filtered++;
+            }
+
+            assertIsoDateTime(email.receivedAt);
+            await runEmailPipelineEffect(
+              insertProcessedEmailEffect(db, {
+                id: generateProcessedEmailId(),
+                externalId: email.externalId,
+                provider: email.provider,
+                status,
+                failureReason,
+                subject: email.subject,
+                rawBodyPreview: email.body.slice(0, 500),
+                receivedAt: email.receivedAt,
+                transactionId: null,
+                confidence: null,
+                createdAt: toIsoDateTime(new Date()),
+                ...(parseError
+                  ? {
+                      rawBody: email.body,
+                      retryCount: 0,
+                      nextRetryAt: computeNextRetryAt(0),
+                    }
+                  : {}),
+              })
+            );
+            completed++;
+            onProgress?.(getProgressSnapshot(total, completed, result));
+            continue;
+          }
+
+          assertCopAmount(parsed.amount);
+          assertIsoDate(parsed.date);
+          assertIsoDateTime(email.receivedAt);
+
+          const existingTxId = await runEmailPipelineEffect(
+            findDuplicateTransactionEffect(db, userId, parsed)
+          );
+          if (existingTxId) {
+            await runEmailPipelineEffect(
+              insertProcessedEmailEffect(db, {
+                id: generateProcessedEmailId(),
+                externalId: email.externalId,
+                provider: email.provider,
+                status: "skipped_duplicate",
+                failureReason: null,
+                subject: email.subject,
+                rawBodyPreview: email.body.slice(0, 500),
+                receivedAt: email.receivedAt,
+                transactionId: existingTxId,
+                confidence: parsed.confidence,
+                createdAt: toIsoDateTime(new Date()),
+              })
+            );
+            result.skippedCrossSource++;
+            completed++;
+            onProgress?.(getProgressSnapshot(total, completed, result));
+            continue;
+          }
+
+          const status = parsed.confidence < 0.7 ? "needs_review" : "success";
+          try {
+            await runEmailPipelineEffect(saveTransactionEffect(db, userId, parsed, email, status));
+            if (status === "needs_review") {
+              result.needsReview++;
+            } else {
+              result.saved++;
+            }
+          } catch (saveErr) {
+            await runEmailPipelineEffect(captureErrorEffect(saveErr));
+            result.failed++;
+            completed++;
+            onProgress?.(getProgressSnapshot(total, completed, result));
+            continue;
+          }
+
+          if (status === "success") {
+            try {
+              const merchantKey = normalizeMerchant(parsed.description);
+              await runEmailPipelineEffect(
+                insertMerchantRuleEffect(
+                  db,
+                  userId,
+                  merchantKey,
+                  getPersistedCategoryId(parsed.categoryId),
+                  toIsoDateTime(new Date())
+                )
+              );
+            } catch (ruleErr) {
+              await runEmailPipelineEffect(captureErrorEffect(ruleErr));
+            }
+          }
+
+          completed++;
+          onProgress?.(getProgressSnapshot(total, completed, result));
+        }
+      }
+
+      await Promise.all(Array.from({ length: Math.min(Concurrency, total) }, () => worker()));
+
+      await runEmailPipelineEffect(
+        capturePipelineEventEffect({
+          source: "email",
+          batchSize: rawEmails.length,
+          uniqueProviders: new Set(rawEmails.map((email) => email.provider)).size,
+          dedupedInBatch,
+          skippedAlreadyProcessed,
+          skippedCrossSource: result.skippedCrossSource,
+          saved: result.saved,
+          failed: result.failed,
+          needsReview: result.needsReview,
+        })
+      );
+
+      return result;
+    },
+
+    async processRetries(db, userId) {
+      const result: RetryResult = { retried: 0, succeeded: 0, permanentlyFailed: 0 };
+      const pendingEmails = await runEmailPipelineEffect(getPendingRetryEmailsEffect(db));
+
+      for (const email of pendingEmails) {
+        if (!email.rawBody) {
+          await runEmailPipelineEffect(markPermanentlyFailedEffect(db, email.id));
+          result.permanentlyFailed++;
+          continue;
+        }
+
+        let parsed: LlmParsedTransaction | null = null;
+        let parseError = false;
+
+        try {
+          parsed = await runEmailPipelineEffect(parseBodyEffect(db, userId, email.rawBody));
+        } catch (err) {
+          await runEmailPipelineEffect(
+            captureWarningEffect("email_retry_parse_exception", {
+              provider: email.provider,
+              errorType: err instanceof Error ? err.message : "unknown",
+            })
+          );
+          parseError = true;
+        }
+
+        if (parseError) {
+          const nextCount = (email.retryCount ?? 0) + 1;
+          if (isMaxRetriesReached(nextCount)) {
+            await runEmailPipelineEffect(markPermanentlyFailedEffect(db, email.id));
+            result.permanentlyFailed++;
+          } else {
+            await runEmailPipelineEffect(
+              markForRetryEffect(db, email.id, nextCount, computeNextRetryAt(nextCount))
+            );
+            result.retried++;
+          }
+          continue;
+        }
+
+        if (!parsed) {
+          await runEmailPipelineEffect(
+            updateProcessedEmailStatusEffect(db, email.id, "skipped", null)
+          );
+          continue;
+        }
+
+        assertCopAmount(parsed.amount);
+        assertIsoDate(parsed.date);
+
+        const existingTxId = await runEmailPipelineEffect(
+          findDuplicateTransactionEffect(db, userId, parsed)
+        );
+        if (existingTxId) {
+          await runEmailPipelineEffect(
+            markRetrySuccessEffect(db, email.id, "success", existingTxId, parsed.confidence)
+          );
+          result.succeeded++;
+          continue;
+        }
+
+        try {
+          const { txId, status } = await runEmailPipelineEffect(
+            saveRetryTransactionEffect(db, userId, parsed, email)
+          );
+          await runEmailPipelineEffect(
+            markRetrySuccessEffect(db, email.id, status, txId, parsed.confidence)
+          );
+          result.succeeded++;
+        } catch (saveErr) {
+          await runEmailPipelineEffect(captureErrorEffect(saveErr));
+          const nextCount = (email.retryCount ?? 0) + 1;
+          if (isMaxRetriesReached(nextCount)) {
+            await runEmailPipelineEffect(markPermanentlyFailedEffect(db, email.id));
+            result.permanentlyFailed++;
+          } else {
+            await runEmailPipelineEffect(
+              markForRetryEffect(db, email.id, nextCount, computeNextRetryAt(nextCount))
+            );
+            result.retried++;
+          }
+        }
+      }
+
+      return result;
+    },
+  };
+}
+
+export type ProcessEmails = EmailPipelineService["processEmails"];
+export type ProcessRetries = EmailPipelineService["processRetries"];

--- a/apps/mobile/features/email-capture/services/create-email-pipeline-service.ts
+++ b/apps/mobile/features/email-capture/services/create-email-pipeline-service.ts
@@ -508,14 +508,22 @@ export function createEmailPipelineService(
             continue;
           }
 
-          assertCopAmount(parsed.amount);
-          assertIsoDate(parsed.date);
-          assertIsoDateTime(email.receivedAt);
+          let existingTxId: TransactionId | null = null;
+          try {
+            existingTxId = await runEmailPipelineEffect(
+              findDuplicateTransactionEffect(db, userId, parsed)
+            );
+          } catch (saveErr) {
+            await runEmailPipelineEffect(captureErrorEffect(saveErr));
+            result.failed++;
+            completed++;
+            onProgress?.(getProgressSnapshot(total, completed, result));
+            continue;
+          }
 
-          const existingTxId = await runEmailPipelineEffect(
-            findDuplicateTransactionEffect(db, userId, parsed)
-          );
           if (existingTxId) {
+            const receivedAt = email.receivedAt;
+            assertIsoDateTime(receivedAt);
             await runEmailPipelineEffect(
               insertProcessedEmailEffect(db, {
                 id: generateProcessedEmailId(),
@@ -525,7 +533,7 @@ export function createEmailPipelineService(
                 failureReason: null,
                 subject: email.subject,
                 rawBodyPreview: email.body.slice(0, 500),
-                receivedAt: email.receivedAt,
+                receivedAt,
                 transactionId: existingTxId,
                 confidence: parsed.confidence,
                 createdAt: toIsoDateTime(new Date()),
@@ -641,12 +649,26 @@ export function createEmailPipelineService(
           continue;
         }
 
-        assertCopAmount(parsed.amount);
-        assertIsoDate(parsed.date);
+        let existingTxId: TransactionId | null = null;
+        try {
+          existingTxId = await runEmailPipelineEffect(
+            findDuplicateTransactionEffect(db, userId, parsed)
+          );
+        } catch (saveErr) {
+          await runEmailPipelineEffect(captureErrorEffect(saveErr));
+          const nextCount = (email.retryCount ?? 0) + 1;
+          if (isMaxRetriesReached(nextCount)) {
+            await runEmailPipelineEffect(markPermanentlyFailedEffect(db, email.id));
+            result.permanentlyFailed++;
+          } else {
+            await runEmailPipelineEffect(
+              markForRetryEffect(db, email.id, nextCount, computeNextRetryAt(nextCount))
+            );
+            result.retried++;
+          }
+          continue;
+        }
 
-        const existingTxId = await runEmailPipelineEffect(
-          findDuplicateTransactionEffect(db, userId, parsed)
-        );
         if (existingTxId) {
           await runEmailPipelineEffect(
             markRetrySuccessEffect(db, email.id, "success", existingTxId, parsed.confidence)

--- a/apps/mobile/features/email-capture/services/email-pipeline.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline.ts
@@ -1,18 +1,9 @@
 import { findDuplicateTransaction } from "@/features/capture-sources/lib/dedup";
-import { getBuiltInCategoryId, isValidCategoryId } from "@/features/transactions/lib/categories";
 import { insertTransaction } from "@/features/transactions/lib/repository";
 import type { AnyDb } from "@/shared/db";
 import { enqueueSync } from "@/shared/db";
 import { trackTransactionCreated } from "@/shared/lib/analytics";
-import { toIsoDateTime } from "@/shared/lib/format-date";
-import {
-  generateProcessedEmailId,
-  generateSyncQueueId,
-  generateTransactionId,
-} from "@/shared/lib/generate-id";
-import { normalizeMerchant } from "@/shared/lib/normalize-merchant";
 import { captureError, capturePipelineEvent, captureWarning } from "@/shared/lib/sentry";
-import { assertCopAmount, assertIsoDate, assertIsoDateTime } from "@/shared/types/assertions";
 import type { UserId } from "@/shared/types/branded";
 import { insertMerchantRule, lookupMerchantRule } from "../lib/merchant-rules";
 import {
@@ -24,449 +15,45 @@ import {
   markRetrySuccess,
   updateProcessedEmailStatus,
 } from "../lib/repository";
-import { computeNextRetryAt, isMaxRetriesReached } from "../lib/retry-backoff";
 import type { RawEmail } from "../schema";
-import type { LlmParsedTransaction } from "./llm-parser";
+import {
+  createEmailPipelineService,
+  type PipelineResult,
+  type ProcessEmails,
+  type ProcessRetries,
+  type ProgressCallback,
+  type RetryResult,
+} from "./create-email-pipeline-service";
 import { parseEmailApi } from "./parse-email-api";
 
-export type PipelineResult = {
-  filtered: number;
-  skippedDuplicate: number;
-  skippedCrossSource: number;
-  saved: number;
-  failed: number;
-  needsReview: number;
-};
+export type { PipelineResult, ProcessEmails, ProcessRetries, ProgressCallback, RetryResult };
 
-async function parseBody(
-  db: AnyDb,
-  userId: UserId,
-  body: string
-): Promise<LlmParsedTransaction | null> {
-  const llmResult = await parseEmailApi(body);
-  if (!llmResult) return null;
+const emailPipeline = createEmailPipelineService({
+  parseEmailApi,
+  lookupMerchantRule,
+  findDuplicateTransaction,
+  getProcessedExternalIds,
+  getPendingRetryEmails,
+  insertProcessedEmail,
+  markForRetry,
+  markPermanentlyFailed,
+  markRetrySuccess,
+  updateProcessedEmailStatus,
+  insertTransaction,
+  enqueueSync,
+  insertMerchantRule,
+  trackTransactionCreated,
+  captureError,
+  captureWarning,
+  capturePipelineEvent,
+});
 
-  // Check if we have a cached category for this merchant name
-  const merchantKey = normalizeMerchant(llmResult.description);
-  const cachedCategoryId = await lookupMerchantRule(db, userId, merchantKey);
-
-  return cachedCategoryId
-    ? { ...llmResult, categoryId: cachedCategoryId, confidence: 1.0 }
-    : llmResult;
-}
-
-async function saveTransaction(
-  db: AnyDb,
-  userId: UserId,
-  validated: LlmParsedTransaction,
-  email: RawEmail,
-  status: "success" | "needs_review"
-): Promise<string> {
-  const source = email.provider === "gmail" ? "email_gmail" : "email_outlook";
-  const txId = generateTransactionId();
-  const now = toIsoDateTime(new Date());
-  const fallbackCategoryId = getBuiltInCategoryId("other");
-
-  const categoryId = isValidCategoryId(validated.categoryId)
-    ? validated.categoryId
-    : fallbackCategoryId;
-  assertCopAmount(validated.amount);
-  assertIsoDate(validated.date);
-  assertIsoDateTime(email.receivedAt);
-
-  insertTransaction(db, {
-    id: txId,
-    userId,
-    type: validated.type,
-    amount: validated.amount,
-    categoryId,
-    description: validated.description,
-    date: validated.date,
-    source,
-    createdAt: now,
-    updatedAt: now,
-  });
-
-  enqueueSync(db, {
-    id: generateSyncQueueId(),
-    tableName: "transactions",
-    rowId: txId,
-    operation: "insert",
-    createdAt: now,
-  });
-
-  await insertProcessedEmail(db, {
-    id: generateProcessedEmailId(),
-    externalId: email.externalId,
-    provider: email.provider,
-    status,
-    failureReason: null,
-    subject: email.subject,
-    rawBodyPreview: email.body.slice(0, 500),
-    receivedAt: email.receivedAt,
-    transactionId: txId,
-    confidence: validated.confidence,
-    createdAt: now,
-  });
-
-  if (status === "success") {
-    trackTransactionCreated({
-      type: validated.type,
-      category: String(categoryId),
-      source: "email",
-    });
-  }
-
-  return txId;
-}
-
-export type ProgressCallback = (progress: {
-  total: number;
-  completed: number;
-  saved: number;
-  failed: number;
-  needsReview: number;
-}) => void;
-
-export async function processEmails(
+export const processEmails: ProcessEmails = (
   db: AnyDb,
   userId: UserId,
   rawEmails: RawEmail[],
   onProgress?: ProgressCallback
-): Promise<PipelineResult> {
-  // Deduplicate by externalId within the batch (same account connected twice
-  // or same email forwarded across providers produces duplicate entries)
-  const uniqueEmails = Array.from(
-    new Map(rawEmails.map((email) => [email.externalId, email])).values()
-  );
-  const dedupedInBatch = rawEmails.length - uniqueEmails.length;
+) => emailPipeline.processEmails(db, userId, rawEmails, onProgress);
 
-  const allExternalIds = uniqueEmails.map((e) => e.externalId);
-  const processedIds = await getProcessedExternalIds(db, allExternalIds);
-
-  const toProcess = uniqueEmails.filter((email) => !processedIds.has(email.externalId));
-  const skippedAlreadyProcessed = uniqueEmails.length - toProcess.length;
-
-  const result: PipelineResult = {
-    filtered: 0,
-    skippedDuplicate: dedupedInBatch + skippedAlreadyProcessed,
-    skippedCrossSource: 0,
-    saved: 0,
-    failed: 0,
-    needsReview: 0,
-  };
-
-  const total = toProcess.length;
-  onProgress?.({ total, completed: 0, saved: 0, failed: 0, needsReview: 0 });
-
-  // FP exemption: worker pool requires shared mutable state for real-time onProgress across workers.
-  const Concurrency = 5;
-  let completed = 0;
-  let nextIdx = 0;
-
-  async function worker(): Promise<void> {
-    while (nextIdx < toProcess.length) {
-      const email = toProcess[nextIdx++];
-      // noUncheckedIndexedAccess: email is always defined here (guarded by while condition)
-      if (email == null) break;
-
-      let parsed: LlmParsedTransaction | null = null;
-      let parseError = false;
-      try {
-        parsed = await parseBody(db, userId, email.body);
-      } catch (err) {
-        captureWarning("email_parse_exception", {
-          provider: email.provider,
-          errorType: err instanceof Error ? err.message : "unknown",
-        });
-        parseError = true;
-      }
-
-      if (!parsed) {
-        const status = parseError ? "pending_retry" : "skipped";
-        const failureReason = parseError ? "parse_error" : null;
-
-        if (parseError) {
-          result.failed++;
-        } else {
-          result.filtered++;
-        }
-
-        assertIsoDateTime(email.receivedAt);
-        await insertProcessedEmail(db, {
-          id: generateProcessedEmailId(),
-          externalId: email.externalId,
-          provider: email.provider,
-          status,
-          failureReason,
-          subject: email.subject,
-          rawBodyPreview: email.body.slice(0, 500),
-          receivedAt: email.receivedAt,
-          transactionId: null,
-          confidence: null,
-          createdAt: toIsoDateTime(new Date()),
-          ...(parseError
-            ? {
-                rawBody: email.body,
-                retryCount: 0,
-                nextRetryAt: computeNextRetryAt(0),
-              }
-            : {}),
-        });
-        completed++;
-        onProgress?.({
-          total,
-          completed,
-          saved: result.saved,
-          failed: result.failed,
-          needsReview: result.needsReview,
-        });
-        continue;
-      }
-
-      assertCopAmount(parsed.amount);
-      assertIsoDate(parsed.date);
-      assertIsoDateTime(email.receivedAt);
-
-      // Cross-source dedup: skip if this transaction was already captured via notification/Apple Pay
-      const existingTxId = await findDuplicateTransaction(
-        db,
-        userId,
-        parsed.amount,
-        parsed.date,
-        parsed.description
-      );
-      if (existingTxId) {
-        await insertProcessedEmail(db, {
-          id: generateProcessedEmailId(),
-          externalId: email.externalId,
-          provider: email.provider,
-          status: "skipped_duplicate",
-          failureReason: null,
-          subject: email.subject,
-          rawBodyPreview: email.body.slice(0, 500),
-          receivedAt: email.receivedAt,
-          transactionId: existingTxId,
-          confidence: parsed.confidence,
-          createdAt: toIsoDateTime(new Date()),
-        });
-        result.skippedCrossSource++;
-        completed++;
-        onProgress?.({
-          total,
-          completed,
-          saved: result.saved,
-          failed: result.failed,
-          needsReview: result.needsReview,
-        });
-        continue;
-      }
-
-      // parseEmailApi already validates via llmOutputSchema.safeParse
-      if (parsed.confidence < 0.7) {
-        try {
-          await saveTransaction(db, userId, parsed, email, "needs_review");
-          result.needsReview++;
-        } catch (saveErr) {
-          captureError(saveErr);
-          result.failed++;
-        }
-        completed++;
-        onProgress?.({
-          total,
-          completed,
-          saved: result.saved,
-          failed: result.failed,
-          needsReview: result.needsReview,
-        });
-        continue;
-      }
-
-      try {
-        await saveTransaction(db, userId, parsed, email, "success");
-        result.saved++;
-      } catch (saveErr) {
-        captureError(saveErr);
-        result.failed++;
-        completed++;
-        onProgress?.({
-          total,
-          completed,
-          saved: result.saved,
-          failed: result.failed,
-          needsReview: result.needsReview,
-        });
-        continue;
-      }
-
-      try {
-        const merchantKey = normalizeMerchant(parsed.description);
-        const validatedCategoryId = isValidCategoryId(parsed.categoryId)
-          ? parsed.categoryId
-          : getBuiltInCategoryId("other");
-        await insertMerchantRule(
-          db,
-          userId,
-          merchantKey,
-          validatedCategoryId,
-          toIsoDateTime(new Date())
-        );
-      } catch (ruleErr) {
-        captureError(ruleErr);
-      }
-      completed++;
-      onProgress?.({
-        total,
-        completed,
-        saved: result.saved,
-        failed: result.failed,
-        needsReview: result.needsReview,
-      });
-    }
-  }
-
-  await Promise.all(Array.from({ length: Math.min(Concurrency, total) }, () => worker()));
-
-  const uniqueProviders = new Set(rawEmails.map((e) => e.provider)).size;
-  capturePipelineEvent({
-    source: "email",
-    batchSize: rawEmails.length,
-    uniqueProviders,
-    dedupedInBatch,
-    skippedAlreadyProcessed,
-    skippedCrossSource: result.skippedCrossSource,
-    saved: result.saved,
-    failed: result.failed,
-    needsReview: result.needsReview,
-  });
-
-  return result;
-}
-
-export type ProcessEmails = typeof processEmails;
-
-export type RetryResult = {
-  retried: number;
-  succeeded: number;
-  permanentlyFailed: number;
-};
-
-export async function processRetries(db: AnyDb, userId: UserId): Promise<RetryResult> {
-  const result: RetryResult = { retried: 0, succeeded: 0, permanentlyFailed: 0 };
-  const pendingEmails = await getPendingRetryEmails(db);
-
-  for (const email of pendingEmails) {
-    if (!email.rawBody) {
-      await markPermanentlyFailed(db, email.id);
-      result.permanentlyFailed++;
-      continue;
-    }
-
-    let parsed: LlmParsedTransaction | null = null;
-    let parseError = false;
-
-    try {
-      parsed = await parseBody(db, userId, email.rawBody);
-    } catch (err) {
-      captureWarning("email_retry_parse_exception", {
-        provider: email.provider,
-        errorType: err instanceof Error ? err.message : "unknown",
-      });
-      parseError = true;
-    }
-
-    if (parseError) {
-      const nextCount = email.retryCount + 1;
-      if (isMaxRetriesReached(nextCount)) {
-        await markPermanentlyFailed(db, email.id);
-        result.permanentlyFailed++;
-      } else {
-        await markForRetry(db, email.id, nextCount, computeNextRetryAt(nextCount));
-        result.retried++;
-      }
-      continue;
-    }
-
-    if (!parsed) {
-      await updateProcessedEmailStatus(db, email.id, "skipped", null);
-      continue;
-    }
-
-    assertCopAmount(parsed.amount);
-    assertIsoDate(parsed.date);
-
-    // Cross-source dedup: skip if this transaction was already captured via another source
-    const existingTxId = await findDuplicateTransaction(
-      db,
-      userId,
-      parsed.amount,
-      parsed.date,
-      parsed.description
-    );
-    if (existingTxId) {
-      await markRetrySuccess(db, email.id, "success", existingTxId, parsed.confidence);
-      result.succeeded++;
-      continue;
-    }
-
-    // Save retry transaction
-    try {
-      const txId = generateTransactionId();
-      const now = toIsoDateTime(new Date());
-      const source = email.provider === "gmail" ? "email_gmail" : "email_outlook";
-      const status = parsed.confidence < 0.7 ? "needs_review" : "success";
-      const fallbackCategoryId = getBuiltInCategoryId("other");
-      const retryCategoryId = isValidCategoryId(parsed.categoryId)
-        ? parsed.categoryId
-        : fallbackCategoryId;
-
-      insertTransaction(db, {
-        id: txId,
-        userId,
-        type: parsed.type,
-        amount: parsed.amount,
-        categoryId: retryCategoryId,
-        description: parsed.description,
-        date: parsed.date,
-        source,
-        createdAt: now,
-        updatedAt: now,
-      });
-
-      enqueueSync(db, {
-        id: generateSyncQueueId(),
-        tableName: "transactions",
-        rowId: txId,
-        operation: "insert",
-        createdAt: now,
-      });
-
-      if (status === "success") {
-        const merchantKey = normalizeMerchant(parsed.description);
-        await insertMerchantRule(db, userId, merchantKey, retryCategoryId, now);
-        trackTransactionCreated({
-          type: parsed.type,
-          category: String(retryCategoryId),
-          source: "email",
-        });
-      }
-
-      await markRetrySuccess(db, email.id, status, txId, parsed.confidence);
-      result.succeeded++;
-    } catch (saveErr) {
-      captureError(saveErr);
-      const nextCount = email.retryCount + 1;
-      if (isMaxRetriesReached(nextCount)) {
-        await markPermanentlyFailed(db, email.id);
-        result.permanentlyFailed++;
-      } else {
-        await markForRetry(db, email.id, nextCount, computeNextRetryAt(nextCount));
-        result.retried++;
-      }
-    }
-  }
-
-  return result;
-}
-
-export type ProcessRetries = typeof processRetries;
+export const processRetries: ProcessRetries = (db: AnyDb, userId: UserId) =>
+  emailPipeline.processRetries(db, userId);

--- a/apps/mobile/shared/effect/runtime.ts
+++ b/apps/mobile/shared/effect/runtime.ts
@@ -1,9 +1,13 @@
-import { Context, Effect } from "effect";
+import { Cause, Context, Effect, Exit } from "effect";
 
 export type AppEffect<A, E = unknown, R = never> = Effect.Effect<A, E, R>;
 
-export function runAppEffect<A, E>(effect: AppEffect<A, E>): Promise<A> {
-  return Effect.runPromise(effect);
+export async function runAppEffect<A, E>(effect: AppEffect<A, E>): Promise<A> {
+  const exit = await Effect.runPromiseExit(effect);
+  if (Exit.isFailure(exit)) {
+    throw Cause.squash(exit.cause);
+  }
+  return exit.value;
 }
 
 export function makeAppTag<Service>(key: string): Context.Tag<Service, Service> {


### PR DESCRIPTION
- add Effect-backed email pipeline service
- keep public wrapper stable
- squash Effect failures at boundary
- update pipeline and sync test mocks
- pass lint, typecheck, mobile tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the email capture pipeline into an `effect`-backed service with a stable public API. Errors are squashed to the original Error at the boundary, and malformed LLM payloads no longer break batches or retries.

- **Refactors**
  - Introduced `createEmailPipelineService` using `effect` with explicit deps and clear boundaries.
  - Kept `processEmails` and `processRetries` exports stable via a thin wrapper.
  - Moved parsing, dedup, save, retry, and metrics into Effect flows; existing behavior and concurrency preserved.

- **Bug Fixes**
  - Squash `FiberFailure` using `Effect.runPromiseExit` + `Cause.squash`, and guard malformed parsed payloads so batches continue and retries reschedule; added regression tests.

<sup>Written for commit 4128c84377251ffe51abdcdace64ebb9e80935a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

