### PR TITLE
refactor(mobile): inject effect clock

### DIFF
--- a/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
@@ -1,8 +1,9 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: mock db needs flexible typing
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RawEmail } from "@/features/email-capture/schema";
+import { createEmailPipelineService } from "@/features/email-capture/services/create-email-pipeline-service";
 import { processEmails, processRetries } from "@/features/email-capture/services/email-pipeline";
-import { requireUserId } from "@/shared/types/assertions";
+import { requireIsoDateTime, requireUserId } from "@/shared/types/assertions";
 
 const mockGetProcessedExternalIds = vi.fn().mockResolvedValue(new Set<string>());
 const mockInsertProcessedEmail = vi.fn();
@@ -173,6 +174,45 @@ describe("email processing pipeline", () => {
       "compra en exito",
       "other",
       expect.any(String)
+    );
+  });
+
+  it("uses the injected clock for persisted email timestamps and retry backoff", async () => {
+    const fixedNow = requireIsoDateTime("2026-04-18T12:34:56.000Z");
+    const service = createEmailPipelineService({
+      parseEmailApi: mockParseEmailApi,
+      lookupMerchantRule: mockLookupMerchantRule,
+      findDuplicateTransaction: mockFindDuplicateTransaction,
+      getProcessedExternalIds: mockGetProcessedExternalIds,
+      getPendingRetryEmails: mockGetPendingRetryEmails,
+      insertProcessedEmail: mockInsertProcessedEmail,
+      markForRetry: mockMarkForRetry,
+      markPermanentlyFailed: mockMarkPermanentlyFailed,
+      markRetrySuccess: mockMarkRetrySuccess,
+      updateProcessedEmailStatus: mockUpdateProcessedEmailStatus,
+      insertTransaction: mockInsertTransaction,
+      enqueueSync: mockEnqueueSync,
+      insertMerchantRule: mockInsertMerchantRule,
+      trackTransactionCreated: vi.fn(),
+      captureError: vi.fn(),
+      captureWarning: vi.fn(),
+      capturePipelineEvent: vi.fn(),
+      clock: {
+        now: () => new Date(fixedNow),
+        nowIsoDateTime: () => fixedNow,
+      },
+    });
+
+    mockParseEmailApi.mockRejectedValueOnce(new Error("LLM timeout"));
+
+    await service.processEmails(mockDb, USER_ID, [makeRawEmail()]);
+
+    expect(mockInsertProcessedEmail).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        createdAt: fixedNow,
+        nextRetryAt: "2026-04-18T12:35:56.000Z",
+      })
     );
   });
 

