### PR TITLE
refactor(mobile): effectify ai chat streaming

### DIFF
--- a/apps/mobile/__tests__/ai-chat/streaming-service.test.ts
+++ b/apps/mobile/__tests__/ai-chat/streaming-service.test.ts
@@ -1,0 +1,252 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatAction, ChatMessage } from "@/features/ai-chat/schema";
+import { createStreamingChatService } from "@/features/ai-chat/services/create-streaming-chat-service";
+import { requireCategoryId, requireUserId } from "@/shared/types/assertions";
+import type { ChatSessionId, IsoDateTime } from "@/shared/types/branded";
+
+const USER_ID = requireUserId("user-1");
+const mockDb = {} as never;
+
+function makeAssistantMessage(content: string): ChatMessage {
+  return {
+    id: "message-1" as never,
+    sessionId: "chat-1" as ChatSessionId,
+    role: "assistant",
+    content,
+    action: null,
+    actionStatus: null,
+    createdAt: "2026-04-18T10:15:00.000Z" as IsoDateTime,
+  };
+}
+
+function makeAddAction(): ChatAction {
+  return {
+    type: "add",
+    data: {
+      type: "expense",
+      amount: 50000,
+      categoryId: requireCategoryId("food"),
+      description: "Lunch",
+      date: "2026-04-18" as never,
+    },
+  };
+}
+
+function createState() {
+  let state: {
+    isStreaming: boolean;
+    currentSessionId: ChatSessionId | null;
+    messages: readonly ChatMessage[];
+    streamingContent: string;
+  } = {
+    isStreaming: false,
+    currentSessionId: null,
+    messages: [],
+    streamingContent: "",
+  };
+
+  return {
+    getState: () => state,
+    setStreaming: (isStreaming: boolean) => {
+      state = { ...state, isStreaming };
+    },
+    setStreamingContent: (streamingContent: string) => {
+      state = { ...state, streamingContent };
+    },
+    setCurrentSessionId: (currentSessionId: ChatSessionId | null) => {
+      state = { ...state, currentSessionId };
+    },
+    appendMessage: (message: ChatMessage) => {
+      state = { ...state, messages: [...state.messages, message] };
+    },
+  };
+}
+
+describe("streaming chat service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a session, streams the reply, executes add actions, and resets stream state", async () => {
+    const state = createState();
+    const executeAction = vi.fn().mockResolvedValue(undefined);
+    const createChatSession = vi.fn().mockImplementation(async () => {
+      state.setCurrentSessionId("chat-1" as ChatSessionId);
+      return "chat-1" as ChatSessionId;
+    });
+    const addUserChatMessage = vi.fn().mockImplementation(async () => {
+      state.appendMessage({
+        id: "message-user" as never,
+        sessionId: "chat-1" as ChatSessionId,
+        role: "user",
+        content: "hello",
+        action: null,
+        actionStatus: null,
+        createdAt: "2026-04-18T10:10:00.000Z" as IsoDateTime,
+      });
+    });
+    const addAssistantChatMessage = vi.fn().mockResolvedValue(makeAssistantMessage("hello back"));
+    const trackAiMessageSent = vi.fn();
+    const captureWarning = vi.fn();
+    const captureError = vi.fn();
+
+    const service = createStreamingChatService({
+      getState: state.getState,
+      setStreaming: state.setStreaming,
+      setStreamingContent: state.setStreamingContent,
+      streamChat: async (_messages, callbacks) => {
+        callbacks.onChunk("hello");
+        callbacks.onChunk(" back");
+        callbacks.onDone();
+      },
+      createChatSession,
+      addUserChatMessage,
+      addAssistantChatMessage,
+      parseActionFromResponse: () => makeAddAction(),
+      trackAiMessageSent,
+      captureWarning,
+      captureError,
+    });
+
+    await service.sendMessage({
+      db: mockDb,
+      userId: USER_ID,
+      text: "hello",
+      executeAction,
+    });
+
+    expect(createChatSession).toHaveBeenCalledWith(mockDb, USER_ID, "hello");
+    expect(addUserChatMessage).toHaveBeenCalledWith(mockDb, USER_ID, "hello");
+    expect(trackAiMessageSent).toHaveBeenCalled();
+    expect(addAssistantChatMessage).toHaveBeenCalledWith(
+      mockDb,
+      USER_ID,
+      "hello back",
+      makeAddAction()
+    );
+    expect(executeAction).toHaveBeenCalledWith(makeAddAction());
+    expect(captureWarning).not.toHaveBeenCalled();
+    expect(state.getState()).toMatchObject({
+      isStreaming: false,
+      streamingContent: "",
+    });
+  });
+
+  it("captures action failures without breaking the assistant reply", async () => {
+    const state = createState();
+    state.setCurrentSessionId("chat-1" as ChatSessionId);
+    const executeAction = vi.fn().mockRejectedValue(new Error("action failed"));
+    const captureWarning = vi.fn();
+
+    const service = createStreamingChatService({
+      getState: state.getState,
+      setStreaming: state.setStreaming,
+      setStreamingContent: state.setStreamingContent,
+      streamChat: async (_messages, callbacks) => {
+        callbacks.onChunk("reply");
+        callbacks.onDone();
+      },
+      createChatSession: vi.fn(),
+      addUserChatMessage: vi.fn().mockResolvedValue(undefined),
+      addAssistantChatMessage: vi.fn().mockResolvedValue(makeAssistantMessage("reply")),
+      parseActionFromResponse: () => makeAddAction(),
+      trackAiMessageSent: vi.fn(),
+      captureWarning,
+      captureError: vi.fn(),
+    });
+
+    await service.sendMessage({
+      db: mockDb,
+      userId: USER_ID,
+      text: "hello",
+      executeAction,
+    });
+
+    expect(captureWarning).toHaveBeenCalledWith("ai_action_failed", {
+      actionType: "add",
+      errorType: "action failed",
+    });
+  });
+
+  it("persists an assistant error message when the stream reports an error", async () => {
+    const state = createState();
+    state.setCurrentSessionId("chat-1" as ChatSessionId);
+    const addAssistantChatMessage = vi.fn().mockResolvedValue(makeAssistantMessage("partial"));
+
+    const service = createStreamingChatService({
+      getState: state.getState,
+      setStreaming: state.setStreaming,
+      setStreamingContent: state.setStreamingContent,
+      streamChat: async (_messages, callbacks) => {
+        callbacks.onChunk("partial");
+        callbacks.onError("boom");
+      },
+      createChatSession: vi.fn(),
+      addUserChatMessage: vi.fn().mockResolvedValue(undefined),
+      addAssistantChatMessage,
+      parseActionFromResponse: () => null,
+      trackAiMessageSent: vi.fn(),
+      captureWarning: vi.fn(),
+      captureError: vi.fn(),
+    });
+
+    await service.sendMessage({
+      db: mockDb,
+      userId: USER_ID,
+      text: "hello",
+      executeAction: vi.fn(),
+    });
+
+    expect(addAssistantChatMessage).toHaveBeenCalledWith(mockDb, USER_ID, "partial");
+    expect(state.getState()).toMatchObject({
+      isStreaming: false,
+      streamingContent: "",
+    });
+  });
+
+  it("aborts the active stream and resets state on cancel", async () => {
+    const state = createState();
+    state.setCurrentSessionId("chat-1" as ChatSessionId);
+    let capturedSignal: AbortSignal | undefined;
+    let resolveStarted: (() => void) | null = null;
+    const started = new Promise<void>((resolve) => {
+      resolveStarted = resolve;
+    });
+
+    const service = createStreamingChatService({
+      getState: state.getState,
+      setStreaming: state.setStreaming,
+      setStreamingContent: state.setStreamingContent,
+      streamChat: (_messages, _callbacks, signal) =>
+        new Promise<void>((resolve) => {
+          capturedSignal = signal;
+          resolveStarted?.();
+          signal?.addEventListener("abort", () => resolve());
+        }),
+      createChatSession: vi.fn(),
+      addUserChatMessage: vi.fn().mockResolvedValue(undefined),
+      addAssistantChatMessage: vi.fn().mockResolvedValue(makeAssistantMessage("reply")),
+      parseActionFromResponse: () => null,
+      trackAiMessageSent: vi.fn(),
+      captureWarning: vi.fn(),
+      captureError: vi.fn(),
+    });
+
+    const sendPromise = service.sendMessage({
+      db: mockDb,
+      userId: USER_ID,
+      text: "hello",
+      executeAction: vi.fn(),
+    });
+
+    await started;
+    service.cancel();
+    await sendPromise;
+
+    expect(capturedSignal?.aborted).toBe(true);
+    expect(state.getState()).toMatchObject({
+      isStreaming: false,
+      streamingContent: "",
+    });
+  });
+});

