### PR TITLE
feat(mobile): persist capture evidence

### DIFF
--- a/apps/mobile/__tests__/capture-evidence/builders.test.ts
+++ b/apps/mobile/__tests__/capture-evidence/builders.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildApplePayCaptureEvidence,
+  buildEmailCaptureEvidence,
+  buildNotificationCaptureEvidence,
+} from "@/features/capture-evidence";
+
+describe("capture evidence builders", () => {
+  it("builds normalized sender and domain evidence from email senders", () => {
+    expect(buildEmailCaptureEvidence({ from: "Notificaciones@Bancolombia.com.co" })).toEqual([
+      {
+        sourceFamily: "bancolombia",
+        evidenceType: "sender_email",
+        scope: "email:bancolombia:sender",
+        value: "notificaciones@bancolombia.com.co",
+      },
+      {
+        sourceFamily: "bancolombia",
+        evidenceType: "sender_domain",
+        scope: "email:bancolombia:domain",
+        value: "bancolombia.com.co",
+      },
+    ]);
+  });
+
+  it("extracts package family, alias tokens, and last4 evidence from notifications", () => {
+    expect(
+      buildNotificationCaptureEvidence({
+        packageName: "com.todo1.mobile.co.bancolombia",
+        title: "Bancolombia",
+        subText: "Cuenta ahorros",
+        text: "Compra aprobada",
+        bigText: "Compra aprobada con tarjeta ****1234 desde tu cuenta de ahorros",
+        timestamp: Date.UTC(2026, 3, 19),
+      })
+    ).toEqual([
+      {
+        sourceFamily: "bancolombia",
+        evidenceType: "package_name",
+        scope: "notification:bancolombia:package",
+        value: "com.todo1.mobile.co.bancolombia",
+      },
+      {
+        sourceFamily: "bancolombia",
+        evidenceType: "alias_token",
+        scope: "notification:bancolombia:alias",
+        value: "ahorros",
+      },
+      {
+        sourceFamily: "bancolombia",
+        evidenceType: "last4",
+        scope: "notification:bancolombia:last4",
+        value: "1234",
+      },
+    ]);
+  });
+
+  it("preserves Apple Pay card hints and extracts last4 when present", () => {
+    expect(
+      buildApplePayCaptureEvidence({
+        amount: 50000,
+        merchant: "Farmatodo",
+        card: "Visa *1234",
+      })
+    ).toEqual([
+      {
+        sourceFamily: "apple_pay",
+        evidenceType: "card_hint",
+        scope: "apple_pay:card_hint",
+        value: "visa *1234",
+      },
+      {
+        sourceFamily: "apple_pay",
+        evidenceType: "last4",
+        scope: "apple_pay:last4",
+        value: "1234",
+      },
+    ]);
+  });
+});

--- a/apps/mobile/__tests__/capture-evidence/repository.test.ts
+++ b/apps/mobile/__tests__/capture-evidence/repository.test.ts
@@ -1,0 +1,137 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: integration test uses a real SQLite DB
+import { resolve } from "node:path";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  countCaptureEvidenceOccurrences,
+  getRepeatedCaptureEvidenceForUser,
+  saveCaptureEvidence,
+} from "@/features/capture-evidence";
+import { getQueuedSyncEntries } from "@/features/transactions";
+import type {
+  CaptureEvidenceId,
+  IsoDateTime,
+  ProcessedCaptureId,
+  ProcessedEmailId,
+  TransactionId,
+  UserId,
+} from "@/shared/types/branded";
+
+let sqlite: InstanceType<typeof Database>;
+let db: ReturnType<typeof drizzle>;
+
+const USER_ID = "user-1" as UserId;
+const NOW = "2026-04-19T10:00:00.000Z" as IsoDateTime;
+
+beforeEach(() => {
+  sqlite = new Database(":memory:");
+  db = drizzle(sqlite);
+  migrate(db, { migrationsFolder: resolve(__dirname, "../../drizzle") });
+});
+
+afterEach(() => {
+  sqlite.close();
+});
+
+describe("capture evidence repository", () => {
+  it("saves evidence, enqueues sync, and counts repeated scoped evidence for one user", () => {
+    saveCaptureEvidence(db as any, {
+      id: "ce-1" as CaptureEvidenceId,
+      userId: USER_ID,
+      sourceFamily: "bancolombia",
+      evidenceType: "last4",
+      scope: "notification:bancolombia:last4",
+      value: "1234",
+      transactionId: "tx-1" as TransactionId,
+      processedEmailId: null,
+      processedCaptureId: "pc-1" as ProcessedCaptureId,
+      createdAt: NOW,
+      updatedAt: NOW,
+      deletedAt: null,
+    });
+
+    saveCaptureEvidence(db as any, {
+      id: "ce-2" as CaptureEvidenceId,
+      userId: USER_ID,
+      sourceFamily: "bancolombia",
+      evidenceType: "last4",
+      scope: "notification:bancolombia:last4",
+      value: "1234",
+      transactionId: null,
+      processedEmailId: null,
+      processedCaptureId: "pc-2" as ProcessedCaptureId,
+      createdAt: "2026-04-19T11:00:00.000Z" as IsoDateTime,
+      updatedAt: "2026-04-19T11:00:00.000Z" as IsoDateTime,
+      deletedAt: null,
+    });
+
+    saveCaptureEvidence(db as any, {
+      id: "ce-3" as CaptureEvidenceId,
+      userId: USER_ID,
+      sourceFamily: "bancolombia",
+      evidenceType: "sender_email",
+      scope: "email:bancolombia:sender",
+      value: "notificaciones@bancolombia.com.co",
+      transactionId: "tx-3" as TransactionId,
+      processedEmailId: "pe-1" as ProcessedEmailId,
+      processedCaptureId: null,
+      createdAt: NOW,
+      updatedAt: NOW,
+      deletedAt: null,
+    });
+
+    saveCaptureEvidence(db as any, {
+      id: "ce-4" as CaptureEvidenceId,
+      userId: USER_ID,
+      sourceFamily: "bancolombia",
+      evidenceType: "last4",
+      scope: "notification:bancolombia:last4",
+      value: "1234",
+      transactionId: null,
+      processedEmailId: null,
+      processedCaptureId: "pc-4" as ProcessedCaptureId,
+      createdAt: NOW,
+      updatedAt: NOW,
+      deletedAt: "2026-04-19T12:00:00.000Z" as IsoDateTime,
+    });
+
+    expect(
+      countCaptureEvidenceOccurrences(db as any, USER_ID, "notification:bancolombia:last4", "1234")
+    ).toBe(2);
+
+    expect(getRepeatedCaptureEvidenceForUser(db as any, USER_ID, 2)).toEqual([
+      {
+        scope: "notification:bancolombia:last4",
+        value: "1234",
+        sourceFamily: "bancolombia",
+        evidenceType: "last4",
+        occurrences: 2,
+      },
+    ]);
+
+    expect(getQueuedSyncEntries(db as any)).toEqual([
+      expect.objectContaining({
+        tableName: "captureEvidence",
+        rowId: "ce-1",
+        operation: "insert",
+      }),
+      expect.objectContaining({
+        tableName: "captureEvidence",
+        rowId: "ce-2",
+        operation: "insert",
+      }),
+      expect.objectContaining({
+        tableName: "captureEvidence",
+        rowId: "ce-3",
+        operation: "insert",
+      }),
+      expect.objectContaining({
+        tableName: "captureEvidence",
+        rowId: "ce-4",
+        operation: "insert",
+      }),
+    ]);
+  });
+});

--- a/apps/mobile/__tests__/capture-sources/apple-pay-pipeline.test.ts
+++ b/apps/mobile/__tests__/capture-sources/apple-pay-pipeline.test.ts
@@ -24,6 +24,15 @@ const mockEnsureDefaultFinancialAccount = vi.fn().mockReturnValue({
   updatedAt: "2026-04-18T10:00:00.000Z",
   deletedAt: null,
 });
