### PR TITLE
refactor(mobile): finish effect service edges

### DIFF
--- a/apps/mobile/__tests__/ai-chat/ai-chat-api-service.test.ts
+++ b/apps/mobile/__tests__/ai-chat/ai-chat-api-service.test.ts
@@ -1,0 +1,141 @@
+// biome-ignore-all lint/style/useNamingConvention: test fixtures mirror HTTP headers and Supabase payloads
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("expo/fetch", () => ({
+  fetch: globalThis.fetch,
+}));
+
+import { createAiChatApiService } from "@/features/ai-chat/services/create-ai-chat-api-service";
+
+describe("createAiChatApiService", () => {
+  it("streams chunks with auth headers from Supabase session", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response('data: {"content":"Hello"}\n\ndata: [DONE]\n\n', {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      })
+    );
+
+    const service = createAiChatApiService({
+      fetchImpl: fetchImpl as never,
+      getBaseUrl: () => "https://example.supabase.co",
+      supabase: {
+        getSupabase: () =>
+          ({
+            auth: {
+              getSession: vi.fn().mockResolvedValue({
+                data: { session: { access_token: "token-123" } },
+              }),
+            },
+          }) as never,
+      },
+      telemetry: {
+        captureError: vi.fn(),
+        captureWarning: vi.fn(),
+        capturePipelineEvent: vi.fn(),
+      },
+    });
+
+    const onChunk = vi.fn();
+    const onDone = vi.fn();
+    const onError = vi.fn();
+
+    await service.streamChat([{ role: "user", content: "hello" }], {
+      onChunk,
+      onDone,
+      onError,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://example.supabase.co/functions/v1/ai-chat",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer token-123",
+          "Content-Type": "application/json",
+        }),
+      })
+    );
+    expect(onChunk).toHaveBeenCalledWith("Hello");
+    expect(onDone).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("captures chunk callback failures without crashing the stream", async () => {
+    const captureError = vi.fn().mockResolvedValue(undefined);
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response('data: {"content":"Hello"}\n\ndata: [DONE]\n\n', {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      })
+    );
+
+    const service = createAiChatApiService({
+      fetchImpl: fetchImpl as never,
+      getBaseUrl: () => "https://example.supabase.co",
+      supabase: {
+        getSupabase: () =>
+          ({
+            auth: {
+              getSession: vi.fn().mockResolvedValue({
+                data: { session: { access_token: "token-123" } },
+              }),
+            },
+          }) as never,
+      },
+      telemetry: {
+        captureError,
+        captureWarning: vi.fn(),
+        capturePipelineEvent: vi.fn(),
+      },
+    });
+
+    const onDone = vi.fn();
+
+    await service.streamChat([{ role: "user", content: "hello" }], {
+      onChunk: () => {
+        throw new Error("callback boom");
+      },
+      onDone,
+      onError: vi.fn(),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(captureError).toHaveBeenCalledWith(expect.any(Error));
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports non-OK responses as stream errors", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response("nope", { status: 503 }));
+
+    const service = createAiChatApiService({
+      fetchImpl: fetchImpl as never,
+      getBaseUrl: () => "https://example.supabase.co",
+      supabase: {
+        getSupabase: () =>
+          ({
+            auth: {
+              getSession: vi.fn().mockResolvedValue({
+                data: { session: { access_token: "token-123" } },
+              }),
+            },
+          }) as never,
+      },
+      telemetry: {
+        captureError: vi.fn(),
+        captureWarning: vi.fn(),
+        capturePipelineEvent: vi.fn(),
+      },
+    });
+
+    const onError = vi.fn();
+
+    await service.streamChat([{ role: "user", content: "hello" }], {
+      onChunk: vi.fn(),
+      onDone: vi.fn(),
+      onError,
+    });
+
+    expect(onError).toHaveBeenCalledWith("HTTP 503");
+  });
+});

--- a/apps/mobile/__tests__/ai-chat/ai-chat-api-service.test.ts
+++ b/apps/mobile/__tests__/ai-chat/ai-chat-api-service.test.ts
@@ -138,4 +138,39 @@ describe("createAiChatApiService", () => {
 
     expect(onError).toHaveBeenCalledWith("HTTP 503");
   });
+
+  it("reports auth header resolution failures through onError", async () => {
+    const fetchImpl = vi.fn();
+
+    const service = createAiChatApiService({
+      fetchImpl: fetchImpl as never,
+      getBaseUrl: () => "https://example.supabase.co",
+      supabase: {
+        getSupabase: () =>
+          ({
+            auth: {
+              getSession: vi.fn().mockRejectedValue(new Error("session offline")),
+            },
+          }) as never,
+      },
+      telemetry: {
+        captureError: vi.fn(),
+        captureWarning: vi.fn(),
+        capturePipelineEvent: vi.fn(),
+      },
+    });
+
+    const onError = vi.fn();
+
+    await expect(
+      service.streamChat([{ role: "user", content: "hello" }], {
+        onChunk: vi.fn(),
+        onDone: vi.fn(),
+        onError,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith("session offline");
+  });
 });

--- a/apps/mobile/__tests__/ai-chat/user-memories.test.ts
+++ b/apps/mobile/__tests__/ai-chat/user-memories.test.ts
@@ -2,18 +2,10 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { beforeEach, describe, expect, test, vi } from "vitest";
-
-vi.mock("@/shared/db", () => ({
-  getSupabase: vi.fn(),
-}));
-
 import {
-  extractMemoriesFromConversation,
-  listUserMemories,
-  softDeleteUserMemory,
+  createUserMemoryRemoteService,
   toUserMemory,
-} from "@/features/ai-chat/data/user-memories";
-import { getSupabase } from "@/shared/db";
+} from "@/features/ai-chat/data/create-user-memory-remote-service";
 import type { UserId, UserMemoryId } from "@/shared/types/branded";
 
 const mockSelect = vi.fn();
