### PR TITLE
refactor(mobile): consolidate effect binding

### DIFF
--- a/apps/mobile/__tests__/shared/effect/runtime.test.ts
+++ b/apps/mobile/__tests__/shared/effect/runtime.test.ts
@@ -1,0 +1,32 @@
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import { fromSync, makeAppService } from "@/shared/effect/runtime";
+
+describe("shared/effect/runtime", () => {
+  it("runs tagged effects with a bound service", async () => {
+    const Numbers = makeAppService<{ readonly getValue: () => number }>("test/Numbers");
+    const runtime = Numbers.bind({
+      getValue: () => 42,
+    });
+
+    const value = await runtime.run(
+      Effect.flatMap(Numbers.tag, ({ getValue }) => Effect.succeed(getValue()))
+    );
+
+    expect(value).toBe(42);
+  });
+
+  it("preserves the original error when a bound effect fails", async () => {
+    const expected = new Error("boom");
+    const Failing = makeAppService<{ readonly explode: () => never }>("test/Failing");
+    const runtime = Failing.bind({
+      explode: () => {
+        throw expected;
+      },
+    });
+
+    await expect(
+      runtime.run(Effect.flatMap(Failing.tag, ({ explode }) => fromSync(explode)))
+    ).rejects.toBe(expected);
+  });
+});

--- a/apps/mobile/features/ai-chat/services/create-streaming-chat-service.ts
+++ b/apps/mobile/features/ai-chat/services/create-streaming-chat-service.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect";
 import type { AnyDb } from "@/shared/db";
-import { fromPromise, fromThunk, makeAppTag, runWithService } from "@/shared/effect/runtime";
+import { fromPromise, fromThunk, makeAppService } from "@/shared/effect/runtime";
 import type { ChatSessionId, UserId } from "@/shared/types/branded";
 import type { ChatAction, ChatMessage } from "../schema";
 
@@ -72,7 +72,7 @@ type ReadySendMessageInput = {
   readonly executeAction: (action: ChatAction) => Promise<void>;
 };
 