+const mockBuildApplePayCaptureEvidence = vi.fn().mockReturnValue([
+  {
+    sourceFamily: "apple_pay",
+    evidenceType: "card_hint",
+    scope: "apple_pay:card_hint",
+    value: "visa *1234",
+  },
+]);
+const mockSaveCaptureEvidenceRows = vi.fn();
 
 vi.mock("@/features/transactions/lib/repository", () => ({
   insertTransaction: (...args: any[]) => mockInsertTransaction(...args),
@@ -54,6 +63,18 @@ vi.mock("@/features/capture-sources/lib/repository", () => ({
 
 vi.mock("@/features/financial-accounts", () => ({
   ensureDefaultFinancialAccount: (...args: any[]) => mockEnsureDefaultFinancialAccount(...args),
+}));
+
+vi.mock("@/features/capture-evidence", () => ({
+  buildApplePayCaptureEvidence: (...args: any[]) => mockBuildApplePayCaptureEvidence(...args),
+  materializeCaptureEvidenceRows: (evidence: any[], link: Record<string, unknown>) =>
+    evidence.map((row, index) => ({
+      id: `ce-${index + 1}`,
+      ...row,
+      ...link,
+      deletedAt: null,
+    })),
+  saveCaptureEvidenceRows: (...args: any[]) => mockSaveCaptureEvidenceRows(...args),
 }));
 
 const mockGenerateId = vi.fn();
@@ -89,6 +110,15 @@ describe("processApplePayIntent", () => {
     mockFindDuplicateTransaction.mockResolvedValue(null);
     mockLookupMerchantRule.mockResolvedValue(null);
     mockClassifyMerchantApi.mockResolvedValue("other");
+    mockBuildApplePayCaptureEvidence.mockReturnValue([
+      {
+        sourceFamily: "apple_pay",
+        evidenceType: "card_hint",
+        scope: "apple_pay:card_hint",
+        value: "visa *1234",
+      },
+    ]);
+    mockSaveCaptureEvidenceRows.mockResolvedValue(undefined);
   });
 
   it("saves transaction with apple_pay source", async () => {
@@ -109,6 +139,19 @@ describe("processApplePayIntent", () => {
       })
     );
     expect(mockEnqueueSync).toHaveBeenCalled();
+    expect(mockSaveCaptureEvidenceRows).toHaveBeenCalledWith(
+      mockDb,
+      expect.arrayContaining([
+        expect.objectContaining({
+          userId: USER_ID,
+          processedCaptureId: expect.any(String),
+          processedEmailId: null,
+          transactionId: "tx-1",
+          scope: "apple_pay:card_hint",
+          value: "visa *1234",
+        }),
+      ])
+    );
   });
 
   it("converts amount to pesos correctly", async () => {

--- a/apps/mobile/__tests__/capture-sources/notification-pipeline.test.ts
+++ b/apps/mobile/__tests__/capture-sources/notification-pipeline.test.ts
@@ -25,6 +25,15 @@ const mockEnsureDefaultFinancialAccount = vi.fn().mockReturnValue({
   updatedAt: "2026-04-18T10:00:00.000Z",
   deletedAt: null,
 });
+const mockBuildNotificationCaptureEvidence = vi.fn().mockReturnValue([
+  {
+    sourceFamily: "bancolombia",
+    evidenceType: "last4",
+    scope: "notification:bancolombia:last4",
+    value: "1234",
+  },
+]);
+const mockSaveCaptureEvidenceRows = vi.fn();
 
 vi.mock("@/features/transactions/lib/repository", () => ({
   insertTransaction: (...args: any[]) => mockInsertTransaction(...args),
@@ -59,6 +68,19 @@ vi.mock("@/features/email-capture/services/parse-email-api", () => ({
 
 vi.mock("@/features/financial-accounts", () => ({
   ensureDefaultFinancialAccount: (...args: any[]) => mockEnsureDefaultFinancialAccount(...args),
+}));
+
+vi.mock("@/features/capture-evidence", () => ({
+  buildNotificationCaptureEvidence: (...args: any[]) =>
+    mockBuildNotificationCaptureEvidence(...args),
+  materializeCaptureEvidenceRows: (evidence: any[], link: Record<string, unknown>) =>
+    evidence.map((row, index) => ({
+      id: `ce-${index + 1}`,
+      ...row,
+      ...link,
+      deletedAt: null,
+    })),
+  saveCaptureEvidenceRows: (...args: any[]) => mockSaveCaptureEvidenceRows(...args),
 }));
 
 const mockGenerateId = vi.fn();
@@ -97,6 +119,15 @@ describe("processNotification", () => {
     mockParseNotificationApi.mockResolvedValue(null);
     mockCaptureFingerprint.mockReturnValue("test-fingerprint");
     mockStripPii.mockImplementation((t: string) => t);
+    mockBuildNotificationCaptureEvidence.mockReturnValue([
+      {
+        sourceFamily: "bancolombia",
+        evidenceType: "last4",
+        scope: "notification:bancolombia:last4",
+        value: "1234",
+      },
+    ]);
+    mockSaveCaptureEvidenceRows.mockResolvedValue(undefined);
   });
 
   it("saves transaction when local regex parses successfully", async () => {
@@ -124,6 +155,19 @@ describe("processNotification", () => {
         status: "success",
         transactionId: "tx-1",
       })
+    );
+    expect(mockSaveCaptureEvidenceRows).toHaveBeenCalledWith(
+      mockDb,
+      expect.arrayContaining([
+        expect.objectContaining({
+          userId: USER_ID,
+          processedCaptureId: expect.any(String),
+          processedEmailId: null,
+          transactionId: "tx-1",
+          scope: "notification:bancolombia:last4",
+          value: "1234",
+        }),
+      ])
     );
   });
 

--- a/apps/mobile/__tests__/db/schema.test.ts
+++ b/apps/mobile/__tests__/db/schema.test.ts
@@ -1,6 +1,13 @@
 import { getTableColumns, getTableName } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
-import { billPayments, bills, syncMeta, syncQueue, transactions } from "@/shared/db/schema";
+import {
+  billPayments,
+  bills,
+  captureEvidence,
+  syncMeta,
+  syncQueue,
+  transactions,
+} from "@/shared/db/schema";
 
 describe("transactions table schema", () => {
   it("is named 'transactions'", () => {
@@ -83,6 +90,39 @@ describe("syncQueue table schema", () => {
     expect(names).toContain("operation");
     expect(names).toContain("createdAt");
     expect(names).toHaveLength(5);
+  });
+});
+
+describe("captureEvidence table schema", () => {
+  it("is named 'capture_evidence'", () => {
+    expect(getTableName(captureEvidence)).toBe("capture_evidence");
+  });
+
+  it("has the normalized evidence columns", () => {
+    const cols = getTableColumns(captureEvidence);
+    const names = Object.keys(cols);
+
+    expect(names).toContain("id");
+    expect(names).toContain("userId");
+    expect(names).toContain("sourceFamily");
+    expect(names).toContain("evidenceType");
+    expect(names).toContain("scope");
+    expect(names).toContain("value");
+    expect(names).toContain("transactionId");
+    expect(names).toContain("processedEmailId");
+    expect(names).toContain("processedCaptureId");
+    expect(names).toContain("createdAt");
+    expect(names).toContain("updatedAt");
+    expect(names).toContain("deletedAt");
+    expect(names).toHaveLength(12);
+  });
+
+  it("requires userId, scope, and value", () => {
+    const cols = getTableColumns(captureEvidence);
+
+    expect(cols.userId.notNull).toBe(true);
+    expect(cols.scope.notNull).toBe(true);
+    expect(cols.value.notNull).toBe(true);
   });
 });
 

--- a/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
@@ -29,6 +29,22 @@ const mockEnsureDefaultFinancialAccount = vi.fn().mockReturnValue({
   updatedAt: "2026-04-18T10:00:00.000Z",
   deletedAt: null,
 });
+const mockBuildEmailCaptureEvidence = vi.fn().mockReturnValue([
+  {
+    sourceFamily: "bancolombia",
+    evidenceType: "sender_email",
+    scope: "email:bancolombia:sender",
+    value: "notificaciones@bancolombia.com.co",
+  },
+  {
+    sourceFamily: "bancolombia",
+    evidenceType: "sender_domain",
+    scope: "email:bancolombia:domain",
+    value: "bancolombia.com.co",
+  },
+]);
+const mockSaveCaptureEvidenceRows = vi.fn();
+const mockLinkCaptureEvidenceToTransaction = vi.fn();
 
 vi.mock("@/features/capture-sources/lib/dedup", () => ({
   findDuplicateTransaction: (...args: unknown[]) => mockFindDuplicateTransaction(...args),
@@ -63,6 +79,20 @@ vi.mock("@/features/email-capture/services/parse-email-api", () => ({
 
 vi.mock("@/features/financial-accounts", () => ({
   ensureDefaultFinancialAccount: (...args: unknown[]) => mockEnsureDefaultFinancialAccount(...args),
+}));
+
+vi.mock("@/features/capture-evidence", () => ({
+  buildEmailCaptureEvidence: (...args: unknown[]) => mockBuildEmailCaptureEvidence(...args),
+  materializeCaptureEvidenceRows: (evidence: any[], link: Record<string, unknown>) =>
+    evidence.map((row, index) => ({
+      id: `ce-${index + 1}`,
+      ...row,
+      ...link,
+      deletedAt: null,
+    })),
+  saveCaptureEvidenceRows: (...args: unknown[]) => mockSaveCaptureEvidenceRows(...args),
+  linkCaptureEvidenceToTransaction: (...args: unknown[]) =>
+    mockLinkCaptureEvidenceToTransaction(...args),
 }));
 
 vi.mock("@/shared/lib/sentry", () => ({
@@ -117,6 +147,22 @@ describe("email processing pipeline", () => {
     mockMarkPermanentlyFailed.mockResolvedValue(undefined);
     mockMarkRetrySuccess.mockResolvedValue(undefined);
     mockUpdateProcessedEmailStatus.mockResolvedValue(undefined);
+    mockBuildEmailCaptureEvidence.mockReturnValue([
+      {
+        sourceFamily: "bancolombia",
+        evidenceType: "sender_email",
+        scope: "email:bancolombia:sender",
+        value: "notificaciones@bancolombia.com.co",
+      },
+      {
+        sourceFamily: "bancolombia",
+        evidenceType: "sender_domain",
+        scope: "email:bancolombia:domain",
+        value: "bancolombia.com.co",
+      },
+    ]);
+    mockSaveCaptureEvidenceRows.mockResolvedValue(undefined);
+    mockLinkCaptureEvidenceToTransaction.mockResolvedValue(undefined);
   });
 
   it("skips already processed emails", async () => {
@@ -146,6 +192,19 @@ describe("email processing pipeline", () => {
         status: "skipped",
         failureReason: null,
       })
+    );
+    expect(mockSaveCaptureEvidenceRows).toHaveBeenCalledWith(
+      mockDb,
+      expect.arrayContaining([
+        expect.objectContaining({
+          userId: USER_ID,
+          processedEmailId: expect.any(String),
+          processedCaptureId: null,
+          transactionId: null,
+          scope: "email:bancolombia:sender",
+          value: "notificaciones@bancolombia.com.co",
+        }),
+      ])
     );
   });
 
@@ -185,6 +244,19 @@ describe("email processing pipeline", () => {
         confidence: 0.9,
       })
     );
+    expect(mockSaveCaptureEvidenceRows).toHaveBeenCalledWith(
+      mockDb,
+      expect.arrayContaining([
+        expect.objectContaining({
+          userId: USER_ID,
+          processedEmailId: expect.any(String),
+          processedCaptureId: null,
+          transactionId: "tx-1",
+          scope: "email:bancolombia:sender",
+          value: "notificaciones@bancolombia.com.co",
+        }),
+      ])
+    );
     expect(mockInsertMerchantRule).toHaveBeenCalledWith(
       mockDb,
       USER_ID,
@@ -208,6 +280,9 @@ describe("email processing pipeline", () => {
       markRetrySuccess: mockMarkRetrySuccess,
       updateProcessedEmailStatus: mockUpdateProcessedEmailStatus,
       ensureDefaultFinancialAccount: mockEnsureDefaultFinancialAccount,
+      buildEmailCaptureEvidence: mockBuildEmailCaptureEvidence,
+      saveCaptureEvidenceRows: mockSaveCaptureEvidenceRows,
+      linkCaptureEvidenceToTransaction: mockLinkCaptureEvidenceToTransaction,
       insertTransaction: mockInsertTransaction,
       enqueueSync: mockEnqueueSync,
       insertMerchantRule: mockInsertMerchantRule,

--- a/apps/mobile/__tests__/error-handling/pipeline-save-error.test.ts
+++ b/apps/mobile/__tests__/error-handling/pipeline-save-error.test.ts
@@ -28,6 +28,16 @@ const mockMarkForRetry = vi.fn();
 const mockMarkPermanentlyFailed = vi.fn();
 const mockMarkRetrySuccess = vi.fn();
 const mockUpdateProcessedEmailStatus = vi.fn();
+const mockBuildEmailCaptureEvidence = vi.fn().mockReturnValue([
+  {
+    sourceFamily: "bancolombia",
+    evidenceType: "sender_email",
+    scope: "email:bancolombia:sender",
+    value: "notificaciones@bancolombia.com.co",
+  },
+]);
+const mockSaveCaptureEvidenceRows = vi.fn();
+const mockLinkCaptureEvidenceToTransaction = vi.fn();
 
 vi.mock("@/features/capture-sources/lib/dedup", () => ({
   findDuplicateTransaction: (...args: unknown[]) => mockFindDuplicateTransaction(...args),
@@ -49,6 +59,20 @@ vi.mock("@/features/transactions/lib/repository", () => ({
 
 vi.mock("@/features/financial-accounts", () => ({
   ensureDefaultFinancialAccount: (...args: unknown[]) => mockEnsureDefaultFinancialAccount(...args),
+}));
+
+vi.mock("@/features/capture-evidence", () => ({
+  buildEmailCaptureEvidence: (...args: unknown[]) => mockBuildEmailCaptureEvidence(...args),
+  materializeCaptureEvidenceRows: (evidence: any[], link: Record<string, unknown>) =>
+    evidence.map((row, index) => ({
+      id: `ce-${index + 1}`,
+      ...row,
+      ...link,
+      deletedAt: null,
+    })),
+  saveCaptureEvidenceRows: (...args: unknown[]) => mockSaveCaptureEvidenceRows(...args),
+  linkCaptureEvidenceToTransaction: (...args: unknown[]) =>
+    mockLinkCaptureEvidenceToTransaction(...args),
 }));
 
 vi.mock("@/shared/db/enqueue-sync", () => ({
@@ -110,6 +134,8 @@ describe("pipeline worker save error path", () => {
     mockMarkPermanentlyFailed.mockResolvedValue(undefined);
     mockMarkRetrySuccess.mockResolvedValue(undefined);
     mockUpdateProcessedEmailStatus.mockResolvedValue(undefined);
+    mockSaveCaptureEvidenceRows.mockResolvedValue(undefined);
+    mockLinkCaptureEvidenceToTransaction.mockResolvedValue(undefined);
   });
 
   it("calls captureError and continues processing when saveTransaction throws", async () => {

--- a/apps/mobile/__tests__/sync/syncEngine.test.ts
+++ b/apps/mobile/__tests__/sync/syncEngine.test.ts
@@ -10,6 +10,7 @@ const mockGetFinancialAccountIdentifierById = vi.fn().mockReturnValue(null);
 const mockGetOpeningBalanceById = vi.fn().mockReturnValue(null);
 const mockGetOpeningBalanceForAccount = vi.fn().mockReturnValue(null);
 const mockGetTransferById = vi.fn().mockReturnValue(null);
+const mockGetCaptureEvidenceById = vi.fn().mockReturnValue(null);
 const mockEnsureDefaultFinancialAccount = vi
   .fn()
   .mockImplementation((_: unknown, userId: string) => ({ id: `fa-default-${userId}` }));
@@ -21,6 +22,7 @@ const mockUpsertFinancialAccount = vi.fn();
 const mockUpsertFinancialAccountIdentifier = vi.fn();
 const mockUpsertOpeningBalance = vi.fn();
 const mockUpsertTransfer = vi.fn();
+const mockUpsertCaptureEvidence = vi.fn();
 
 const mockInsertConflict = vi.fn();
 vi.mock("@/features/sync/lib/conflict-repository", () => ({
@@ -55,6 +57,15 @@ vi.mock("@/features/transfers", () => ({
   getTransferById: (...args: any[]) => mockGetTransferById(...args),
   upsertTransfer: (...args: any[]) => mockUpsertTransfer(...args),
 }));
+
+vi.mock("@/features/capture-evidence", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/capture-evidence")>();
+  return {
+    ...actual,
+    getCaptureEvidenceById: (...args: any[]) => mockGetCaptureEvidenceById(...args),
+    upsertCaptureEvidence: (...args: any[]) => mockUpsertCaptureEvidence(...args),
+  };
+});
 
 const mockDb = {} as any;
 const mockUpsert = vi.fn().mockReturnValue({ error: null });
@@ -364,6 +375,51 @@ describe("syncEngine", () => {
       expect(mockClearSyncEntries).toHaveBeenCalledWith(mockDb, ["sq-financial-identifier-1"]);
     });
 
+    it("upserts capture evidence rows and clears the queue entry on success", async () => {
+      mockGetQueuedSyncEntries.mockReturnValueOnce([
+        {
+          id: "sq-capture-evidence-1",
+          tableName: "captureEvidence",
+          rowId: "ce-1",
+          operation: "insert",
+          createdAt: "2026-04-19T10:00:00.000Z",
+        },
+      ]);
+      mockGetCaptureEvidenceById.mockReturnValueOnce({
+        id: "ce-1",
+        userId: "user-1",
+        sourceFamily: "bancolombia",
+        evidenceType: "last4",
+        scope: "notification:bancolombia:last4",
+        value: "1234",
+        transactionId: "tx-1",
+        processedEmailId: null,
+        processedCaptureId: "pc-1",
+        createdAt: "2026-04-19T10:00:00.000Z",
+        updatedAt: "2026-04-19T10:00:00.000Z",
+        deletedAt: null,
+      });
+      mockUpsert.mockReturnValueOnce({ error: null });
+      const mockSupabase = createMockSupabase();
+
+      const { syncPush } = await import("@/features/sync/services/syncEngine");
+      await syncPush(mockDb, mockSupabase, "user-1");
+
+      expect(mockSupabase.from).toHaveBeenCalledWith("capture_evidence");
+      expect(mockUpsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "ce-1",
+          user_id: "user-1",
+          source_family: "bancolombia",
+          evidence_type: "last4",
+          scope: "notification:bancolombia:last4",
+          value: "1234",
+          processed_capture_id: "pc-1",
+        })
+      );
+      expect(mockClearSyncEntries).toHaveBeenCalledWith(mockDb, ["sq-capture-evidence-1"]);
+    });
+
     it("clears queue entry when local row is missing", async () => {
       mockGetQueuedSyncEntries.mockReturnValueOnce([
         {
@@ -432,6 +488,25 @@ describe("syncEngine", () => {
       mockGetSyncMeta.mockReturnValueOnce(null);
       const mockSupabase = createMockSupabase({
         transactions: { data: [], error: null },
+        capture_evidence: {
+          data: [
+            {
+              id: "ce-1",
+              user_id: "user-1",
+              source_family: "bancolombia",
+              evidence_type: "last4",
+              scope: "notification:bancolombia:last4",
+              value: "1234",
+              transaction_id: "tx-1",
+              processed_email_id: null,
+              processed_capture_id: "pc-1",
+              created_at: "2026-04-18T07:30:00.000Z",
+              updated_at: "2026-04-18T08:00:00.000Z",
+              deleted_at: null,
+            },
+          ],
+          error: null,
+        },
         financial_accounts: {
           data: [
             {
@@ -497,6 +572,7 @@ describe("syncEngine", () => {
           error: null,
         },
       });
+      mockGetCaptureEvidenceById.mockReturnValueOnce(null);
       mockGetFinancialAccountById.mockReturnValueOnce(null);
       mockGetTransferById.mockReturnValueOnce(null);
       mockGetOpeningBalanceById.mockReturnValueOnce(null);
@@ -506,6 +582,15 @@ describe("syncEngine", () => {
       const result = await syncPull(mockDb, mockSupabase, "user-1");
 
       expect(result).toBe(true);
+      expect(mockUpsertCaptureEvidence).toHaveBeenCalledWith(
+        mockDb,
+        expect.objectContaining({
+          id: "ce-1",
+          scope: "notification:bancolombia:last4",
+          value: "1234",
+          processedCaptureId: "pc-1",
+        })
+      );
       expect(mockUpsertFinancialAccount).toHaveBeenCalledWith(
         mockDb,
         expect.objectContaining({
@@ -543,6 +628,10 @@ describe("syncEngine", () => {
       ).toEqual({
         updatedAt: "2026-04-18T12:00:00.000Z",
         id: "fai-1",
+      });
+      expect(JSON.parse(getLastSetSyncMetaValue("last_sync_at_capture_evidence")!)).toEqual({
+        updatedAt: "2026-04-18T08:00:00.000Z",
+        id: "ce-1",
       });
     });
 
@@ -686,6 +775,7 @@ describe("syncEngine", () => {
       await syncPull(mockDb, mockSupabase, "user-1");
 
       expect(mockSupabase._getChain("transactions").gte).toHaveBeenCalled();
+      expect(mockSupabase._getChain("capture_evidence").gte).toHaveBeenCalled();
       expect(mockSupabase._getChain("financial_accounts").gte).toHaveBeenCalled();
       expect(mockSupabase._getChain("transfers").gte).toHaveBeenCalled();
       expect(mockSupabase._getChain("opening_balances").gte).toHaveBeenCalled();

--- a/apps/mobile/drizzle/0020_tidy_husk.sql
+++ b/apps/mobile/drizzle/0020_tidy_husk.sql
@@ -1,0 +1,29 @@
+CREATE TABLE `capture_evidence` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`source_family` text NOT NULL,
+	`evidence_type` text NOT NULL,
+	`scope` text NOT NULL,
+	`value` text NOT NULL,
+	`transaction_id` text,
+	`processed_email_id` text,
+	`processed_capture_id` text,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	`deleted_at` text,
+	CONSTRAINT `ck_capture_evidence_source_record` CHECK((CASE WHEN `processed_email_id` IS NOT NULL THEN 1 ELSE 0 END) + (CASE WHEN `processed_capture_id` IS NOT NULL THEN 1 ELSE 0 END) = 1)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_capture_evidence_email` ON `capture_evidence` (`user_id`,`processed_email_id`,`scope`,`value`) WHERE `processed_email_id` IS NOT NULL AND `deleted_at` IS NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_capture_evidence_capture` ON `capture_evidence` (`user_id`,`processed_capture_id`,`scope`,`value`) WHERE `processed_capture_id` IS NOT NULL AND `deleted_at` IS NULL;
+--> statement-breakpoint
+CREATE INDEX `idx_capture_evidence_user_scope_value` ON `capture_evidence` (`user_id`,`scope`,`value`);
+--> statement-breakpoint
+CREATE INDEX `idx_capture_evidence_transaction` ON `capture_evidence` (`transaction_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_capture_evidence_processed_email` ON `capture_evidence` (`processed_email_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_capture_evidence_processed_capture` ON `capture_evidence` (`processed_capture_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_capture_evidence_user_updated` ON `capture_evidence` (`user_id`,`updated_at`);

--- a/apps/mobile/drizzle/meta/_journal.json
+++ b/apps/mobile/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1776564415724,
       "tag": "0019_watery_leopardon",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "6",
+      "when": 1776593600000,
+      "tag": "0020_tidy_husk",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/mobile/drizzle/migrations.js
+++ b/apps/mobile/drizzle/migrations.js
@@ -19,6 +19,7 @@ import m0016 from "./0016_high_outlaw_kid.sql";
 import m0017 from "./0017_nostalgic_blade.sql";
 import m0018 from "./0018_notification_dedup_partial.sql";
 import m0019 from "./0019_watery_leopardon.sql";
+import m0020 from "./0020_tidy_husk.sql";
 import journal from "./meta/_journal.json";
 
 export default {
@@ -44,5 +45,6 @@ export default {
     m0017,
     m0018,
     m0019,
+    m0020,
   },
 };

--- a/apps/mobile/features/capture-evidence/index.ts
+++ b/apps/mobile/features/capture-evidence/index.ts
@@ -1,0 +1,17 @@
+export {
+  buildApplePayCaptureEvidence,
+  buildEmailCaptureEvidence,
+  buildNotificationCaptureEvidence,
+} from "./lib/build-capture-evidence";
+export type { CaptureEvidenceRow } from "./lib/repository";
+export {
+  countCaptureEvidenceOccurrences,
+  getCaptureEvidenceById,
+  getRepeatedCaptureEvidenceForUser,
+  linkCaptureEvidenceToTransaction,
+  materializeCaptureEvidenceRows,
+  saveCaptureEvidence,
+  saveCaptureEvidenceRows,
+  upsertCaptureEvidence,
+} from "./lib/repository";
+export type { CaptureEvidenceSeed, CaptureEvidenceType } from "./schema";

--- a/apps/mobile/features/capture-evidence/lib/build-capture-evidence.ts
+++ b/apps/mobile/features/capture-evidence/lib/build-capture-evidence.ts
@@ -1,0 +1,156 @@
+import type { ApplePayIntentData, NotificationData } from "@/features/capture-sources/schema";
+import { KNOWN_BANK_PACKAGES } from "@/features/capture-sources/schema";
+import { extractDomain } from "@/features/email-capture/lib/bank-senders";
+import type { CaptureEvidenceSeed } from "../schema";
+
+const ALIAS_TOKENS = [
+  "ahorros",
+  "corriente",
+  "credito",
+  "debito",
+  "nomina",
+  "visa",
+  "mastercard",
+  "amex",
+] as const;
+
+const LAST4_PATTERNS = [
+  /(?:\*{1,4}|x{2,4})[\s.-]*(\d{4})\b/gi,
+  /(?:tarjeta|card|cuenta|cta\.?|account|ending in|terminad[ao] en)\D{0,16}(\d{4})\b/gi,
+] as const;
+
+type EmailCaptureInput = {
+  readonly from: string;
+};
+
+function normalizeWhitespace(value: string) {
+  return value.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function normalizeFamily(value: string) {
+  return normalizeWhitespace(value)
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function uniqueEvidence(rows: readonly CaptureEvidenceSeed[]) {
+  return Array.from(new Map(rows.map((row) => [`${row.scope}:${row.value}`, row])).values());
+}
+
+function familyFromDomain(domain: string) {
+  const parts = domain.split(".").filter(Boolean);
+  return normalizeFamily(parts[0] ?? domain);
+}
+
+function familyFromPackageName(packageName: string) {
+  const knownPackage = KNOWN_BANK_PACKAGES.find((entry) => entry.packageName === packageName);
+  if (knownPackage) {
+    return normalizeFamily(knownPackage.label);
+  }
+
+  const parts = packageName.toLowerCase().split(".").filter(Boolean);
+  return normalizeFamily(parts.at(-1) ?? packageName);
+}
+
+function extractAliasEvidence(
+  family: string,
+  combinedText: string
+): readonly CaptureEvidenceSeed[] {
+  return ALIAS_TOKENS.filter((token) => combinedText.includes(token)).map((token) => ({
+    sourceFamily: family,
+    evidenceType: "alias_token",
+    scope: `notification:${family}:alias`,
+    value: token,
+  }));
+}
+
+function extractLast4Evidence(scopePrefix: string, family: string, rawText: string) {
+  const values = LAST4_PATTERNS.flatMap((pattern) =>
+    Array.from(rawText.matchAll(pattern), (match) => match[1] ?? "")
+  )
+    .filter((value) => value.length === 4)
+    .map((value) => ({
+      sourceFamily: family,
+      evidenceType: "last4" as const,
+      scope: `${scopePrefix}:${family}:last4`,
+      value,
+    }));
+
+  return uniqueEvidence(values);
+}
+
+export function buildEmailCaptureEvidence(
+  input: EmailCaptureInput
+): readonly CaptureEvidenceSeed[] {
+  const senderEmail = normalizeWhitespace(input.from);
+  const senderDomain = extractDomain(senderEmail);
+  const family = familyFromDomain(senderDomain);
+
+  return uniqueEvidence([
+    {
+      sourceFamily: family,
+      evidenceType: "sender_email",
+      scope: `email:${family}:sender`,
+      value: senderEmail,
+    },
+    {
+      sourceFamily: family,
+      evidenceType: "sender_domain",
+      scope: `email:${family}:domain`,
+      value: senderDomain,
+    },
+  ]);
+}
+
+export function buildNotificationCaptureEvidence(
+  notification: NotificationData
+): readonly CaptureEvidenceSeed[] {
+  const family = familyFromPackageName(notification.packageName);
+  const combinedText = normalizeWhitespace(
+    [
+      notification.title,
+      notification.subText,
+      notification.bigText,
+      notification.text,
+      notification.packageName,
+    ]
+      .filter(Boolean)
+      .join(" ")
+  );
+
+  return uniqueEvidence([
+    {
+      sourceFamily: family,
+      evidenceType: "package_name",
+      scope: `notification:${family}:package`,
+      value: notification.packageName.toLowerCase(),
+    },
+    ...extractAliasEvidence(family, combinedText),
+    ...extractLast4Evidence("notification", family, combinedText),
+  ]);
+}
+
+export function buildApplePayCaptureEvidence(
+  intent: ApplePayIntentData
+): readonly CaptureEvidenceSeed[] {
+  if (!intent.card) {
+    return [];
+  }
+
+  const cardHint = normalizeWhitespace(intent.card);
+  const family = "apple_pay";
+
+  return uniqueEvidence([
+    {
+      sourceFamily: family,
+      evidenceType: "card_hint",
+      scope: "apple_pay:card_hint",
+      value: cardHint,
+    },
+    ...extractLast4Evidence("apple_pay", "", cardHint).map((row) => ({
+      ...row,
+      sourceFamily: family,
+      scope: "apple_pay:last4",
+    })),
+  ]);
+}

--- a/apps/mobile/features/capture-evidence/lib/repository.ts
+++ b/apps/mobile/features/capture-evidence/lib/repository.ts
@@ -1,0 +1,187 @@
+import { and, count, desc, eq, isNull, sql } from "drizzle-orm";
+import { type AnyDb, captureEvidence, enqueueSync } from "@/shared/db";
+import { generateCaptureEvidenceId, generateSyncQueueId } from "@/shared/lib";
+import type { CaptureEvidenceSeed } from "../schema";
+
+export type CaptureEvidenceRow = typeof captureEvidence.$inferInsert;
+type CaptureEvidenceLink = Pick<
+  CaptureEvidenceRow,
+  "processedEmailId" | "processedCaptureId" | "transactionId" | "userId" | "createdAt" | "updatedAt"
+>;
+
+type RepeatedCaptureEvidenceRow = {
+  readonly scope: string;
+  readonly value: string;
+  readonly sourceFamily: string;
+  readonly evidenceType: string;
+  readonly occurrences: number;
+};
+
+function saveCaptureEvidenceInTransaction(db: AnyDb, row: CaptureEvidenceRow) {
+  const existing = getCaptureEvidenceById(db, row.id);
+
+  persistCaptureEvidence(db, row);
+
+  enqueueSync(db, {
+    id: generateSyncQueueId(),
+    tableName: "captureEvidence",
+    rowId: row.id,
+    operation: existing ? "update" : "insert",
+    createdAt: row.updatedAt,
+  });
+}
+
+function persistCaptureEvidence(db: AnyDb, row: CaptureEvidenceRow) {
+  db.insert(captureEvidence)
+    .values(row)
+    .onConflictDoUpdate({
+      target: captureEvidence.id,
+      set: {
+        userId: row.userId,
+        sourceFamily: row.sourceFamily,
+        evidenceType: row.evidenceType,
+        scope: row.scope,
+        value: row.value,
+        transactionId: row.transactionId,
+        processedEmailId: row.processedEmailId,
+        processedCaptureId: row.processedCaptureId,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+        deletedAt: row.deletedAt,
+      },
+    })
+    .run();
+}
+
+export function getCaptureEvidenceById(db: AnyDb, id: CaptureEvidenceRow["id"]) {
+  const rows = db.select().from(captureEvidence).where(eq(captureEvidence.id, id)).all();
+  return rows[0] ?? null;
+}
+
+export function upsertCaptureEvidence(db: AnyDb, row: CaptureEvidenceRow) {
+  const existing = getCaptureEvidenceById(db, row.id);
+  if (existing && existing.updatedAt >= row.updatedAt) {
+    return;
+  }
+
+  persistCaptureEvidence(db, row);
+}
+
+export function saveCaptureEvidence(db: AnyDb, row: CaptureEvidenceRow) {
+  db.transaction((tx) => saveCaptureEvidenceInTransaction(tx, row));
+}
+
+export function saveCaptureEvidenceRows(db: AnyDb, rows: readonly CaptureEvidenceRow[]) {
+  if (rows.length === 0) {
+    return;
+  }
+
+  db.transaction((tx) => {
+    rows.forEach((row) => {
+      saveCaptureEvidenceInTransaction(tx, row);
+    });
+  });
+}
+
+export function materializeCaptureEvidenceRows(
+  evidence: readonly CaptureEvidenceSeed[],
+  link: CaptureEvidenceLink
+): readonly CaptureEvidenceRow[] {
+  return evidence.map((row) => ({
+    id: generateCaptureEvidenceId(),
+    userId: link.userId,
+    sourceFamily: row.sourceFamily,
+    evidenceType: row.evidenceType,
+    scope: row.scope,
+    value: row.value,
+    transactionId: link.transactionId,
+    processedEmailId: link.processedEmailId,
+    processedCaptureId: link.processedCaptureId,
+    createdAt: link.createdAt,
+    updatedAt: link.updatedAt,
+    deletedAt: null,
+  }));
+}
+
+export function linkCaptureEvidenceToTransaction(
+  db: AnyDb,
+  processedEmailId: NonNullable<CaptureEvidenceRow["processedEmailId"]>,
+  transactionId: NonNullable<CaptureEvidenceRow["transactionId"]>,
+  updatedAt: CaptureEvidenceRow["updatedAt"]
+) {
+  const rows = db
+    .select()
+    .from(captureEvidence)
+    .where(
+      and(eq(captureEvidence.processedEmailId, processedEmailId), isNull(captureEvidence.deletedAt))
+    )
+    .all();
+
+  if (rows.length === 0) {
+    return;
+  }
+
+  db.transaction((tx) => {
+    rows.forEach((row) => {
+      if (row.transactionId === transactionId && row.updatedAt >= updatedAt) {
+        return;
+      }
+
+      saveCaptureEvidenceInTransaction(tx, {
+        ...row,
+        transactionId,
+        updatedAt,
+      });
+    });
+  });
+}
+
+export function countCaptureEvidenceOccurrences(
+  db: AnyDb,
+  userId: CaptureEvidenceRow["userId"],
+  scope: CaptureEvidenceRow["scope"],
+  value: CaptureEvidenceRow["value"]
+) {
+  const rows = db
+    .select({ total: count() })
+    .from(captureEvidence)
+    .where(
+      and(
+        eq(captureEvidence.userId, userId),
+        eq(captureEvidence.scope, scope),
+        eq(captureEvidence.value, value),
+        isNull(captureEvidence.deletedAt)
+      )
+    )
+    .all();
+
+  return rows[0]?.total ?? 0;
+}
+
+export function getRepeatedCaptureEvidenceForUser(
+  db: AnyDb,
+  userId: CaptureEvidenceRow["userId"],
+  minimumOccurrences = 2
+): readonly RepeatedCaptureEvidenceRow[] {
+  const occurrences = sql<number>`count(*)`;
+
+  return db
+    .select({
+      scope: captureEvidence.scope,
+      value: captureEvidence.value,
+      sourceFamily: captureEvidence.sourceFamily,
+      evidenceType: captureEvidence.evidenceType,
+      occurrences,
+    })
+    .from(captureEvidence)
+    .where(and(eq(captureEvidence.userId, userId), isNull(captureEvidence.deletedAt)))
+    .groupBy(
+      captureEvidence.scope,
+      captureEvidence.value,
+      captureEvidence.sourceFamily,
+      captureEvidence.evidenceType
+    )
+    .having(sql`${occurrences} >= ${minimumOccurrences}`)
+    .orderBy(desc(occurrences), captureEvidence.scope, captureEvidence.value)
+    .all();
+}

--- a/apps/mobile/features/capture-evidence/schema.ts
+++ b/apps/mobile/features/capture-evidence/schema.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+export const captureEvidenceTypeSchema = z.enum([
+  "sender_email",
+  "sender_domain",
+  "package_name",
+  "alias_token",
+  "card_hint",
+  "last4",
+]);
+export type CaptureEvidenceType = z.infer<typeof captureEvidenceTypeSchema>;
+
+export type CaptureEvidenceSeed = {
+  readonly sourceFamily: string;
+  readonly evidenceType: CaptureEvidenceType;
+  readonly scope: string;
+  readonly value: string;
+};

--- a/apps/mobile/features/capture-sources/services/apple-pay-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/apple-pay-pipeline.ts
@@ -1,4 +1,9 @@
 import {
+  buildApplePayCaptureEvidence,
+  materializeCaptureEvidenceRows,
+  saveCaptureEvidenceRows,
+} from "@/features/capture-evidence";
+import {
   insertMerchantRule,
   lookupMerchantRule,
 } from "@/features/email-capture/merchant-rules.public";
@@ -63,8 +68,9 @@ export async function processApplePayIntent(
 
     if (existingTxId) {
       const now = toIsoDateTime(new Date());
+      const processedCaptureId = generateProcessedCaptureId();
       await insertProcessedCapture(db, {
-        id: generateProcessedCaptureId(),
+        id: processedCaptureId,
         fingerprintHash: fingerprint,
         source,
         status: "skipped_duplicate",
@@ -74,6 +80,17 @@ export async function processApplePayIntent(
         receivedAt: now,
         createdAt: now,
       });
+      await saveCaptureEvidenceRows(
+        db,
+        materializeCaptureEvidenceRows(buildApplePayCaptureEvidence(intent), {
+          userId,
+          transactionId: existingTxId,
+          processedEmailId: null,
+          processedCaptureId,
+          createdAt: now,
+          updatedAt: now,
+        })
+      );
       capturePipelineEvent({ source: "apple_pay", saved: 0, skippedDuplicate: 1 });
       return { saved: false, skippedDuplicate: true, transactionId: existingTxId };
     }
@@ -119,8 +136,9 @@ export async function processApplePayIntent(
     });
 
     // Record in processedCaptures
+    const processedCaptureId = generateProcessedCaptureId();
     await insertProcessedCapture(db, {
-      id: generateProcessedCaptureId(),
+      id: processedCaptureId,
       fingerprintHash: fingerprint,
       source,
       status: "success",
@@ -130,6 +148,17 @@ export async function processApplePayIntent(
       receivedAt: now,
       createdAt: now,
     });
+    await saveCaptureEvidenceRows(
+      db,
+      materializeCaptureEvidenceRows(buildApplePayCaptureEvidence(intent), {
+        userId,
+        transactionId: txId,
+        processedEmailId: null,
+        processedCaptureId,
+        createdAt: now,
+        updatedAt: now,
+      })
+    );
 
     // Always cache merchant rule (Apple Pay data is high confidence)
     await insertMerchantRule(db, userId, merchantKey, categoryId, now);

--- a/apps/mobile/features/capture-sources/services/notification-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/notification-pipeline.ts
@@ -1,4 +1,9 @@
 import {
+  buildNotificationCaptureEvidence,
+  materializeCaptureEvidenceRows,
+  saveCaptureEvidenceRows,
+} from "@/features/capture-evidence";
+import {
   insertMerchantRule,
   lookupMerchantRule,
 } from "@/features/email-capture/merchant-rules.public";
@@ -69,8 +74,10 @@ export async function processNotification(
       })();
 
   if (!parsed) {
+    const now = toIsoDateTime(new Date());
+    const processedCaptureId = generateProcessedCaptureId();
     await insertProcessedCapture(db, {
-      id: generateProcessedCaptureId(),
+      id: processedCaptureId,
       fingerprintHash: `failed:${notification.packageName}:${notification.timestamp}`,
       source,
       status: "failed",
@@ -78,8 +85,19 @@ export async function processNotification(
       transactionId: null,
       confidence: null,
       receivedAt,
-      createdAt: toIsoDateTime(new Date()),
+      createdAt: now,
     });
+    await saveCaptureEvidenceRows(
+      db,
+      materializeCaptureEvidenceRows(buildNotificationCaptureEvidence(notification), {
+        userId,
+        transactionId: null,
+        processedEmailId: null,
+        processedCaptureId,
+        createdAt: now,
+        updatedAt: now,
+      })
+    );
     capturePipelineEvent({
       source: "notification",
       bankSource: source,
@@ -136,8 +154,10 @@ export async function processNotification(
     );
 
     if (existingTxId) {
+      const now = toIsoDateTime(new Date());
+      const processedCaptureId = generateProcessedCaptureId();
       await insertProcessedCapture(db, {
-        id: generateProcessedCaptureId(),
+        id: processedCaptureId,
         fingerprintHash: fingerprint,
         source,
         status: "skipped_duplicate",
@@ -145,8 +165,19 @@ export async function processNotification(
         transactionId: existingTxId,
         confidence: parsed.confidence,
         receivedAt,
-        createdAt: toIsoDateTime(new Date()),
+        createdAt: now,
       });
+      await saveCaptureEvidenceRows(
+        db,
+        materializeCaptureEvidenceRows(buildNotificationCaptureEvidence(notification), {
+          userId,
+          transactionId: existingTxId,
+          processedEmailId: null,
+          processedCaptureId,
+          createdAt: now,
+          updatedAt: now,
+        })
+      );
       capturePipelineEvent({
         source: "notification",
         bankSource: source,
@@ -197,8 +228,9 @@ export async function processNotification(
     });
 
     // Record in processedCaptures
+    const processedCaptureId = generateProcessedCaptureId();
     await insertProcessedCapture(db, {
-      id: generateProcessedCaptureId(),
+      id: processedCaptureId,
       fingerprintHash: fingerprint,
       source,
       status: "success",
@@ -208,6 +240,17 @@ export async function processNotification(
       receivedAt,
       createdAt: now,
     });
+    await saveCaptureEvidenceRows(
+      db,
+      materializeCaptureEvidenceRows(buildNotificationCaptureEvidence(notification), {
+        userId,
+        transactionId: txId,
+        processedEmailId: null,
+        processedCaptureId,
+        createdAt: now,
+        updatedAt: now,
+      })
+    );
 
     // Cache merchant rule if confidence >= 0.7
     if (parsed.confidence >= 0.7) {

--- a/apps/mobile/features/email-capture/services/create-email-pipeline-service.ts
+++ b/apps/mobile/features/email-capture/services/create-email-pipeline-service.ts
@@ -1,4 +1,6 @@
 import { Effect } from "effect";
+import type { CaptureEvidenceRow, CaptureEvidenceSeed } from "@/features/capture-evidence";
+import { materializeCaptureEvidenceRows } from "@/features/capture-evidence";
 import type { ProcessedEmailRow } from "@/features/email-capture/lib/repository";
 import type { FinancialAccountRow } from "@/features/financial-accounts";
 import { getBuiltInCategoryId, isValidCategoryId } from "@/features/transactions/lib/categories";
@@ -96,6 +98,17 @@ type CreateEmailPipelineServiceDeps = {
     status: string,
     transactionId: TransactionId | null
   ) => Promise<void>;
+  readonly buildEmailCaptureEvidence: (input: { from: string }) => readonly CaptureEvidenceSeed[];
+  readonly saveCaptureEvidenceRows: (
+    db: AnyDb,
+    rows: readonly CaptureEvidenceRow[]
+  ) => void | Promise<void>;
+  readonly linkCaptureEvidenceToTransaction: (
+    db: AnyDb,
+    processedEmailId: ProcessedEmailId,
+    transactionId: TransactionId,
+    updatedAt: IsoDateTime
+  ) => void | Promise<void>;
   readonly ensureDefaultFinancialAccount: (
     db: AnyDb,
     userId: UserId,
@@ -196,6 +209,43 @@ function insertProcessedEmailEffect(db: AnyDb, row: ProcessedEmailRow) {
   );
 }
 
+function buildEmailCaptureEvidenceRows(
+  userId: UserId,
+  from: string,
+  processedEmailId: ProcessedEmailId,
+  transactionId: TransactionId | null,
+  now: IsoDateTime,
+  buildEmailCaptureEvidence: (input: { from: string }) => readonly CaptureEvidenceSeed[]
+) {
+  return materializeCaptureEvidenceRows(buildEmailCaptureEvidence({ from }), {
+    userId,
+    transactionId,
+    processedEmailId,
+    processedCaptureId: null,
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
+function saveCaptureEvidenceRowsEffect(db: AnyDb, rows: readonly CaptureEvidenceRow[]) {
+  return Effect.flatMap(EmailPipelineDeps.tag, ({ saveCaptureEvidenceRows }) =>
+    fromThunk(() => saveCaptureEvidenceRows(db, rows))
+  );
+}
+
+function linkCaptureEvidenceToTransactionEffect(
+  db: AnyDb,
+  processedEmailId: ProcessedEmailId,
+  transactionId: TransactionId,
+  updatedAt: IsoDateTime
+) {
+  return Effect.flatMap(EmailPipelineDeps.tag, ({ linkCaptureEvidenceToTransaction }) =>
+    fromThunk(() =>
+      linkCaptureEvidenceToTransaction(db, processedEmailId, transactionId, updatedAt)
+    )
+  );
+}
+
 function saveTransactionEffect(
   db: AnyDb,
   userId: UserId,
@@ -209,10 +259,13 @@ function saveTransactionEffect(
       insertTransaction,
       enqueueSync,
       insertProcessedEmail,
+      buildEmailCaptureEvidence,
+      saveCaptureEvidenceRows,
       trackTransactionCreated,
     } = yield* EmailPipelineDeps.tag;
     const source = getTransactionSource(email.provider);
     const txId = generateTransactionId();
+    const processedEmailId = generateProcessedEmailId();
     const now = yield* currentIsoDateTimeEffect;
     const amount = validated.amount;
     const date = validated.date;
@@ -255,7 +308,7 @@ function saveTransactionEffect(
 
     yield* fromPromise(() =>
       insertProcessedEmail(db, {
-        id: generateProcessedEmailId(),
+        id: processedEmailId,
         externalId: email.externalId,
         provider: email.provider,
         status,
@@ -267,6 +320,20 @@ function saveTransactionEffect(
         confidence: validated.confidence,
         createdAt: now,
       })
+    );
+
+    yield* fromThunk(() =>
+      saveCaptureEvidenceRows(
+        db,
+        buildEmailCaptureEvidenceRows(
+          userId,
+          email.from,
+          processedEmailId,
+          txId,
+          now,
+          buildEmailCaptureEvidence
+        )
+      )
     );
 
     if (status === "success") {
@@ -488,9 +555,10 @@ export function createEmailPipelineService(
             assertIsoDateTime(email.receivedAt);
             const createdAt = await runClockEffect(currentIsoDateTimeEffect);
             const nextRetryAt = parseError ? await runClockEffect(nextRetryAtEffect(0)) : null;
+            const processedEmailId = generateProcessedEmailId();
             await runEmailEffect(
               insertProcessedEmailEffect(db, {
-                id: generateProcessedEmailId(),
+                id: processedEmailId,
                 externalId: email.externalId,
                 provider: email.provider,
                 status,
@@ -509,6 +577,21 @@ export function createEmailPipelineService(
                     }
                   : {}),
               })
+            );
+            await runEmailEffect(
+              Effect.flatMap(EmailPipelineDeps.tag, ({ buildEmailCaptureEvidence }) =>
+                saveCaptureEvidenceRowsEffect(
+                  db,
+                  buildEmailCaptureEvidenceRows(
+                    userId,
+                    email.from,
+                    processedEmailId,
+                    null,
+                    createdAt,
+                    buildEmailCaptureEvidence
+                  )
+                )
+              )
             );
             completed++;
             onProgress?.(getProgressSnapshot(total, completed, result));
@@ -530,9 +613,10 @@ export function createEmailPipelineService(
             const receivedAt = email.receivedAt;
             assertIsoDateTime(receivedAt);
             const createdAt = await runClockEffect(currentIsoDateTimeEffect);
+            const processedEmailId = generateProcessedEmailId();
             await runEmailEffect(
               insertProcessedEmailEffect(db, {
-                id: generateProcessedEmailId(),
+                id: processedEmailId,
                 externalId: email.externalId,
                 provider: email.provider,
                 status: "skipped_duplicate",
@@ -544,6 +628,21 @@ export function createEmailPipelineService(
                 confidence: parsed.confidence,
                 createdAt,
               })
+            );
+            await runEmailEffect(
+              Effect.flatMap(EmailPipelineDeps.tag, ({ buildEmailCaptureEvidence }) =>
+                saveCaptureEvidenceRowsEffect(
+                  db,
+                  buildEmailCaptureEvidenceRows(
+                    userId,
+                    email.from,
+                    processedEmailId,
+                    existingTxId,
+                    createdAt,
+                    buildEmailCaptureEvidence
+                  )
+                )
+              )
             );
             result.skippedCrossSource++;
             completed++;
@@ -672,6 +771,14 @@ export function createEmailPipelineService(
 
         if (existingTxId) {
           await runEmailEffect(
+            linkCaptureEvidenceToTransactionEffect(
+              db,
+              email.id,
+              existingTxId,
+              await runClockEffect(currentIsoDateTimeEffect)
+            )
+          );
+          await runEmailEffect(
             markRetrySuccessEffect(db, email.id, "success", existingTxId, parsed.confidence)
           );
           result.succeeded++;
@@ -681,6 +788,14 @@ export function createEmailPipelineService(
         try {
           const { txId, status } = await runEmailWithClock(
             saveRetryTransactionEffect(db, userId, parsed, email)
+          );
+          await runEmailEffect(
+            linkCaptureEvidenceToTransactionEffect(
+              db,
+              email.id,
+              txId,
+              await runClockEffect(currentIsoDateTimeEffect)
+            )
           );
           await runEmailEffect(
             markRetrySuccessEffect(db, email.id, status, txId, parsed.confidence)

--- a/apps/mobile/features/email-capture/services/email-pipeline.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline.ts
@@ -1,3 +1,8 @@
+import {
+  buildEmailCaptureEvidence,
+  linkCaptureEvidenceToTransaction,
+  saveCaptureEvidenceRows,
+} from "@/features/capture-evidence";
 import { findDuplicateTransaction } from "@/features/capture-sources/lib/dedup";
 import { ensureDefaultFinancialAccount } from "@/features/financial-accounts";
 import { insertTransaction } from "@/features/transactions/lib/repository";
@@ -39,6 +44,9 @@ const emailPipeline = createEmailPipelineService({
   markPermanentlyFailed,
   markRetrySuccess,
   updateProcessedEmailStatus,
+  buildEmailCaptureEvidence,
+  saveCaptureEvidenceRows,
+  linkCaptureEvidenceToTransaction,
   ensureDefaultFinancialAccount,
   insertTransaction,
   enqueueSync,

--- a/apps/mobile/features/sync/services/syncEngine.ts
+++ b/apps/mobile/features/sync/services/syncEngine.ts
@@ -1,6 +1,7 @@
 // biome-ignore-all lint/style/useNamingConvention: snake_case matches Supabase Postgres column names
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { getBudgetById } from "@/features/budget";
+import { getCaptureEvidenceById, upsertCaptureEvidence } from "@/features/capture-evidence";
 import {
   buildDefaultFinancialAccountId,
   getFinancialAccountById,
@@ -36,6 +37,7 @@ import { insertConflict } from "../lib/conflict-repository";
 const LEGACY_LAST_SYNC_AT = "last_sync_at";
 const LAST_SYNC_AT_BY_TABLE = {
   transactions: "last_sync_at_transactions",
+  capture_evidence: "last_sync_at_capture_evidence",
   financial_accounts: "last_sync_at_financial_accounts",
   transfers: "last_sync_at_transfers",
   opening_balances: "last_sync_at_opening_balances",
@@ -102,6 +104,21 @@ type SupabaseFinancialAccountIdentifierRow = {
   account_id: string;
   scope: string;
   value: string;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+};
+
+type SupabaseCaptureEvidenceRow = {
+  id: string;
+  user_id: string;
+  source_family: string;
+  evidence_type: string;
+  scope: string;
+  value: string;
+  transaction_id: string | null;
+  processed_email_id: string | null;
+  processed_capture_id: string | null;
   created_at: string;
   updated_at: string;
   deleted_at: string | null;
@@ -221,6 +238,25 @@ function fromSupabaseFinancialAccountIdentifierRow(
     updatedAt: row.updated_at,
     deletedAt: row.deleted_at,
   } as Parameters<typeof upsertFinancialAccountIdentifier>[1];
+}
+
+function fromSupabaseCaptureEvidenceRow(
+  row: SupabaseCaptureEvidenceRow
+): Parameters<typeof upsertCaptureEvidence>[1] {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    sourceFamily: row.source_family,
+    evidenceType: row.evidence_type,
+    scope: row.scope,
+    value: row.value,
+    transactionId: row.transaction_id,
+    processedEmailId: row.processed_email_id,
+    processedCaptureId: row.processed_capture_id,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    deletedAt: row.deleted_at,
+  } as Parameters<typeof upsertCaptureEvidence>[1];
 }
 
 type PullTableName = keyof typeof LAST_SYNC_AT_BY_TABLE;
@@ -542,6 +578,30 @@ async function processFinancialAccountIdentifierEntry(
   return !error;
 }
 
+async function processCaptureEvidenceEntry(
+  db: AnyDb,
+  supabase: SupabaseClient,
+  rowId: string
+): Promise<boolean> {
+  const row = getCaptureEvidenceById(db, rowId as Parameters<typeof getCaptureEvidenceById>[1]);
+  if (!row) return true;
+  const { error } = await supabase.from("capture_evidence").upsert({
+    id: row.id,
+    user_id: row.userId,
+    source_family: row.sourceFamily,
+    evidence_type: row.evidenceType,
+    scope: row.scope,
+    value: row.value,
+    transaction_id: row.transactionId,
+    processed_email_id: row.processedEmailId,
+    processed_capture_id: row.processedCaptureId,
+    created_at: row.createdAt,
+    updated_at: row.updatedAt,
+    deleted_at: row.deletedAt,
+  });
+  return !error;
+}
+
 async function processContributionEntry(
   db: AnyDb,
   supabase: SupabaseClient,
@@ -591,6 +651,12 @@ async function processEntry(
   if (entry.tableName === "financialAccounts") {
     const ok = await processFinancialAccountEntry(db, supabase, entry.rowId);
     if (!ok) captureWarning("sync_push_entry_failed", { tableName: "financialAccounts" });
+    return ok ? entry.id : null;
+  }
+
+  if (entry.tableName === "captureEvidence") {
+    const ok = await processCaptureEvidenceEntry(db, supabase, entry.rowId);
+    if (!ok) captureWarning("sync_push_entry_failed", { tableName: "captureEvidence" });
     return ok ? entry.id : null;
   }
 
@@ -664,12 +730,14 @@ export async function syncPull(
   userId: string
 ): Promise<boolean> {
   const [
+    captureEvidenceCursor,
     financialAccountsCursor,
     transfersCursor,
     openingBalancesCursor,
     financialAccountIdentifiersCursor,
     transactionsCursor,
   ] = await Promise.all([
+    getPullCursor(db, "capture_evidence"),
     getPullCursor(db, "financial_accounts"),
     getPullCursor(db, "transfers"),
     getPullCursor(db, "opening_balances"),
@@ -677,12 +745,19 @@ export async function syncPull(
     getPullCursor(db, "transactions"),
   ]);
   const [
+    captureEvidenceFetchResult,
     financialAccountsFetchResult,
     transfersFetchResult,
     openingBalancesFetchResult,
     financialAccountIdentifiersFetchResult,
     transactionsFetchResult,
   ] = await Promise.allSettled([
+    fetchPullRows<SupabaseCaptureEvidenceRow>(
+      supabase,
+      userId,
+      "capture_evidence",
+      captureEvidenceCursor
+    ),
     fetchPullRows<SupabaseFinancialAccountRow>(
       supabase,
       userId,
@@ -706,12 +781,14 @@ export async function syncPull(
   ]);
 
   const [
+    captureEvidenceResult,
     financialAccountsResult,
     transfersResult,
     openingBalancesResult,
     financialAccountIdentifiersResult,
     transactionsResult,
   ] = [
+    toPullFetchOutcome("capture_evidence", captureEvidenceFetchResult),
     toPullFetchOutcome("financial_accounts", financialAccountsFetchResult),
     toPullFetchOutcome("transfers", transfersFetchResult),
     toPullFetchOutcome("opening_balances", openingBalancesFetchResult),
@@ -720,6 +797,7 @@ export async function syncPull(
   ];
 
   const failedFetches = [
+    captureEvidenceResult,
     financialAccountsResult,
     transfersResult,
     openingBalancesResult,
@@ -736,11 +814,13 @@ export async function syncPull(
   }
 
   const financialAccountRows = financialAccountsResult.rows;
+  const captureEvidenceRows = captureEvidenceResult.rows;
   const transferRows = transfersResult.rows;
   const openingBalanceRows = openingBalancesResult.rows;
   const financialAccountIdentifierRows = financialAccountIdentifiersResult.rows;
   const transactionRows = transactionsResult.rows;
   const allUpdatedAts = [
+    ...captureEvidenceRows.map((row) => row.updated_at),
     ...financialAccountRows.map((row) => row.updated_at),
     ...transferRows.map((row) => row.updated_at),
     ...openingBalanceRows.map((row) => row.updated_at),
@@ -750,6 +830,13 @@ export async function syncPull(
   // FP exemption: each row may depend on prior upserts for conflict detection.
   let failedCount = 0;
   let conflictCount = 0;
+  const captureEvidenceOutcome = applyServerRows(db, captureEvidenceRows, {
+    getLocalRow: (database, rowId) =>
+      getCaptureEvidenceById(database, rowId as Parameters<typeof getCaptureEvidenceById>[1]),
+    upsertLocalRow: upsertCaptureEvidence,
+    mapServerRow: fromSupabaseCaptureEvidenceRow,
+  });
+  failedCount += captureEvidenceOutcome.failedCount;
   const financialAccountsOutcome = applyServerRows(db, financialAccountRows, {
     getLocalRow: (database, rowId) =>
       getFinancialAccountById(database, rowId as Parameters<typeof getFinancialAccountById>[1]),
@@ -848,6 +935,7 @@ export async function syncPull(
   });
 
   await Promise.all([
+    advancePullCursor(db, "capture_evidence", captureEvidenceOutcome.safeCursor),
     advancePullCursor(db, "financial_accounts", financialAccountsOutcome.safeCursor),
     advancePullCursor(db, "transfers", transfersOutcome.safeCursor),
     advancePullCursor(db, "opening_balances", openingBalancesOutcome.safeCursor),

--- a/apps/mobile/shared/db/enqueue-sync.ts
+++ b/apps/mobile/shared/db/enqueue-sync.ts
@@ -5,6 +5,7 @@ import { syncQueue } from "./schema";
 export type SyncOperation = "insert" | "update" | "delete";
 export type SyncTableName =
   | "transactions"
+  | "captureEvidence"
   | "financialAccounts"
   | "financialAccountIdentifiers"
   | "openingBalances"

--- a/apps/mobile/shared/db/index.ts
+++ b/apps/mobile/shared/db/index.ts
@@ -6,6 +6,7 @@ export {
   billPayments,
   bills,
   budgets,
+  captureEvidence,
   chatMessages,
   chatSessions,
   detectedSmsEvents,

--- a/apps/mobile/shared/db/schema.ts
+++ b/apps/mobile/shared/db/schema.ts
@@ -12,6 +12,7 @@ import type {
   BillId,
   BillPaymentId,
   BudgetId,
+  CaptureEvidenceId,
   CategoryId,
   ChatMessageId,
   ChatSessionId,
@@ -183,6 +184,41 @@ export const financialAccountIdentifiers = sqliteTable(
       .on(table.userId, table.accountId, table.scope, table.value)
       .where(sql`${table.deletedAt} is null`),
     index("idx_financial_account_identifiers_account").on(table.accountId),
+  ]
+);
+
+export const captureEvidence = sqliteTable(
+  "capture_evidence",
+  {
+    id: text("id").$type<CaptureEvidenceId>().primaryKey(),
+    userId: text("user_id").$type<UserId>().notNull(),
+    sourceFamily: text("source_family").notNull(),
+    evidenceType: text("evidence_type").notNull(),
+    scope: text("scope").notNull(),
+    value: text("value").notNull(),
+    transactionId: text("transaction_id").$type<TransactionId>(),
+    processedEmailId: text("processed_email_id").$type<ProcessedEmailId>(),
+    processedCaptureId: text("processed_capture_id").$type<ProcessedCaptureId>(),
+    createdAt: text("created_at").$type<IsoDateTime>().notNull(),
+    updatedAt: text("updated_at").$type<IsoDateTime>().notNull(),
+    deletedAt: text("deleted_at").$type<IsoDateTime>(),
+  },
+  (table) => [
+    check(
+      "ck_capture_evidence_source_record",
+      sql`(case when ${table.processedEmailId} is not null then 1 else 0 end) + (case when ${table.processedCaptureId} is not null then 1 else 0 end) = 1`
+    ),
+    uniqueIndex("uq_capture_evidence_email")
+      .on(table.userId, table.processedEmailId, table.scope, table.value)
+      .where(sql`${table.processedEmailId} is not null and ${table.deletedAt} is null`),
+    uniqueIndex("uq_capture_evidence_capture")
+      .on(table.userId, table.processedCaptureId, table.scope, table.value)
+      .where(sql`${table.processedCaptureId} is not null and ${table.deletedAt} is null`),
+    index("idx_capture_evidence_user_scope_value").on(table.userId, table.scope, table.value),
+    index("idx_capture_evidence_transaction").on(table.transactionId),
+    index("idx_capture_evidence_processed_email").on(table.processedEmailId),
+    index("idx_capture_evidence_processed_capture").on(table.processedCaptureId),
+    index("idx_capture_evidence_user_updated").on(table.userId, table.updatedAt),
   ]
 );
 

--- a/apps/mobile/shared/lib/generate-id.ts
+++ b/apps/mobile/shared/lib/generate-id.ts
@@ -2,6 +2,7 @@ import type {
   BillId,
   BillPaymentId,
   BudgetId,
+  CaptureEvidenceId,
   ChatMessageId,
   ChatSessionId,
   DetectedSmsEventId,
@@ -40,6 +41,10 @@ export function generateTransactionId(): TransactionId {
 
 export function generateBudgetId(): BudgetId {
   return generateId("budget") as BudgetId;
+}
+
+export function generateCaptureEvidenceId(): CaptureEvidenceId {
+  return generateId("ce") as CaptureEvidenceId;
 }
 
 export function generateBillId(): BillId {

--- a/apps/mobile/shared/lib/index.ts
+++ b/apps/mobile/shared/lib/index.ts
@@ -41,6 +41,7 @@ export {
   generateBillId,
   generateBillPaymentId,
   generateBudgetId,
+  generateCaptureEvidenceId,
   generateChatMessageId,
   generateChatSessionId,
   generateDetectedSmsEventId,

--- a/apps/mobile/shared/types/branded.ts
+++ b/apps/mobile/shared/types/branded.ts
@@ -6,6 +6,7 @@ export type BudgetId = Brand<string, "BudgetId">;
 export type BillId = Brand<string, "BillId">;
 export type BillPaymentId = Brand<string, "BillPaymentId">;
 export type CategoryId = Brand<string, "CategoryId">;
+export type CaptureEvidenceId = Brand<string, "CaptureEvidenceId">;
 export type FinancialAccountId = Brand<string, "FinancialAccountId">;
 export type FinancialAccountIdentifierId = Brand<string, "FinancialAccountIdentifierId">;
 export type UserId = Brand<string, "UserId">;

--- a/apps/mobile/supabase/migrations/20260419104500_capture_evidence.sql
+++ b/apps/mobile/supabase/migrations/20260419104500_capture_evidence.sql
@@ -1,0 +1,60 @@
+create table public.capture_evidence (
+  id text primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  source_family text not null,
+  evidence_type text not null,
+  scope text not null,
+  value text not null,
+  transaction_id text,
+  processed_email_id text,
+  processed_capture_id text,
+  created_at text not null,
+  updated_at text not null,
+  deleted_at text,
+  constraint ck_capture_evidence_source_record
+    check (
+      (case when processed_email_id is not null then 1 else 0 end) +
+      (case when processed_capture_id is not null then 1 else 0 end) = 1
+    )
+);
+
+create unique index uq_capture_evidence_email
+  on public.capture_evidence (user_id, processed_email_id, scope, value)
+  where processed_email_id is not null and deleted_at is null;
+
+create unique index uq_capture_evidence_capture
+  on public.capture_evidence (user_id, processed_capture_id, scope, value)
+  where processed_capture_id is not null and deleted_at is null;
+
+create index idx_capture_evidence_user_scope_value
+  on public.capture_evidence (user_id, scope, value);
+
+create index idx_capture_evidence_transaction
+  on public.capture_evidence (transaction_id);
+
+create index idx_capture_evidence_processed_email
+  on public.capture_evidence (processed_email_id);
+
+create index idx_capture_evidence_processed_capture
+  on public.capture_evidence (processed_capture_id);
+
+create index idx_capture_evidence_user_updated_id
+  on public.capture_evidence (user_id, updated_at, id);
+
+alter table public.capture_evidence enable row level security;
+
+create policy "Users can read own capture evidence"
+  on public.capture_evidence for select
+  using (auth.uid() = user_id);
+
+create policy "Users can insert own capture evidence"
+  on public.capture_evidence for insert
+  with check (auth.uid() = user_id);
+
+create policy "Users can update own capture evidence"
+  on public.capture_evidence for update
+  using (auth.uid() = user_id);
+
+create policy "Users can delete own capture evidence"
+  on public.capture_evidence for delete
+  using (auth.uid() = user_id);


### PR DESCRIPTION
- add normalized capture evidence storage
- persist evidence in email notification and Apple Pay flows
- sync evidence rows and extend test coverage


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add normalized capture evidence and persist it across email, notification, and Apple Pay flows to improve source linking and future rules. Includes full sync support and DB migrations.

- **New Features**
  - Added `capture_evidence` table with normalized fields (source family, evidence type, scope, value) and unique indexes to prevent duplicates.
  - Built evidence extractors: email (sender email/domain), notifications (package, alias tokens, last4), Apple Pay (card hint, last4).
  - Persist evidence in pipelines on success, duplicates, and failures; link to transactions when available.
  - Repository utilities: materialize seeds, save/upsert rows, link evidence to transactions, count and query repeated evidence.
  - Sync push/pull for `capture_evidence` with a dedicated per-table cursor; tests cover builders, repository, pipelines, and sync.

- **Migration**
  - Run local Drizzle migration `0020_tidy_husk`.
  - Apply Supabase migration `20260419104500_capture_evidence.sql` (includes RLS policies).
  - A new cursor key `last_sync_at_capture_evidence` is tracked automatically during sync.

<sup>Written for commit 3de3361716e6ce61f0791da29457a43333533ba1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