--- a/apps/mobile/__tests__/ai-chat/streaming-service.test.ts
+++ b/apps/mobile/__tests__/ai-chat/streaming-service.test.ts
@@ -249,4 +249,97 @@ describe("streaming chat service", () => {
       streamingContent: "",
     });
   });
+
+  it("does not let a canceled stream clear a newer stream when it settles later", async () => {
+    const state = createState();
+    state.setCurrentSessionId("chat-1" as ChatSessionId);
+    let firstSignal: AbortSignal | undefined;
+    let secondSignal: AbortSignal | undefined;
+    let resolveFirst: (() => void) | null = null;
+    let resolveSecond: (() => void) | null = null;
+    let resolveFirstStarted: (() => void) | null = null;
+    let resolveSecondStarted: (() => void) | null = null;
+    const firstStarted = new Promise<void>((resolve) => {
+      resolveFirstStarted = resolve;
+    });
+    const secondStarted = new Promise<void>((resolve) => {
+      resolveSecondStarted = resolve;
+    });
+    let invocation = 0;
+
+    const service = createStreamingChatService({
+      getState: state.getState,
+      setStreaming: state.setStreaming,
+      setStreamingContent: state.setStreamingContent,
+      streamChat: (_messages, callbacks, signal) => {
+        invocation += 1;
+
+        if (invocation === 1) {
+          return new Promise<void>((resolve) => {
+            firstSignal = signal;
+            resolveFirst = resolve;
+            resolveFirstStarted?.();
+          });
+        }
+
+        return new Promise<void>((resolve) => {
+          secondSignal = signal;
+          callbacks.onChunk("new stream");
+          resolveSecond = resolve;
+          resolveSecondStarted?.();
+          signal?.addEventListener("abort", () => resolve());
+        });
+      },
+      createChatSession: vi.fn(),
+      addUserChatMessage: vi.fn().mockResolvedValue(undefined),
+      addAssistantChatMessage: vi.fn().mockResolvedValue(makeAssistantMessage("reply")),
+      parseActionFromResponse: () => null,
+      trackAiMessageSent: vi.fn(),
+      captureWarning: vi.fn(),
+      captureError: vi.fn(),
+    });
+
+    const firstSend = service.sendMessage({
+      db: mockDb,
+      userId: USER_ID,
+      text: "first",
+      executeAction: vi.fn(),
+    });
+
+    await firstStarted;
+    service.cancel();
+
+    const secondSend = service.sendMessage({
+      db: mockDb,
+      userId: USER_ID,
+      text: "second",
+      executeAction: vi.fn(),
+    });
+
+    await secondStarted;
+    expect(firstSignal?.aborted).toBe(true);
+    expect(state.getState()).toMatchObject({
+      isStreaming: true,
+      streamingContent: "new stream",
+    });
+
+    resolveFirst!();
+    await firstSend;
+
+    expect(secondSignal?.aborted).toBe(false);
+    expect(state.getState()).toMatchObject({
+      isStreaming: true,
+      streamingContent: "new stream",
+    });
+
+    service.cancel();
+    await secondSend;
+    resolveSecond!();
+
+    expect(secondSignal?.aborted).toBe(true);
+    expect(state.getState()).toMatchObject({
+      isStreaming: false,
+      streamingContent: "",
+    });
+  });
 });

