### PR TITLE
refactor(mobile): inject effect network and supabase

### DIFF
--- a/apps/mobile/__tests__/shared/effect/network.test.ts
+++ b/apps/mobile/__tests__/shared/effect/network.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it, vi } from "vitest";
+import { bindAppNetwork, isOnlineEffect } from "@/shared/effect/network";
+
+describe("shared/effect/network", () => {
+  it("runs the bound network service", async () => {
+    const network = bindAppNetwork({
+      isOnline: vi.fn().mockResolvedValue(true),
+    });
+
+    await expect(network.run(isOnlineEffect)).resolves.toBe(true);
+  });
+});

--- a/apps/mobile/__tests__/shared/effect/supabase.test.ts
+++ b/apps/mobile/__tests__/shared/effect/supabase.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { bindAppSupabase, currentSupabaseClientEffect } from "@/shared/effect/supabase";
+
+describe("shared/effect/supabase", () => {
+  it("runs the bound supabase service", async () => {
+    const client = { from: () => ({}) } as never;
+    const supabase = bindAppSupabase({
+      getSupabase: () => client,
+    });
+
+    await expect(supabase.run(currentSupabaseClientEffect)).resolves.toBe(client);
+  });
+});

--- a/apps/mobile/__tests__/sync/sync-module.test.ts
+++ b/apps/mobile/__tests__/sync/sync-module.test.ts
@@ -9,18 +9,30 @@ const mockGetUnresolvedConflicts = vi.fn();
 const mockRefreshTransactions = vi.fn();
 const mockUpsertTransaction = vi.fn();
 
-vi.mock("@/shared/db", () => ({
-  getSupabase: (...args: any[]) => mockGetSupabase(...args),
-}));
-
 vi.mock("@/features/transactions", () => ({
   refreshTransactions: (...args: any[]) => mockRefreshTransactions(...args),
   upsertTransaction: (...args: any[]) => mockUpsertTransaction(...args),
 }));
 