-const StreamingChatDeps = makeAppTag<CreateStreamingChatServiceDeps>(
+const StreamingChatDeps = makeAppService<CreateStreamingChatServiceDeps>(
   "@/features/ai-chat/StreamingChatDeps"
 );
 
@@ -244,7 +244,7 @@ function sendMessageEffect(input: SendMessageInput, runtime: StreamingRuntime, r
     const db = input.db;
     const userId = input.userId;
 
-    const deps = yield* StreamingChatDeps;
+    const deps = yield* StreamingChatDeps.tag;
 
     if (!deps.getState().currentSessionId) {
       yield* fromPromise(() => deps.createChatSession(db, userId, trimmed));
@@ -285,6 +285,7 @@ function sendMessageEffect(input: SendMessageInput, runtime: StreamingRuntime, r
 export function createStreamingChatService(
   deps: CreateStreamingChatServiceDeps
 ): StreamingChatService {
+  const runtimeService = StreamingChatDeps.bind(deps);
   const runtime: StreamingRuntime = {
     lastRunId: 0,
     currentRunId: null,
@@ -299,7 +300,7 @@ export function createStreamingChatService(
 
       const runId = beginStreamRun(runtime);
       try {
-        await runWithService(sendMessageEffect(input, runtime, runId), StreamingChatDeps, deps);
+        await runtimeService.run(sendMessageEffect(input, runtime, runId));
       } catch (error) {
         await Promise.resolve(deps.captureError(error));
         resetStreamStateIfCurrent(runtime, deps, runId);

--- a/apps/mobile/features/email-capture/services/create-email-pipeline-service.ts
+++ b/apps/mobile/features/email-capture/services/create-email-pipeline-service.ts
@@ -3,7 +3,7 @@ import type { ProcessedEmailRow } from "@/features/email-capture/lib/repository"
 import { getBuiltInCategoryId, isValidCategoryId } from "@/features/transactions/lib/categories";
 import type { TransactionRow } from "@/features/transactions/lib/repository";
 import type { AnyDb, SyncQueueEntry } from "@/shared/db";
-import { fromPromise, fromThunk, makeAppTag, runWithService } from "@/shared/effect/runtime";
+import { fromPromise, fromThunk, makeAppService } from "@/shared/effect/runtime";
 import { toIsoDateTime } from "@/shared/lib/format-date";
 import {
   generateProcessedEmailId,
@@ -132,7 +132,7 @@ export type EmailPipelineService = {
   readonly processRetries: (db: AnyDb, userId: UserId) => Promise<RetryResult>;
 };
 
-const EmailPipelineDeps = makeAppTag<CreateEmailPipelineServiceDeps>(
+const EmailPipelineDeps = makeAppService<CreateEmailPipelineServiceDeps>(
   "@/features/email-capture/EmailPipelineDeps"
 );
 
@@ -160,7 +160,7 @@ function getProgressSnapshot(
 
 function parseBodyEffect(db: AnyDb, userId: UserId, body: string) {
   return Effect.gen(function* () {
-    const { parseEmailApi, lookupMerchantRule } = yield* EmailPipelineDeps;
+    const { parseEmailApi, lookupMerchantRule } = yield* EmailPipelineDeps.tag;
     const llmResult = yield* fromPromise(() => parseEmailApi(body));
     if (!llmResult) return null;
 
@@ -174,19 +174,19 @@ function parseBodyEffect(db: AnyDb, userId: UserId, body: string) {
 }
 
 function getProcessedExternalIdsEffect(db: AnyDb, externalIds: string[]) {
-  return Effect.flatMap(EmailPipelineDeps, ({ getProcessedExternalIds }) =>
+  return Effect.flatMap(EmailPipelineDeps.tag, ({ getProcessedExternalIds }) =>
     fromPromise(() => getProcessedExternalIds(db, externalIds))
   );
 }
 
 function getPendingRetryEmailsEffect(db: AnyDb) {
-  return Effect.flatMap(EmailPipelineDeps, ({ getPendingRetryEmails }) =>
+  return Effect.flatMap(EmailPipelineDeps.tag, ({ getPendingRetryEmails }) =>
     fromPromise(() => getPendingRetryEmails(db))
   );
 }
 
 function findDuplicateTransactionEffect(db: AnyDb, userId: UserId, parsed: LlmParsedTransaction) {
-  return Effect.flatMap(EmailPipelineDeps, ({ findDuplicateTransaction }) =>
+  return Effect.flatMap(EmailPipelineDeps.tag, ({ findDuplicateTransaction }) =>
     fromPromise(() =>
       findDuplicateTransaction(db, userId, parsed.amount, parsed.date, parsed.description)
     )
@@ -194,7 +194,7 @@ function findDuplicateTransactionEffect(db: AnyDb, userId: UserId, parsed: LlmPa
 }
 
 function insertProcessedEmailEffect(db: AnyDb, row: ProcessedEmailRow) {
-  return Effect.flatMap(EmailPipelineDeps, ({ insertProcessedEmail }) =>
+  return Effect.flatMap(EmailPipelineDeps.tag, ({ insertProcessedEmail }) =>
     fromPromise(() => insertProcessedEmail(db, row))
   );
 }
@@ -208,7 +208,7 @@ function saveTransactionEffect(
 ) {
   return Effect.gen(function* () {
     const { insertTransaction, enqueueSync, insertProcessedEmail, trackTransactionCreated } =
-      yield* EmailPipelineDeps;
+      yield* EmailPipelineDeps.tag;
     const source = getTransactionSource(email.provider);
     const txId = generateTransactionId();
     const now = toIsoDateTime(new Date());
@@ -283,13 +283,13 @@ function insertMerchantRuleEffect(
   categoryId: CategoryId,
   createdAt: IsoDateTime
 ) {
-  return Effect.flatMap(EmailPipelineDeps, ({ insertMerchantRule }) =>
+  return Effect.flatMap(EmailPipelineDeps.tag, ({ insertMerchantRule }) =>
     fromPromise(() => insertMerchantRule(db, userId, merchantKey, categoryId, createdAt))
   );
 }
 
 function captureErrorEffect(error: unknown) {
-  return Effect.flatMap(EmailPipelineDeps, ({ captureError }) =>
+  return Effect.flatMap(EmailPipelineDeps.tag, ({ captureError }) =>
     fromThunk(() => captureError(error))
   );
 }
@@ -301,13 +301,13 @@ function captureWarningEffect(
     errorType: string;
   }
 ) {
-  return Effect.flatMap(EmailPipelineDeps, ({ captureWarning }) =>
+  return Effect.flatMap(EmailPipelineDeps.tag, ({ captureWarning }) =>
     fromThunk(() => captureWarning(name, tags))
   );
 }
 
 function capturePipelineEventEffect(input: Parameters<CapturePipelineEvent>[0]) {
-  return Effect.flatMap(EmailPipelineDeps, ({ capturePipelineEvent }) =>
+  return Effect.flatMap(EmailPipelineDeps.tag, ({ capturePipelineEvent }) =>
     fromThunk(() => capturePipelineEvent(input))
   );
 }
@@ -318,13 +318,13 @@ function markForRetryEffect(
   retryCount: number,
   nextRetryAt: IsoDateTime
 ) {
-  return Effect.flatMap(EmailPipelineDeps, ({ markForRetry }) =>
+  return Effect.flatMap(EmailPipelineDeps.tag, ({ markForRetry }) =>
     fromPromise(() => markForRetry(db, id, retryCount, nextRetryAt))
   );
 }
 
 function markPermanentlyFailedEffect(db: AnyDb, id: ProcessedEmailId) {
-  return Effect.flatMap(EmailPipelineDeps, ({ markPermanentlyFailed }) =>
+  return Effect.flatMap(EmailPipelineDeps.tag, ({ markPermanentlyFailed }) =>
     fromPromise(() => markPermanentlyFailed(db, id))
   );
 }
@@ -336,7 +336,7 @@ function markRetrySuccessEffect(
   transactionId: TransactionId,
   confidence: number
 ) {
-  return Effect.flatMap(EmailPipelineDeps, ({ markRetrySuccess }) =>
+  return Effect.flatMap(EmailPipelineDeps.tag, ({ markRetrySuccess }) =>
     fromPromise(() => markRetrySuccess(db, id, status, transactionId, confidence))
   );
 }
@@ -347,7 +347,7 @@ function updateProcessedEmailStatusEffect(
   status: string,
   transactionId: TransactionId | null
 ) {
-  return Effect.flatMap(EmailPipelineDeps, ({ updateProcessedEmailStatus }) =>
+  return Effect.flatMap(EmailPipelineDeps.tag, ({ updateProcessedEmailStatus }) =>
     fromPromise(() => updateProcessedEmailStatus(db, id, status, transactionId))
   );
 }
@@ -360,7 +360,7 @@ function saveRetryTransactionEffect(
 ) {
   return Effect.gen(function* () {
     const { insertTransaction, enqueueSync, insertMerchantRule, trackTransactionCreated } =
-      yield* EmailPipelineDeps;
+      yield* EmailPipelineDeps.tag;
     const txId = generateTransactionId();
     const now = toIsoDateTime(new Date());
     const source = getTransactionSource(email.provider);
@@ -416,9 +416,7 @@ function saveRetryTransactionEffect(
 export function createEmailPipelineService(
   deps: CreateEmailPipelineServiceDeps
 ): EmailPipelineService {
-  const runEmailPipelineEffect = <A>(
-    effect: Effect.Effect<A, unknown, CreateEmailPipelineServiceDeps>
-  ): Promise<A> => runWithService(effect, EmailPipelineDeps, deps);
+  const runtime = EmailPipelineDeps.bind(deps);
 
   return {
     async processEmails(db, userId, rawEmails, onProgress) {
@@ -427,9 +425,7 @@ export function createEmailPipelineService(
       );
       const dedupedInBatch = rawEmails.length - uniqueEmails.length;
       const allExternalIds = uniqueEmails.map((email) => email.externalId);
-      const processedIds = await runEmailPipelineEffect(
-        getProcessedExternalIdsEffect(db, allExternalIds)
-      );
+      const processedIds = await runtime.run(getProcessedExternalIdsEffect(db, allExternalIds));
       const toProcess = uniqueEmails.filter((email) => !processedIds.has(email.externalId));
       const skippedAlreadyProcessed = uniqueEmails.length - toProcess.length;
 
@@ -459,9 +455,9 @@ export function createEmailPipelineService(
           let parseError = false;
 
           try {
-            parsed = await runEmailPipelineEffect(parseBodyEffect(db, userId, email.body));
+            parsed = await runtime.run(parseBodyEffect(db, userId, email.body));
           } catch (err) {
-            await runEmailPipelineEffect(
+            await runtime.run(
               captureWarningEffect("email_parse_exception", {
                 provider: email.provider,
                 errorType: err instanceof Error ? err.message : "unknown",
@@ -481,7 +477,7 @@ export function createEmailPipelineService(
             }
 
             assertIsoDateTime(email.receivedAt);
-            await runEmailPipelineEffect(
+            await runtime.run(
               insertProcessedEmailEffect(db, {
                 id: generateProcessedEmailId(),
                 externalId: email.externalId,
@@ -510,11 +506,9 @@ export function createEmailPipelineService(
 
           let existingTxId: TransactionId | null = null;
           try {
-            existingTxId = await runEmailPipelineEffect(
-              findDuplicateTransactionEffect(db, userId, parsed)
-            );
+            existingTxId = await runtime.run(findDuplicateTransactionEffect(db, userId, parsed));
           } catch (saveErr) {
-            await runEmailPipelineEffect(captureErrorEffect(saveErr));
+            await runtime.run(captureErrorEffect(saveErr));
             result.failed++;
             completed++;
             onProgress?.(getProgressSnapshot(total, completed, result));
@@ -524,7 +518,7 @@ export function createEmailPipelineService(
           if (existingTxId) {
             const receivedAt = email.receivedAt;
             assertIsoDateTime(receivedAt);
-            await runEmailPipelineEffect(
+            await runtime.run(
               insertProcessedEmailEffect(db, {
                 id: generateProcessedEmailId(),
                 externalId: email.externalId,
@@ -547,14 +541,14 @@ export function createEmailPipelineService(
 
           const status = parsed.confidence < 0.7 ? "needs_review" : "success";
           try {
-            await runEmailPipelineEffect(saveTransactionEffect(db, userId, parsed, email, status));
+            await runtime.run(saveTransactionEffect(db, userId, parsed, email, status));
             if (status === "needs_review") {
               result.needsReview++;
             } else {
               result.saved++;
             }
           } catch (saveErr) {
-            await runEmailPipelineEffect(captureErrorEffect(saveErr));
+            await runtime.run(captureErrorEffect(saveErr));
             result.failed++;
             completed++;
             onProgress?.(getProgressSnapshot(total, completed, result));
@@ -564,7 +558,7 @@ export function createEmailPipelineService(
           if (status === "success") {
             try {
               const merchantKey = normalizeMerchant(parsed.description);
-              await runEmailPipelineEffect(
+              await runtime.run(
                 insertMerchantRuleEffect(
                   db,
                   userId,
@@ -574,7 +568,7 @@ export function createEmailPipelineService(
                 )
               );
             } catch (ruleErr) {
-              await runEmailPipelineEffect(captureErrorEffect(ruleErr));
+              await runtime.run(captureErrorEffect(ruleErr));
             }
           }
 
@@ -585,7 +579,7 @@ export function createEmailPipelineService(
 
       await Promise.all(Array.from({ length: Math.min(Concurrency, total) }, () => worker()));
 
-      await runEmailPipelineEffect(
+      await runtime.run(
         capturePipelineEventEffect({
           source: "email",
           batchSize: rawEmails.length,
@@ -604,11 +598,11 @@ export function createEmailPipelineService(
 
     async processRetries(db, userId) {
       const result: RetryResult = { retried: 0, succeeded: 0, permanentlyFailed: 0 };
-      const pendingEmails = await runEmailPipelineEffect(getPendingRetryEmailsEffect(db));
+      const pendingEmails = await runtime.run(getPendingRetryEmailsEffect(db));
 
       for (const email of pendingEmails) {
         if (!email.rawBody) {
-          await runEmailPipelineEffect(markPermanentlyFailedEffect(db, email.id));
+          await runtime.run(markPermanentlyFailedEffect(db, email.id));
           result.permanentlyFailed++;
           continue;
         }
@@ -617,9 +611,9 @@ export function createEmailPipelineService(
         let parseError = false;
 
         try {
-          parsed = await runEmailPipelineEffect(parseBodyEffect(db, userId, email.rawBody));
+          parsed = await runtime.run(parseBodyEffect(db, userId, email.rawBody));
         } catch (err) {
-          await runEmailPipelineEffect(
+          await runtime.run(
             captureWarningEffect("email_retry_parse_exception", {
               provider: email.provider,
               errorType: err instanceof Error ? err.message : "unknown",
@@ -631,10 +625,10 @@ export function createEmailPipelineService(
         if (parseError) {
           const nextCount = (email.retryCount ?? 0) + 1;
           if (isMaxRetriesReached(nextCount)) {
-            await runEmailPipelineEffect(markPermanentlyFailedEffect(db, email.id));
+            await runtime.run(markPermanentlyFailedEffect(db, email.id));
             result.permanentlyFailed++;
           } else {
-            await runEmailPipelineEffect(
+            await runtime.run(
               markForRetryEffect(db, email.id, nextCount, computeNextRetryAt(nextCount))
             );
             result.retried++;
@@ -643,25 +637,21 @@ export function createEmailPipelineService(
         }
 
         if (!parsed) {
-          await runEmailPipelineEffect(
-            updateProcessedEmailStatusEffect(db, email.id, "skipped", null)
-          );
+          await runtime.run(updateProcessedEmailStatusEffect(db, email.id, "skipped", null));
           continue;
         }
 
         let existingTxId: TransactionId | null = null;
         try {
-          existingTxId = await runEmailPipelineEffect(
-            findDuplicateTransactionEffect(db, userId, parsed)
-          );
+          existingTxId = await runtime.run(findDuplicateTransactionEffect(db, userId, parsed));
         } catch (saveErr) {
-          await runEmailPipelineEffect(captureErrorEffect(saveErr));
+          await runtime.run(captureErrorEffect(saveErr));
           const nextCount = (email.retryCount ?? 0) + 1;
           if (isMaxRetriesReached(nextCount)) {
-            await runEmailPipelineEffect(markPermanentlyFailedEffect(db, email.id));
+            await runtime.run(markPermanentlyFailedEffect(db, email.id));
             result.permanentlyFailed++;
           } else {
-            await runEmailPipelineEffect(
+            await runtime.run(
               markForRetryEffect(db, email.id, nextCount, computeNextRetryAt(nextCount))
             );
             result.retried++;
@@ -670,7 +660,7 @@ export function createEmailPipelineService(
         }
 
         if (existingTxId) {
-          await runEmailPipelineEffect(
+          await runtime.run(
             markRetrySuccessEffect(db, email.id, "success", existingTxId, parsed.confidence)
           );
           result.succeeded++;
@@ -678,21 +668,19 @@ export function createEmailPipelineService(
         }
 
         try {
-          const { txId, status } = await runEmailPipelineEffect(
+          const { txId, status } = await runtime.run(
             saveRetryTransactionEffect(db, userId, parsed, email)
           );
-          await runEmailPipelineEffect(
-            markRetrySuccessEffect(db, email.id, status, txId, parsed.confidence)
-          );
+          await runtime.run(markRetrySuccessEffect(db, email.id, status, txId, parsed.confidence));
           result.succeeded++;
         } catch (saveErr) {
-          await runEmailPipelineEffect(captureErrorEffect(saveErr));
+          await runtime.run(captureErrorEffect(saveErr));
           const nextCount = (email.retryCount ?? 0) + 1;
           if (isMaxRetriesReached(nextCount)) {
-            await runEmailPipelineEffect(markPermanentlyFailedEffect(db, email.id));
+            await runtime.run(markPermanentlyFailedEffect(db, email.id));
             result.permanentlyFailed++;
           } else {
-            await runEmailPipelineEffect(
+            await runtime.run(
               markForRetryEffect(db, email.id, nextCount, computeNextRetryAt(nextCount))
             );
             result.retried++;

--- a/apps/mobile/features/sync/services/create-sync-service.ts
+++ b/apps/mobile/features/sync/services/create-sync-service.ts
@@ -1,12 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { Effect } from "effect";
-import {
-  fromPromise,
-  fromSync,
-  fromThunk,
-  makeAppTag,
-  runWithService,
-} from "@/shared/effect/runtime";
+import { fromPromise, fromSync, fromThunk, makeAppService } from "@/shared/effect/runtime";
 import { toIsoDateTime } from "@/shared/lib";
 import type { IsoDateTime } from "@/shared/types/branded";
 import type {
@@ -66,7 +60,7 @@ export type SyncService = {
   ) => Promise<ResolveConflictResult>;
 };
 
-const SyncDeps = makeAppTag<CreateSyncServiceDeps>("@/features/sync/SyncDeps");
+const SyncDeps = makeAppService<CreateSyncServiceDeps>("@/features/sync/SyncDeps");
 
 function tryParseTransactionSnapshot(value: string): TransactionSnapshot | null {
   try {
@@ -77,7 +71,7 @@ function tryParseTransactionSnapshot(value: string): TransactionSnapshot | null 
 }
 
 const getConflictRowsEffect = (db: SyncContext["db"]) =>
-  Effect.flatMap(SyncDeps, ({ getConflictRows }) => fromPromise(() => getConflictRows({ db })));
+  Effect.flatMap(SyncDeps.tag, ({ getConflictRows }) => fromPromise(() => getConflictRows({ db })));
 
 const unresolvedConflictCountEffect = (db: SyncContext["db"]) =>
   Effect.map(listConflictsEffect({ db }), (conflicts) => conflicts.length);
@@ -107,7 +101,7 @@ function resolveConflictEffect({ db, conflictId, resolution }: ResolveTransactio
     }
 
     const { upsertTransaction, enqueueTransactionSync, resolveConflictRow, refreshTransactions } =
-      yield* SyncDeps;
+      yield* SyncDeps.tag;
     const resolvedAt = toIsoDateTime(new Date());
     const serverData = tryParseTransactionSnapshot(row.serverData);
     const localData =
@@ -134,7 +128,7 @@ function runSyncEffect({ db, userId, reason: _reason = "foreground" }: SyncInput
   return Effect.gen(function* () {
     void _reason;
 
-    const { isOnline, getSupabase, syncPull, syncPush, refreshTransactions } = yield* SyncDeps;
+    const { isOnline, getSupabase, syncPull, syncPush, refreshTransactions } = yield* SyncDeps.tag;
     const online = yield* fromPromise(isOnline);
     if (!online) {
       return {
@@ -168,7 +162,7 @@ export function createSyncService({
   enqueueTransactionSync,
   resolveConflictRow,
 }: CreateSyncServiceDeps): SyncService {
-  const deps = {
+  const runtime = SyncDeps.bind({
     isOnline,
     getSupabase,
     syncPull,
@@ -178,11 +172,11 @@ export function createSyncService({
     upsertTransaction,
     enqueueTransactionSync,
     resolveConflictRow,
-  } satisfies CreateSyncServiceDeps;
+  } satisfies CreateSyncServiceDeps);
 
   return {
-    listConflicts: (input) => runWithService(listConflictsEffect(input), SyncDeps, deps),
-    resolveConflict: (input) => runWithService(resolveConflictEffect(input), SyncDeps, deps),
-    run: (input) => runWithService(runSyncEffect(input), SyncDeps, deps),
+    listConflicts: (input) => runtime.run(listConflictsEffect(input)),
+    resolveConflict: (input) => runtime.run(resolveConflictEffect(input)),
+    run: (input) => runtime.run(runSyncEffect(input)),
   };
 }

--- a/apps/mobile/shared/effect/runtime.ts
+++ b/apps/mobile/shared/effect/runtime.ts
@@ -1,6 +1,14 @@
 import { Cause, Context, Effect, Exit } from "effect";
 
 export type AppEffect<A, E = unknown, R = never> = Effect.Effect<A, E, R>;
+export type BoundAppService<I, _S> = {
+  readonly provide: <A, E, R>(effect: AppEffect<A, E, I | R>) => AppEffect<A, E, R>;
+  readonly run: <A, E>(effect: AppEffect<A, E, I>) => Promise<A>;
+};
+export type AppService<I, S> = {
+  readonly tag: Context.Tag<I, S>;
+  readonly bind: (service: S) => BoundAppService<I, S>;
+};
 
 export async function runAppEffect<A, E>(effect: AppEffect<A, E>): Promise<A> {
   const exit = await Effect.runPromiseExit(effect);
@@ -20,6 +28,22 @@ export function runWithService<A, E, I, S>(
   service: S
 ): Promise<A> {
   return runAppEffect(Effect.provideService(effect, tag, service));
+}
+
+export function bindAppService<I, S>(tag: Context.Tag<I, S>, service: S): BoundAppService<I, S> {
+  return {
+    provide: <A, E, R>(effect: AppEffect<A, E, I | R>) =>
+      Effect.provideService(effect, tag, service),
+    run: <A, E>(effect: AppEffect<A, E, I>) => runWithService(effect, tag, service),
+  };
+}
+
+export function makeAppService<Service>(key: string): AppService<Service, Service> {
+  const tag = makeAppTag<Service>(key);
+  return {
+    tag,
+    bind: (service) => bindAppService(tag, service),
+  };
 }
 
 export function fromSync<A>(thunk: () => A): AppEffect<A> {


### PR DESCRIPTION
- add shared effect service binder
- reuse binder in sync email ai chat
- test runtime boundary failures


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates Effect service binding behind a shared API and refactors sync, email pipeline, and AI chat to use it for simpler, safer dependency injection. Adds tests to verify bound effects run correctly and preserve original errors.

- **Refactors**
  - Introduce `makeAppService` and `bindAppService` in `@/shared/effect/runtime` to bind a service once and `run`/`provide` effects via a `BoundAppService`.
  - Replace `makeAppTag`/`runWithService` with the new binder in `create-email-pipeline-service`, `create-sync-service`, and `create-streaming-chat-service`; use `.tag` for reads and `runtime.run(...)` for execution.
  - Add `shared/effect/runtime` tests covering successful binding and error preservation.

<sup>Written for commit e3c02397993ac19b8dea0556ecde469fb5322435. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