--- a/apps/mobile/features/ai-chat/hooks/use-streaming-chat.ts
+++ b/apps/mobile/features/ai-chat/hooks/use-streaming-chat.ts
@@ -3,6 +3,7 @@ import { useOptionalUserId } from "@/features/auth";
 import { saveCurrentTransaction, useTransactionStore } from "@/features/transactions";
 import { tryGetDb } from "@/shared/db";
 import {
+  captureError,
   captureWarning,
   parseIsoDate,
   trackAiMessageSent,
@@ -11,6 +12,7 @@ import {
 import { parseActionFromResponse } from "../lib/parse-action";
 import type { ChatAction } from "../schema";
 import { streamChat } from "../services/ai-chat-api";
+import { createStreamingChatService } from "../services/create-streaming-chat-service";
 import {
   addAssistantChatMessage,
   addUserChatMessage,
@@ -18,17 +20,29 @@ import {
   useChatStore,
 } from "../store";
 
-let activeController: AbortController | null = null;
-
-function resetStreamState(): void {
-  useChatStore.getState().setStreaming(false);
-  useChatStore.getState().setStreamingContent("");
-  activeController = null;
-}
+const streamingChatService = createStreamingChatService({
+  getState: () => {
+    const state = useChatStore.getState();
+    return {
+      isStreaming: state.isStreaming,
+      currentSessionId: state.currentSessionId,
+      messages: state.messages,
+    };
+  },
+  setStreaming: (isStreaming) => useChatStore.getState().setStreaming(isStreaming),
+  setStreamingContent: (content) => useChatStore.getState().setStreamingContent(content),
+  streamChat,
+  createChatSession,
+  addUserChatMessage,
+  addAssistantChatMessage,
+  parseActionFromResponse,
+  trackAiMessageSent,
+  captureWarning,
+  captureError,
+});
 
 export function cancelActiveStream(): void {
-  activeController?.abort();
-  resetStreamState();
+  streamingChatService.cancel();
 }
 
 export function useStreamingChat() {
@@ -77,86 +91,9 @@ export function useStreamingChat() {
 
   const sendMessage = useCallback(
     async (text: string) => {
-      if (isStreaming || !text.trim() || !db || !userId) return;
-
-      const store = useChatStore.getState();
-
-      if (!store.currentSessionId) {
-        await createChatSession(db, userId, text);
-      }
-
-      if (!useChatStore.getState().currentSessionId) {
-        return;
-      }
-
-      await addUserChatMessage(db, userId, text);
-      trackAiMessageSent();
-
-      const allMessages = [
-        ...store.messages.map((m) => ({
-          role: m.role,
-          content: m.content,
-        })),
-        { role: "user" as const, content: text },
-      ];
-
-      store.setStreaming(true);
-      store.setStreamingContent("");
-
-      const controller = new AbortController();
-      activeController = controller;
-
-      let accumulated = "";
-
-      try {
-        await streamChat(
-          allMessages,
-          {
-            onChunk: (chunk) => {
-              accumulated += chunk;
-              useChatStore.getState().setStreamingContent(accumulated);
-            },
-            onDone: () => {
-              void (async () => {
-                const action = parseActionFromResponse(accumulated);
-                await addAssistantChatMessage(db, userId, accumulated, action);
-
-                if (action?.type === "add") {
-                  try {
-                    await executeAction(action);
-                  } catch (actionErr) {
-                    captureWarning("ai_action_failed", {
-                      actionType: action.type,
-                      errorType: actionErr instanceof Error ? actionErr.message : "unknown",
-                    });
-                  }
-                }
-
-                resetStreamState();
-              })();
-            },
-            onError: (error) => {
-              void (async () => {
-                const errorMessage =
-                  accumulated || `I'm sorry, something went wrong. Please try again. (${error})`;
-                await addAssistantChatMessage(db, userId, errorMessage);
-                resetStreamState();
-              })();
-            },
-          },
-          controller.signal
-        );
-      } catch (err) {
-        if (!controller.signal.aborted) {
-          const errorMessage =
-            accumulated ||
-            `I'm sorry, something went wrong. Please try again. (${err instanceof Error ? err.message : "Unknown error"})`;
-          await addAssistantChatMessage(db, userId, errorMessage);
-        }
-        resetStreamState();
-      }
+      await streamingChatService.sendMessage({ db, userId, text, executeAction });
     },
-    [db, executeAction, isStreaming, userId]
+    [db, executeAction, userId]
   );
 
   return { sendMessage, cancelStream: cancelActiveStream, isStreaming, streamingContent };

--- a/apps/mobile/features/ai-chat/services/create-streaming-chat-service.ts
+++ b/apps/mobile/features/ai-chat/services/create-streaming-chat-service.ts
@@ -60,6 +60,8 @@ export type StreamingChatService = {
 };
 
 type StreamingRuntime = {
+  lastRunId: number;
+  currentRunId: number | null;
   activeController: AbortController | null;
 };
 
@@ -74,10 +76,31 @@ const StreamingChatDeps = makeAppTag<CreateStreamingChatServiceDeps>(
   "@/features/ai-chat/StreamingChatDeps"
 );
 
+function beginStreamRun(runtime: StreamingRuntime): number {
+  const runId = runtime.lastRunId + 1;
+  runtime.lastRunId = runId;
+  runtime.currentRunId = runId;
+  return runId;
+}
+
+function isCurrentRun(runtime: StreamingRuntime, runId: number): boolean {
+  return runtime.currentRunId === runId;
+}
+
 function resetStreamState(runtime: StreamingRuntime, deps: CreateStreamingChatServiceDeps): void {
   deps.setStreaming(false);
   deps.setStreamingContent("");
   runtime.activeController = null;
+  runtime.currentRunId = null;
+}
+
+function resetStreamStateIfCurrent(
+  runtime: StreamingRuntime,
+  deps: CreateStreamingChatServiceDeps,
+  runId: number
+): void {
+  if (!isCurrentRun(runtime, runId)) return;
+  resetStreamState(runtime, deps);
 }
 
 function toConversation(
@@ -91,12 +114,14 @@ function toConversation(
 }
 
 async function handleStreamDone(
+  runtime: StreamingRuntime,
   deps: CreateStreamingChatServiceDeps,
+  runId: number,
   input: ReadySendMessageInput,
   controller: AbortController,
   accumulated: string
 ): Promise<void> {
-  if (controller.signal.aborted) return;
+  if (controller.signal.aborted || !isCurrentRun(runtime, runId)) return;
 
   const action = deps.parseActionFromResponse(accumulated);
   await deps.addAssistantChatMessage(input.db, input.userId, accumulated, action);
@@ -114,13 +139,15 @@ async function handleStreamDone(
 }
 
 async function handleStreamError(
+  runtime: StreamingRuntime,
   deps: CreateStreamingChatServiceDeps,
+  runId: number,
   input: ReadySendMessageInput,
   controller: AbortController,
   accumulated: string,
   error: string
 ): Promise<void> {
-  if (controller.signal.aborted) return;
+  if (controller.signal.aborted || !isCurrentRun(runtime, runId)) return;
 
   const errorMessage =
     accumulated || `I'm sorry, something went wrong. Please try again. (${error})`;
@@ -130,6 +157,7 @@ async function handleStreamError(
 async function runStreamLifecycle(
   runtime: StreamingRuntime,
   deps: CreateStreamingChatServiceDeps,
+  runId: number,
   input: ReadySendMessageInput,
   conversation: readonly StreamChatMessage[],
   controller: AbortController
@@ -143,7 +171,7 @@ async function runStreamLifecycle(
     void handler()
       .catch((error) => deps.captureError(error))
       .finally(() => {
-        resetStreamState(runtime, deps);
+        resetStreamStateIfCurrent(runtime, deps, runId);
         resolve();
       });
   };
@@ -154,14 +182,21 @@ async function runStreamLifecycle(
         conversation,
         {
           onChunk: (chunk) => {
+            if (!isCurrentRun(runtime, runId)) return;
             accumulated += chunk;
             deps.setStreamingContent(accumulated);
           },
           onDone: () => {
-            settle(() => handleStreamDone(deps, input, controller, accumulated), resolve);
+            settle(
+              () => handleStreamDone(runtime, deps, runId, input, controller, accumulated),
+              resolve
+            );
           },
           onError: (error) => {
-            settle(() => handleStreamError(deps, input, controller, accumulated, error), resolve);
+            settle(
+              () => handleStreamError(runtime, deps, runId, input, controller, accumulated, error),
+              resolve
+            );
           },
         },
         controller.signal
@@ -170,33 +205,39 @@ async function runStreamLifecycle(
         if (controller.signal.aborted) {
           if (!settled) {
             settled = true;
-            resetStreamState(runtime, deps);
+            resetStreamStateIfCurrent(runtime, deps, runId);
             resolve();
           }
           return;
         }
 
         if (!settled) {
-          settle(() => handleStreamDone(deps, input, controller, accumulated), resolve);
+          settle(
+            () => handleStreamDone(runtime, deps, runId, input, controller, accumulated),
+            resolve
+          );
         }
       })
       .catch((error) => {
         if (controller.signal.aborted) {
           if (!settled) {
             settled = true;
-            resetStreamState(runtime, deps);
+            resetStreamStateIfCurrent(runtime, deps, runId);
             resolve();
           }
           return;
         }
 
         const message = error instanceof Error ? error.message : "Unknown error";
-        settle(() => handleStreamError(deps, input, controller, accumulated, message), resolve);
+        settle(
+          () => handleStreamError(runtime, deps, runId, input, controller, accumulated, message),
+          resolve
+        );
       });
   });
 }
 
-function sendMessageEffect(input: SendMessageInput, runtime: StreamingRuntime) {
+function sendMessageEffect(input: SendMessageInput, runtime: StreamingRuntime, runId: number) {
   return Effect.gen(function* () {
     const trimmed = input.text.trim();
     if (!trimmed || !input.db || !input.userId) return;
@@ -204,10 +245,8 @@ function sendMessageEffect(input: SendMessageInput, runtime: StreamingRuntime) {
     const userId = input.userId;
 
     const deps = yield* StreamingChatDeps;
-    const state = deps.getState();
-    if (state.isStreaming) return;
 
-    if (!state.currentSessionId) {
+    if (!deps.getState().currentSessionId) {
       yield* fromPromise(() => deps.createChatSession(db, userId, trimmed));
     }
 
@@ -229,6 +268,7 @@ function sendMessageEffect(input: SendMessageInput, runtime: StreamingRuntime) {
       runStreamLifecycle(
         runtime,
         deps,
+        runId,
         {
           db,
           userId,
@@ -245,15 +285,26 @@ function sendMessageEffect(input: SendMessageInput, runtime: StreamingRuntime) {
 export function createStreamingChatService(
   deps: CreateStreamingChatServiceDeps
 ): StreamingChatService {
-  const runtime: StreamingRuntime = { activeController: null };
+  const runtime: StreamingRuntime = {
+    lastRunId: 0,
+    currentRunId: null,
+    activeController: null,
+  };
 
   return {
-    sendMessage: (input) =>
-      runWithService(sendMessageEffect(input, runtime), StreamingChatDeps, deps).catch((error) =>
-        Promise.resolve(deps.captureError(error)).then(() => {
-          resetStreamState(runtime, deps);
-        })
-      ),
+    sendMessage: async (input) => {
+      const trimmed = input.text.trim();
+      if (!trimmed || !input.db || !input.userId) return;
+      if (deps.getState().isStreaming || runtime.currentRunId !== null) return;
+
+      const runId = beginStreamRun(runtime);
+      try {
+        await runWithService(sendMessageEffect(input, runtime, runId), StreamingChatDeps, deps);
+      } catch (error) {
+        await Promise.resolve(deps.captureError(error));
+        resetStreamStateIfCurrent(runtime, deps, runId);
+      }
+    },
     cancel: () => {
       runtime.activeController?.abort();
       resetStreamState(runtime, deps);

--- a/apps/mobile/features/ai-chat/services/create-streaming-chat-service.ts
+++ b/apps/mobile/features/ai-chat/services/create-streaming-chat-service.ts
@@ -1,0 +1,262 @@
+import { Effect } from "effect";
+import type { AnyDb } from "@/shared/db";
+import { fromPromise, fromThunk, makeAppTag, runWithService } from "@/shared/effect/runtime";
+import type { ChatSessionId, UserId } from "@/shared/types/branded";
+import type { ChatAction, ChatMessage } from "../schema";
+
+type StreamChatMessage = Pick<ChatMessage, "role" | "content">;
+
+type StreamCallbacks = {
+  readonly onChunk: (text: string) => void;
+  readonly onDone: () => void;
+  readonly onError: (error: string) => void;
+};
+
+type StreamingChatState = {
+  readonly isStreaming: boolean;
+  readonly currentSessionId: ChatSessionId | null;
+  readonly messages: readonly ChatMessage[];
+};
+
+type SendMessageInput = {
+  readonly db: AnyDb | null;
+  readonly userId: UserId | null;
+  readonly text: string;
+  readonly executeAction: (action: ChatAction) => Promise<void>;
+};
+
+type CreateStreamingChatServiceDeps = {
+  readonly getState: () => StreamingChatState;
+  readonly setStreaming: (isStreaming: boolean) => void;
+  readonly setStreamingContent: (content: string) => void;
+  readonly streamChat: (
+    messages: readonly StreamChatMessage[],
+    callbacks: StreamCallbacks,
+    signal?: AbortSignal
+  ) => Promise<void>;
+  readonly createChatSession: (db: AnyDb, userId: UserId, firstMessage: string) => Promise<unknown>;
+  readonly addUserChatMessage: (db: AnyDb, userId: UserId, content: string) => Promise<unknown>;
+  readonly addAssistantChatMessage: (
+    db: AnyDb,
+    userId: UserId,
+    content: string,
+    action?: ChatAction | null
+  ) => Promise<unknown>;
+  readonly parseActionFromResponse: (content: string) => ChatAction | null;
+  readonly trackAiMessageSent: () => void | Promise<void>;
+  readonly captureWarning: (
+    name: "ai_action_failed",
+    tags: {
+      actionType: ChatAction["type"];
+      errorType: string;
+    }
+  ) => void | Promise<void>;
+  readonly captureError: (error: unknown) => void | Promise<void>;
+};
+
+export type StreamingChatService = {
+  readonly sendMessage: (input: SendMessageInput) => Promise<void>;
+  readonly cancel: () => void;
+};
+
+type StreamingRuntime = {
+  activeController: AbortController | null;
+};
+
+type ReadySendMessageInput = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly text: string;
+  readonly executeAction: (action: ChatAction) => Promise<void>;
+};
+
+const StreamingChatDeps = makeAppTag<CreateStreamingChatServiceDeps>(
+  "@/features/ai-chat/StreamingChatDeps"
+);
+
+function resetStreamState(runtime: StreamingRuntime, deps: CreateStreamingChatServiceDeps): void {
+  deps.setStreaming(false);
+  deps.setStreamingContent("");
+  runtime.activeController = null;
+}
+
+function toConversation(
+  messages: readonly ChatMessage[],
+  text: string
+): readonly StreamChatMessage[] {
+  return [
+    ...messages.map((message) => ({ role: message.role, content: message.content })),
+    { role: "user" as const, content: text },
+  ];
+}
+
+async function handleStreamDone(
+  deps: CreateStreamingChatServiceDeps,
+  input: ReadySendMessageInput,
+  controller: AbortController,
+  accumulated: string
+): Promise<void> {
+  if (controller.signal.aborted) return;
+
+  const action = deps.parseActionFromResponse(accumulated);
+  await deps.addAssistantChatMessage(input.db, input.userId, accumulated, action);
+
+  if (action?.type === "add") {
+    try {
+      await input.executeAction(action);
+    } catch (actionErr) {
+      await deps.captureWarning("ai_action_failed", {
+        actionType: action.type,
+        errorType: actionErr instanceof Error ? actionErr.message : "unknown",
+      });
+    }
+  }
+}
+
+async function handleStreamError(
+  deps: CreateStreamingChatServiceDeps,
+  input: ReadySendMessageInput,
+  controller: AbortController,
+  accumulated: string,
+  error: string
+): Promise<void> {
+  if (controller.signal.aborted) return;
+
+  const errorMessage =
+    accumulated || `I'm sorry, something went wrong. Please try again. (${error})`;
+  await deps.addAssistantChatMessage(input.db, input.userId, errorMessage);
+}
+
+async function runStreamLifecycle(
+  runtime: StreamingRuntime,
+  deps: CreateStreamingChatServiceDeps,
+  input: ReadySendMessageInput,
+  conversation: readonly StreamChatMessage[],
+  controller: AbortController
+): Promise<void> {
+  let accumulated = "";
+  let settled = false;
+
+  const settle = (handler: () => Promise<void>, resolve: () => void): void => {
+    if (settled) return;
+    settled = true;
+    void handler()
+      .catch((error) => deps.captureError(error))
+      .finally(() => {
+        resetStreamState(runtime, deps);
+        resolve();
+      });
+  };
+
+  await new Promise<void>((resolve) => {
+    void deps
+      .streamChat(
+        conversation,
+        {
+          onChunk: (chunk) => {
+            accumulated += chunk;
+            deps.setStreamingContent(accumulated);
+          },
+          onDone: () => {
+            settle(() => handleStreamDone(deps, input, controller, accumulated), resolve);
+          },
+          onError: (error) => {
+            settle(() => handleStreamError(deps, input, controller, accumulated, error), resolve);
+          },
+        },
+        controller.signal
+      )
+      .then(() => {
+        if (controller.signal.aborted) {
+          if (!settled) {
+            settled = true;
+            resetStreamState(runtime, deps);
+            resolve();
+          }
+          return;
+        }
+
+        if (!settled) {
+          settle(() => handleStreamDone(deps, input, controller, accumulated), resolve);
+        }
+      })
+      .catch((error) => {
+        if (controller.signal.aborted) {
+          if (!settled) {
+            settled = true;
+            resetStreamState(runtime, deps);
+            resolve();
+          }
+          return;
+        }
+
+        const message = error instanceof Error ? error.message : "Unknown error";
+        settle(() => handleStreamError(deps, input, controller, accumulated, message), resolve);
+      });
+  });
+}
+
+function sendMessageEffect(input: SendMessageInput, runtime: StreamingRuntime) {
+  return Effect.gen(function* () {
+    const trimmed = input.text.trim();
+    if (!trimmed || !input.db || !input.userId) return;
+    const db = input.db;
+    const userId = input.userId;
+
+    const deps = yield* StreamingChatDeps;
+    const state = deps.getState();
+    if (state.isStreaming) return;
+
+    if (!state.currentSessionId) {
+      yield* fromPromise(() => deps.createChatSession(db, userId, trimmed));
+    }
+
+    if (!deps.getState().currentSessionId) return;
+
+    const conversation = toConversation(deps.getState().messages, trimmed);
+
+    yield* fromPromise(() => deps.addUserChatMessage(db, userId, trimmed));
+    yield* fromThunk(() => deps.trackAiMessageSent());
+    yield* fromThunk(() => {
+      deps.setStreaming(true);
+      deps.setStreamingContent("");
+    });
+
+    const controller = new AbortController();
+    runtime.activeController = controller;
+
+    yield* fromPromise(() =>
+      runStreamLifecycle(
+        runtime,
+        deps,
+        {
+          db,
+          userId,
+          text: trimmed,
+          executeAction: input.executeAction,
+        },
+        conversation,
+        controller
+      )
+    );
+  });
+}
+
+export function createStreamingChatService(
+  deps: CreateStreamingChatServiceDeps
+): StreamingChatService {
+  const runtime: StreamingRuntime = { activeController: null };
+
+  return {
+    sendMessage: (input) =>
+      runWithService(sendMessageEffect(input, runtime), StreamingChatDeps, deps).catch((error) =>
+        Promise.resolve(deps.captureError(error)).then(() => {
+          resetStreamState(runtime, deps);
+        })
+      ),
+    cancel: () => {
+      runtime.activeController?.abort();
+      resetStreamState(runtime, deps);
+    },
+  };
+}


### PR DESCRIPTION
- add deep streaming chat service
- keep hook api stable
- cover stream lifecycle and cancel
- pass lint typecheck tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces an effect-based streaming chat service and refactors the mobile chat hook to use it, keeping the hook API unchanged. Improves lifecycle handling, cancel, scoped stream resets, and error reporting, with full tests.

- **New Features**
  - Added `create-streaming-chat-service` that runs streaming with Effect, manages state, action execution, and cancel via `AbortController`.
  - Persists partial assistant replies on errors; logs action failures with `captureWarning`; centralizes error capture with `captureError`.
  - Tests in `__tests__/ai-chat/streaming-service.test.ts` cover happy path, action failure, stream error, and cancel.

- **Bug Fixes**
  - Scoped stream resets to the active run so canceled/older streams can’t clear a newer stream’s state; verified by a new test.

<sup>Written for commit 4e658111fce0301bdd7f53d31928d3546e7404c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