-vi.mock("@/features/sync/services/networkMonitor", () => ({
-  isOnline: (...args: any[]) => mockIsOnline(...args),
-}));
+vi.mock("@/shared/effect/network", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/shared/effect/network")>();
+  return {
+    ...actual,
+    liveAppNetwork: {
+      isOnline: (...args: any[]) => mockIsOnline(...args),
+    },
+  };
+});
+
+vi.mock("@/shared/effect/supabase", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/shared/effect/supabase")>();
+  return {
+    ...actual,
+    liveAppSupabase: {
+      getSupabase: (...args: any[]) => mockGetSupabase(...args),
+    },
+  };
+});
 
 vi.mock("@/features/sync/services/syncEngine", () => ({
   syncPull: (...args: any[]) => mockSyncPull(...args),
@@ -33,6 +45,7 @@ vi.mock("@/features/sync/lib/conflict-repository", () => ({
 
 describe("sync module", () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     mockGetSupabase.mockReturnValue({ from: vi.fn() });
     mockIsOnline.mockResolvedValue(true);

--- a/apps/mobile/__tests__/sync/sync-service.test.ts
+++ b/apps/mobile/__tests__/sync/sync-service.test.ts
@@ -45,8 +45,6 @@ describe("createSyncService", () => {
     ]);
 
     const service = createSyncService({
-      isOnline,
-      getSupabase,
       syncPull,
       syncPush,
       refreshTransactions,
@@ -54,6 +52,8 @@ describe("createSyncService", () => {
       upsertTransaction: vi.fn(),
       enqueueTransactionSync: vi.fn(),
       resolveConflictRow: vi.fn(),
+      network: { isOnline },
+      supabase: { getSupabase },
     });
 
     const result = await service.run({
@@ -74,8 +74,8 @@ describe("createSyncService", () => {
 
   it("maps unresolved conflict rows into sync conflict records", async () => {
     const service = createSyncService({
-      isOnline: vi.fn().mockResolvedValue(true),
-      getSupabase: vi.fn(),
+      network: { isOnline: vi.fn().mockResolvedValue(true) },
+      supabase: { getSupabase: vi.fn() },
       syncPull: vi.fn(),
       syncPush: vi.fn(),
       refreshTransactions: vi.fn(),
@@ -173,8 +173,8 @@ describe("createSyncService", () => {
       .mockResolvedValueOnce([]);
 
     const service = createSyncService({
-      isOnline: vi.fn().mockResolvedValue(true),
-      getSupabase: vi.fn(),
+      network: { isOnline: vi.fn().mockResolvedValue(true) },
+      supabase: { getSupabase: vi.fn() },
       syncPull: vi.fn(),
       syncPush: vi.fn(),
       refreshTransactions,
@@ -240,8 +240,8 @@ describe("createSyncService", () => {
       .mockResolvedValueOnce([]);
 
     const service = createSyncService({
-      isOnline: vi.fn().mockResolvedValue(true),
-      getSupabase: vi.fn(),
+      network: { isOnline: vi.fn().mockResolvedValue(true) },
+      supabase: { getSupabase: vi.fn() },
       syncPull: vi.fn(),
       syncPush: vi.fn(),
       refreshTransactions,

--- a/apps/mobile/features/sync/services/create-sync-service.ts
+++ b/apps/mobile/features/sync/services/create-sync-service.ts
@@ -1,7 +1,13 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { Effect } from "effect";
 import { type AppClock, bindAppClock, currentIsoDateTimeEffect } from "@/shared/effect/clock";
+import { type AppNetwork, bindAppNetwork, isOnlineEffect } from "@/shared/effect/network";
 import { fromPromise, fromSync, fromThunk, makeAppService } from "@/shared/effect/runtime";
+import {
+  type AppSupabase,
+  bindAppSupabase,
+  currentSupabaseClientEffect,
+} from "@/shared/effect/supabase";
 import type { IsoDateTime } from "@/shared/types/branded";
 import type {
   ConflictResolution,
@@ -41,8 +47,6 @@ type ResolveConflictRow = (
 ) => void | Promise<void>;
 
 type CreateSyncServiceDeps = {
-  readonly isOnline: () => Promise<boolean>;
-  readonly getSupabase: () => SupabaseClient;
   readonly syncPull: SyncPull;
   readonly syncPush: SyncPush;
   readonly refreshTransactions: RefreshTransactions;
@@ -51,6 +55,8 @@ type CreateSyncServiceDeps = {
   readonly enqueueTransactionSync: EnqueueTransactionSync;
   readonly resolveConflictRow: ResolveConflictRow;
   readonly clock?: AppClock;
+  readonly network?: AppNetwork;
+  readonly supabase?: AppSupabase;
 };
 
 export type SyncService = {
@@ -129,8 +135,8 @@ function runSyncEffect({ db, userId, reason: _reason = "foreground" }: SyncInput
   return Effect.gen(function* () {
     void _reason;
 
-    const { isOnline, getSupabase, syncPull, syncPush, refreshTransactions } = yield* SyncDeps.tag;
-    const online = yield* fromPromise(isOnline);
+    const { syncPull, syncPush, refreshTransactions } = yield* SyncDeps.tag;
+    const online = yield* isOnlineEffect;
     if (!online) {
       return {
         status: "skipped_offline" as const,
@@ -138,7 +144,7 @@ function runSyncEffect({ db, userId, reason: _reason = "foreground" }: SyncInput
       };
     }
 
-    const supabase = yield* fromSync(getSupabase);
+    const supabase = yield* currentSupabaseClientEffect;
     const pullOk = yield* fromPromise(() => syncPull(db, supabase, userId));
     if (pullOk) {
       yield* fromPromise(() => syncPush(db, supabase, userId));
@@ -153,8 +159,6 @@ function runSyncEffect({ db, userId, reason: _reason = "foreground" }: SyncInput
 }
 
 export function createSyncService({
-  isOnline,
-  getSupabase,
   syncPull,
   syncPush,
   refreshTransactions,
@@ -163,11 +167,13 @@ export function createSyncService({
   enqueueTransactionSync,
   resolveConflictRow,
   clock,
+  network,
+  supabase,
 }: CreateSyncServiceDeps): SyncService {
   const clockRuntime = bindAppClock(clock);
+  const networkRuntime = bindAppNetwork(network);
+  const supabaseRuntime = bindAppSupabase(supabase);
   const runtime = SyncDeps.bind({
-    isOnline,
-    getSupabase,
     syncPull,
     syncPush,
     refreshTransactions,
@@ -180,6 +186,9 @@ export function createSyncService({
   return {
     listConflicts: (input) => runtime.run(clockRuntime.provide(listConflictsEffect(input))),
     resolveConflict: (input) => runtime.run(clockRuntime.provide(resolveConflictEffect(input))),
-    run: (input) => runtime.run(clockRuntime.provide(runSyncEffect(input))),
+    run: (input) =>
+      runtime.run(
+        supabaseRuntime.provide(networkRuntime.provide(clockRuntime.provide(runSyncEffect(input))))
+      ),
   };
 }

--- a/apps/mobile/features/sync/services/sync.ts
+++ b/apps/mobile/features/sync/services/sync.ts
@@ -1,6 +1,8 @@
 // biome-ignore-all lint/style/useNamingConvention: snake_case matches Supabase Postgres column names
 import { refreshTransactions, upsertTransaction } from "@/features/transactions";
-import { enqueueSync, getSupabase } from "@/shared/db";
+import { enqueueSync } from "@/shared/db";
+import { liveAppNetwork } from "@/shared/effect/network";
+import { liveAppSupabase } from "@/shared/effect/supabase";
 import { generateSyncQueueId } from "@/shared/lib";
 import type { UserId } from "@/shared/types/branded";
 import {
@@ -8,7 +10,6 @@ import {
   resolveConflict as resolveConflictDb,
 } from "../lib/conflict-repository";
 import { createSyncService } from "./create-sync-service";
-import { isOnline } from "./networkMonitor";
 import { syncPull, syncPush } from "./syncEngine";
 import type {
   ResolveConflictResult,
@@ -20,8 +21,6 @@ import type {
 } from "./types";
 
 const syncService = createSyncService({
-  isOnline,
-  getSupabase,
   syncPull,
   syncPush,
   refreshTransactions: async ({ db, userId }) => {
@@ -43,6 +42,8 @@ const syncService = createSyncService({
   resolveConflictRow: async (db, conflictId, resolution, resolvedAt) => {
     resolveConflictDb(db, conflictId, resolution, resolvedAt);
   },
+  network: liveAppNetwork,
+  supabase: liveAppSupabase,
 });
 
 export async function sync(input: SyncInput): Promise<SyncRunResult> {

--- a/apps/mobile/shared/effect/network.ts
+++ b/apps/mobile/shared/effect/network.ts
@@ -1,0 +1,26 @@
+import NetInfo from "@react-native-community/netinfo";
+import { Effect } from "effect";
+import { type BoundAppService, fromPromise, makeAppService } from "./runtime";
+
+export type AppNetwork = {
+  readonly isOnline: () => Promise<boolean>;
+};
+
+export const liveAppNetwork: AppNetwork = {
+  isOnline: async () => {
+    const state = await NetInfo.fetch();
+    return state.isConnected ?? false;
+  },
+};
+
+export const AppNetworkService = makeAppService<AppNetwork>("@/shared/effect/AppNetwork");
+
+export const isOnlineEffect = Effect.flatMap(AppNetworkService.tag, ({ isOnline }) =>
+  fromPromise(isOnline)
+);
+
+export function bindAppNetwork(
+  network: AppNetwork = liveAppNetwork
+): BoundAppService<AppNetwork, AppNetwork> {
+  return AppNetworkService.bind(network);
+}

--- a/apps/mobile/shared/effect/supabase.ts
+++ b/apps/mobile/shared/effect/supabase.ts
@@ -1,0 +1,25 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { Effect } from "effect";
+import { getSupabase } from "@/shared/db/supabase";
+import { type BoundAppService, fromSync, makeAppService } from "./runtime";
+
+export type AppSupabase = {
+  readonly getSupabase: () => SupabaseClient;
+};
+
+export const liveAppSupabase: AppSupabase = {
+  getSupabase,
+};
+
+export const AppSupabaseService = makeAppService<AppSupabase>("@/shared/effect/AppSupabase");
+
+export const currentSupabaseClientEffect = Effect.flatMap(
+  AppSupabaseService.tag,
+  ({ getSupabase }) => fromSync(getSupabase)
+);
+
+export function bindAppSupabase(
+  supabase: AppSupabase = liveAppSupabase
+): BoundAppService<AppSupabase, AppSupabase> {
+  return AppSupabaseService.bind(supabase);
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored mobile sync to inject network and Supabase via Effect services. This decouples sync from platform APIs, improves testability, and standardizes dependency injection.

- **Refactors**
  - Added `@/shared/effect/network` and `@/shared/effect/supabase` with `liveAppNetwork`, `liveAppSupabase`, `bindAppNetwork`, `bindAppSupabase`, `isOnlineEffect`, and `currentSupabaseClientEffect` (uses `@react-native-community/netinfo` for connectivity).
  - Updated `createSyncService` to accept `network: AppNetwork` and `supabase: AppSupabase`; removed direct `isOnline`/`getSupabase` params and composed runtimes to provide effects.
  - Switched sync wiring to use `liveAppNetwork` and `liveAppSupabase`; tests now bind mocks via the new effect services.

<sup>Written for commit e6f5f3f0820ff10af5bc18c16daa1be63e955cac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

