### PR TITLE
refactor(mobile): inject effect telemetry

### DIFF
--- a/apps/mobile/__tests__/ai-chat/streaming-service.test.ts
+++ b/apps/mobile/__tests__/ai-chat/streaming-service.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChatAction, ChatMessage } from "@/features/ai-chat/schema";
 import { createStreamingChatService } from "@/features/ai-chat/services/create-streaming-chat-service";
+import type { AppTelemetry } from "@/shared/effect/telemetry";
 import { requireCategoryId, requireUserId } from "@/shared/types/assertions";
 import type { ChatSessionId, IsoDateTime } from "@/shared/types/branded";
 
@@ -62,6 +63,32 @@ function createState() {
   };
 }
 
+function makeTelemetry(
+  overrides: {
+    captureWarning?: ReturnType<
+      typeof vi.fn<(message: string, context?: Record<string, string | number | boolean>) => void>
+    >;
+    captureError?: ReturnType<typeof vi.fn<(error: unknown) => void>>;
+  } = {}
+) {
+  const captureError = overrides.captureError ?? vi.fn<(error: unknown) => void>();
+  const captureWarning =
+    overrides.captureWarning ??
+    vi.fn<(message: string, context?: Record<string, string | number | boolean>) => void>();
+  const telemetry = {
+    captureError: (error: unknown) => captureError(error),
+    captureWarning: (message: string, context?: Record<string, string | number | boolean>) =>
+      captureWarning(message, context),
+    capturePipelineEvent: (_data: Record<string, string | number | boolean>) => undefined,
+  } satisfies AppTelemetry;
+
+  return {
+    telemetry,
+    captureError,
+    captureWarning,
+  };
+}
+
 describe("streaming chat service", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -89,6 +116,7 @@ describe("streaming chat service", () => {
     const trackAiMessageSent = vi.fn();
     const captureWarning = vi.fn();
     const captureError = vi.fn();
+    const telemetry = makeTelemetry({ captureWarning, captureError });
 
     const service = createStreamingChatService({
       getState: state.getState,
@@ -104,8 +132,7 @@ describe("streaming chat service", () => {
       addAssistantChatMessage,
       parseActionFromResponse: () => makeAddAction(),
       trackAiMessageSent,
-      captureWarning,
-      captureError,
+      telemetry: telemetry.telemetry,
     });
 
     await service.sendMessage({
@@ -136,7 +163,7 @@ describe("streaming chat service", () => {
     const state = createState();
     state.setCurrentSessionId("chat-1" as ChatSessionId);
     const executeAction = vi.fn().mockRejectedValue(new Error("action failed"));
-    const captureWarning = vi.fn();
+    const telemetry = makeTelemetry({ captureWarning: vi.fn() });
 
     const service = createStreamingChatService({
       getState: state.getState,
@@ -151,8 +178,7 @@ describe("streaming chat service", () => {
       addAssistantChatMessage: vi.fn().mockResolvedValue(makeAssistantMessage("reply")),
       parseActionFromResponse: () => makeAddAction(),
       trackAiMessageSent: vi.fn(),
-      captureWarning,
-      captureError: vi.fn(),
+      telemetry: telemetry.telemetry,
     });
 
     await service.sendMessage({
@@ -162,7 +188,7 @@ describe("streaming chat service", () => {
       executeAction,
     });
 
-    expect(captureWarning).toHaveBeenCalledWith("ai_action_failed", {
+    expect(telemetry.captureWarning).toHaveBeenCalledWith("ai_action_failed", {
       actionType: "add",
       errorType: "action failed",
     });
@@ -186,8 +212,7 @@ describe("streaming chat service", () => {
       addAssistantChatMessage,
       parseActionFromResponse: () => null,
       trackAiMessageSent: vi.fn(),
-      captureWarning: vi.fn(),
-      captureError: vi.fn(),
+      telemetry: makeTelemetry().telemetry,
     });
 
     await service.sendMessage({
@@ -228,8 +253,7 @@ describe("streaming chat service", () => {
       addAssistantChatMessage: vi.fn().mockResolvedValue(makeAssistantMessage("reply")),
       parseActionFromResponse: () => null,
       trackAiMessageSent: vi.fn(),
-      captureWarning: vi.fn(),
-      captureError: vi.fn(),
+      telemetry: makeTelemetry().telemetry,
     });
 
     const sendPromise = service.sendMessage({
@@ -295,8 +319,7 @@ describe("streaming chat service", () => {
       addAssistantChatMessage: vi.fn().mockResolvedValue(makeAssistantMessage("reply")),
       parseActionFromResponse: () => null,
       trackAiMessageSent: vi.fn(),
-      captureWarning: vi.fn(),
-      captureError: vi.fn(),
+      telemetry: makeTelemetry().telemetry,
     });
 
     const firstSend = service.sendMessage({

--- a/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
@@ -194,9 +194,6 @@ describe("email processing pipeline", () => {
       enqueueSync: mockEnqueueSync,
       insertMerchantRule: mockInsertMerchantRule,
       trackTransactionCreated: vi.fn(),
-      captureError: vi.fn(),
-      captureWarning: vi.fn(),
-      capturePipelineEvent: vi.fn(),
       clock: {
         now: () => new Date(fixedNow),
         nowIsoDateTime: () => fixedNow,

--- a/apps/mobile/features/ai-chat/hooks/use-streaming-chat.ts
+++ b/apps/mobile/features/ai-chat/hooks/use-streaming-chat.ts
@@ -2,13 +2,7 @@ import { useCallback } from "react";
 import { useOptionalUserId } from "@/features/auth";
 import { saveCurrentTransaction, useTransactionStore } from "@/features/transactions";
 import { tryGetDb } from "@/shared/db";
-import {
-  captureError,
-  captureWarning,
-  parseIsoDate,
-  trackAiMessageSent,
-  trackTransactionCreated,
-} from "@/shared/lib";
+import { parseIsoDate, trackAiMessageSent, trackTransactionCreated } from "@/shared/lib";
 import { parseActionFromResponse } from "../lib/parse-action";
 import type { ChatAction } from "../schema";
 import { streamChat } from "../services/ai-chat-api";
@@ -37,8 +31,6 @@ const streamingChatService = createStreamingChatService({
   addAssistantChatMessage,
   parseActionFromResponse,
   trackAiMessageSent,
-  captureWarning,
-  captureError,
 });
 
 export function cancelActiveStream(): void {

--- a/apps/mobile/features/ai-chat/services/create-streaming-chat-service.ts
+++ b/apps/mobile/features/ai-chat/services/create-streaming-chat-service.ts
@@ -1,6 +1,12 @@
 import { Effect } from "effect";
 import type { AnyDb } from "@/shared/db";
 import { fromPromise, fromThunk, makeAppService } from "@/shared/effect/runtime";
+import {
+  type AppTelemetry,
+  bindAppTelemetry,
+  captureErrorEffect,
+  captureWarningEffect,
+} from "@/shared/effect/telemetry";
 import type { ChatSessionId, UserId } from "@/shared/types/branded";
 import type { ChatAction, ChatMessage } from "../schema";
 
@@ -44,14 +50,7 @@ type CreateStreamingChatServiceDeps = {
   ) => Promise<unknown>;
   readonly parseActionFromResponse: (content: string) => ChatAction | null;
   readonly trackAiMessageSent: () => void | Promise<void>;
-  readonly captureWarning: (
-    name: "ai_action_failed",
-    tags: {
-      actionType: ChatAction["type"];
-      errorType: string;
-    }
-  ) => void | Promise<void>;
-  readonly captureError: (error: unknown) => void | Promise<void>;
+  readonly telemetry?: AppTelemetry;
 };
 
 export type StreamingChatService = {
@@ -70,6 +69,17 @@ type ReadySendMessageInput = {
   readonly userId: UserId;
   readonly text: string;
   readonly executeAction: (action: ChatAction) => Promise<void>;
+};
+
+type StreamingTelemetry = {
+  readonly captureError: (error: unknown) => Promise<void>;
+  readonly captureWarning: (
+    name: "ai_action_failed",
+    tags: {
+      actionType: ChatAction["type"];
+      errorType: string;
+    }
+  ) => Promise<void>;
 };
 
 const StreamingChatDeps = makeAppService<CreateStreamingChatServiceDeps>(
@@ -116,6 +126,7 @@ function toConversation(
 async function handleStreamDone(
   runtime: StreamingRuntime,
   deps: CreateStreamingChatServiceDeps,
+  telemetry: StreamingTelemetry,
   runId: number,
   input: ReadySendMessageInput,
   controller: AbortController,
@@ -130,7 +141,7 @@ async function handleStreamDone(
     try {
       await input.executeAction(action);
     } catch (actionErr) {
-      await deps.captureWarning("ai_action_failed", {
+      await telemetry.captureWarning("ai_action_failed", {
         actionType: action.type,
         errorType: actionErr instanceof Error ? actionErr.message : "unknown",
       });
@@ -157,6 +168,7 @@ async function handleStreamError(
 async function runStreamLifecycle(
   runtime: StreamingRuntime,
   deps: CreateStreamingChatServiceDeps,
+  telemetry: StreamingTelemetry,
   runId: number,
   input: ReadySendMessageInput,
   conversation: readonly StreamChatMessage[],
@@ -169,7 +181,7 @@ async function runStreamLifecycle(
     if (settled) return;
     settled = true;
     void handler()
-      .catch((error) => deps.captureError(error))
+      .catch((error) => telemetry.captureError(error))
       .finally(() => {
         resetStreamStateIfCurrent(runtime, deps, runId);
         resolve();
@@ -188,7 +200,8 @@ async function runStreamLifecycle(
           },
           onDone: () => {
             settle(
-              () => handleStreamDone(runtime, deps, runId, input, controller, accumulated),
+              () =>
+                handleStreamDone(runtime, deps, telemetry, runId, input, controller, accumulated),
               resolve
             );
           },
@@ -213,7 +226,7 @@ async function runStreamLifecycle(
 
         if (!settled) {
           settle(
-            () => handleStreamDone(runtime, deps, runId, input, controller, accumulated),
+            () => handleStreamDone(runtime, deps, telemetry, runId, input, controller, accumulated),
             resolve
           );
         }
@@ -237,7 +250,12 @@ async function runStreamLifecycle(
   });
 }
 
-function sendMessageEffect(input: SendMessageInput, runtime: StreamingRuntime, runId: number) {
+function sendMessageEffect(
+  input: SendMessageInput,
+  runtime: StreamingRuntime,
+  telemetry: StreamingTelemetry,
+  runId: number
+) {
   return Effect.gen(function* () {
     const trimmed = input.text.trim();
     if (!trimmed || !input.db || !input.userId) return;
@@ -268,6 +286,7 @@ function sendMessageEffect(input: SendMessageInput, runtime: StreamingRuntime, r
       runStreamLifecycle(
         runtime,
         deps,
+        telemetry,
         runId,
         {
           db,
@@ -285,7 +304,13 @@ function sendMessageEffect(input: SendMessageInput, runtime: StreamingRuntime, r
 export function createStreamingChatService(
   deps: CreateStreamingChatServiceDeps
 ): StreamingChatService {
-  const runtimeService = StreamingChatDeps.bind(deps);
+  const { telemetry, ...runtimeDeps } = deps;
+  const telemetryRuntime = bindAppTelemetry(telemetry);
+  const streamingTelemetry: StreamingTelemetry = {
+    captureError: (error) => telemetryRuntime.run(captureErrorEffect(error)),
+    captureWarning: (message, tags) => telemetryRuntime.run(captureWarningEffect(message, tags)),
+  };
+  const runtimeService = StreamingChatDeps.bind(runtimeDeps);
   const runtime: StreamingRuntime = {
     lastRunId: 0,
     currentRunId: null,
@@ -300,9 +325,9 @@ export function createStreamingChatService(
 
       const runId = beginStreamRun(runtime);
       try {
-        await runtimeService.run(sendMessageEffect(input, runtime, runId));
+        await runtimeService.run(sendMessageEffect(input, runtime, streamingTelemetry, runId));
       } catch (error) {
-        await Promise.resolve(deps.captureError(error));
+        await streamingTelemetry.captureError(error);
         resetStreamStateIfCurrent(runtime, deps, runId);
       }
     },

--- a/apps/mobile/features/email-capture/services/create-email-pipeline-service.ts
+++ b/apps/mobile/features/email-capture/services/create-email-pipeline-service.ts
@@ -11,6 +11,13 @@ import {
 } from "@/shared/effect/clock";
 import { fromPromise, fromThunk, makeAppService } from "@/shared/effect/runtime";
 import {
+  type AppTelemetry,
+  bindAppTelemetry,
+  captureErrorEffect,
+  capturePipelineEventEffect,
+  captureWarningEffect,
+} from "@/shared/effect/telemetry";
+import {
   generateProcessedEmailId,
   generateSyncQueueId,
   generateTransactionId,
@@ -50,26 +57,6 @@ export type RetryResult = {
   succeeded: number;
   permanentlyFailed: number;
 };
-
-type CaptureWarning = (
-  name: "email_parse_exception" | "email_retry_parse_exception",
-  tags: {
-    provider: RawEmail["provider"] | ProcessedEmailRow["provider"];
-    errorType: string;
-  }
-) => void | Promise<void>;
-
-type CapturePipelineEvent = (input: {
-  source: "email";
-  batchSize: number;
-  uniqueProviders: number;
-  dedupedInBatch: number;
-  skippedAlreadyProcessed: number;
-  skippedCrossSource: number;
-  saved: number;
-  failed: number;
-  needsReview: number;
-}) => void | Promise<void>;
 
 type CreateEmailPipelineServiceDeps = {
   readonly parseEmailApi: (body: string) => Promise<LlmParsedTransaction | null>;
@@ -122,10 +109,8 @@ type CreateEmailPipelineServiceDeps = {
     category: string;
     source: "email";
   }) => void | Promise<void>;
-  readonly captureError: (error: unknown) => void | Promise<void>;
-  readonly captureWarning: CaptureWarning;
-  readonly capturePipelineEvent: CapturePipelineEvent;
   readonly clock?: AppClock;
+  readonly telemetry?: AppTelemetry;
 };
 
 export type EmailPipelineService = {
@@ -294,30 +279,6 @@ function insertMerchantRuleEffect(
   );
 }
 
-function captureErrorEffect(error: unknown) {
-  return Effect.flatMap(EmailPipelineDeps.tag, ({ captureError }) =>
-    fromThunk(() => captureError(error))
-  );
-}
-
-function captureWarningEffect(
-  name: "email_parse_exception" | "email_retry_parse_exception",
-  tags: {
-    provider: RawEmail["provider"] | ProcessedEmailRow["provider"];
-    errorType: string;
-  }
-) {
-  return Effect.flatMap(EmailPipelineDeps.tag, ({ captureWarning }) =>
-    fromThunk(() => captureWarning(name, tags))
-  );
-}
-
-function capturePipelineEventEffect(input: Parameters<CapturePipelineEvent>[0]) {
-  return Effect.flatMap(EmailPipelineDeps.tag, ({ capturePipelineEvent }) =>
-    fromThunk(() => capturePipelineEvent(input))
-  );
-}
-
 function markForRetryEffect(
   db: AnyDb,
   id: ProcessedEmailId,
@@ -426,11 +387,14 @@ function nextRetryAtEffect(retryCount: number) {
 export function createEmailPipelineService(
   deps: CreateEmailPipelineServiceDeps
 ): EmailPipelineService {
-  const { clock, ...runtimeDeps } = deps;
+  const { clock, telemetry, ...runtimeDeps } = deps;
   const clockRuntime = bindAppClock(clock);
+  const telemetryRuntime = bindAppTelemetry(telemetry);
   const runtime = EmailPipelineDeps.bind(runtimeDeps);
   const runClockEffect = <A>(effect: Effect.Effect<A, unknown, AppClock>) =>
     clockRuntime.run(effect);
+  const runTelemetryEffect = <A>(effect: Effect.Effect<A, unknown, AppTelemetry>) =>
+    telemetryRuntime.run(effect);
   const runEmailEffect = <A>(effect: Effect.Effect<A, unknown, CreateEmailPipelineServiceDeps>) =>
     runtime.run(effect);
   const runEmailWithClock = <A>(
@@ -476,7 +440,7 @@ export function createEmailPipelineService(
           try {
             parsed = await runEmailEffect(parseBodyEffect(db, userId, email.body));
           } catch (err) {
-            await runEmailEffect(
+            await runTelemetryEffect(
               captureWarningEffect("email_parse_exception", {
                 provider: email.provider,
                 errorType: err instanceof Error ? err.message : "unknown",
@@ -529,7 +493,7 @@ export function createEmailPipelineService(
           try {
             existingTxId = await runEmailEffect(findDuplicateTransactionEffect(db, userId, parsed));
           } catch (saveErr) {
-            await runEmailEffect(captureErrorEffect(saveErr));
+            await runTelemetryEffect(captureErrorEffect(saveErr));
             result.failed++;
             completed++;
             onProgress?.(getProgressSnapshot(total, completed, result));
@@ -570,7 +534,7 @@ export function createEmailPipelineService(
               result.saved++;
             }
           } catch (saveErr) {
-            await runEmailEffect(captureErrorEffect(saveErr));
+            await runTelemetryEffect(captureErrorEffect(saveErr));
             result.failed++;
             completed++;
             onProgress?.(getProgressSnapshot(total, completed, result));
@@ -591,7 +555,7 @@ export function createEmailPipelineService(
                 )
               );
             } catch (ruleErr) {
-              await runEmailEffect(captureErrorEffect(ruleErr));
+              await runTelemetryEffect(captureErrorEffect(ruleErr));
             }
           }
 
@@ -602,7 +566,7 @@ export function createEmailPipelineService(
 
       await Promise.all(Array.from({ length: Math.min(Concurrency, total) }, () => worker()));
 
-      await runEmailEffect(
+      await runTelemetryEffect(
         capturePipelineEventEffect({
           source: "email",
           batchSize: rawEmails.length,
@@ -636,7 +600,7 @@ export function createEmailPipelineService(
         try {
           parsed = await runEmailEffect(parseBodyEffect(db, userId, email.rawBody));
         } catch (err) {
-          await runEmailEffect(
+          await runTelemetryEffect(
             captureWarningEffect("email_retry_parse_exception", {
               provider: email.provider,
               errorType: err instanceof Error ? err.message : "unknown",
@@ -667,7 +631,7 @@ export function createEmailPipelineService(
         try {
           existingTxId = await runEmailEffect(findDuplicateTransactionEffect(db, userId, parsed));
         } catch (saveErr) {
-          await runEmailEffect(captureErrorEffect(saveErr));
+          await runTelemetryEffect(captureErrorEffect(saveErr));
           const nextCount = (email.retryCount ?? 0) + 1;
           const nextRetryAt = await runClockEffect(nextRetryAtEffect(nextCount));
           if (isMaxRetriesReached(nextCount)) {
@@ -697,7 +661,7 @@ export function createEmailPipelineService(
           );
           result.succeeded++;
         } catch (saveErr) {
-          await runEmailEffect(captureErrorEffect(saveErr));
+          await runTelemetryEffect(captureErrorEffect(saveErr));
           const nextCount = (email.retryCount ?? 0) + 1;
           const nextRetryAt = await runClockEffect(nextRetryAtEffect(nextCount));
           if (isMaxRetriesReached(nextCount)) {

--- a/apps/mobile/features/email-capture/services/email-pipeline.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline.ts
@@ -3,7 +3,6 @@ import { insertTransaction } from "@/features/transactions/lib/repository";
 import type { AnyDb } from "@/shared/db";
 import { enqueueSync } from "@/shared/db";
 import { trackTransactionCreated } from "@/shared/lib/analytics";
-import { captureError, capturePipelineEvent, captureWarning } from "@/shared/lib/sentry";
 import type { UserId } from "@/shared/types/branded";
 import { insertMerchantRule, lookupMerchantRule } from "../lib/merchant-rules";
 import {
@@ -43,9 +42,6 @@ const emailPipeline = createEmailPipelineService({
   enqueueSync,
   insertMerchantRule,
   trackTransactionCreated,
-  captureError,
-  captureWarning,
-  capturePipelineEvent,
 });
 
 export const processEmails: ProcessEmails = (

--- a/apps/mobile/shared/effect/telemetry.ts
+++ b/apps/mobile/shared/effect/telemetry.ts
@@ -1,0 +1,47 @@
+import { Effect } from "effect";
+import {
+  captureError as captureSentryError,
+  capturePipelineEvent as captureSentryPipelineEvent,
+  captureWarning as captureSentryWarning,
+} from "@/shared/lib/sentry";
+import { type BoundAppService, fromThunk, makeAppService } from "./runtime";
+
+export type TelemetryContext = Record<string, string | number | boolean>;
+
+export type AppTelemetry = {
+  readonly captureError: (error: unknown) => void | Promise<void>;
+  readonly captureWarning: (
+    message: string,
+    context?: TelemetryContext | undefined
+  ) => void | Promise<void>;
+  readonly capturePipelineEvent: (data: TelemetryContext) => void | Promise<void>;
+};
+
+export const liveAppTelemetry: AppTelemetry = {
+  captureError: captureSentryError,
+  captureWarning: captureSentryWarning,
+  capturePipelineEvent: captureSentryPipelineEvent,
+};
+
+export const AppTelemetryService = makeAppService<AppTelemetry>("@/shared/effect/AppTelemetry");
+
+export const captureErrorEffect = (error: unknown) =>
+  Effect.flatMap(AppTelemetryService.tag, ({ captureError }) =>
+    fromThunk(() => captureError(error))
+  );
+
+export const captureWarningEffect = (message: string, context?: TelemetryContext) =>
+  Effect.flatMap(AppTelemetryService.tag, ({ captureWarning }) =>
+    fromThunk(() => captureWarning(message, context))
+  );
+
+export const capturePipelineEventEffect = (data: TelemetryContext) =>
+  Effect.flatMap(AppTelemetryService.tag, ({ capturePipelineEvent }) =>
+    fromThunk(() => capturePipelineEvent(data))
+  );
+
+export function bindAppTelemetry(
+  telemetry: AppTelemetry = liveAppTelemetry
+): BoundAppService<AppTelemetry, AppTelemetry> {
+  return AppTelemetryService.bind(telemetry);
+}


### PR DESCRIPTION
- add shared effect telemetry
- wire email and ai chat services
- keep service tests green


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce a shared Effect-based telemetry service and wire it into AI chat streaming and the email pipeline to standardize error/warning/event reporting and improve testability.

- **Refactors**
  - Added `@/shared/effect/telemetry` with `AppTelemetry`, live Sentry bindings, and Effect helpers.
  - Updated `create-streaming-chat-service` to accept optional `telemetry`, replacing separate `captureWarning`/`captureError` deps.
  - Updated `create-email-pipeline-service` to use `telemetry` for warnings, errors, and pipeline events; removed direct capture deps.
  - Simplified `use-streaming-chat` and email pipeline wiring to rely on default telemetry; adjusted tests to mock `AppTelemetry`.

<sup>Written for commit 12066f224d127e44e1de0009ecdf1142403e126b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