--- a/apps/mobile/__tests__/sync/sync-service.test.ts
+++ b/apps/mobile/__tests__/sync/sync-service.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { createSyncService } from "@/features/sync/services/create-sync-service";
+import { requireIsoDateTime } from "@/shared/types/assertions";
 
 describe("createSyncService", () => {
   it("returns skipped_offline and does not touch remote sync when offline", async () => {
@@ -129,6 +130,7 @@ describe("createSyncService", () => {
   });
 
   it("re-enqueues the local transaction when resolving a conflict in favor of local data", async () => {
+    const resolvedAt = requireIsoDateTime("2026-04-18T12:34:56.000Z");
     const upsertTransaction = vi.fn();
     const enqueueTransactionSync = vi.fn();
     const resolveConflictRow = vi.fn();
@@ -180,6 +182,10 @@ describe("createSyncService", () => {
       upsertTransaction,
       enqueueTransactionSync,
       resolveConflictRow,
+      clock: {
+        now: () => new Date(resolvedAt),
+        nowIsoDateTime: () => resolvedAt,
+      },
     });
 
     const result = await service.resolveConflict({
@@ -194,16 +200,11 @@ describe("createSyncService", () => {
         id: "tx-1",
         amount: 1000,
         source: "manual",
-        updatedAt: expect.any(String),
+        updatedAt: resolvedAt,
       })
     );
-    expect(enqueueTransactionSync).toHaveBeenCalledWith({} as never, "tx-1", expect.any(String));
-    expect(resolveConflictRow).toHaveBeenCalledWith(
-      {} as never,
-      "conflict-1",
-      "local",
-      expect.any(String)
-    );
+    expect(enqueueTransactionSync).toHaveBeenCalledWith({} as never, "tx-1", resolvedAt);
+    expect(resolveConflictRow).toHaveBeenCalledWith({} as never, "conflict-1", "local", resolvedAt);
     expect(refreshTransactions).toHaveBeenCalledTimes(1);
     expect(result).toEqual({ unresolvedConflicts: 0 });
   });

--- a/apps/mobile/features/email-capture/services/create-email-pipeline-service.ts
+++ b/apps/mobile/features/email-capture/services/create-email-pipeline-service.ts
@@ -3,8 +3,13 @@ import type { ProcessedEmailRow } from "@/features/email-capture/lib/repository"
 import { getBuiltInCategoryId, isValidCategoryId } from "@/features/transactions/lib/categories";
 import type { TransactionRow } from "@/features/transactions/lib/repository";
 import type { AnyDb, SyncQueueEntry } from "@/shared/db";
+import {
+  type AppClock,
+  bindAppClock,
+  currentDateEffect,
+  currentIsoDateTimeEffect,
+} from "@/shared/effect/clock";
 import { fromPromise, fromThunk, makeAppService } from "@/shared/effect/runtime";
-import { toIsoDateTime } from "@/shared/lib/format-date";
 import {
   generateProcessedEmailId,
   generateSyncQueueId,
@@ -120,6 +125,7 @@ type CreateEmailPipelineServiceDeps = {
   readonly captureError: (error: unknown) => void | Promise<void>;
   readonly captureWarning: CaptureWarning;
   readonly capturePipelineEvent: CapturePipelineEvent;
+  readonly clock?: AppClock;
 };
 
 export type EmailPipelineService = {
@@ -211,7 +217,7 @@ function saveTransactionEffect(
       yield* EmailPipelineDeps.tag;
     const source = getTransactionSource(email.provider);
     const txId = generateTransactionId();
-    const now = toIsoDateTime(new Date());
+    const now = yield* currentIsoDateTimeEffect;
     const amount = validated.amount;
     const date = validated.date;
     const receivedAt = email.receivedAt;
@@ -362,7 +368,7 @@ function saveRetryTransactionEffect(
     const { insertTransaction, enqueueSync, insertMerchantRule, trackTransactionCreated } =
       yield* EmailPipelineDeps.tag;
     const txId = generateTransactionId();
-    const now = toIsoDateTime(new Date());
+    const now = yield* currentIsoDateTimeEffect;
     const source = getTransactionSource(email.provider);
     const amount = parsed.amount;
     const date = parsed.date;
@@ -413,10 +419,23 @@ function saveRetryTransactionEffect(
   });
 }
 
+function nextRetryAtEffect(retryCount: number) {
+  return Effect.map(currentDateEffect, (now) => computeNextRetryAt(retryCount, now));
+}
+
 export function createEmailPipelineService(
   deps: CreateEmailPipelineServiceDeps
 ): EmailPipelineService {
-  const runtime = EmailPipelineDeps.bind(deps);
+  const { clock, ...runtimeDeps } = deps;
+  const clockRuntime = bindAppClock(clock);
+  const runtime = EmailPipelineDeps.bind(runtimeDeps);
+  const runClockEffect = <A>(effect: Effect.Effect<A, unknown, AppClock>) =>
+    clockRuntime.run(effect);
+  const runEmailEffect = <A>(effect: Effect.Effect<A, unknown, CreateEmailPipelineServiceDeps>) =>
+    runtime.run(effect);
+  const runEmailWithClock = <A>(
+    effect: Effect.Effect<A, unknown, CreateEmailPipelineServiceDeps | AppClock>
+  ) => runtime.run(clockRuntime.provide(effect));
 
   return {
     async processEmails(db, userId, rawEmails, onProgress) {
@@ -425,7 +444,7 @@ export function createEmailPipelineService(
       );
       const dedupedInBatch = rawEmails.length - uniqueEmails.length;
       const allExternalIds = uniqueEmails.map((email) => email.externalId);
-      const processedIds = await runtime.run(getProcessedExternalIdsEffect(db, allExternalIds));
+      const processedIds = await runEmailEffect(getProcessedExternalIdsEffect(db, allExternalIds));
       const toProcess = uniqueEmails.filter((email) => !processedIds.has(email.externalId));
       const skippedAlreadyProcessed = uniqueEmails.length - toProcess.length;
 
@@ -455,9 +474,9 @@ export function createEmailPipelineService(
           let parseError = false;
 
           try {
-            parsed = await runtime.run(parseBodyEffect(db, userId, email.body));
+            parsed = await runEmailEffect(parseBodyEffect(db, userId, email.body));
           } catch (err) {
-            await runtime.run(
+            await runEmailEffect(
               captureWarningEffect("email_parse_exception", {
                 provider: email.provider,
                 errorType: err instanceof Error ? err.message : "unknown",
@@ -477,7 +496,9 @@ export function createEmailPipelineService(
             }
 
             assertIsoDateTime(email.receivedAt);
-            await runtime.run(
+            const createdAt = await runClockEffect(currentIsoDateTimeEffect);
+            const nextRetryAt = parseError ? await runClockEffect(nextRetryAtEffect(0)) : null;
+            await runEmailEffect(
               insertProcessedEmailEffect(db, {
                 id: generateProcessedEmailId(),
                 externalId: email.externalId,
@@ -489,12 +510,12 @@ export function createEmailPipelineService(
                 receivedAt: email.receivedAt,
                 transactionId: null,
                 confidence: null,
-                createdAt: toIsoDateTime(new Date()),
+                createdAt,
                 ...(parseError
                   ? {
                       rawBody: email.body,
                       retryCount: 0,
-                      nextRetryAt: computeNextRetryAt(0),
+                      nextRetryAt,
                     }
                   : {}),
               })
@@ -506,9 +527,9 @@ export function createEmailPipelineService(
 
           let existingTxId: TransactionId | null = null;
           try {
-            existingTxId = await runtime.run(findDuplicateTransactionEffect(db, userId, parsed));
+            existingTxId = await runEmailEffect(findDuplicateTransactionEffect(db, userId, parsed));
           } catch (saveErr) {
-            await runtime.run(captureErrorEffect(saveErr));
+            await runEmailEffect(captureErrorEffect(saveErr));
             result.failed++;
             completed++;
             onProgress?.(getProgressSnapshot(total, completed, result));
@@ -518,7 +539,8 @@ export function createEmailPipelineService(
           if (existingTxId) {
             const receivedAt = email.receivedAt;
             assertIsoDateTime(receivedAt);
-            await runtime.run(
+            const createdAt = await runClockEffect(currentIsoDateTimeEffect);
+            await runEmailEffect(
               insertProcessedEmailEffect(db, {
                 id: generateProcessedEmailId(),
                 externalId: email.externalId,
@@ -530,7 +552,7 @@ export function createEmailPipelineService(
                 receivedAt,
                 transactionId: existingTxId,
                 confidence: parsed.confidence,
-                createdAt: toIsoDateTime(new Date()),
+                createdAt,
               })
             );
             result.skippedCrossSource++;
@@ -541,14 +563,14 @@ export function createEmailPipelineService(
 
           const status = parsed.confidence < 0.7 ? "needs_review" : "success";
           try {
-            await runtime.run(saveTransactionEffect(db, userId, parsed, email, status));
+            await runEmailWithClock(saveTransactionEffect(db, userId, parsed, email, status));
             if (status === "needs_review") {
               result.needsReview++;
             } else {
               result.saved++;
             }
           } catch (saveErr) {
-            await runtime.run(captureErrorEffect(saveErr));
+            await runEmailEffect(captureErrorEffect(saveErr));
             result.failed++;
             completed++;
             onProgress?.(getProgressSnapshot(total, completed, result));
@@ -558,17 +580,18 @@ export function createEmailPipelineService(
           if (status === "success") {
             try {
               const merchantKey = normalizeMerchant(parsed.description);
-              await runtime.run(
+              const createdAt = await runClockEffect(currentIsoDateTimeEffect);
+              await runEmailEffect(
                 insertMerchantRuleEffect(
                   db,
                   userId,
                   merchantKey,
                   getPersistedCategoryId(parsed.categoryId),
-                  toIsoDateTime(new Date())
+                  createdAt
                 )
               );
             } catch (ruleErr) {
-              await runtime.run(captureErrorEffect(ruleErr));
+              await runEmailEffect(captureErrorEffect(ruleErr));
             }
           }
 
@@ -579,7 +602,7 @@ export function createEmailPipelineService(
 
       await Promise.all(Array.from({ length: Math.min(Concurrency, total) }, () => worker()));
 
-      await runtime.run(
+      await runEmailEffect(
         capturePipelineEventEffect({
           source: "email",
           batchSize: rawEmails.length,
@@ -598,11 +621,11 @@ export function createEmailPipelineService(
 
     async processRetries(db, userId) {
       const result: RetryResult = { retried: 0, succeeded: 0, permanentlyFailed: 0 };
-      const pendingEmails = await runtime.run(getPendingRetryEmailsEffect(db));
+      const pendingEmails = await runEmailEffect(getPendingRetryEmailsEffect(db));
 
       for (const email of pendingEmails) {
         if (!email.rawBody) {
-          await runtime.run(markPermanentlyFailedEffect(db, email.id));
+          await runEmailEffect(markPermanentlyFailedEffect(db, email.id));
           result.permanentlyFailed++;
           continue;
         }
@@ -611,9 +634,9 @@ export function createEmailPipelineService(
         let parseError = false;
 
         try {
-          parsed = await runtime.run(parseBodyEffect(db, userId, email.rawBody));
+          parsed = await runEmailEffect(parseBodyEffect(db, userId, email.rawBody));
         } catch (err) {
-          await runtime.run(
+          await runEmailEffect(
             captureWarningEffect("email_retry_parse_exception", {
               provider: email.provider,
               errorType: err instanceof Error ? err.message : "unknown",
@@ -624,43 +647,41 @@ export function createEmailPipelineService(
 
         if (parseError) {
           const nextCount = (email.retryCount ?? 0) + 1;
+          const nextRetryAt = await runClockEffect(nextRetryAtEffect(nextCount));
           if (isMaxRetriesReached(nextCount)) {
-            await runtime.run(markPermanentlyFailedEffect(db, email.id));
+            await runEmailEffect(markPermanentlyFailedEffect(db, email.id));
             result.permanentlyFailed++;
           } else {
-            await runtime.run(
-              markForRetryEffect(db, email.id, nextCount, computeNextRetryAt(nextCount))
-            );
+            await runEmailEffect(markForRetryEffect(db, email.id, nextCount, nextRetryAt));
             result.retried++;
           }
           continue;
         }
 
         if (!parsed) {
-          await runtime.run(updateProcessedEmailStatusEffect(db, email.id, "skipped", null));
+          await runEmailEffect(updateProcessedEmailStatusEffect(db, email.id, "skipped", null));
           continue;
         }
 
         let existingTxId: TransactionId | null = null;
         try {
-          existingTxId = await runtime.run(findDuplicateTransactionEffect(db, userId, parsed));
+          existingTxId = await runEmailEffect(findDuplicateTransactionEffect(db, userId, parsed));
         } catch (saveErr) {
-          await runtime.run(captureErrorEffect(saveErr));
+          await runEmailEffect(captureErrorEffect(saveErr));
           const nextCount = (email.retryCount ?? 0) + 1;
+          const nextRetryAt = await runClockEffect(nextRetryAtEffect(nextCount));
           if (isMaxRetriesReached(nextCount)) {
-            await runtime.run(markPermanentlyFailedEffect(db, email.id));
+            await runEmailEffect(markPermanentlyFailedEffect(db, email.id));
             result.permanentlyFailed++;
           } else {
-            await runtime.run(
-              markForRetryEffect(db, email.id, nextCount, computeNextRetryAt(nextCount))
-            );
+            await runEmailEffect(markForRetryEffect(db, email.id, nextCount, nextRetryAt));
             result.retried++;
           }
           continue;
         }
 
         if (existingTxId) {
-          await runtime.run(
+          await runEmailEffect(
             markRetrySuccessEffect(db, email.id, "success", existingTxId, parsed.confidence)
           );
           result.succeeded++;
@@ -668,21 +689,22 @@ export function createEmailPipelineService(
         }
 
         try {
-          const { txId, status } = await runtime.run(
+          const { txId, status } = await runEmailWithClock(
             saveRetryTransactionEffect(db, userId, parsed, email)
           );
-          await runtime.run(markRetrySuccessEffect(db, email.id, status, txId, parsed.confidence));
+          await runEmailEffect(
+            markRetrySuccessEffect(db, email.id, status, txId, parsed.confidence)
+          );
           result.succeeded++;
         } catch (saveErr) {
-          await runtime.run(captureErrorEffect(saveErr));
+          await runEmailEffect(captureErrorEffect(saveErr));
           const nextCount = (email.retryCount ?? 0) + 1;
+          const nextRetryAt = await runClockEffect(nextRetryAtEffect(nextCount));
           if (isMaxRetriesReached(nextCount)) {
-            await runtime.run(markPermanentlyFailedEffect(db, email.id));
+            await runEmailEffect(markPermanentlyFailedEffect(db, email.id));
             result.permanentlyFailed++;
           } else {
-            await runtime.run(
-              markForRetryEffect(db, email.id, nextCount, computeNextRetryAt(nextCount))
-            );
+            await runEmailEffect(markForRetryEffect(db, email.id, nextCount, nextRetryAt));
             result.retried++;
           }
         }

--- a/apps/mobile/features/sync/services/create-sync-service.ts
+++ b/apps/mobile/features/sync/services/create-sync-service.ts
@@ -1,7 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { Effect } from "effect";
+import { type AppClock, bindAppClock, currentIsoDateTimeEffect } from "@/shared/effect/clock";
 import { fromPromise, fromSync, fromThunk, makeAppService } from "@/shared/effect/runtime";
-import { toIsoDateTime } from "@/shared/lib";
 import type { IsoDateTime } from "@/shared/types/branded";
 import type {
   ConflictResolution,
@@ -50,6 +50,7 @@ type CreateSyncServiceDeps = {
   readonly upsertTransaction: UpsertTransaction;
   readonly enqueueTransactionSync: EnqueueTransactionSync;
   readonly resolveConflictRow: ResolveConflictRow;
+  readonly clock?: AppClock;
 };
 
 export type SyncService = {
@@ -102,7 +103,7 @@ function resolveConflictEffect({ db, conflictId, resolution }: ResolveTransactio
 
     const { upsertTransaction, enqueueTransactionSync, resolveConflictRow, refreshTransactions } =
       yield* SyncDeps.tag;
-    const resolvedAt = toIsoDateTime(new Date());
+    const resolvedAt = yield* currentIsoDateTimeEffect;
     const serverData = tryParseTransactionSnapshot(row.serverData);
     const localData =
       resolution === "local" ? (JSON.parse(row.localData) as TransactionSnapshot) : null;
@@ -161,7 +162,9 @@ export function createSyncService({
   upsertTransaction,
   enqueueTransactionSync,
   resolveConflictRow,
+  clock,
 }: CreateSyncServiceDeps): SyncService {
+  const clockRuntime = bindAppClock(clock);
   const runtime = SyncDeps.bind({
     isOnline,
     getSupabase,
@@ -175,8 +178,8 @@ export function createSyncService({
   } satisfies CreateSyncServiceDeps);
 
   return {
-    listConflicts: (input) => runtime.run(listConflictsEffect(input)),
-    resolveConflict: (input) => runtime.run(resolveConflictEffect(input)),
-    run: (input) => runtime.run(runSyncEffect(input)),
+    listConflicts: (input) => runtime.run(clockRuntime.provide(listConflictsEffect(input))),
+    resolveConflict: (input) => runtime.run(clockRuntime.provide(resolveConflictEffect(input))),
+    run: (input) => runtime.run(clockRuntime.provide(runSyncEffect(input))),
   };
 }

--- a/apps/mobile/shared/effect/clock.ts
+++ b/apps/mobile/shared/effect/clock.ts
@@ -1,0 +1,26 @@
+import { Effect } from "effect";
+import { toIsoDateTime } from "@/shared/lib";
+import type { IsoDateTime } from "@/shared/types/branded";
+import { type BoundAppService, fromSync, makeAppService } from "./runtime";
+
+export type AppClock = {
+  readonly now: () => Date;
+  readonly nowIsoDateTime: () => IsoDateTime;
+};
+
+export const liveAppClock: AppClock = {
+  now: () => new Date(),
+  nowIsoDateTime: () => toIsoDateTime(new Date()),
+};
+
+export const AppClockService = makeAppService<AppClock>("@/shared/effect/AppClock");
+
+export const currentDateEffect = Effect.flatMap(AppClockService.tag, ({ now }) => fromSync(now));
+
+export const currentIsoDateTimeEffect = Effect.flatMap(AppClockService.tag, ({ nowIsoDateTime }) =>
+  fromSync(nowIsoDateTime)
+);
+
+export function bindAppClock(clock: AppClock = liveAppClock): BoundAppService<AppClock, AppClock> {
+  return AppClockService.bind(clock);
+}


### PR DESCRIPTION
- add shared effect clock
- use clock in sync and email pipeline
- test deterministic timestamps


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Injects an effect-based clock into the email pipeline and sync services to make timestamps deterministic and testable. Adds a shared `AppClock` and updates retry backoff and timestamps to use it.

- **Refactors**
  - Added `shared/effect/clock.ts` with `AppClock`, `liveAppClock`, `bindAppClock`, `currentDateEffect`, and `currentIsoDateTimeEffect`.
  - Email pipeline now accepts an optional `clock`; uses time effects for `createdAt` and `nextRetryAt` (including retries) and wires effects via a combined runtime.
  - Sync service now accepts an optional `clock`; uses `currentIsoDateTimeEffect` for conflict resolution timestamps and provides the clock to all effects.
  - Tests inject a fixed clock to assert exact timestamps and retry backoff deterministically.

<sup>Written for commit 0077ed6cad302c0fe4e24bcac7d9fae484e7f47e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

