### PR TITLE
feat(mobile): bootstrap transaction ownership

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,10 @@ When a new slice branch is created from an older feature branch and that parent 
 
 Tests that `await import(...)` a large service module inside `beforeEach` can intermittently hit the 10s hook timeout during full-suite runs, even if the file passes in isolation. We hit this in `__tests__/email-capture/email-pipeline.test.ts` because the hook imported `email-pipeline.ts`, which itself pulled broad barrels like `@/features/transactions` and `@/shared/lib`. Fix: prefer static imports (or `beforeAll`) for the module under test, and narrow production imports to deep modules when the test only needs a small subset of functionality.
 
+### Dark-mode category icon colors are inconsistent between screens (⚠️ AGENT SURPRISE)
+
+`apps/mobile/features/categories/components/CategoriesScreen.tsx` special-cases the clothing category icon color in dark mode (`#1A1A1A` -> `#E0E0E0`) so it stays visible on dark surfaces, but the shared `apps/mobile/features/transactions/components/CategoryPill.tsx` does not. If you mirror category visuals from the categories screen into transaction-entry or budget-selection flows, the clothing icon can become too low-contrast unless you add the same override or normalize the shared category-color treatment first.
+
 ## External Fidy Vault
 
 The persistent Fidy knowledge vault lives outside the repo on the local machine.

--- a/apps/mobile/__tests__/capture-sources/apple-pay-pipeline.test.ts
+++ b/apps/mobile/__tests__/capture-sources/apple-pay-pipeline.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ApplePayIntentData } from "@/features/capture-sources/schema";
 import { processApplePayIntent } from "@/features/capture-sources/services/apple-pay-pipeline";
+import type { FinancialAccountId } from "@/shared/types/branded";
 
 const mockInsertTransaction = vi.fn();
 const mockEnqueueSync = vi.fn();
@@ -13,6 +14,16 @@ const mockIsCaptureProcessed = vi.fn().mockResolvedValue(false);
 const mockFindDuplicateTransaction = vi.fn().mockResolvedValue(null);
 const mockCaptureFingerprint = vi.fn().mockReturnValue("test-fingerprint");
 const mockInsertProcessedCapture = vi.fn();