@@ -36,13 +28,23 @@ const mockFrom = vi.fn((table: string) => {
   throw new Error(`Unexpected table ${table}`);
 });
 
+const userMemoryRemoteService = createUserMemoryRemoteService({
+  supabase: {
+    getSupabase: () =>
+      ({
+        from: mockFrom,
+        functions: { invoke: mockInvoke },
+      }) as never,
+  },
+  clock: {
+    now: () => new Date("2026-04-19T12:00:00.000Z"),
+    nowIsoDateTime: () => "2026-04-19T12:00:00.000Z" as never,
+  },
+});
+
 describe("user memories remote adapters", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(getSupabase).mockReturnValue({
-      from: mockFrom,
-      functions: { invoke: mockInvoke },
-    } as never);
   });
 
   test("maps a Supabase row to UserMemory", () => {
@@ -88,7 +90,7 @@ describe("user memories remote adapters", () => {
       error: null,
     });
 
-    const result = await listUserMemories("user-1" as UserId);
+    const result = await userMemoryRemoteService.listUserMemories("user-1" as UserId);
 
     expect(mockFrom).toHaveBeenCalledWith("user_memories");
     expect(mockEqSelect).toHaveBeenCalledWith("user_id", "user-1");
@@ -100,9 +102,9 @@ describe("user memories remote adapters", () => {
   test("soft delete updates deleted_at", async () => {
     mockEqUpdate.mockResolvedValue({ error: null });
 
-    await softDeleteUserMemory("memory-1" as UserMemoryId);
+    await userMemoryRemoteService.softDeleteUserMemory("memory-1" as UserMemoryId);
 
-    expect(mockUpdate).toHaveBeenCalledWith({ deleted_at: expect.any(String) });
+    expect(mockUpdate).toHaveBeenCalledWith({ deleted_at: "2026-04-19T12:00:00.000Z" });
     expect(mockEqUpdate).toHaveBeenCalledWith("id", "memory-1");
   });
 
@@ -124,7 +126,7 @@ describe("user memories remote adapters", () => {
       error: null,
     });
 
-    const result = await extractMemoriesFromConversation([
+    const result = await userMemoryRemoteService.extractMemoriesFromConversation([
       { role: "user", content: "I shop every Sunday" },
       { role: "assistant", content: "I'll remember that" },
     ]);
@@ -160,7 +162,7 @@ describe("user memories remote adapters", () => {
     });
 
     await expect(
-      extractMemoriesFromConversation([
+      userMemoryRemoteService.extractMemoriesFromConversation([
         { role: "user", content: "I shop every Sunday" },
         { role: "assistant", content: "I'll remember that" },
       ])
@@ -170,7 +172,9 @@ describe("user memories remote adapters", () => {
   test("throws when the remote list fetch fails", async () => {
     mockOrder.mockResolvedValue({ data: null, error: { message: "offline" } });
 
-    await expect(listUserMemories("user-1" as UserId)).rejects.toThrow("offline");
+    await expect(userMemoryRemoteService.listUserMemories("user-1" as UserId)).rejects.toThrow(
+      "offline"
+    );
   });
 });
 

--- a/apps/mobile/__tests__/email-capture/parse-email-service.test.ts
+++ b/apps/mobile/__tests__/email-capture/parse-email-service.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from "vitest";
+import { createParseEmailService } from "@/features/email-capture/services/create-parse-email-service";
+
+describe("createParseEmailService", () => {
+  it("classifies merchants through the parse-email edge function", async () => {
+    const mockInvoke = vi.fn().mockResolvedValue({
+      data: { success: true, data: { categoryId: "food" } },
+      error: null,
+    });
+
+    const service = createParseEmailService({
+      validCategoryIds: ["food", "transport"],
+      supabase: {
+        getSupabase: () =>
+          ({
+            functions: { invoke: mockInvoke },
+          }) as never,
+      },
+      telemetry: {
+        captureError: vi.fn(),
+        captureWarning: vi.fn(),
+        capturePipelineEvent: vi.fn(),
+      },
+    });
+
+    await expect(service.classifyMerchant("EXITO")).resolves.toBe("food");
+    expect(mockInvoke).toHaveBeenCalledWith("parse-email", {
+      body: { body: "EXITO", mode: "classify" },
+    });
+  });
+
+  it("returns a validated transaction for full_parse mode", async () => {
+    const mockInvoke = vi.fn().mockResolvedValue({
+      data: {
+        success: true,
+        data: {
+          type: "expense",
+          amount: 50000,
+          categoryId: "food",
+          description: "Exito",
+          date: "2026-03-05",
+          confidence: 0.9,
+        },
+      },
+      error: null,
+    });
+
+    const service = createParseEmailService({
+      validCategoryIds: ["food"],
+      supabase: {
+        getSupabase: () =>
+          ({
+            functions: { invoke: mockInvoke },
+          }) as never,
+      },
+      telemetry: {
+        captureError: vi.fn(),
+        captureWarning: vi.fn(),
+        capturePipelineEvent: vi.fn(),
+      },
+    });
+
+    await expect(service.parseEmail("Compra por $50,000")).resolves.toEqual(
+      expect.objectContaining({
+        amount: 50000,
+        categoryId: "food",
+        description: "Exito",
+      })
+    );
+  });
+
+  it("returns null and captures a warning when parse_notification payload is invalid", async () => {
+    const captureWarning = vi.fn();
+    const mockInvoke = vi.fn().mockResolvedValue({
+      data: {
+        success: true,
+        data: {
+          type: "expense",
+          amount: -100,
+          categoryId: "food",
+          description: "Bad",
+          date: "2026-03-05",
+          confidence: 0.9,
+        },
+      },
+      error: null,
+    });
+
+    const service = createParseEmailService({
+      validCategoryIds: ["food"],
+      supabase: {
+        getSupabase: () =>
+          ({
+            functions: { invoke: mockInvoke },
+          }) as never,
+      },
+      telemetry: {
+        captureError: vi.fn(),
+        captureWarning,
+        capturePipelineEvent: vi.fn(),
+      },
+    });
+
+    await expect(service.parseNotification("sanitized body")).resolves.toBeNull();
+    expect(captureWarning).toHaveBeenCalledWith("parse_notification_validation_failed", {
+      issueCount: 1,
+    });
+  });
+});

--- a/apps/mobile/features/ai-chat/data/create-user-memory-remote-service.ts
+++ b/apps/mobile/features/ai-chat/data/create-user-memory-remote-service.ts
@@ -1,0 +1,144 @@
+import { Effect } from "effect";
+import { z } from "zod";
+import { type AppClock, bindAppClock, currentIsoDateTimeEffect } from "@/shared/effect/clock";
+import { fromPromise } from "@/shared/effect/runtime";
+import {
+  type AppSupabase,
+  bindAppSupabase,
+  currentSupabaseClientEffect,
+} from "@/shared/effect/supabase";
+import { requireIsoDateTime, requireUserId, requireUserMemoryId } from "@/shared/types/assertions";
+import type { UserId, UserMemoryId } from "@/shared/types/branded";
+import { memoryCategory, type UserMemory } from "../schema";
+
+const userMemoryRowSchema = z.object({
+  id: z.string().min(1),
+  // biome-ignore lint/style/useNamingConvention: Supabase column name
+  user_id: z.string().min(1),
+  fact: z.string(),
+  category: memoryCategory,
+  // biome-ignore lint/style/useNamingConvention: Supabase column name
+  created_at: z.string(),
+  // biome-ignore lint/style/useNamingConvention: Supabase column name
+  updated_at: z.string().nullable(),
+});
+
+type UserMemoryRow = z.infer<typeof userMemoryRowSchema>;
+const userMemoryRowsSchema = z.array(userMemoryRowSchema);
+
+type ConversationMessage = {
+  readonly role: "user" | "assistant";
+  readonly content: string;
+};
+
+const extractMemoriesResponseSchema = z.object({
+  success: z.literal(true),
+  data: userMemoryRowsSchema,
+});
+
+type CreateUserMemoryRemoteServiceDeps = {
+  readonly supabase?: AppSupabase;
+  readonly clock?: AppClock;
+};
+
+export type UserMemoryRemoteService = {
+  readonly listUserMemories: (userId: UserId) => Promise<readonly UserMemory[]>;
+  readonly softDeleteUserMemory: (id: UserMemoryId) => Promise<void>;
+  readonly extractMemoriesFromConversation: (
+    messages: readonly ConversationMessage[]
+  ) => Promise<readonly UserMemory[]>;
+};
+
+export function toUserMemory(row: UserMemoryRow): UserMemory {
+  return {
+    id: requireUserMemoryId(row.id),
+    userId: requireUserId(row.user_id),
+    fact: row.fact,
+    category: row.category,
+    createdAt: requireIsoDateTime(row.created_at),
+    updatedAt: requireIsoDateTime(row.updated_at ?? row.created_at),
+  };
+}
+
+function listUserMemoriesEffect(userId: UserId) {
+  return Effect.flatMap(currentSupabaseClientEffect, (supabase) =>
+    Effect.map(
+      fromPromise(
+        async () =>
+          await supabase
+            .from("user_memories")
+            .select("id, user_id, fact, category, created_at, updated_at")
+            .eq("user_id", userId)
+            .is("deleted_at", null)
+            .order("created_at", { ascending: false })
+      ),
+      ({ data, error }) => {
+        if (error != null) {
+          throw new Error(error.message);
+        }
+
+        return userMemoryRowsSchema.parse(data ?? []).map(toUserMemory);
+      }
+    )
+  );
+}
+
+function softDeleteUserMemoryEffect(id: UserMemoryId) {
+  return Effect.gen(function* () {
+    const supabase = yield* currentSupabaseClientEffect;
+    const deletedAt = yield* currentIsoDateTimeEffect;
+    const { error } = yield* fromPromise(() =>
+      Promise.resolve(
+        supabase
+          .from("user_memories")
+          // biome-ignore lint/style/useNamingConvention: Supabase column name
+          .update({ deleted_at: deletedAt })
+          .eq("id", id)
+      )
+    );
+
+    if (error != null) {
+      throw new Error(error.message);
+    }
+  });
+}
+
+function extractMemoriesEffect(messages: readonly ConversationMessage[]) {
+  return Effect.flatMap(currentSupabaseClientEffect, (supabase) =>
+    Effect.map(
+      fromPromise(() =>
+        supabase.functions.invoke("ai-chat", {
+          body: { mode: "extract_memories", messages },
+        })
+      ),
+      ({ data, error }) => {
+        if (error != null) {
+          throw error;
+        }
+
+        const result = extractMemoriesResponseSchema.safeParse(data);
+        if (!result.success) {
+          throw new Error("extract_memories_failed");
+        }
+
+        return result.data.data.map(toUserMemory);
+      }
+    )
+  );
+}
+
+export function createUserMemoryRemoteService({
+  supabase,
+  clock,
+}: CreateUserMemoryRemoteServiceDeps = {}): UserMemoryRemoteService {
+  const supabaseRuntime = bindAppSupabase(supabase);
+  const clockRuntime = bindAppClock(clock);
+  const runEffect = <A>(effect: Effect.Effect<A, unknown, AppSupabase | AppClock>) =>
+    clockRuntime.run(supabaseRuntime.provide(effect));
+
+  return {
+    listUserMemories: (userId) => runEffect(listUserMemoriesEffect(userId)),
+    softDeleteUserMemory: (id) => runEffect(softDeleteUserMemoryEffect(id)),
+    extractMemoriesFromConversation: (messages) => runEffect(extractMemoriesEffect(messages)),
+  };
+}

--- a/apps/mobile/features/ai-chat/data/user-memories.ts
+++ b/apps/mobile/features/ai-chat/data/user-memories.ts
@@ -1,87 +1,26 @@
-import { z } from "zod";
-import { getSupabase } from "@/shared/db";
-import { requireIsoDateTime, requireUserId, requireUserMemoryId } from "@/shared/types/assertions";
 import type { UserId, UserMemoryId } from "@/shared/types/branded";
-import { memoryCategory, type UserMemory } from "../schema";
-
-const userMemoryRowSchema = z.object({
-  id: z.string().min(1),
-  // biome-ignore lint/style/useNamingConvention: Supabase column name
-  user_id: z.string().min(1),
-  fact: z.string(),
-  category: memoryCategory,
-  // biome-ignore lint/style/useNamingConvention: Supabase column name
-  created_at: z.string(),
-  // biome-ignore lint/style/useNamingConvention: Supabase column name
-  updated_at: z.string().nullable(),
-});
-
-type UserMemoryRow = z.infer<typeof userMemoryRowSchema>;
-const userMemoryRowsSchema = z.array(userMemoryRowSchema);
+import type { UserMemory } from "../schema";
+import { createUserMemoryRemoteService, toUserMemory } from "./create-user-memory-remote-service";
 
 type ConversationMessage = {
   readonly role: "user" | "assistant";
   readonly content: string;
 };
 
-const extractMemoriesResponseSchema = z.object({
-  success: z.literal(true),
-  data: userMemoryRowsSchema,
-});
-
-export function toUserMemory(row: UserMemoryRow): UserMemory {
-  return {
-    id: requireUserMemoryId(row.id),
-    userId: requireUserId(row.user_id),
-    fact: row.fact,
-    category: row.category,
-    createdAt: requireIsoDateTime(row.created_at),
-    updatedAt: requireIsoDateTime(row.updated_at ?? row.created_at),
-  };
-}
+const userMemoryRemoteService = createUserMemoryRemoteService();
 
 export async function listUserMemories(userId: UserId): Promise<readonly UserMemory[]> {
-  const { data, error } = await getSupabase()
-    .from("user_memories")
-    .select("id, user_id, fact, category, created_at, updated_at")
-    .eq("user_id", userId)
-    .is("deleted_at", null)
-    .order("created_at", { ascending: false });
-
-  if (error != null) {
-    throw new Error(error.message);
-  }
-
-  return userMemoryRowsSchema.parse(data ?? []).map(toUserMemory);
+  return userMemoryRemoteService.listUserMemories(userId);
 }
 
 export async function softDeleteUserMemory(id: UserMemoryId): Promise<void> {
-  const { error } = await getSupabase()
-    .from("user_memories")
-    // biome-ignore lint/style/useNamingConvention: Supabase column name
-    .update({ deleted_at: new Date().toISOString() })
-    .eq("id", id);
-
-  if (error != null) {
-    throw new Error(error.message);
-  }
+  return userMemoryRemoteService.softDeleteUserMemory(id);
 }
 
 export async function extractMemoriesFromConversation(
   messages: readonly ConversationMessage[]
 ): Promise<readonly UserMemory[]> {
-  const { data, error } = await getSupabase().functions.invoke("ai-chat", {
-    body: { mode: "extract_memories", messages },
-  });
-
-  if (error != null) {
-    throw error;
-  }
-
-  const result = extractMemoriesResponseSchema.safeParse(data);
-  if (!result.success) {
-    throw new Error("extract_memories_failed");
-  }
-
-  return result.data.data.map(toUserMemory);
+  return userMemoryRemoteService.extractMemoriesFromConversation(messages);
 }
+
+export { toUserMemory };

--- a/apps/mobile/features/ai-chat/services/ai-chat-api.ts
+++ b/apps/mobile/features/ai-chat/services/ai-chat-api.ts
@@ -1,6 +1,4 @@
-import { fetch } from "expo/fetch";
-import { getSupabase } from "@/shared/db";
-import { captureError } from "@/shared/lib";
+import { createAiChatApiService } from "./create-ai-chat-api-service";
 
 type ChatMessage = { readonly role: "user" | "assistant"; readonly content: string };
 
@@ -10,98 +8,12 @@ type StreamCallbacks = {
   readonly onError: (error: string) => void;
 };
 
-async function getAuthHeaders(): Promise<Record<string, string>> {
-  const { data } = await getSupabase().auth.getSession();
-  const token = data.session?.access_token ?? "";
-  return {
-    // biome-ignore lint/style/useNamingConvention: HTTP header name
-    Authorization: `Bearer ${token}`,
-    "Content-Type": "application/json",
-  };
-}
-
-function getBaseUrl(): string {
-  return process.env.EXPO_PUBLIC_SUPABASE_URL ?? "";
-}
+const aiChatApi = createAiChatApiService();
 
 export async function streamChat(
   messages: readonly ChatMessage[],
   callbacks: StreamCallbacks,
   signal?: AbortSignal
 ): Promise<void> {
-  const headers = await getAuthHeaders();
-  const url = `${getBaseUrl()}/functions/v1/ai-chat`;
-
-  let response: Response;
-  try {
-    response = await fetch(url, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({ messages }),
-      signal,
-    });
-  } catch (err) {
-    if (signal?.aborted) return;
-    callbacks.onError(err instanceof Error ? err.message : "Network error");
-    return;
-  }
-
-  if (!response.ok) {
-    callbacks.onError(`HTTP ${response.status}`);
-    return;
-  }
-
-  const reader = response.body?.getReader();
-  if (!reader) {
-    callbacks.onError("No response body");
-    return;
-  }
-
-  const decoder = new TextDecoder();
-  // FP exemption: streaming SSE requires imperative buffering.
-  let buffer = "";
-
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional streaming loop
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split("\n");
-      buffer = lines.pop() ?? "";
-
-      for (const line of lines) {
-        if (!line.startsWith("data: ")) continue;
-        const payload = line.slice(6).trim();
-
-        if (payload === "[DONE]") {
-          callbacks.onDone();
-          return;
-        }
-
-        try {
-          const parsed: unknown = JSON.parse(payload);
-          const record = parsed as Record<string, unknown>;
-          if (record.error) {
-            callbacks.onError(String(record.error));
-            return;
-          }
-          if (record.content) {
-            try {
-              callbacks.onChunk(String(record.content));
-            } catch (callbackErr) {
-              captureError(callbackErr);
-            }
-          }
-        } catch {
-          // Skip malformed SSE lines
-        }
-      }
-    }
-    callbacks.onDone();
-  } catch (err) {
-    if (signal?.aborted) return;
-    callbacks.onError(err instanceof Error ? err.message : "Stream error");
-  }
+  return aiChatApi.streamChat(messages, callbacks, signal);
 }

--- a/apps/mobile/features/ai-chat/services/create-ai-chat-api-service.ts
+++ b/apps/mobile/features/ai-chat/services/create-ai-chat-api-service.ts
@@ -1,0 +1,140 @@
+import { Effect } from "effect";
+import { fetch as expoFetch } from "expo/fetch";
+import { fromPromise } from "@/shared/effect/runtime";
+import {
+  type AppSupabase,
+  bindAppSupabase,
+  currentSupabaseClientEffect,
+} from "@/shared/effect/supabase";
+import { type AppTelemetry, bindAppTelemetry, captureErrorEffect } from "@/shared/effect/telemetry";
+
+type ChatMessage = { readonly role: "user" | "assistant"; readonly content: string };
+
+type StreamCallbacks = {
+  readonly onChunk: (text: string) => void;
+  readonly onDone: () => void;
+  readonly onError: (error: string) => void;
+};
+
+type CreateAiChatApiServiceDeps = {
+  readonly fetchImpl?: typeof expoFetch;
+  readonly getBaseUrl?: () => string;
+  readonly supabase?: AppSupabase;
+  readonly telemetry?: AppTelemetry;
+};
+
+export type AiChatApiService = {
+  readonly streamChat: (
+    messages: readonly ChatMessage[],
+    callbacks: StreamCallbacks,
+    signal?: AbortSignal
+  ) => Promise<void>;
+};
+
+function authHeadersEffect() {
+  return Effect.flatMap(currentSupabaseClientEffect, (supabase) =>
+    Effect.map(
+      fromPromise(() => supabase.auth.getSession()),
+      ({ data }) =>
+        ({
+          // biome-ignore lint/style/useNamingConvention: HTTP header name
+          Authorization: `Bearer ${data.session?.access_token ?? ""}`,
+          "Content-Type": "application/json",
+        }) satisfies Record<string, string>
+    )
+  );
+}
+
+export function createAiChatApiService({
+  fetchImpl = expoFetch,
+  getBaseUrl = () => process.env.EXPO_PUBLIC_SUPABASE_URL ?? "",
+  supabase,
+  telemetry,
+}: CreateAiChatApiServiceDeps = {}): AiChatApiService {
+  const supabaseRuntime = bindAppSupabase(supabase);
+  const telemetryRuntime = bindAppTelemetry(telemetry);
+  const runSupabaseEffect = <A>(effect: Effect.Effect<A, unknown, AppSupabase>) =>
+    supabaseRuntime.run(effect);
+  const captureCallbackError = (error: unknown) =>
+    telemetryRuntime.run(captureErrorEffect(error)).catch(() => undefined);
+
+  return {
+    async streamChat(messages, callbacks, signal) {
+      const headers = await runSupabaseEffect(authHeadersEffect());
+      const url = `${getBaseUrl()}/functions/v1/ai-chat`;
+
+      let response: Response;
+      try {
+        response = await fetchImpl(url, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({ messages }),
+          signal,
+        });
+      } catch (error) {
+        if (signal?.aborted) return;
+        callbacks.onError(error instanceof Error ? error.message : "Network error");
+        return;
+      }
+
+      if (!response.ok) {
+        callbacks.onError(`HTTP ${response.status}`);
+        return;
+      }
+
+      const reader = response.body?.getReader();
+      if (!reader) {
+        callbacks.onError("No response body");
+        return;
+      }
+
+      const decoder = new TextDecoder();
+      // FP exemption: streaming SSE requires imperative buffering.
+      let buffer = "";
+
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional streaming loop
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() ?? "";
+
+          for (const line of lines) {
+            if (!line.startsWith("data: ")) continue;
+            const payload = line.slice(6).trim();
+
+            if (payload === "[DONE]") {
+              callbacks.onDone();
+              return;
+            }
+
+            try {
+              const parsed = JSON.parse(payload) as Record<string, unknown>;
+              if (parsed.error) {
+                callbacks.onError(String(parsed.error));
+                return;
+              }
+              if (parsed.content) {
+                try {
+                  callbacks.onChunk(String(parsed.content));
+                } catch (callbackError) {
+                  void captureCallbackError(callbackError);
+                }
+              }
+            } catch {
+              // Skip malformed SSE lines
+            }
+          }
+        }
+
+        callbacks.onDone();
+      } catch (error) {
+        if (signal?.aborted) return;
+        callbacks.onError(error instanceof Error ? error.message : "Stream error");
+      }
+    },
+  };
+}

--- a/apps/mobile/features/ai-chat/services/create-ai-chat-api-service.ts
+++ b/apps/mobile/features/ai-chat/services/create-ai-chat-api-service.ts
@@ -60,7 +60,15 @@ export function createAiChatApiService({
 
   return {
     async streamChat(messages, callbacks, signal) {
-      const headers = await runSupabaseEffect(authHeadersEffect());
+      let headers: Record<string, string>;
+      try {
+        headers = await runSupabaseEffect(authHeadersEffect());
+      } catch (error) {
+        if (signal?.aborted) return;
+        callbacks.onError(error instanceof Error ? error.message : "Auth error");
+        return;
+      }
+
       const url = `${getBaseUrl()}/functions/v1/ai-chat`;
 
       let response: Response;

--- a/apps/mobile/features/capture-sources/services/parse-notification-api.ts
+++ b/apps/mobile/features/capture-sources/services/parse-notification-api.ts
@@ -1,42 +1,8 @@
-import {
-  type LlmParsedTransaction,
-  llmOutputSchema,
-} from "@/features/email-capture/llm-parser.public";
-import { getSupabase } from "@/shared/db";
-import { captureWarning } from "@/shared/lib";
-
-type ParseEmailResponse = { success: boolean; data: unknown };
+import type { LlmParsedTransaction } from "@/features/email-capture/llm-parser.public";
+import { liveParseEmailService } from "@/features/email-capture/services/parse-email-service";
 
 export async function parseNotificationApi(
   sanitizedText: string
 ): Promise<LlmParsedTransaction | null> {
-  try {
-    const response = await getSupabase().functions.invoke<ParseEmailResponse>("parse-email", {
-      body: { body: sanitizedText, mode: "parse_notification" },
-    });
-    const data = response.data;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Supabase FunctionsError types are untyped
-    const error: { message?: string } | null = response.error;
-
-    if (error != null || !data?.success) {
-      captureWarning("parse_notification_api_failed", {
-        errorMessage: error?.message ?? "unknown",
-        hasData: data != null,
-      });
-      return null;
-    }
-
-    const result = llmOutputSchema.safeParse(data.data);
-    if (!result.success) {
-      captureWarning("parse_notification_validation_failed", {
-        issueCount: result.error.issues.length,
-      });
-    }
-    return result.success ? result.data : null;
-  } catch (err) {
-    captureWarning("parse_notification_api_exception", {
-      errorType: err instanceof Error ? err.message : "unknown",
-    });
-    return null;
-  }
+  return liveParseEmailService.parseNotification(sanitizedText);
 }

--- a/apps/mobile/features/email-capture/services/create-parse-email-service.ts
+++ b/apps/mobile/features/email-capture/services/create-parse-email-service.ts
@@ -1,0 +1,131 @@
+import { Effect } from "effect";
+import { fromPromise } from "@/shared/effect/runtime";
+import {
+  type AppSupabase,
+  bindAppSupabase,
+  currentSupabaseClientEffect,
+} from "@/shared/effect/supabase";
+import {
+  type AppTelemetry,
+  bindAppTelemetry,
+  captureWarningEffect,
+} from "@/shared/effect/telemetry";
+import type { LlmParsedTransaction } from "./llm-parser";
+import { llmOutputSchema } from "./llm-parser";
+
+type ParseMode = "classify" | "full_parse" | "parse_notification";
+
+type ParseEmailResponse = {
+  readonly success: boolean;
+  readonly data?: unknown;
+};
+
+type ClassifyResponse = {
+  readonly success: boolean;
+  readonly data?: {
+    readonly categoryId?: string;
+  };
+};
+
+type CreateParseEmailServiceDeps = {
+  readonly validCategoryIds: readonly string[];
+  readonly supabase?: AppSupabase;
+  readonly telemetry?: AppTelemetry;
+};
+
+export type ParseEmailService = {
+  readonly classifyMerchant: (merchant: string) => Promise<string>;
+  readonly parseEmail: (emailBody: string) => Promise<LlmParsedTransaction | null>;
+  readonly parseNotification: (sanitizedText: string) => Promise<LlmParsedTransaction | null>;
+};
+
+function invokeParseEmailFunctionEffect<Response>(body: string, mode: ParseMode) {
+  return Effect.flatMap(currentSupabaseClientEffect, (supabase) =>
+    fromPromise(() =>
+      supabase.functions.invoke<Response>("parse-email", {
+        body: { body, mode },
+      })
+    )
+  );
+}
+
+function parseTransactionEffect(
+  body: string,
+  mode: Extract<ParseMode, "full_parse" | "parse_notification">,
+  warningPrefix: "parse_email" | "parse_notification"
+) {
+  return Effect.catchAll(
+    Effect.gen(function* () {
+      const response = yield* invokeParseEmailFunctionEffect<ParseEmailResponse>(body, mode);
+      const { data, error } = response;
+
+      if (error != null || !data?.success) {
+        yield* captureWarningEffect(`${warningPrefix}_api_failed`, {
+          errorMessage: error?.message ?? "unknown",
+          hasData: data != null,
+        });
+        return null;
+      }
+
+      const result = llmOutputSchema.safeParse(data.data);
+      if (!result.success) {
+        yield* captureWarningEffect(`${warningPrefix}_validation_failed`, {
+          issueCount: result.error.issues.length,
+        });
+        return null;
+      }
+
+      return result.data;
+    }),
+    (error) =>
+      Effect.zipRight(
+        captureWarningEffect(`${warningPrefix}_api_exception`, {
+          errorType: error instanceof Error ? error.message : "unknown",
+        }),
+        Effect.succeed(null)
+      )
+  );
+}
+
+function classifyMerchantEffect(merchant: string, validCategoryIds: readonly string[]) {
+  return Effect.catchAll(
+    Effect.gen(function* () {
+      const response = yield* invokeParseEmailFunctionEffect<ClassifyResponse>(
+        merchant,
+        "classify"
+      );
+      const { data, error } = response;
+
+      if (error != null || !data?.success) {
+        yield* captureWarningEffect("classify_merchant_failed", {
+          hasError: error != null,
+          errorMessage: error?.message ?? "unknown",
+        });
+        return "other";
+      }
+
+      const categoryId = data.data?.categoryId;
+      return categoryId != null && validCategoryIds.includes(categoryId) ? categoryId : "other";
+    }),
+    () => Effect.succeed("other")
+  );
+}
+
+export function createParseEmailService({
+  validCategoryIds,
+  supabase,
+  telemetry,
+}: CreateParseEmailServiceDeps): ParseEmailService {
+  const supabaseRuntime = bindAppSupabase(supabase);
+  const telemetryRuntime = bindAppTelemetry(telemetry);
+  const runEffect = <A>(effect: Effect.Effect<A, unknown, AppSupabase | AppTelemetry>) =>
+    telemetryRuntime.run(supabaseRuntime.provide(effect));
+
+  return {
+    classifyMerchant: (merchant) => runEffect(classifyMerchantEffect(merchant, validCategoryIds)),
+    parseEmail: (emailBody) =>
+      runEffect(parseTransactionEffect(emailBody, "full_parse", "parse_email")),
+    parseNotification: (sanitizedText) =>
+      runEffect(parseTransactionEffect(sanitizedText, "parse_notification", "parse_notification")),
+  };
+}

--- a/apps/mobile/features/email-capture/services/parse-email-api.ts
+++ b/apps/mobile/features/email-capture/services/parse-email-api.ts
@@ -1,7 +1,5 @@
-import { CATEGORY_IDS } from "@/features/transactions";
-import { getSupabase } from "@/shared/db";
-import { captureWarning } from "@/shared/lib";
-import { type LlmParsedTransaction, llmOutputSchema } from "./llm-parser";
+import type { LlmParsedTransaction } from "./llm-parser";
+import { liveParseEmailService } from "./parse-email-service";
 
 export function stripPii(text: string): string {
   return (
@@ -27,66 +25,12 @@ export function stripPii(text: string): string {
   );
 }
 
-type ClassifyResponse = { success: boolean; data?: { categoryId: string } };
-
 export async function classifyMerchantApi(merchant: string): Promise<string> {
-  try {
-    const response = await getSupabase().functions.invoke<ClassifyResponse>("parse-email", {
-      body: { body: merchant, mode: "classify" },
-    });
-    const data = response.data;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Supabase FunctionsError types are untyped
-    const error: { message?: string } | null = response.error;
-
-    if (error != null || !data?.success) {
-      captureWarning("classify_merchant_failed", {
-        hasError: error != null,
-        errorMessage: error?.message ?? "unknown",
-      });
-      return "other";
-    }
-
-    const categoryId = data.data?.categoryId;
-    const ids: readonly string[] = CATEGORY_IDS;
-    return categoryId != null && ids.includes(categoryId) ? categoryId : "other";
-  } catch {
-    return "other";
-  }
+  return liveParseEmailService.classifyMerchant(merchant);
 }
 
 export async function parseEmailApi(emailBody: string): Promise<LlmParsedTransaction | null> {
-  try {
-    const stripped = stripPii(emailBody);
-    const truncated = stripped.slice(0, 2000);
-    const supabase = getSupabase();
-
-    type ParseEmailResponse = { success: boolean; data: unknown };
-    const response = await supabase.functions.invoke<ParseEmailResponse>("parse-email", {
-      body: { body: truncated, mode: "full_parse" },
-    });
-    const data = response.data;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Supabase FunctionsError types are untyped
-    const error: { message?: string } | null = response.error;
-
-    if (error != null || !data?.success) {
-      captureWarning("parse_email_api_failed", {
-        errorMessage: error?.message ?? "unknown",
-        hasData: data != null,
-      });
-      return null;
-    }
-
-    const result = llmOutputSchema.safeParse(data.data);
-    if (!result.success) {
-      captureWarning("parse_email_validation_failed", {
-        issueCount: result.error.issues.length,
-      });
-    }
-    return result.success ? result.data : null;
-  } catch (err) {
-    captureWarning("parse_email_api_exception", {
-      errorType: err instanceof Error ? err.message : "unknown",
-    });
-    return null;
-  }
+  const stripped = stripPii(emailBody);
+  const truncated = stripped.slice(0, 2000);
+  return liveParseEmailService.parseEmail(truncated);
 }

--- a/apps/mobile/features/email-capture/services/parse-email-service.ts
+++ b/apps/mobile/features/email-capture/services/parse-email-service.ts
@@ -1,0 +1,6 @@
+import { CATEGORY_IDS } from "@/features/transactions";
+import { createParseEmailService } from "./create-parse-email-service";
+
+export const liveParseEmailService = createParseEmailService({
+  validCategoryIds: CATEGORY_IDS,
+});


### PR DESCRIPTION
- share parse-email boundary\n- effectify ai chat remotes\n- deepen user memory adapter tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored mobile edge integrations to effect-based services for chat, user memories, and email parsing. Centralizes auth, telemetry, and validation, improves testability, and keeps existing API calls intact.

- **Refactors**
  - AI Chat: added `create-ai-chat-api-service` with Supabase auth headers, SSE streaming, and telemetry-safe chunk callbacks; handles auth failures and non-OK responses via `onError`; `ai-chat-api` now delegates; fetch/base URL are injectable for tests.
  - User Memories: added `create-user-memory-remote-service` (Effect + Supabase/Clock); `user-memories` delegates; soft delete uses clock ISO time; memory extraction via `ai-chat` edge; exports `toUserMemory`.
  - Parse Email: added `create-parse-email-service` and `liveParseEmailService`; `parse-email-api` and `parse-notification-api` delegate; validates output with `llmOutputSchema`, checks `CATEGORY_IDS`, falls back to "other", and captures warnings on API/validation failures.
  - Tests: coverage for AI chat streaming, callback error capture, non-OK responses, and auth failure path; parse-email classify/full_parse/notification cases; expanded user memory adapter tests.

<sup>Written for commit 2d3b07d641c2c370cf7ff110034bb9fcdceab17a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