+const mockEnsureDefaultFinancialAccount = vi.fn().mockReturnValue({
+  id: "fa-default-user-1" as FinancialAccountId,
+  userId: "user-1",
+  name: "Cash",
+  kind: "cash",
+  isDefault: true,
+  createdAt: "2026-04-18T10:00:00.000Z",
+  updatedAt: "2026-04-18T10:00:00.000Z",
+  deletedAt: null,
+});
 
 vi.mock("@/features/transactions/lib/repository", () => ({
   insertTransaction: (...args: any[]) => mockInsertTransaction(...args),
@@ -39,6 +50,10 @@ vi.mock("@/features/capture-sources/lib/dedup", () => ({
 
 vi.mock("@/features/capture-sources/lib/repository", () => ({
   insertProcessedCapture: (...args: any[]) => mockInsertProcessedCapture(...args),
+}));
+
+vi.mock("@/features/financial-accounts", () => ({
+  ensureDefaultFinancialAccount: (...args: any[]) => mockEnsureDefaultFinancialAccount(...args),
 }));
 
 const mockGenerateId = vi.fn();
@@ -88,6 +103,8 @@ describe("processApplePayIntent", () => {
         type: "expense",
         amount: 50000,
         description: "Farmatodo",
+        accountId: "fa-default-user-1",
+        accountAttributionState: "unresolved",
         source: "apple_pay",
       })
     );

--- a/apps/mobile/__tests__/capture-sources/notification-pipeline.test.ts
+++ b/apps/mobile/__tests__/capture-sources/notification-pipeline.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { NotificationData } from "@/features/capture-sources/schema";
 import { processNotification } from "@/features/capture-sources/services/notification-pipeline";
+import type { FinancialAccountId } from "@/shared/types/branded";
 
 const mockInsertTransaction = vi.fn();
 const mockEnqueueSync = vi.fn();
@@ -14,6 +15,16 @@ const mockFindDuplicateTransaction = vi.fn().mockResolvedValue(null);
 const mockCaptureFingerprint = vi.fn().mockReturnValue("test-fingerprint");
 const mockInsertProcessedCapture = vi.fn();
 const mockStripPii = vi.fn().mockImplementation((t: string) => t);
+const mockEnsureDefaultFinancialAccount = vi.fn().mockReturnValue({
+  id: "fa-default-user-1" as FinancialAccountId,
+  userId: "user-1",
+  name: "Cash",
+  kind: "cash",
+  isDefault: true,
+  createdAt: "2026-04-18T10:00:00.000Z",
+  updatedAt: "2026-04-18T10:00:00.000Z",
+  deletedAt: null,
+});
 
 vi.mock("@/features/transactions/lib/repository", () => ({
   insertTransaction: (...args: any[]) => mockInsertTransaction(...args),
@@ -44,6 +55,10 @@ vi.mock("@/features/capture-sources/lib/repository", () => ({
 
 vi.mock("@/features/email-capture/services/parse-email-api", () => ({
   stripPii: (...args: any[]) => mockStripPii(...args),
+}));
+
+vi.mock("@/features/financial-accounts", () => ({
+  ensureDefaultFinancialAccount: (...args: any[]) => mockEnsureDefaultFinancialAccount(...args),
 }));
 
 const mockGenerateId = vi.fn();
@@ -97,6 +112,8 @@ describe("processNotification", () => {
         type: "expense",
         amount: 50000,
         description: "EDS LA CASTELLANA",
+        accountId: "fa-default-user-1",
+        accountAttributionState: "unresolved",
         source: "notification_android",
       })
     );

--- a/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
@@ -4,6 +4,7 @@ import type { RawEmail } from "@/features/email-capture/schema";
 import { createEmailPipelineService } from "@/features/email-capture/services/create-email-pipeline-service";
 import { processEmails, processRetries } from "@/features/email-capture/services/email-pipeline";
 import { requireIsoDateTime, requireUserId } from "@/shared/types/assertions";
+import type { FinancialAccountId } from "@/shared/types/branded";
 
 const mockGetProcessedExternalIds = vi.fn().mockResolvedValue(new Set<string>());
 const mockInsertProcessedEmail = vi.fn();
@@ -18,6 +19,16 @@ const mockMarkForRetry = vi.fn();
 const mockMarkPermanentlyFailed = vi.fn();
 const mockMarkRetrySuccess = vi.fn();
 const mockUpdateProcessedEmailStatus = vi.fn();
+const mockEnsureDefaultFinancialAccount = vi.fn().mockReturnValue({
+  id: "fa-default-user-1" as FinancialAccountId,
+  userId: requireUserId("user-1"),
+  name: "Cash",
+  kind: "cash",
+  isDefault: true,
+  createdAt: "2026-04-18T10:00:00.000Z",
+  updatedAt: "2026-04-18T10:00:00.000Z",
+  deletedAt: null,
+});
 
 vi.mock("@/features/capture-sources/lib/dedup", () => ({
   findDuplicateTransaction: (...args: unknown[]) => mockFindDuplicateTransaction(...args),
@@ -48,6 +59,10 @@ vi.mock("@/features/email-capture/lib/merchant-rules", () => ({
 
 vi.mock("@/features/email-capture/services/parse-email-api", () => ({
   parseEmailApi: (...args: unknown[]) => mockParseEmailApi(...args),
+}));
+
+vi.mock("@/features/financial-accounts", () => ({
+  ensureDefaultFinancialAccount: (...args: unknown[]) => mockEnsureDefaultFinancialAccount(...args),
 }));
 
 vi.mock("@/shared/lib/sentry", () => ({
@@ -156,6 +171,8 @@ describe("email processing pipeline", () => {
         userId: USER_ID,
         type: "expense",
         amount: 50000,
+        accountId: "fa-default-user-1",
+        accountAttributionState: "unresolved",
         source: "email_gmail",
       })
     );
@@ -190,6 +207,7 @@ describe("email processing pipeline", () => {
       markPermanentlyFailed: mockMarkPermanentlyFailed,
       markRetrySuccess: mockMarkRetrySuccess,
       updateProcessedEmailStatus: mockUpdateProcessedEmailStatus,
+      ensureDefaultFinancialAccount: mockEnsureDefaultFinancialAccount,
       insertTransaction: mockInsertTransaction,
       enqueueSync: mockEnqueueSync,
       insertMerchantRule: mockInsertMerchantRule,

--- a/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
@@ -558,7 +558,18 @@ describe("processRetries", () => {
 
     const result = await processRetries(mockDb, USER_ID);
 
-    expect(mockInsertTransaction).toHaveBeenCalled();
+    expect(mockEnsureDefaultFinancialAccount).toHaveBeenCalledWith(
+      mockDb,
+      USER_ID,
+      expect.objectContaining({ now: expect.any(String) })
+    );
+    expect(mockInsertTransaction).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        accountId: "fa-default-user-1",
+        accountAttributionState: "unresolved",
+      })
+    );
     expect(mockEnqueueSync).toHaveBeenCalled();
     expect(result.succeeded).toBe(1);
   });

--- a/apps/mobile/__tests__/email-capture/retry-integration.test.ts
+++ b/apps/mobile/__tests__/email-capture/retry-integration.test.ts
@@ -205,11 +205,17 @@ describe("retry queue integration (real SQLite)", () => {
     expect(txRows).toHaveLength(1);
     expect(txRows[0]?.amount).toBe(50000);
     expect(txRows[0]?.source).toBe("email_gmail");
+    expect(txRows[0]?.accountId).toBe(`fa-default-${USER_ID}`);
+    expect(txRows[0]?.accountAttributionState).toBe("unresolved");
 
     // Verify sync queue entry
     const syncRows = await db.select().from(syncQueue);
-    expect(syncRows).toHaveLength(1);
-    expect(syncRows[0]?.tableName).toBe("transactions");
+    expect(syncRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ tableName: "financialAccounts" }),
+        expect.objectContaining({ tableName: "transactions" }),
+      ])
+    );
 
     // Verify processed email was updated
     const [pe] = await db

--- a/apps/mobile/__tests__/error-handling/pipeline-save-error.test.ts
+++ b/apps/mobile/__tests__/error-handling/pipeline-save-error.test.ts
@@ -20,6 +20,9 @@ const mockLookupMerchantRule = vi.fn().mockResolvedValue(null);
 const mockInsertMerchantRule = vi.fn();
 const mockParseEmailApi = vi.fn().mockResolvedValue(null);
 const mockFindDuplicateTransaction = vi.fn().mockResolvedValue(null);
+const mockEnsureDefaultFinancialAccount = vi
+  .fn()
+  .mockImplementation((_: unknown, userId: string) => ({ id: `fa-default-${userId}` }));
 const mockGetPendingRetryEmails = vi.fn().mockResolvedValue([]);
 const mockMarkForRetry = vi.fn();
 const mockMarkPermanentlyFailed = vi.fn();
@@ -42,6 +45,10 @@ vi.mock("@/features/email-capture/lib/repository", () => ({
 
 vi.mock("@/features/transactions/lib/repository", () => ({
   insertTransaction: (...args: unknown[]) => mockInsertTransaction(...args),
+}));
+
+vi.mock("@/features/financial-accounts", () => ({
+  ensureDefaultFinancialAccount: (...args: unknown[]) => mockEnsureDefaultFinancialAccount(...args),
 }));
 
 vi.mock("@/shared/db/enqueue-sync", () => ({

--- a/apps/mobile/__tests__/financial-accounts/repository.test.ts
+++ b/apps/mobile/__tests__/financial-accounts/repository.test.ts
@@ -4,7 +4,12 @@ import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { getFinancialAccountsForUser, saveFinancialAccount } from "@/features/financial-accounts";
+import {
+  ensureDefaultFinancialAccount,
+  getDefaultFinancialAccountForUser,
+  getFinancialAccountsForUser,
+  saveFinancialAccount,
+} from "@/features/financial-accounts";
 import { getQueuedSyncEntries } from "@/features/transactions/lib/repository";
 import type { FinancialAccountId, IsoDateTime, UserId } from "@/shared/types/branded";
 
@@ -54,5 +59,53 @@ describe("financial accounts repository", () => {
         operation: "insert",
       }),
     ]);
+  });
+
+  it("bootstraps the default account once and reuses it on later calls", () => {
+    const first = ensureDefaultFinancialAccount(db as any, USER_ID, { now: NOW, name: "Cash" });
+    const second = ensureDefaultFinancialAccount(db as any, USER_ID, { now: NOW, name: "Cash" });
+
+    expect(first).toMatchObject({
+      userId: USER_ID,
+      name: "Cash",
+      kind: "cash",
+      isDefault: true,
+    });
+    expect(second).toEqual(first);
+    expect(getDefaultFinancialAccountForUser(db as any, USER_ID)).toEqual(first);
+    expect(getFinancialAccountsForUser(db as any, USER_ID)).toHaveLength(1);
+    expect(getQueuedSyncEntries(db as any)).toEqual([
+      expect.objectContaining({
+        tableName: "financialAccounts",
+        rowId: first.id,
+        operation: "insert",
+      }),
+    ]);
+  });
+
+  it("reuses an existing default account instead of creating a new canonical one", () => {
+    saveFinancialAccount(db as any, {
+      id: "fa-bank-1" as FinancialAccountId,
+      userId: USER_ID,
+      name: "Bancolombia",
+      kind: "checking",
+      isDefault: true,
+      createdAt: NOW,
+      updatedAt: NOW,
+      deletedAt: null,
+    });
+
+    const defaultAccount = ensureDefaultFinancialAccount(db as any, USER_ID, {
+      now: "2026-04-18T12:00:00.000Z" as IsoDateTime,
+    });
+
+    expect(defaultAccount).toMatchObject({
+      id: "fa-bank-1",
+      userId: USER_ID,
+      name: "Bancolombia",
+      kind: "checking",
+      isDefault: true,
+    });
+    expect(getFinancialAccountsForUser(db as any, USER_ID)).toHaveLength(1);
   });
 });

--- a/apps/mobile/__tests__/financial-accounts/repository.test.ts
+++ b/apps/mobile/__tests__/financial-accounts/repository.test.ts
@@ -108,4 +108,45 @@ describe("financial accounts repository", () => {
     });
     expect(getFinancialAccountsForUser(db as any, USER_ID)).toHaveLength(1);
   });
+
+  it("promotes an existing canonical account to the actual default when the flag is missing", () => {
+    saveFinancialAccount(db as any, {
+      id: "fa-default-user-1" as FinancialAccountId,
+      userId: USER_ID,
+      name: "Cash",
+      kind: "cash",
+      isDefault: false,
+      createdAt: NOW,
+      updatedAt: NOW,
+      deletedAt: null,
+    });
+
+    const defaultAccount = ensureDefaultFinancialAccount(db as any, USER_ID, {
+      now: "2026-04-18T12:00:00.000Z" as IsoDateTime,
+    });
+
+    expect(defaultAccount).toMatchObject({
+      id: "fa-default-user-1",
+      userId: USER_ID,
+      name: "Cash",
+      kind: "cash",
+      isDefault: true,
+    });
+    expect(getDefaultFinancialAccountForUser(db as any, USER_ID)).toMatchObject({
+      id: "fa-default-user-1",
+      isDefault: true,
+    });
+    expect(getQueuedSyncEntries(db as any)).toEqual([
+      expect.objectContaining({
+        tableName: "financialAccounts",
+        rowId: "fa-default-user-1",
+        operation: "insert",
+      }),
+      expect.objectContaining({
+        tableName: "financialAccounts",
+        rowId: "fa-default-user-1",
+        operation: "update",
+      }),
+    ]);
+  });
 });

--- a/apps/mobile/__tests__/financial-accounts/try-ensure-default-account.test.ts
+++ b/apps/mobile/__tests__/financial-accounts/try-ensure-default-account.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { tryEnsureDefaultFinancialAccount } from "@/features/financial-accounts/services/try-ensure-default-account";
+import { requireUserId } from "@/shared/types/assertions";
+
+const mockEnsureDefaultFinancialAccount = vi.fn();
+const mockCaptureError = vi.fn();
+
+vi.mock("@/features/financial-accounts/lib/repository", () => ({
+  ensureDefaultFinancialAccount: (...args: unknown[]) => mockEnsureDefaultFinancialAccount(...args),
+}));
+
+vi.mock("@/shared/lib/sentry", () => ({
+  captureError: (...args: unknown[]) => mockCaptureError(...args),
+}));
+
+const mockDb = {} as never;
+const USER_ID = requireUserId("user-1");
+
+describe("tryEnsureDefaultFinancialAccount", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the ensured default account when bootstrap succeeds", () => {
+    const account = {
+      id: "fa-default-user-1",
+      userId: USER_ID,
+      name: "Cash",
+      kind: "cash",
+      isDefault: true,
+      createdAt: "2026-04-18T10:00:00.000Z",
+      updatedAt: "2026-04-18T10:00:00.000Z",
+      deletedAt: null,
+    };
+    mockEnsureDefaultFinancialAccount.mockReturnValueOnce(account);
+
+    expect(tryEnsureDefaultFinancialAccount(mockDb, USER_ID)).toEqual(account);
+    expect(mockCaptureError).not.toHaveBeenCalled();
+  });
+
+  it("captures bootstrap errors and returns null instead of throwing", () => {
+    const error = new Error("db locked");
+    mockEnsureDefaultFinancialAccount.mockImplementationOnce(() => {
+      throw error;
+    });
+
+    expect(tryEnsureDefaultFinancialAccount(mockDb, USER_ID)).toBeNull();
+    expect(mockCaptureError).toHaveBeenCalledWith(error);
+  });
+});

--- a/apps/mobile/__tests__/notifications/derive.test.ts
+++ b/apps/mobile/__tests__/notifications/derive.test.ts
@@ -7,6 +7,7 @@ import type {
   BudgetId,
   CategoryId,
   CopAmount,
+  FinancialAccountId,
   TransactionId,
   UserId,
 } from "@/shared/types/branded";
@@ -38,6 +39,8 @@ const makeTx = (overrides: Partial<StoredTransaction> = {}): StoredTransaction =
   createdAt: new Date(),
   updatedAt: new Date(),
   deletedAt: null,
+  accountId: "fa-default-u1" as FinancialAccountId,
+  accountAttributionState: "confirmed",
   ...overrides,
 });
 

--- a/apps/mobile/__tests__/sync/syncEngine.test.ts
+++ b/apps/mobile/__tests__/sync/syncEngine.test.ts
@@ -10,6 +10,9 @@ const mockGetFinancialAccountIdentifierById = vi.fn().mockReturnValue(null);
 const mockGetOpeningBalanceById = vi.fn().mockReturnValue(null);
 const mockGetOpeningBalanceForAccount = vi.fn().mockReturnValue(null);
 const mockGetTransferById = vi.fn().mockReturnValue(null);
+const mockEnsureDefaultFinancialAccount = vi
+  .fn()
+  .mockImplementation((_: unknown, userId: string) => ({ id: `fa-default-${userId}` }));
 const mockGetSyncMeta = vi.fn().mockReturnValue(null);
 const mockSetSyncMeta = vi.fn();
 const mockUpsertTransaction = vi.fn();
@@ -36,6 +39,7 @@ vi.mock("@/features/transactions/lib/repository", () => ({
 
 vi.mock("@/features/financial-accounts", () => ({
   buildDefaultFinancialAccountId: (userId: string) => `fa-default-${userId}`,
+  ensureDefaultFinancialAccount: (...args: any[]) => mockEnsureDefaultFinancialAccount(...args),
   getFinancialAccountById: (...args: any[]) => mockGetFinancialAccountById(...args),
   upsertFinancialAccount: (...args: any[]) => mockUpsertFinancialAccount(...args),
   getFinancialAccountIdentifierById: (...args: any[]) =>

--- a/apps/mobile/__tests__/transactions/account-selection.test.ts
+++ b/apps/mobile/__tests__/transactions/account-selection.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { hasSelectedFinancialAccount } from "@/features/transactions/lib/account-selection";
+import { requireIsoDateTime, requireUserId } from "@/shared/types/assertions";
+import type { FinancialAccountId } from "@/shared/types/branded";
+
+const USER_ID = requireUserId("user-1");
+
+const ACCOUNTS = [
+  {
+    id: "fa-default-user-1" as FinancialAccountId,
+    userId: USER_ID,
+    name: "Cash",
+    kind: "cash" as const,
+    isDefault: true,
+    createdAt: requireIsoDateTime("2026-04-18T10:00:00.000Z"),
+    updatedAt: requireIsoDateTime("2026-04-18T10:00:00.000Z"),
+    deletedAt: null,
+  },
+  {
+    id: "fa-bank-1" as FinancialAccountId,
+    userId: USER_ID,
+    name: "Bancolombia",
+    kind: "checking" as const,
+    isDefault: false,
+    createdAt: requireIsoDateTime("2026-04-18T10:00:00.000Z"),
+    updatedAt: requireIsoDateTime("2026-04-18T10:00:00.000Z"),
+    deletedAt: null,
+  },
+] as const;
+
+describe("hasSelectedFinancialAccount", () => {
+  it("returns true when the selected account exists in the available list", () => {
+    expect(hasSelectedFinancialAccount(ACCOUNTS, "fa-default-user-1" as FinancialAccountId)).toBe(
+      true
+    );
+  });
+
+  it("returns false when the selected account is missing from the available list", () => {
+    expect(hasSelectedFinancialAccount(ACCOUNTS, "fa-missing" as FinancialAccountId)).toBe(false);
+  });
+
+  it("returns false when no account is selected", () => {
+    expect(hasSelectedFinancialAccount(ACCOUNTS, null)).toBe(false);
+  });
+});

--- a/apps/mobile/__tests__/transactions/build-transaction.test.ts
+++ b/apps/mobile/__tests__/transactions/build-transaction.test.ts
@@ -23,6 +23,7 @@ describe("buildTransaction", () => {
     type: "expense" as const,
     digits: "1234",
     categoryId: "food" as CategoryId,
+    accountId: "fa-default-user-1" as FinancialAccountId,
     description: "Lunch",
     date: new Date(2026, 2, 5),
   };
@@ -35,6 +36,8 @@ describe("buildTransaction", () => {
     expect(result.transaction.userId).toBe("user-1");
     expect(result.transaction.amount).toBe(1234);
     expect(result.transaction.categoryId).toBe("food");
+    expect(result.transaction.accountId).toBe("fa-default-user-1");
+    expect(result.transaction.accountAttributionState).toBe("confirmed");
     expect(result.transaction.createdAt).toBe(NOW);
     expect(result.transaction.updatedAt).toBe(NOW);
     expect(result.transaction.deletedAt).toBeNull();
@@ -67,6 +70,16 @@ describe("buildTransaction", () => {
       { ...validInput, digits: "abc" },
       "user-1" as UserId,
       "tx-4" as TransactionId,
+      NOW
+    );
+    expect(result.success).toBe(false);
+  });
+
+  test("returns error when the owning account is missing", () => {
+    const result = buildTransaction(
+      { ...validInput, accountId: null },
+      "user-1" as UserId,
+      "tx-5" as TransactionId,
       NOW
     );
     expect(result.success).toBe(false);

--- a/apps/mobile/__tests__/transactions/derive.test.ts
+++ b/apps/mobile/__tests__/transactions/derive.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type {
   CategoryId,
   CopAmount,
+  FinancialAccountId,
   IsoDate,
   Month,
   TransactionId,
@@ -27,6 +28,8 @@ const makeTx = (overrides: Partial<StoredTransaction>): StoredTransaction => ({
   createdAt: NOW,
   updatedAt: NOW,
   deletedAt: null,
+  accountId: "fa-default-u1" as FinancialAccountId,
+  accountAttributionState: "confirmed",
   ...overrides,
 });
 

--- a/apps/mobile/__tests__/transactions/group-by-date.test.ts
+++ b/apps/mobile/__tests__/transactions/group-by-date.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import type { StoredTransaction } from "@/features/transactions/schema";
-import type { CategoryId, CopAmount, TransactionId, UserId } from "@/shared/types/branded";
+import type {
+  CategoryId,
+  CopAmount,
+  FinancialAccountId,
+  TransactionId,
+  UserId,
+} from "@/shared/types/branded";
 
 function makeTx(overrides: Partial<StoredTransaction> & { date: Date }): StoredTransaction {
   return {
@@ -13,6 +19,8 @@ function makeTx(overrides: Partial<StoredTransaction> & { date: Date }): StoredT
     createdAt: new Date(),
     updatedAt: new Date(),
     deletedAt: null,
+    accountId: "fa-default-user-1" as FinancialAccountId,
+    accountAttributionState: "confirmed",
     ...overrides,
   };
 }

--- a/apps/mobile/__tests__/transactions/mutation-service.test.ts
+++ b/apps/mobile/__tests__/transactions/mutation-service.test.ts
@@ -311,5 +311,7 @@ describe("transaction mutation service", () => {
       success: false,
       error: "Account is required",
     });
+    expect(currentCommit).not.toHaveBeenCalled();
+    expect(refreshMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/mobile/__tests__/transactions/mutation-service.test.ts
+++ b/apps/mobile/__tests__/transactions/mutation-service.test.ts
@@ -16,6 +16,7 @@ const input = {
   type: "expense" as const,
   digits: "1200",
   categoryId: "food" as CategoryId,
+  accountId: "fa-default-user-1" as FinancialAccountId,
   description: "Lunch",
   date: new Date("2026-04-12T00:00:00.000Z"),
 };
@@ -113,6 +114,7 @@ describe("transaction mutation service", () => {
         userId: "user-1",
         amount: 1200,
         categoryId: "food",
+        accountId: "fa-default-user-1",
       }),
     });
     expect(currentCommit).toHaveBeenCalledWith(
@@ -206,7 +208,10 @@ describe("transaction mutation service", () => {
     } satisfies StoredTransaction);
     const service = createService();
 
-    await service.updateDirect("txn-9" as TransactionId, input);
+    await service.updateDirect("txn-9" as TransactionId, {
+      ...input,
+      accountId: "fa-card-1" as FinancialAccountId,
+    });
 
     expect(currentCommit).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -297,5 +302,14 @@ describe("transaction mutation service", () => {
     );
     expect(trackDeletedMock).toHaveBeenCalledOnce();
     expect(refreshMock).toHaveBeenCalledOnce();
+  });
+
+  it("returns a validation failure when no owning account is selected", async () => {
+    const service = createService();
+
+    await expect(service.save({ ...input, accountId: null })).resolves.toEqual({
+      success: false,
+      error: "Account is required",
+    });
   });
 });

--- a/apps/mobile/__tests__/transactions/query-service.test.ts
+++ b/apps/mobile/__tests__/transactions/query-service.test.ts
@@ -3,6 +3,7 @@ import { createTransactionQueryService } from "@/features/transactions/services/
 import type {
   CategoryId,
   CopAmount,
+  FinancialAccountId,
   IsoDate,
   IsoDateTime,
   TransactionId,
@@ -35,6 +36,8 @@ function makeRow(
     createdAt: "2026-04-12T10:00:00.000Z" as IsoDateTime,
     updatedAt: "2026-04-12T10:00:00.000Z" as IsoDateTime,
     deletedAt: null,
+    accountId: "fa-default-user-1" as FinancialAccountId,
+    accountAttributionState: "confirmed",
     source: "manual",
     ...overrides,
   };
@@ -102,6 +105,8 @@ describe("transaction query service", () => {
         createdAt: new Date("2026-04-12T10:00:00.000Z"),
         updatedAt: new Date("2026-04-12T10:00:00.000Z"),
         deletedAt: null,
+        accountId: "fa-default-user-1" as FinancialAccountId,
+        accountAttributionState: "confirmed" as const,
       },
     ];
 

--- a/apps/mobile/__tests__/transactions/schema.test.ts
+++ b/apps/mobile/__tests__/transactions/schema.test.ts
@@ -6,6 +6,7 @@ describe("createTransactionSchema", () => {
     type: "expense" as const,
     amount: 4520,
     categoryId: "food" as const,
+    accountId: "fa-default-user-1",
     description: "Groceries",
     date: new Date("2026-03-01"),
   };

--- a/apps/mobile/__tests__/transactions/store.test.ts
+++ b/apps/mobile/__tests__/transactions/store.test.ts
@@ -24,6 +24,7 @@ import { enqueueSync } from "@/shared/db/enqueue-sync";
 import type {
   CategoryId,
   CopAmount,
+  FinancialAccountId,
   IsoDate,
   IsoDateTime,
   TransactionId,
@@ -62,6 +63,8 @@ function makeStoredTransaction(overrides: Partial<{ id: TransactionId; updatedAt
     createdAt: new Date("2026-03-04T10:00:00.000Z"),
     updatedAt: new Date("2026-03-04T10:00:00.000Z"),
     deletedAt: null,
+    accountId: "fa-default-user-1" as FinancialAccountId,
+    accountAttributionState: "confirmed" as const,
     ...overrides,
   };
 }
@@ -90,6 +93,8 @@ function makeRow(
     createdAt: "2026-03-04T10:00:00.000Z" as IsoDateTime,
     updatedAt: "2026-03-04T10:00:00.000Z" as IsoDateTime,
     deletedAt: null,
+    accountId: "fa-default-user-1" as FinancialAccountId,
+    accountAttributionState: "confirmed" as const,
     source: "manual",
     ...overrides,
   };
@@ -99,6 +104,7 @@ describe("transaction boundaries", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     initializeTransactionSession(mockUserId);
+    useTransactionStore.getState().setDefaultAccountId("fa-default-user-1" as FinancialAccountId);
   });
 
   it("starts with default form values after session initialization", () => {
@@ -108,6 +114,7 @@ describe("transaction boundaries", () => {
     expect(state.type).toBe("expense");
     expect(state.digits).toBe("");
     expect(state.categoryId).toBeNull();
+    expect(state.accountId).toBe("fa-default-user-1");
     expect(state.description).toBe("");
     expect(state.pages).toEqual([]);
   });
@@ -116,6 +123,7 @@ describe("transaction boundaries", () => {
     useTransactionStore.getState().setType("income");
     useTransactionStore.getState().setDigits("4520");
     useTransactionStore.getState().setCategoryId("food" as CategoryId);
+    useTransactionStore.getState().setAccountId("fa-cash-1" as FinancialAccountId);
     useTransactionStore.getState().setDescription("Lunch");
     useTransactionStore.getState().setDate(new Date("2026-06-15T00:00:00.000Z"));
     useTransactionStore.setState({ pages: [makeStoredTransaction()] });
@@ -126,6 +134,7 @@ describe("transaction boundaries", () => {
       type: "expense",
       digits: "",
       categoryId: null,
+      accountId: "fa-default-user-1",
       description: "",
     });
     expect(useTransactionStore.getState().pages).toHaveLength(1);

--- a/apps/mobile/app/(auth)/onboarding.tsx
+++ b/apps/mobile/app/(auth)/onboarding.tsx
@@ -5,6 +5,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useOptionalUserId } from "@/features/auth";
 import { initializeBudgetSession } from "@/features/budget";
 import { initializeEmailCaptureSession, loadEmailAccounts } from "@/features/email-capture";
+import { ensureDefaultFinancialAccount } from "@/features/financial-accounts";
 import {
   BudgetSetupStep,
   CompleteStep,
@@ -15,7 +16,11 @@ import {
   useOnboardingStore,
   WelcomeStep,
 } from "@/features/onboarding";
-import { initializeTransactionSession, loadInitialTransactions } from "@/features/transactions";
+import {
+  initializeTransactionSession,
+  loadInitialTransactions,
+  useTransactionStore,
+} from "@/features/transactions";
 import { StyleSheet, View } from "@/shared/components/rn";
 import { getDb } from "@/shared/db";
 import { useSubscription, useThemeColor } from "@/shared/hooks";
@@ -51,8 +56,10 @@ function AuthenticatedOnboardingScreen({
   // Initialize minimal stores needed for onboarding
   useSubscription(
     () => {
+      const defaultAccount = ensureDefaultFinancialAccount(db, userId);
       initializeEmailCaptureSession(userId);
       initializeTransactionSession(userId);
+      useTransactionStore.getState().setDefaultAccountId(defaultAccount.id);
       initializeBudgetSession(userId);
       Promise.all([loadEmailAccounts(db, userId), loadInitialTransactions(db, userId)])
         .catch(captureError)

--- a/apps/mobile/app/(auth)/onboarding.tsx
+++ b/apps/mobile/app/(auth)/onboarding.tsx
@@ -5,7 +5,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useOptionalUserId } from "@/features/auth";
 import { initializeBudgetSession } from "@/features/budget";
 import { initializeEmailCaptureSession, loadEmailAccounts } from "@/features/email-capture";
-import { ensureDefaultFinancialAccount } from "@/features/financial-accounts";
+import { tryEnsureDefaultFinancialAccount } from "@/features/financial-accounts";
 import {
   BudgetSetupStep,
   CompleteStep,
@@ -56,12 +56,17 @@ function AuthenticatedOnboardingScreen({
   // Initialize minimal stores needed for onboarding
   useSubscription(
     () => {
-      const defaultAccount = ensureDefaultFinancialAccount(db, userId);
-      initializeEmailCaptureSession(userId);
-      initializeTransactionSession(userId);
-      useTransactionStore.getState().setDefaultAccountId(defaultAccount.id);
-      initializeBudgetSession(userId);
-      Promise.all([loadEmailAccounts(db, userId), loadInitialTransactions(db, userId)])
+      void Promise.resolve()
+        .then(() => {
+          initializeEmailCaptureSession(userId);
+          initializeTransactionSession(userId);
+          const defaultAccount = tryEnsureDefaultFinancialAccount(db, userId);
+          if (defaultAccount) {
+            useTransactionStore.getState().setDefaultAccountId(defaultAccount.id);
+          }
+          initializeBudgetSession(userId);
+          return Promise.all([loadEmailAccounts(db, userId), loadInitialTransactions(db, userId)]);
+        })
         .catch(captureError)
         .finally(() => {
           setStoresReady(true);

--- a/apps/mobile/app/(tabs)/add.tsx
+++ b/apps/mobile/app/(tabs)/add.tsx
@@ -1,9 +1,12 @@
 import * as Haptics from "expo-haptics";
 import { useRouter } from "expo-router";
+import { useState } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { useOptionalUserId } from "@/features/auth";
 import {
-  ensureDefaultFinancialAccount,
+  type FinancialAccountRow,
   getFinancialAccountsForUser,
+  tryEnsureDefaultFinancialAccount,
 } from "@/features/financial-accounts";
 import {
   saveCurrentTransaction,
@@ -12,14 +15,15 @@ import {
   useTransactionStore,
 } from "@/features/transactions";
 import { tryGetDb } from "@/shared/db";
-import { useAsyncGuard, useMountEffect, useTranslation } from "@/shared/hooks";
-import { trackTransactionCreated } from "@/shared/lib";
+import { useAsyncGuard, useSubscription, useTranslation } from "@/shared/hooks";
+import { captureError, trackTransactionCreated } from "@/shared/lib";
 
 export default function AddTransactionScreen() {
   const { navigate } = useRouter();
   const { t } = useTranslation();
   const userId = useOptionalUserId();
   const db = userId ? tryGetDb(userId) : null;
+  const [accounts, setAccounts] = useState<readonly FinancialAccountRow[]>([]);
   const {
     type,
     digits,
@@ -35,17 +39,43 @@ export default function AddTransactionScreen() {
     setAccountId,
     setDescription,
     resetForm,
-  } = useTransactionStore();
+  } = useTransactionStore(
+    useShallow((state) => ({
+      type: state.type,
+      digits: state.digits,
+      categoryId: state.categoryId,
+      accountId: state.accountId,
+      description: state.description,
+      date: state.date,
+      editingId: state.editingId,
+      setType: state.setType,
+      setDigits: state.setDigits,
+      setCategoryId: state.setCategoryId,
+      setDefaultAccountId: state.setDefaultAccountId,
+      setAccountId: state.setAccountId,
+      setDescription: state.setDescription,
+      resetForm: state.resetForm,
+    }))
+  );
 
   const isEditing = editingId != null;
 
-  useMountEffect(() => {
-    if (!db || !userId) return;
-    const defaultAccount = ensureDefaultFinancialAccount(db, userId);
-    setDefaultAccountId(defaultAccount.id);
-  });
-
-  const accounts = db && userId ? getFinancialAccountsForUser(db, userId) : [];
+  useSubscription(
+    () => {
+      if (!db || !userId) return;
+      try {
+        const defaultAccount = tryEnsureDefaultFinancialAccount(db, userId);
+        if (defaultAccount) {
+          setDefaultAccountId(defaultAccount.id);
+        }
+        setAccounts(getFinancialAccountsForUser(db, userId));
+      } catch (error) {
+        captureError(error);
+      }
+    },
+    [db, userId],
+    db != null && userId != null
+  );
 
   const { isBusy: isSaving, run: guardedSave } = useAsyncGuard();
 

--- a/apps/mobile/app/(tabs)/add.tsx
+++ b/apps/mobile/app/(tabs)/add.tsx
@@ -1,84 +1,51 @@
 import * as Haptics from "expo-haptics";
 import { useRouter } from "expo-router";
-import { useCallback, useMemo, useRef } from "react";
-import Animated from "react-native-reanimated";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { useShallow } from "zustand/react/shallow";
 import { useOptionalUserId } from "@/features/auth";
 import {
-  CATEGORIES,
-  CategoryPill,
-  getDateLabel,
-  handleNumpadPress,
+  ensureDefaultFinancialAccount,
+  getFinancialAccountsForUser,
+} from "@/features/financial-accounts";
+import {
   saveCurrentTransaction,
-  TypeToggle,
+  TransactionForm,
   updateCurrentTransaction,
   useTransactionStore,
 } from "@/features/transactions";
-import { FidyNumpad } from "@/shared/components";
-import { Calendar } from "@/shared/components/icons";
-import { Platform, Pressable, Text, TextInput, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
-import { useAsyncGuard, useBlinkingCursor, useThemeColor, useTranslation } from "@/shared/hooks";
-import { getDateFnsLocale } from "@/shared/i18n";
-import { formatInputDisplay, parseDigitsToAmount, trackTransactionCreated } from "@/shared/lib";
+import { useAsyncGuard, useMountEffect, useTranslation } from "@/shared/hooks";
+import { trackTransactionCreated } from "@/shared/lib";
 
 export default function AddTransactionScreen() {
   const { navigate } = useRouter();
-  const { t, locale } = useTranslation();
+  const { t } = useTranslation();
   const userId = useOptionalUserId();
   const db = userId ? tryGetDb(userId) : null;
-  const { bottom: safeBottom } = useSafeAreaInsets();
   const {
     type,
     digits,
     categoryId,
+    accountId,
     description,
     date,
     editingId,
     setType,
     setDigits,
     setCategoryId,
+    setDefaultAccountId,
+    setAccountId,
     setDescription,
     resetForm,
-  } = useTransactionStore(
-    useShallow((s) => ({
-      type: s.type,
-      digits: s.digits,
-      categoryId: s.categoryId,
-      description: s.description,
-      date: s.date,
-      editingId: s.editingId,
-      setType: s.setType,
-      setDigits: s.setDigits,
-      setCategoryId: s.setCategoryId,
-      setDescription: s.setDescription,
-      resetForm: s.resetForm,
-    }))
-  );
+  } = useTransactionStore();
 
   const isEditing = editingId != null;
 
-  const accentRed = useThemeColor("accentRed");
-  const accentGreen = useThemeColor("accentGreen");
-  const secondary = useThemeColor("secondary");
-  const tertiary = useThemeColor("tertiary");
-  const primary = useThemeColor("primary");
-  const borderSubtle = useThemeColor("borderSubtle");
+  useMountEffect(() => {
+    if (!db || !userId) return;
+    const defaultAccount = ensureDefaultFinancialAccount(db, userId);
+    setDefaultAccountId(defaultAccount.id);
+  });
 
-  const amountColor = type === "expense" ? accentRed : accentGreen;
-  const displayAmount = digits.length > 0 ? formatInputDisplay(digits) : "$";
-  const canSave = parseDigitsToAmount(digits) > 0;
-  const buttonBg = canSave ? accentGreen : "#CCCCCC";
-  const dateLabel = useMemo(
-    () => getDateLabel(date, new Date(), t("dates.today"), getDateFnsLocale(locale)),
-    [date, t, locale]
-  );
-
-  const digitsRef = useRef(digits);
-  digitsRef.current = digits;
-
-  const { cursorStyle } = useBlinkingCursor();
+  const accounts = db && userId ? getFinancialAccountsForUser(db, userId) : [];
 
   const { isBusy: isSaving, run: guardedSave } = useAsyncGuard();
 
@@ -103,147 +70,23 @@ export default function AddTransactionScreen() {
     });
   };
 
-  const handleKey = useCallback(
-    (key: string) => {
-      setDigits(handleNumpadPress(digitsRef.current, key));
-    },
-    [setDigits]
-  );
-
-  const saveLabel = isEditing ? t("common.save") : t("transactions.saveTransaction");
-
   return (
-    <View style={{ flex: 1 }} className="bg-page dark:bg-page-dark">
-      {/* Top zone: amount display + metadata */}
-      <View style={{ flex: 1, justifyContent: "center", paddingHorizontal: 24, gap: 12 }}>
-        {/* Type toggle + Amount */}
-        <View style={{ alignItems: "center", gap: 4 }}>
-          <TypeToggle value={type} onChange={setType} />
-          <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "center" }}>
-            <Text
-              style={{
-                fontFamily: "Poppins_700Bold",
-                fontSize: 40,
-                color: amountColor,
-              }}
-            >
-              {displayAmount}
-            </Text>
-            <Animated.View
-              style={[
-                {
-                  width: 2,
-                  height: 32,
-                  marginLeft: 2,
-                  borderRadius: 1,
-                  backgroundColor: amountColor,
-                },
-                cursorStyle,
-              ]}
-            />
-          </View>
-        </View>
-
-        {/* Categories */}
-        <View style={{ alignItems: "center", gap: 6 }}>
-          <View
-            style={{ flexDirection: "row", flexWrap: "wrap", justifyContent: "center", gap: 6 }}
-          >
-            {CATEGORIES.map((cat) => (
-              <CategoryPill
-                key={cat.id}
-                category={cat}
-                isSelected={categoryId === cat.id}
-                onPress={() => setCategoryId(cat.id)}
-              />
-            ))}
-          </View>
-        </View>
-
-        {/* Description + Date */}
-        <View style={{ flexDirection: "row", gap: 8 }}>
-          <TextInput
-            style={{
-              flex: 1,
-              height: 36,
-              borderRadius: 10,
-              paddingHorizontal: 12,
-              fontFamily: "Poppins_500Medium",
-              fontSize: 12,
-              color: primary,
-              borderWidth: 1,
-              borderColor: borderSubtle,
-            }}
-            placeholder={t("transactions.descriptionOptional")}
-            placeholderTextColor={tertiary}
-            value={description}
-            onChangeText={setDescription}
-            maxLength={200}
-          />
-          <View
-            style={{
-              height: 36,
-              borderRadius: 10,
-              flexDirection: "row",
-              alignItems: "center",
-              gap: 6,
-              paddingHorizontal: 10,
-              borderWidth: 1,
-              borderColor: borderSubtle,
-            }}
-          >
-            <Calendar size={14} color={secondary} />
-            <Text
-              style={{
-                fontFamily: "Poppins_500Medium",
-                fontSize: 12,
-                color: primary,
-              }}
-            >
-              {dateLabel}
-            </Text>
-          </View>
-        </View>
-      </View>
-
-      {/* Bottom zone: save button + numpad, pinned to bottom */}
-      <View
-        style={{
-          paddingHorizontal: 16,
-          paddingTop: 8,
-          paddingBottom: Platform.OS === "ios" ? safeBottom : 16,
-          gap: 8,
-        }}
-      >
-        {/* Save button */}
-        <Pressable
-          style={{
-            height: 48,
-            borderRadius: 12,
-            backgroundColor: buttonBg,
-            alignItems: "center",
-            justifyContent: "center",
-            opacity: isSaving ? 0.5 : 1,
-          }}
-          onPress={canSave ? handleSave : undefined}
-          disabled={!canSave || isSaving}
-          accessibilityRole="button"
-          accessibilityLabel={saveLabel}
-        >
-          <Text
-            style={{
-              fontFamily: "Poppins_600SemiBold",
-              fontSize: 15,
-              color: "#FFFFFF",
-            }}
-          >
-            {saveLabel}
-          </Text>
-        </Pressable>
-
-        {/* Custom numpad */}
-        <FidyNumpad onKeyPress={handleKey} />
-      </View>
-    </View>
+    <TransactionForm
+      type={type}
+      digits={digits}
+      categoryId={categoryId}
+      accounts={accounts}
+      accountId={accountId}
+      description={description}
+      date={date}
+      saveLabel={isEditing ? t("common.save") : t("transactions.saveTransaction")}
+      isSaving={isSaving}
+      onTypeChange={setType}
+      onDigitsChange={setDigits}
+      onCategoryChange={setCategoryId}
+      onAccountChange={setAccountId}
+      onDescriptionChange={setDescription}
+      onSave={handleSave}
+    />
   );
 }

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -52,6 +52,7 @@ import {
   loadEmailAccounts,
   useEmailCapture,
 } from "@/features/email-capture";
+import { ensureDefaultFinancialAccount } from "@/features/financial-accounts";
 import {
   initializeGoalSession,
   loadGoalsForUser,
@@ -107,7 +108,9 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
 
   useSubscription(
     () => {
+      const defaultAccount = ensureDefaultFinancialAccount(db, userId);
       initializeTransactionSession(userId);
+      useTransactionStore.getState().setDefaultAccountId(defaultAccount.id);
       initializeEmailCaptureSession(userId);
       initializeChatSession(userId);
       initializeCalendarSession(userId);

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -52,7 +52,7 @@ import {
   loadEmailAccounts,
   useEmailCapture,
 } from "@/features/email-capture";
-import { ensureDefaultFinancialAccount } from "@/features/financial-accounts";
+import { tryEnsureDefaultFinancialAccount } from "@/features/financial-accounts";
 import {
   initializeGoalSession,
   loadGoalsForUser,
@@ -108,39 +108,51 @@ function AuthenticatedShell({ db, userId }: { db: AnyDb; userId: UserId }) {
 
   useSubscription(
     () => {
-      const defaultAccount = ensureDefaultFinancialAccount(db, userId);
-      initializeTransactionSession(userId);
-      useTransactionStore.getState().setDefaultAccountId(defaultAccount.id);
-      initializeEmailCaptureSession(userId);
-      initializeChatSession(userId);
-      initializeCalendarSession(userId);
-      initializeBudgetSession(userId);
-      initializeGoalSession(userId);
-      initializeAnalyticsSession(userId);
-      void initializeNotificationStore(db, userId);
-      Promise.all([loadCalendarBills(db, userId), loadCalendarPaymentsForMonth(db)]).catch(
-        handleRecoverableError("Failed to load calendar data")
-      );
-      loadBudgetsForUser(db, userId).catch(handleRecoverableError("Failed to load budgets"));
-      loadGoalsForUser(db, userId).catch(handleRecoverableError("Failed to load goals"));
-      loadAnalyticsForUser(db, userId).catch(handleRecoverableError("Failed to load analytics"));
-      loadEmailAccounts(db, userId).catch(handleRecoverableError("Failed to load email accounts"));
-      refreshCategories(db, userId).catch(handleRecoverableError("Failed to load user categories"));
-      loadChatSessions(db, userId)
-        .then(() => cleanupExpiredChatSessions(db, userId))
-        .catch(handleRecoverableError("Failed to load chat sessions"));
-      hydrateCaptureSources(db, userId).catch(
-        handleRecoverableError("Failed to load capture sources")
-      );
-      loadInitialTransactions(db, userId).catch(
-        handleRecoverableError("Failed to load transactions")
-      );
-      void loadSyncConflicts(db);
-      useSettingsStore
-        .getState()
-        .hydrate()
-        .catch(handleRecoverableError("Failed to hydrate settings"));
-      void registerBackgroundTask().catch(captureError);
+      void Promise.resolve()
+        .then(() => {
+          initializeTransactionSession(userId);
+          const defaultAccount = tryEnsureDefaultFinancialAccount(db, userId);
+          if (defaultAccount) {
+            useTransactionStore.getState().setDefaultAccountId(defaultAccount.id);
+          }
+          initializeEmailCaptureSession(userId);
+          initializeChatSession(userId);
+          initializeCalendarSession(userId);
+          initializeBudgetSession(userId);
+          initializeGoalSession(userId);
+          initializeAnalyticsSession(userId);
+          void initializeNotificationStore(db, userId);
+          Promise.all([loadCalendarBills(db, userId), loadCalendarPaymentsForMonth(db)]).catch(
+            handleRecoverableError("Failed to load calendar data")
+          );
+          loadBudgetsForUser(db, userId).catch(handleRecoverableError("Failed to load budgets"));
+          loadGoalsForUser(db, userId).catch(handleRecoverableError("Failed to load goals"));
+          loadAnalyticsForUser(db, userId).catch(
+            handleRecoverableError("Failed to load analytics")
+          );
+          loadEmailAccounts(db, userId).catch(
+            handleRecoverableError("Failed to load email accounts")
+          );
+          refreshCategories(db, userId).catch(
+            handleRecoverableError("Failed to load user categories")
+          );
+          loadChatSessions(db, userId)
+            .then(() => cleanupExpiredChatSessions(db, userId))
+            .catch(handleRecoverableError("Failed to load chat sessions"));
+          hydrateCaptureSources(db, userId).catch(
+            handleRecoverableError("Failed to load capture sources")
+          );
+          loadInitialTransactions(db, userId).catch(
+            handleRecoverableError("Failed to load transactions")
+          );
+          void loadSyncConflicts(db);
+          useSettingsStore
+            .getState()
+            .hydrate()
+            .catch(handleRecoverableError("Failed to hydrate settings"));
+          void registerBackgroundTask().catch(captureError);
+        })
+        .catch(captureError);
     },
     [db, userId],
     migrationsReady

--- a/apps/mobile/app/edit-transaction.tsx
+++ b/apps/mobile/app/edit-transaction.tsx
@@ -3,8 +3,9 @@ import { useLocalSearchParams, useRouter } from "expo-router";
 import { useState } from "react";
 import { useOptionalUserId } from "@/features/auth";
 import {
-  ensureDefaultFinancialAccount,
+  type FinancialAccountRow,
   getFinancialAccountsForUser,
+  tryEnsureDefaultFinancialAccount,
 } from "@/features/financial-accounts";
 import type { TransactionType } from "@/features/transactions";
 import {
@@ -39,12 +40,11 @@ export default function EditTransactionScreen() {
   const [description, setDescription] = useState("");
   const [date, setDate] = useState(new Date());
   const [loaded, setLoaded] = useState(false);
+  const [accounts, setAccounts] = useState<readonly FinancialAccountRow[]>([]);
   const transactionId =
     typeof routeTransactionId === "string" && routeTransactionId.trim().length > 0
       ? requireTransactionId(routeTransactionId.trim())
       : null;
-
-  const accounts = db && userId ? getFinancialAccountsForUser(db, userId) : [];
 
   useMountEffect(() => {
     if (transactionId == null || !db || !userId) {
@@ -52,7 +52,8 @@ export default function EditTransactionScreen() {
       return;
     }
 
-    ensureDefaultFinancialAccount(db, userId);
+    tryEnsureDefaultFinancialAccount(db, userId);
+    setAccounts(getFinancialAccountsForUser(db, userId));
     const tx = getStoredTransactionById(db, userId, transactionId);
     if (tx) {
       setType(tx.type);

--- a/apps/mobile/app/edit-transaction.tsx
+++ b/apps/mobile/app/edit-transaction.tsx
@@ -2,6 +2,10 @@ import * as Haptics from "expo-haptics";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useState } from "react";
 import { useOptionalUserId } from "@/features/auth";
+import {
+  ensureDefaultFinancialAccount,
+  getFinancialAccountsForUser,
+} from "@/features/financial-accounts";
 import type { TransactionType } from "@/features/transactions";
 import {
   deleteTransaction,
@@ -14,7 +18,7 @@ import { tryGetDb } from "@/shared/db";
 import { useAsyncGuard, useMountEffect, useTranslation } from "@/shared/hooks";
 import { showErrorToast } from "@/shared/lib";
 import { requireTransactionId } from "@/shared/types/assertions";
-import type { CategoryId } from "@/shared/types/branded";
+import type { CategoryId, FinancialAccountId } from "@/shared/types/branded";
 
 const afterDismiss = () =>
   new Promise<void>((resolve) => {
@@ -31,6 +35,7 @@ export default function EditTransactionScreen() {
   const [type, setType] = useState<TransactionType>("expense");
   const [digits, setDigits] = useState("");
   const [categoryId, setCategoryId] = useState<CategoryId | null>(null);
+  const [accountId, setAccountId] = useState<FinancialAccountId | null>(null);
   const [description, setDescription] = useState("");
   const [date, setDate] = useState(new Date());
   const [loaded, setLoaded] = useState(false);
@@ -39,17 +44,21 @@ export default function EditTransactionScreen() {
       ? requireTransactionId(routeTransactionId.trim())
       : null;
 
+  const accounts = db && userId ? getFinancialAccountsForUser(db, userId) : [];
+
   useMountEffect(() => {
     if (transactionId == null || !db || !userId) {
       router.back();
       return;
     }
 
+    ensureDefaultFinancialAccount(db, userId);
     const tx = getStoredTransactionById(db, userId, transactionId);
     if (tx) {
       setType(tx.type);
       setDigits(String(tx.amount));
       setCategoryId(tx.categoryId);
+      setAccountId(tx.accountId);
       setDescription(tx.description);
       setDate(tx.date);
       setLoaded(true);
@@ -74,6 +83,7 @@ export default function EditTransactionScreen() {
           type,
           digits,
           categoryId,
+          accountId,
           description,
           date,
         });
@@ -110,6 +120,8 @@ export default function EditTransactionScreen() {
       type={type}
       digits={digits}
       categoryId={categoryId}
+      accounts={accounts}
+      accountId={accountId}
       description={description}
       date={date}
       saveLabel={t("common.save")}
@@ -117,6 +129,7 @@ export default function EditTransactionScreen() {
       onTypeChange={setType}
       onDigitsChange={setDigits}
       onCategoryChange={setCategoryId}
+      onAccountChange={setAccountId}
       onDescriptionChange={setDescription}
       onSave={handleSave}
       onDelete={handleDelete}

--- a/apps/mobile/features/calendar/lib/bill-mutation-service.ts
+++ b/apps/mobile/features/calendar/lib/bill-mutation-service.ts
@@ -1,3 +1,4 @@
+import { buildDefaultFinancialAccountId } from "@/features/financial-accounts";
 import type { StoredTransaction } from "@/features/transactions/public";
 import { toTransactionRow } from "@/features/transactions/public";
 import {
@@ -126,6 +127,8 @@ async function commitBillPayment(
     createdAt: timestamp,
     updatedAt: timestamp,
     deletedAt: null,
+    accountId: buildDefaultFinancialAccountId(userId),
+    accountAttributionState: "confirmed",
   };
 
   const payment: BillPayment = {

--- a/apps/mobile/features/capture-sources/services/apple-pay-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/apple-pay-pipeline.ts
@@ -3,6 +3,7 @@ import {
   lookupMerchantRule,
 } from "@/features/email-capture/merchant-rules.public";
 import { classifyMerchantApi } from "@/features/email-capture/parsing.public";
+import { ensureDefaultFinancialAccount } from "@/features/financial-accounts";
 import { insertTransaction, isValidCategoryId } from "@/features/transactions/write.public";
 import type { AnyDb } from "@/shared/db";
 import { enqueueSync } from "@/shared/db";
@@ -92,6 +93,7 @@ export async function processApplePayIntent(
     // Save transaction
     const txId = generateTransactionId();
     const now = toIsoDateTime(new Date());
+    const defaultAccount = ensureDefaultFinancialAccount(db, userId, { now });
 
     insertTransaction(db, {
       id: txId,
@@ -101,6 +103,8 @@ export async function processApplePayIntent(
       categoryId,
       description: intent.merchant,
       date: today,
+      accountId: defaultAccount.id,
+      accountAttributionState: "unresolved",
       source,
       createdAt: now,
       updatedAt: now,

--- a/apps/mobile/features/capture-sources/services/notification-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/notification-pipeline.ts
@@ -3,6 +3,7 @@ import {
   lookupMerchantRule,
 } from "@/features/email-capture/merchant-rules.public";
 import { stripPii } from "@/features/email-capture/parsing.public";
+import { ensureDefaultFinancialAccount } from "@/features/financial-accounts";
 import { insertTransaction, isValidCategoryId } from "@/features/transactions/write.public";
 import type { AnyDb } from "@/shared/db";
 import { enqueueSync } from "@/shared/db";
@@ -170,6 +171,7 @@ export async function processNotification(
     // Save transaction
     const txId = generateTransactionId();
     const now = toIsoDateTime(new Date());
+    const defaultAccount = ensureDefaultFinancialAccount(db, userId, { now });
 
     insertTransaction(db, {
       id: txId,
@@ -179,6 +181,8 @@ export async function processNotification(
       categoryId: finalCategoryId,
       description: parsed.merchant,
       date: parsed.date,
+      accountId: defaultAccount.id,
+      accountAttributionState: "unresolved",
       source,
       createdAt: now,
       updatedAt: now,

--- a/apps/mobile/features/email-capture/services/create-email-pipeline-service.ts
+++ b/apps/mobile/features/email-capture/services/create-email-pipeline-service.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect";
 import type { ProcessedEmailRow } from "@/features/email-capture/lib/repository";
+import type { FinancialAccountRow } from "@/features/financial-accounts";
 import { getBuiltInCategoryId, isValidCategoryId } from "@/features/transactions/lib/categories";
 import type { TransactionRow } from "@/features/transactions/lib/repository";
 import type { AnyDb, SyncQueueEntry } from "@/shared/db";
@@ -95,6 +96,11 @@ type CreateEmailPipelineServiceDeps = {
     status: string,
     transactionId: TransactionId | null
   ) => Promise<void>;
+  readonly ensureDefaultFinancialAccount: (
+    db: AnyDb,
+    userId: UserId,
+    options?: { now?: IsoDateTime }
+  ) => FinancialAccountRow;
   readonly insertTransaction: (db: AnyDb, row: TransactionRow) => void | Promise<void>;
   readonly enqueueSync: (db: AnyDb, input: SyncQueueEntry) => void | Promise<void>;
   readonly insertMerchantRule: (
@@ -198,8 +204,13 @@ function saveTransactionEffect(
   status: "success" | "needs_review"
 ) {
   return Effect.gen(function* () {
-    const { insertTransaction, enqueueSync, insertProcessedEmail, trackTransactionCreated } =
-      yield* EmailPipelineDeps.tag;
+    const {
+      ensureDefaultFinancialAccount,
+      insertTransaction,
+      enqueueSync,
+      insertProcessedEmail,
+      trackTransactionCreated,
+    } = yield* EmailPipelineDeps.tag;
     const source = getTransactionSource(email.provider);
     const txId = generateTransactionId();
     const now = yield* currentIsoDateTimeEffect;
@@ -207,6 +218,9 @@ function saveTransactionEffect(
     const date = validated.date;
     const receivedAt = email.receivedAt;
     const categoryId = getPersistedCategoryId(validated.categoryId);
+    const defaultAccount = yield* fromThunk(() =>
+      ensureDefaultFinancialAccount(db, userId, { now })
+    );
 
     assertCopAmount(amount);
     assertIsoDate(date);
@@ -221,6 +235,8 @@ function saveTransactionEffect(
         categoryId,
         description: validated.description,
         date,
+        accountId: defaultAccount.id,
+        accountAttributionState: "unresolved",
         source,
         createdAt: now,
         updatedAt: now,

--- a/apps/mobile/features/email-capture/services/create-email-pipeline-service.ts
+++ b/apps/mobile/features/email-capture/services/create-email-pipeline-service.ts
@@ -342,8 +342,13 @@ function saveRetryTransactionEffect(
   email: ProcessedEmailRow
 ) {
   return Effect.gen(function* () {
-    const { insertTransaction, enqueueSync, insertMerchantRule, trackTransactionCreated } =
-      yield* EmailPipelineDeps.tag;
+    const {
+      ensureDefaultFinancialAccount,
+      insertTransaction,
+      enqueueSync,
+      insertMerchantRule,
+      trackTransactionCreated,
+    } = yield* EmailPipelineDeps.tag;
     const txId = generateTransactionId();
     const now = yield* currentIsoDateTimeEffect;
     const source = getTransactionSource(email.provider);
@@ -351,6 +356,9 @@ function saveRetryTransactionEffect(
     const date = parsed.date;
     const status: "success" | "needs_review" = parsed.confidence < 0.7 ? "needs_review" : "success";
     const categoryId = getPersistedCategoryId(parsed.categoryId);
+    const defaultAccount = yield* fromThunk(() =>
+      ensureDefaultFinancialAccount(db, userId, { now })
+    );
 
     assertCopAmount(amount);
     assertIsoDate(date);
@@ -364,6 +372,8 @@ function saveRetryTransactionEffect(
         categoryId,
         description: parsed.description,
         date,
+        accountId: defaultAccount.id,
+        accountAttributionState: "unresolved",
         source,
         createdAt: now,
         updatedAt: now,

--- a/apps/mobile/features/email-capture/services/email-pipeline.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline.ts
@@ -1,4 +1,5 @@
 import { findDuplicateTransaction } from "@/features/capture-sources/lib/dedup";
+import { ensureDefaultFinancialAccount } from "@/features/financial-accounts";
 import { insertTransaction } from "@/features/transactions/lib/repository";
 import type { AnyDb } from "@/shared/db";
 import { enqueueSync } from "@/shared/db";
@@ -38,6 +39,7 @@ const emailPipeline = createEmailPipelineService({
   markPermanentlyFailed,
   markRetrySuccess,
   updateProcessedEmailStatus,
+  ensureDefaultFinancialAccount,
   insertTransaction,
   enqueueSync,
   insertMerchantRule,

--- a/apps/mobile/features/financial-accounts/index.ts
+++ b/apps/mobile/features/financial-accounts/index.ts
@@ -23,3 +23,4 @@ export {
   upsertFinancialAccount,
 } from "./lib/repository";
 export { type FinancialAccountKind, financialAccountKindSchema } from "./schema";
+export { tryEnsureDefaultFinancialAccount } from "./services/try-ensure-default-account";

--- a/apps/mobile/features/financial-accounts/index.ts
+++ b/apps/mobile/features/financial-accounts/index.ts
@@ -14,7 +14,9 @@ export {
   upsertOpeningBalance,
 } from "./lib/opening-balances-repository";
 export {
+  ensureDefaultFinancialAccount,
   type FinancialAccountRow,
+  getDefaultFinancialAccountForUser,
   getFinancialAccountById,
   getFinancialAccountsForUser,
   saveFinancialAccount,

--- a/apps/mobile/features/financial-accounts/lib/repository.ts
+++ b/apps/mobile/features/financial-accounts/lib/repository.ts
@@ -41,18 +41,20 @@ function findCanonicalFinancialAccount(
   return rows.find((row) => row.id === canonicalId) ?? null;
 }
 
-function findChosenDefaultFinancialAccount(
-  rows: readonly FinancialAccountRow[],
-  userId: FinancialAccountRow["userId"]
-) {
-  const canonicalDefault = rows.find(
-    (row) => row.id === buildDefaultFinancialAccountId(userId) && row.isDefault
-  );
-  if (canonicalDefault) {
-    return canonicalDefault;
-  }
+function findExistingDefaultFinancialAccount(rows: readonly FinancialAccountRow[]) {
+  return rows.find((row) => row.isDefault) ?? null;
+}
 
-  return rows.find((row) => row.isDefault) ?? findCanonicalFinancialAccount(rows, userId);
+function promoteFinancialAccountToDefault(
+  row: FinancialAccountRow,
+  now: IsoDateTime
+): FinancialAccountRow {
+  return {
+    ...row,
+    isDefault: true,
+    updatedAt: now,
+    deletedAt: null,
+  };
 }
 
 export function getFinancialAccountById(db: AnyDb, id: FinancialAccountRow["id"]) {
@@ -100,10 +102,7 @@ export function getDefaultFinancialAccountForUser(
   db: AnyDb,
   userId: FinancialAccountRow["userId"]
 ) {
-  return findChosenDefaultFinancialAccount(
-    getActiveFinancialAccountRowsForUser(db, userId),
-    userId
-  );
+  return findExistingDefaultFinancialAccount(getActiveFinancialAccountRowsForUser(db, userId));
 }
 
 export function ensureDefaultFinancialAccount(
@@ -116,10 +115,17 @@ export function ensureDefaultFinancialAccount(
 
   return db.transaction((tx) => {
     const activeRows = getActiveFinancialAccountRowsForUser(tx, userId);
-    const chosenDefault = findChosenDefaultFinancialAccount(activeRows, userId);
+    const existingDefault = findExistingDefaultFinancialAccount(activeRows);
 
-    if (chosenDefault) {
-      return chosenDefault;
+    if (existingDefault) {
+      return existingDefault;
+    }
+
+    const canonicalActive = findCanonicalFinancialAccount(activeRows, userId);
+    if (canonicalActive) {
+      const promotedRow = promoteFinancialAccountToDefault(canonicalActive, now);
+      saveFinancialAccount(tx, promotedRow);
+      return promotedRow;
     }
 
     const canonicalId = buildDefaultFinancialAccountId(userId);

--- a/apps/mobile/features/financial-accounts/lib/repository.ts
+++ b/apps/mobile/features/financial-accounts/lib/repository.ts
@@ -1,9 +1,59 @@
 import { and, desc, eq, isNull } from "drizzle-orm";
 import type { AnyDb } from "@/shared/db";
 import { enqueueSync, financialAccounts } from "@/shared/db";
-import { generateSyncQueueId } from "@/shared/lib";
+import { useLocaleStore } from "@/shared/i18n";
+import { generateSyncQueueId, toIsoDateTime } from "@/shared/lib";
+import type { IsoDateTime } from "@/shared/types/branded";
+import type { FinancialAccountKind } from "../schema";
+import { buildDefaultFinancialAccountId } from "./default-account";
 
 export type FinancialAccountRow = typeof financialAccounts.$inferInsert;
+
+type EnsureDefaultFinancialAccountOptions = {
+  readonly now?: IsoDateTime;
+  readonly name?: string;
+};
+
+const DEFAULT_FINANCIAL_ACCOUNT_KIND: FinancialAccountKind = "cash";
+
+function getDefaultFinancialAccountName() {
+  return useLocaleStore.getState().t("financialAccounts.defaultName");
+}
+
+function getDefaultFinancialAccountCreateTime(now?: IsoDateTime) {
+  return now ?? toIsoDateTime(new Date());
+}
+
+function getActiveFinancialAccountRowsForUser(db: AnyDb, userId: FinancialAccountRow["userId"]) {
+  return db
+    .select()
+    .from(financialAccounts)
+    .where(and(eq(financialAccounts.userId, userId), isNull(financialAccounts.deletedAt)))
+    .orderBy(desc(financialAccounts.isDefault), desc(financialAccounts.updatedAt))
+    .all();
+}
+
+function findCanonicalFinancialAccount(
+  rows: readonly FinancialAccountRow[],
+  userId: FinancialAccountRow["userId"]
+) {
+  const canonicalId = buildDefaultFinancialAccountId(userId);
+  return rows.find((row) => row.id === canonicalId) ?? null;
+}
+
+function findChosenDefaultFinancialAccount(
+  rows: readonly FinancialAccountRow[],
+  userId: FinancialAccountRow["userId"]
+) {
+  const canonicalDefault = rows.find(
+    (row) => row.id === buildDefaultFinancialAccountId(userId) && row.isDefault
+  );
+  if (canonicalDefault) {
+    return canonicalDefault;
+  }
+
+  return rows.find((row) => row.isDefault) ?? findCanonicalFinancialAccount(rows, userId);
+}
 
 export function getFinancialAccountById(db: AnyDb, id: FinancialAccountRow["id"]) {
   const rows = db.select().from(financialAccounts).where(eq(financialAccounts.id, id)).all();
@@ -43,10 +93,49 @@ export function saveFinancialAccount(db: AnyDb, row: FinancialAccountRow) {
 }
 
 export function getFinancialAccountsForUser(db: AnyDb, userId: FinancialAccountRow["userId"]) {
-  return db
-    .select()
-    .from(financialAccounts)
-    .where(and(eq(financialAccounts.userId, userId), isNull(financialAccounts.deletedAt)))
-    .orderBy(desc(financialAccounts.isDefault), desc(financialAccounts.updatedAt))
-    .all();
+  return getActiveFinancialAccountRowsForUser(db, userId);
+}
+
+export function getDefaultFinancialAccountForUser(
+  db: AnyDb,
+  userId: FinancialAccountRow["userId"]
+) {
+  return findChosenDefaultFinancialAccount(
+    getActiveFinancialAccountRowsForUser(db, userId),
+    userId
+  );
+}
+
+export function ensureDefaultFinancialAccount(
+  db: AnyDb,
+  userId: FinancialAccountRow["userId"],
+  options: EnsureDefaultFinancialAccountOptions = {}
+) {
+  const now = getDefaultFinancialAccountCreateTime(options.now);
+  const name = options.name ?? getDefaultFinancialAccountName();
+
+  return db.transaction((tx) => {
+    const activeRows = getActiveFinancialAccountRowsForUser(tx, userId);
+    const chosenDefault = findChosenDefaultFinancialAccount(activeRows, userId);
+
+    if (chosenDefault) {
+      return chosenDefault;
+    }
+
+    const canonicalId = buildDefaultFinancialAccountId(userId);
+    const existingCanonical = getFinancialAccountById(tx, canonicalId);
+    const row = {
+      id: canonicalId,
+      userId,
+      name: existingCanonical?.name || name,
+      kind: existingCanonical?.kind || DEFAULT_FINANCIAL_ACCOUNT_KIND,
+      isDefault: true,
+      createdAt: existingCanonical?.createdAt ?? now,
+      updatedAt: now,
+      deletedAt: null,
+    } satisfies FinancialAccountRow;
+
+    saveFinancialAccount(tx, row);
+    return row;
+  });
 }

--- a/apps/mobile/features/financial-accounts/services/try-ensure-default-account.ts
+++ b/apps/mobile/features/financial-accounts/services/try-ensure-default-account.ts
@@ -1,0 +1,16 @@
+import type { AnyDb } from "@/shared/db";
+import { captureError } from "@/shared/lib/sentry";
+import type { UserId } from "@/shared/types/branded";
+import { ensureDefaultFinancialAccount, type FinancialAccountRow } from "../lib/repository";
+
+export function tryEnsureDefaultFinancialAccount(
+  db: AnyDb,
+  userId: UserId
+): FinancialAccountRow | null {
+  try {
+    return ensureDefaultFinancialAccount(db, userId);
+  } catch (error) {
+    captureError(error);
+    return null;
+  }
+}

--- a/apps/mobile/features/transactions/components/TransactionForm.tsx
+++ b/apps/mobile/features/transactions/components/TransactionForm.tsx
@@ -17,6 +17,7 @@ import { useBlinkingCursor, useThemeColor, useTranslation } from "@/shared/hooks
 import { getDateFnsLocale } from "@/shared/i18n";
 import { formatInputDisplay, parseDigitsToAmount } from "@/shared/lib";
 import type { CategoryId, FinancialAccountId } from "@/shared/types/branded";
+import { hasSelectedFinancialAccount } from "../lib/account-selection";
 import { CATEGORIES } from "../lib/categories";
 import { getDateLabel } from "../lib/format-date";
 import { handleNumpadPress } from "../lib/handle-numpad-press";
@@ -77,7 +78,8 @@ export function TransactionForm({
 
   const amountColor = type === "expense" ? accentRed : accentGreen;
   const displayAmount = digits.length > 0 ? formatInputDisplay(digits) : "$";
-  const canSave = parseDigitsToAmount(digits) > 0 && accountId != null;
+  const hasAccountSelection = hasSelectedFinancialAccount(accounts, accountId);
+  const canSave = parseDigitsToAmount(digits) > 0 && hasAccountSelection;
   const buttonBg = canSave ? accentGreen : "#CCCCCC";
   const dateLabel = useMemo(
     () => getDateLabel(date, new Date(), t("dates.today"), getDateFnsLocale(locale)),
@@ -172,7 +174,11 @@ export function TransactionForm({
           >
             {t("common.account")}
           </Text>
-          <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+          <ScrollView
+            horizontal
+            keyboardShouldPersistTaps="handled"
+            showsHorizontalScrollIndicator={false}
+          >
             <View style={{ flexDirection: "row", gap: 8 }}>
               {accounts.map((account) => {
                 const isSelected = account.id === accountId;

--- a/apps/mobile/features/transactions/components/TransactionForm.tsx
+++ b/apps/mobile/features/transactions/components/TransactionForm.tsx
@@ -1,13 +1,22 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import Animated from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import type { FinancialAccountRow } from "@/features/financial-accounts";
 import { FidyNumpad } from "@/shared/components";
 import { Calendar, X } from "@/shared/components/icons";
-import { Keyboard, Platform, Pressable, Text, TextInput, View } from "@/shared/components/rn";
+import {
+  Keyboard,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from "@/shared/components/rn";
 import { useBlinkingCursor, useThemeColor, useTranslation } from "@/shared/hooks";
 import { getDateFnsLocale } from "@/shared/i18n";
 import { formatInputDisplay, parseDigitsToAmount } from "@/shared/lib";
-import type { CategoryId } from "@/shared/types/branded";
+import type { CategoryId, FinancialAccountId } from "@/shared/types/branded";
 import { CATEGORIES } from "../lib/categories";
 import { getDateLabel } from "../lib/format-date";
 import { handleNumpadPress } from "../lib/handle-numpad-press";
@@ -19,6 +28,8 @@ type TransactionFormProps = {
   readonly type: TransactionType;
   readonly digits: string;
   readonly categoryId: CategoryId | null;
+  readonly accounts: readonly FinancialAccountRow[];
+  readonly accountId: FinancialAccountId | null;
   readonly description: string;
   readonly date: Date;
   readonly saveLabel: string;
@@ -26,6 +37,7 @@ type TransactionFormProps = {
   readonly onTypeChange: (type: TransactionType) => void;
   readonly onDigitsChange: (digits: string) => void;
   readonly onCategoryChange: (id: CategoryId) => void;
+  readonly onAccountChange: (id: FinancialAccountId) => void;
   readonly onDescriptionChange: (text: string) => void;
   readonly onSave: () => void;
   readonly onDelete?: () => void;
@@ -36,6 +48,8 @@ export function TransactionForm({
   type,
   digits,
   categoryId,
+  accounts,
+  accountId,
   description,
   date,
   saveLabel,
@@ -43,6 +57,7 @@ export function TransactionForm({
   onTypeChange,
   onDigitsChange,
   onCategoryChange,
+  onAccountChange,
   onDescriptionChange,
   onSave,
   onDelete,
@@ -57,10 +72,12 @@ export function TransactionForm({
   const tertiary = useThemeColor("tertiary");
   const primary = useThemeColor("primary");
   const borderSubtle = useThemeColor("borderSubtle");
+  const card = useThemeColor("card");
+  const accentGreenLight = useThemeColor("accentGreenLight");
 
   const amountColor = type === "expense" ? accentRed : accentGreen;
   const displayAmount = digits.length > 0 ? formatInputDisplay(digits) : "$";
-  const canSave = parseDigitsToAmount(digits) > 0;
+  const canSave = parseDigitsToAmount(digits) > 0 && accountId != null;
   const buttonBg = canSave ? accentGreen : "#CCCCCC";
   const dateLabel = useMemo(
     () => getDateLabel(date, new Date(), t("dates.today"), getDateFnsLocale(locale)),
@@ -143,6 +160,54 @@ export function TransactionForm({
               />
             ))}
           </View>
+        </View>
+
+        <View style={{ gap: 6 }}>
+          <Text
+            style={{
+              fontFamily: "Poppins_500Medium",
+              fontSize: 12,
+              color: secondary,
+            }}
+          >
+            {t("common.account")}
+          </Text>
+          <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+            <View style={{ flexDirection: "row", gap: 8 }}>
+              {accounts.map((account) => {
+                const isSelected = account.id === accountId;
+
+                return (
+                  <Pressable
+                    key={account.id}
+                    style={{
+                      minHeight: 36,
+                      borderRadius: 12,
+                      paddingHorizontal: 12,
+                      paddingVertical: 8,
+                      borderWidth: 1,
+                      borderColor: isSelected ? accentGreen : borderSubtle,
+                      backgroundColor: isSelected ? accentGreenLight : card,
+                      justifyContent: "center",
+                    }}
+                    onPress={() => onAccountChange(account.id)}
+                    accessibilityRole="button"
+                    accessibilityLabel={account.name}
+                  >
+                    <Text
+                      style={{
+                        fontFamily: isSelected ? "Poppins_600SemiBold" : "Poppins_500Medium",
+                        fontSize: 12,
+                        color: primary,
+                      }}
+                    >
+                      {account.name}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+          </ScrollView>
         </View>
 
         {/* Description + Date */}

--- a/apps/mobile/features/transactions/lib/account-selection.ts
+++ b/apps/mobile/features/transactions/lib/account-selection.ts
@@ -1,0 +1,9 @@
+import type { FinancialAccountRow } from "@/features/financial-accounts";
+import type { FinancialAccountId } from "@/shared/types/branded";
+
+export function hasSelectedFinancialAccount(
+  accounts: readonly FinancialAccountRow[],
+  accountId: FinancialAccountId | null
+): boolean {
+  return accountId != null && accounts.some((account) => account.id === accountId);
+}

--- a/apps/mobile/features/transactions/lib/build-transaction.ts
+++ b/apps/mobile/features/transactions/lib/build-transaction.ts
@@ -1,6 +1,12 @@
 import { buildDefaultFinancialAccountId } from "@/features/financial-accounts";
 import { parseDigitsToAmount, parseIsoDate, toIsoDate, toIsoDateTime } from "@/shared/lib";
-import type { CategoryId, CopAmount, TransactionId, UserId } from "@/shared/types/branded";
+import type {
+  CategoryId,
+  CopAmount,
+  FinancialAccountId,
+  TransactionId,
+  UserId,
+} from "@/shared/types/branded";
 import type { AccountAttributionState, StoredTransaction, TransactionType } from "../schema";
 import { createTransactionSchema } from "../schema";
 import { getBuiltInCategoryId, isValidCategoryId } from "./categories";
@@ -10,6 +16,7 @@ type BuildInput = {
   type: TransactionType;
   digits: string;
   categoryId: CategoryId | null;
+  accountId: FinancialAccountId | null;
   description: string;
   date: Date;
 };
@@ -47,6 +54,7 @@ export function buildTransaction(
     type: input.type,
     amount: amount as number,
     categoryId: (input.categoryId ?? "other") as string,
+    accountId: input.accountId ?? "",
     description: input.description || undefined,
     date: input.date,
   };
@@ -72,7 +80,7 @@ export function buildTransaction(
       createdAt: existing?.createdAt ?? now,
       updatedAt: now,
       deletedAt: existing?.deletedAt ?? null,
-      accountId: existing?.accountId ?? buildDefaultFinancialAccountId(userId),
+      accountId: result.data.accountId,
       accountAttributionState:
         existing?.accountAttributionState ?? getDefaultAccountAttributionState(existing?.source),
       supersededAt: existing?.supersededAt ?? null,
@@ -113,9 +121,8 @@ export function toTransactionRow(tx: StoredTransaction): TransactionRow {
     categoryId: tx.categoryId,
     description: tx.description || null,
     date: toIsoDate(tx.date),
-    accountId: tx.accountId ?? buildDefaultFinancialAccountId(tx.userId),
-    accountAttributionState:
-      tx.accountAttributionState ?? getDefaultAccountAttributionState(source),
+    accountId: tx.accountId,
+    accountAttributionState: tx.accountAttributionState,
     supersededAt: tx.supersededAt ? toIsoDateTime(tx.supersededAt) : null,
     createdAt: toIsoDateTime(tx.createdAt),
     updatedAt: toIsoDateTime(tx.updatedAt),

--- a/apps/mobile/features/transactions/lib/mutation-service.ts
+++ b/apps/mobile/features/transactions/lib/mutation-service.ts
@@ -1,6 +1,6 @@
 import { generateTransactionId, toIsoDateTime } from "@/shared/lib";
 import type { WriteThroughMutationModule } from "@/shared/mutations";
-import type { CategoryId, TransactionId, UserId } from "@/shared/types/branded";
+import type { CategoryId, FinancialAccountId, TransactionId, UserId } from "@/shared/types/branded";
 import type { StoredTransaction, TransactionType } from "../schema";
 import { buildTransaction, toTransactionRow } from "./build-transaction";
 
@@ -8,6 +8,7 @@ export type TransactionFormInput = {
   type: TransactionType;
   digits: string;
   categoryId: CategoryId | null;
+  accountId: FinancialAccountId | null;
   description: string;
   date: Date;
 };

--- a/apps/mobile/features/transactions/schema.ts
+++ b/apps/mobile/features/transactions/schema.ts
@@ -14,6 +14,11 @@ export type TransactionType = z.infer<typeof transactionTypeSchema>;
 export const accountAttributionStateSchema = z.enum(["confirmed", "inferred", "unresolved"]);
 export type AccountAttributionState = z.infer<typeof accountAttributionStateSchema>;
 
+export const financialAccountIdSchema = z
+  .string()
+  .min(1, "Account is required")
+  .transform((value) => value as FinancialAccountId);
+
 export function makeCategoryIdSchema(isValid: (id: string) => boolean) {
   return z
     .string()
@@ -28,6 +33,7 @@ export const createTransactionSchema = z.object({
   /** Amount in whole currency units — must be positive */
   amount: z.number().int().positive(),
   categoryId: categoryIdSchema,
+  accountId: financialAccountIdSchema,
   description: z.string().trim().max(200).optional(),
   date: z.date(),
 });
@@ -45,8 +51,8 @@ export type StoredTransaction = {
   readonly createdAt: Date;
   readonly updatedAt: Date;
   readonly deletedAt: Date | null;
-  readonly accountId?: FinancialAccountId;
-  readonly accountAttributionState?: AccountAttributionState;
+  readonly accountId: FinancialAccountId;
+  readonly accountAttributionState: AccountAttributionState;
   readonly supersededAt?: Date | null;
   readonly source?: string;
 };

--- a/apps/mobile/features/transactions/store.ts
+++ b/apps/mobile/features/transactions/store.ts
@@ -6,7 +6,7 @@ import {
   trackTransactionDeleted,
   trackTransactionEdited,
 } from "@/shared/lib";
-import type { CategoryId, TransactionId, UserId } from "@/shared/types/branded";
+import type { CategoryId, FinancialAccountId, TransactionId, UserId } from "@/shared/types/branded";
 import {
   createTransactionMutationService,
   type TransactionMutationResult,
@@ -34,6 +34,8 @@ type TransactionState = {
   readonly type: TransactionType;
   readonly digits: string;
   readonly categoryId: CategoryId | null;
+  readonly defaultAccountId: FinancialAccountId | null;
+  readonly accountId: FinancialAccountId | null;
   readonly description: string;
   readonly date: Date;
   readonly pages: readonly StoredTransaction[];
@@ -52,6 +54,8 @@ type TransactionActions = {
   setType: (type: TransactionType) => void;
   setDigits: (digits: string) => void;
   setCategoryId: (id: CategoryId) => void;
+  setDefaultAccountId: (id: FinancialAccountId | null) => void;
+  setAccountId: (id: FinancialAccountId | null) => void;
   setDescription: (desc: string) => void;
   setDate: (date: Date) => void;
   setPageSnapshot: (snapshot: TransactionPageSnapshot) => void;
@@ -66,12 +70,13 @@ type TransactionActions = {
 
 const INITIAL_FORM: Pick<
   TransactionState,
-  "step" | "type" | "digits" | "categoryId" | "description"
+  "step" | "type" | "digits" | "categoryId" | "accountId" | "description"
 > = {
   step: 1,
   type: "expense",
   digits: "",
   categoryId: null,
+  accountId: null,
   description: "",
 };
 
@@ -79,6 +84,7 @@ function createInitialState(activeUserId: UserId | null): TransactionState {
   return {
     activeUserId,
     ...INITIAL_FORM,
+    defaultAccountId: null,
     date: new Date(),
     pages: [],
     offset: 0,
@@ -92,12 +98,16 @@ function createInitialState(activeUserId: UserId | null): TransactionState {
 }
 
 function toTransactionFormInput(
-  state: Pick<TransactionState, "type" | "digits" | "categoryId" | "description" | "date">
+  state: Pick<
+    TransactionState,
+    "type" | "digits" | "categoryId" | "accountId" | "description" | "date"
+  >
 ) {
   return {
     type: state.type,
     digits: state.digits,
     categoryId: state.categoryId,
+    accountId: state.accountId,
     description: state.description,
     date: state.date,
   };
@@ -146,6 +156,16 @@ export const useTransactionStore = create<TransactionState & TransactionActions>
   setType: (type) => set({ type }),
   setDigits: (digits) => set({ digits }),
   setCategoryId: (categoryId) => set({ categoryId }),
+  setDefaultAccountId: (defaultAccountId) =>
+    set((state) => ({
+      defaultAccountId,
+      accountId:
+        state.editingId == null &&
+        (state.accountId == null || state.accountId === state.defaultAccountId)
+          ? defaultAccountId
+          : state.accountId,
+    })),
+  setAccountId: (accountId) => set({ accountId }),
   setDescription: (description) => set({ description }),
   setDate: (date) => set({ date }),
 
@@ -187,6 +207,7 @@ export const useTransactionStore = create<TransactionState & TransactionActions>
       type: transaction.type,
       digits: String(transaction.amount),
       categoryId: transaction.categoryId,
+      accountId: transaction.accountId,
       description: transaction.description,
       date: transaction.date,
     }),
@@ -211,11 +232,12 @@ export const useTransactionStore = create<TransactionState & TransactionActions>
     }),
 
   resetForm: () =>
-    set({
+    set((state) => ({
       ...INITIAL_FORM,
+      accountId: state.defaultAccountId,
       date: new Date(),
       editingId: null,
-    }),
+    })),
 }));
 
 export function initializeTransactionSession(userId: UserId): void {
@@ -373,6 +395,7 @@ export async function updateTransactionDirect(
     readonly type: TransactionType;
     readonly digits: string;
     readonly categoryId: CategoryId | null;
+    readonly accountId: FinancialAccountId | null;
     readonly description: string;
     readonly date: Date;
   }

--- a/apps/mobile/shared/i18n/locales/en.ts
+++ b/apps/mobile/shared/i18n/locales/en.ts
@@ -19,6 +19,7 @@ const en = {
     unknown: "Unknown",
     addTransaction: "Add transaction",
     transaction: "Transaction",
+    account: "Account",
     none: "(none)",
     name: "Name",
     other: "Other",
@@ -56,6 +57,10 @@ const en = {
     deleteTransaction: "Delete",
     updateFailed: "Could not update transaction",
     deleteFailed: "Could not delete transaction",
+  },
+
+  financialAccounts: {
+    defaultName: "Cash",
   },
 
   // Bills / Calendar

--- a/apps/mobile/shared/i18n/locales/es.ts
+++ b/apps/mobile/shared/i18n/locales/es.ts
@@ -19,6 +19,7 @@ const es = {
     unknown: "Desconocido",
     addTransaction: "Agregar transacción",
     transaction: "Transacción",
+    account: "Cuenta",
     none: "(ninguno)",
     name: "Nombre",
     other: "Otro",
@@ -57,6 +58,10 @@ const es = {
     deleteTransaction: "Eliminar",
     updateFailed: "No se pudo actualizar la transacción",
     deleteFailed: "No se pudo eliminar la transacción",
+  },
+
+  financialAccounts: {
+    defaultName: "Efectivo",
   },
 
   // Bills / Calendar


### PR DESCRIPTION
- bootstrap default account
- persist capture ownership
- add manual account selection
- cover sync and pipeline tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bootstraps each user’s default financial account and ensures every transaction has an owner. Adds account selection to Add/Edit and persists `accountId` across manual entry and capture pipelines (including retries) with clear attribution.

- **New Features**
  - Added `ensureDefaultFinancialAccount` to create, reuse, or promote the canonical default account; enqueues sync; exposed `getDefaultFinancialAccountForUser`.
  - Introduced `tryEnsureDefaultFinancialAccount` and used during onboarding, the app shell, and Edit; errors are captured and we set `useTransactionStore().setDefaultAccountId` when available; Add/Edit load account options once per screen.
  - Updated `TransactionForm` with an account selector and `hasSelectedFinancialAccount`; save is disabled until an amount and a valid account are set. `accountId` is required and validated.
  - Capture pipelines (`email`, `notification_android`, `apple_pay`, and retries) now save `accountId` with `accountAttributionState: "unresolved"`; bill payments use the default account with `"confirmed"`.

- **Migration**
  - Initialize sessions with `tryEnsureDefaultFinancialAccount(db, userId)` and call `useTransactionStore().setDefaultAccountId(default.id)`.
  - Pass `accountId` when building/saving transactions (via `buildTransaction` or the mutation service).
  - When rendering `TransactionForm`, provide `accounts`, `accountId`, and `onAccountChange`.

<sup>Written for commit 8ee281c11200c9681ce1e521a99a618ecbacd52b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

