### PR TITLE
feat(mobile): add account suggestion engine

### DIFF
--- a/apps/mobile/__tests__/account-suggestions/match-financial-account.test.ts
+++ b/apps/mobile/__tests__/account-suggestions/match-financial-account.test.ts
@@ -1,0 +1,85 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: integration test uses a real SQLite DB
+import { resolve } from "node:path";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { findMatchingFinancialAccountId } from "@/features/account-suggestions";
+import {
+  saveFinancialAccount,
+  saveFinancialAccountIdentifier,
+} from "@/features/financial-accounts";
+import type {
+  FinancialAccountId,
+  FinancialAccountIdentifierId,
+  IsoDateTime,
+  UserId,
+} from "@/shared/types/branded";
+
+let sqlite: InstanceType<typeof Database>;
+let db: ReturnType<typeof drizzle>;
+
+const USER_ID = "user-1" as UserId;
+const NOW = "2026-04-19T10:00:00.000Z" as IsoDateTime;
+
+beforeEach(() => {
+  sqlite = new Database(":memory:");
+  db = drizzle(sqlite);
+  migrate(db, { migrationsFolder: resolve(__dirname, "../../drizzle") });
+});
+
+afterEach(() => {
+  sqlite.close();
+});
+
+function saveAccount(id: FinancialAccountId, deletedAt: IsoDateTime | null = null) {
+  saveFinancialAccount(db as any, {
+    id,
+    userId: USER_ID,
+    name: String(id),
+    kind: "credit_card",
+    isDefault: false,
+    createdAt: NOW,
+    updatedAt: deletedAt ?? NOW,
+    deletedAt,
+  });
+}
+
+function saveIdentifier(id: string, accountId: FinancialAccountId, value: string) {
+  saveFinancialAccountIdentifier(db as any, {
+    id: id as FinancialAccountIdentifierId,
+    userId: USER_ID,
+    accountId,
+    scope: "notification:bancolombia:last4",
+    value,
+    createdAt: NOW,
+    updatedAt: NOW,
+    deletedAt: null,
+  });
+}
+
+describe("findMatchingFinancialAccountId", () => {
+  it("ignores identifiers that belong to deleted accounts", () => {
+    saveAccount("fa-deleted" as FinancialAccountId, "2026-04-19T11:00:00.000Z" as IsoDateTime);
+    saveIdentifier("fai-1", "fa-deleted" as FinancialAccountId, "1234");
+
+    expect(
+      findMatchingFinancialAccountId(db as any, USER_ID, [
+        { scope: "notification:bancolombia:last4", value: "1234" },
+      ])
+    ).toBeNull();
+  });
+
+  it("still matches a single active account when a deleted account has the same identifier", () => {
+    saveAccount("fa-deleted" as FinancialAccountId, "2026-04-19T11:00:00.000Z" as IsoDateTime);
+    saveAccount("fa-active" as FinancialAccountId);
+    saveIdentifier("fai-1", "fa-deleted" as FinancialAccountId, "1234");
+    saveIdentifier("fai-2", "fa-active" as FinancialAccountId, "1234");
+
+    expect(
+      findMatchingFinancialAccountId(db as any, USER_ID, [
+        { scope: "notification:bancolombia:last4", value: "1234" },
+      ])
+    ).toBe("fa-active");
+  });
+});

--- a/apps/mobile/__tests__/account-suggestions/service.test.ts
+++ b/apps/mobile/__tests__/account-suggestions/service.test.ts
@@ -1,0 +1,369 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: integration test uses a real SQLite DB
+import { resolve } from "node:path";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createAccountSuggestionService } from "@/features/account-suggestions";
+import { saveCaptureEvidence } from "@/features/capture-evidence";
+import {
+  getFinancialAccountIdentifiersForAccount,
+  upsertFinancialAccount,
+} from "@/features/financial-accounts";
+import { getTransactionById, insertTransaction } from "@/features/transactions/lib/repository";
+import type {
+  CaptureEvidenceId,
+  CategoryId,
+  CopAmount,
+  FinancialAccountId,
+  IsoDate,
+  IsoDateTime,
+  ProcessedCaptureId,
+  ProcessedEmailId,
+  TransactionId,
+  UserId,
+} from "@/shared/types/branded";
+
+let sqlite: InstanceType<typeof Database>;
+let db: ReturnType<typeof drizzle>;
+
+const USER_ID = "user-1" as UserId;
+const NOW = "2026-04-19T10:00:00.000Z" as IsoDateTime;
+
+beforeEach(() => {
+  sqlite = new Database(":memory:");
+  db = drizzle(sqlite);
+  migrate(db, { migrationsFolder: resolve(__dirname, "../../drizzle") });
+});
+
+afterEach(() => {
+  sqlite.close();
+});
+
+function saveEvidenceRow(
+  id: string,
+  row: {
+    readonly sourceFamily: string;
+    readonly evidenceType: string;
+    readonly scope: string;
+    readonly value: string;
+    readonly processedEmailId?: string;
+    readonly processedCaptureId?: string;
+    readonly transactionId?: string | null;
+    readonly updatedAt?: IsoDateTime;
+  }
+) {
+  saveCaptureEvidence(db as any, {
+    id: id as CaptureEvidenceId,
+    userId: USER_ID,
+    sourceFamily: row.sourceFamily,
+    evidenceType: row.evidenceType,
+    scope: row.scope,
+    value: row.value,
+    transactionId: (row.transactionId ?? null) as TransactionId | null,
+    processedEmailId: (row.processedEmailId ?? null) as ProcessedEmailId | null,
+    processedCaptureId: (row.processedCaptureId ?? null) as ProcessedCaptureId | null,
+    createdAt: row.updatedAt ?? NOW,
+    updatedAt: row.updatedAt ?? NOW,
+    deletedAt: null,
+  });
+}
+
+describe("account suggestion service", () => {
+  it("lists repeated scoped suggestions and ignores repeated sender-only evidence", () => {
+    saveEvidenceRow("ce-last4-1", {
+      sourceFamily: "bancolombia",
+      evidenceType: "last4",
+      scope: "notification:bancolombia:last4",
+      value: "1234",
+      processedCaptureId: "pc-1",
+      transactionId: "tx-1",
+    });
+
+    saveEvidenceRow("ce-last4-2", {
+      sourceFamily: "bancolombia",
+      evidenceType: "last4",
+      scope: "notification:bancolombia:last4",
+      value: "1234",
+      processedCaptureId: "pc-2",
+      transactionId: "tx-2",
+      updatedAt: "2026-04-19T11:00:00.000Z" as IsoDateTime,
+    });
+
+    saveEvidenceRow("ce-sender-1", {
+      sourceFamily: "bancolombia",
+      evidenceType: "sender_email",
+      scope: "email:bancolombia:sender",
+      value: "notificaciones@bancolombia.com.co",
+      processedEmailId: "pe-1",
+    });
+
+    saveEvidenceRow("ce-sender-2", {
+      sourceFamily: "bancolombia",
+      evidenceType: "sender_email",
+      scope: "email:bancolombia:sender",
+      value: "notificaciones@bancolombia.com.co",
+      processedEmailId: "pe-2",
+      updatedAt: "2026-04-19T11:30:00.000Z" as IsoDateTime,
+    });
+
+    const service = createAccountSuggestionService();
+    const suggestions = service.listSuggestions({ db: db as any, userId: USER_ID });
+
+    expect(suggestions).toEqual([
+      expect.objectContaining({
+        scope: "notification:bancolombia:last4",
+        value: "1234",
+        sourceFamily: "bancolombia",
+        evidenceType: "last4",
+        occurrences: 2,
+      }),
+    ]);
+  });
+
+  it("suppresses a dismissed suggestion until stronger evidence appears", () => {
+    saveEvidenceRow("ce-last4-1", {
+      sourceFamily: "bancolombia",
+      evidenceType: "last4",
+      scope: "notification:bancolombia:last4",
+      value: "1234",
+      processedCaptureId: "pc-1",
+      transactionId: "tx-1",
+    });
+
+    saveEvidenceRow("ce-last4-2", {
+      sourceFamily: "bancolombia",
+      evidenceType: "last4",
+      scope: "notification:bancolombia:last4",
+      value: "1234",
+      processedCaptureId: "pc-2",
+      transactionId: "tx-2",
+      updatedAt: "2026-04-19T11:00:00.000Z" as IsoDateTime,
+    });
+
+    const service = createAccountSuggestionService({
+      now: () => NOW,
+      createDismissalId: () => "asd-1" as never,
+    });
+    const suggestion = service.listSuggestions({ db: db as any, userId: USER_ID })[0];
+
+    expect(suggestion).toBeDefined();
+
+    service.dismissSuggestion({
+      db: db as any,
+      userId: USER_ID,
+      suggestion: suggestion!,
+    });
+
+    expect(service.listSuggestions({ db: db as any, userId: USER_ID })).toEqual([]);
+
+    saveEvidenceRow("ce-last4-3", {
+      sourceFamily: "bancolombia",
+      evidenceType: "last4",
+      scope: "notification:bancolombia:last4",
+      value: "1234",
+      processedCaptureId: "pc-3",
+      transactionId: "tx-3",
+      updatedAt: "2026-04-19T12:00:00.000Z" as IsoDateTime,
+    });
+
+    expect(service.listSuggestions({ db: db as any, userId: USER_ID })).toEqual([
+      expect.objectContaining({
+        scope: "notification:bancolombia:last4",
+        value: "1234",
+        occurrences: 3,
+      }),
+    ]);
+  });
+
+  it("accepts a suggestion by saving an identifier and reprocessing matching unresolved transactions only", () => {
+    const linkedAccountId = "fa-2" as FinancialAccountId;
+
+    upsertFinancialAccount(db as any, {
+      id: linkedAccountId,
+      userId: USER_ID,
+      name: "Bancolombia Visa",
+      kind: "credit_card",
+      isDefault: false,
+      createdAt: NOW,
+      updatedAt: NOW,
+      deletedAt: null,
+    });
+
+    insertTransaction(db as any, {
+      id: "tx-unresolved" as TransactionId,
+      userId: USER_ID,
+      type: "expense",
+      amount: 120000 as CopAmount,
+      categoryId: "shopping" as CategoryId,
+      description: "Compra 1234",
+      date: "2026-04-19" as IsoDate,
+      accountId: "fa-default-user-1" as FinancialAccountId,
+      accountAttributionState: "unresolved",
+      source: "notification_android",
+      createdAt: NOW,
+      updatedAt: NOW,
+      deletedAt: null,
+    });
+
+    insertTransaction(db as any, {
+      id: "tx-confirmed" as TransactionId,
+      userId: USER_ID,
+      type: "expense",
+      amount: 98000 as CopAmount,
+      categoryId: "shopping" as CategoryId,
+      description: "Compra confirmada 1234",
+      date: "2026-04-19" as IsoDate,
+      accountId: "fa-default-user-1" as FinancialAccountId,
+      accountAttributionState: "confirmed",
+      source: "notification_android",
+      createdAt: NOW,
+      updatedAt: NOW,
+      deletedAt: null,
+    });
+
+    saveEvidenceRow("ce-match-1", {
+      sourceFamily: "bancolombia",
+      evidenceType: "last4",
+      scope: "notification:bancolombia:last4",
+      value: "1234",
+      processedCaptureId: "pc-1",
+      transactionId: "tx-unresolved",
+    });
+
+    saveEvidenceRow("ce-match-2", {
+      sourceFamily: "bancolombia",
+      evidenceType: "last4",
+      scope: "notification:bancolombia:last4",
+      value: "1234",
+      processedCaptureId: "pc-2",
+      transactionId: "tx-confirmed",
+      updatedAt: "2026-04-19T11:00:00.000Z" as IsoDateTime,
+    });
+
+    const service = createAccountSuggestionService({
+      now: () => "2026-04-19T12:00:00.000Z" as IsoDateTime,
+      createIdentifierId: () => "fai-1" as never,
+    });
+    const suggestion = service.listSuggestions({ db: db as any, userId: USER_ID })[0];
+
+    expect(suggestion).toBeDefined();
+
+    const result = service.acceptSuggestion({
+      db: db as any,
+      userId: USER_ID,
+      accountId: linkedAccountId,
+      suggestion: suggestion!,
+    });
+
+    expect(result).toEqual({
+      accountId: linkedAccountId,
+      identifierScope: "notification:bancolombia:last4",
+      identifierValue: "1234",
+      reprocessedTransactionIds: ["tx-unresolved"],
+    });
+
+    expect(getFinancialAccountIdentifiersForAccount(db as any, linkedAccountId)).toEqual([
+      expect.objectContaining({
+        accountId: linkedAccountId,
+        scope: "notification:bancolombia:last4",
+        value: "1234",
+      }),
+    ]);
+
+    expect(getTransactionById(db as any, "tx-unresolved" as TransactionId)).toEqual(
+      expect.objectContaining({
+        accountId: linkedAccountId,
+        accountAttributionState: "inferred",
+        updatedAt: "2026-04-19T12:00:00.000Z",
+      })
+    );
+
+    expect(getTransactionById(db as any, "tx-confirmed" as TransactionId)).toEqual(
+      expect.objectContaining({
+        accountId: "fa-default-user-1",
+        accountAttributionState: "confirmed",
+        updatedAt: NOW,
+      })
+    );
+
+    expect(service.listSuggestions({ db: db as any, userId: USER_ID })).toEqual([]);
+  });
+
+  it("returns the top three strongest suggestions in stable score order", () => {
+    saveEvidenceRow("ce-last4-a-1", {
+      sourceFamily: "bancolombia",
+      evidenceType: "last4",
+      scope: "notification:bancolombia:last4",
+      value: "1234",
+      processedCaptureId: "pc-1",
+    });
+    saveEvidenceRow("ce-last4-a-2", {
+      sourceFamily: "bancolombia",
+      evidenceType: "last4",
+      scope: "notification:bancolombia:last4",
+      value: "1234",
+      processedCaptureId: "pc-2",
+      updatedAt: "2026-04-19T11:00:00.000Z" as IsoDateTime,
+    });
+    saveEvidenceRow("ce-last4-b-1", {
+      sourceFamily: "davivienda",
+      evidenceType: "last4",
+      scope: "notification:davivienda:last4",
+      value: "9999",
+      processedCaptureId: "pc-3",
+    });
+    saveEvidenceRow("ce-last4-b-2", {
+      sourceFamily: "davivienda",
+      evidenceType: "last4",
+      scope: "notification:davivienda:last4",
+      value: "9999",
+      processedCaptureId: "pc-4",
+      updatedAt: "2026-04-19T11:10:00.000Z" as IsoDateTime,
+    });
+    saveEvidenceRow("ce-card-1", {
+      sourceFamily: "apple_pay",
+      evidenceType: "card_hint",
+      scope: "apple_pay:card_hint",
+      value: "visa platinum 1234",
+      processedCaptureId: "pc-5",
+    });
+    saveEvidenceRow("ce-card-2", {
+      sourceFamily: "apple_pay",
+      evidenceType: "card_hint",
+      scope: "apple_pay:card_hint",
+      value: "visa platinum 1234",
+      processedCaptureId: "pc-6",
+      updatedAt: "2026-04-19T11:20:00.000Z" as IsoDateTime,
+    });
+    saveEvidenceRow("ce-alias-1", {
+      sourceFamily: "nequi",
+      evidenceType: "alias_token",
+      scope: "notification:nequi:alias",
+      value: "debito",
+      processedCaptureId: "pc-7",
+    });
+    saveEvidenceRow("ce-alias-2", {
+      sourceFamily: "nequi",
+      evidenceType: "alias_token",
+      scope: "notification:nequi:alias",
+      value: "debito",
+      processedCaptureId: "pc-8",
+      updatedAt: "2026-04-19T11:30:00.000Z" as IsoDateTime,
+    });
+
+    const service = createAccountSuggestionService();
+    const suggestions = service.listSuggestions({
+      db: db as any,
+      userId: USER_ID,
+      limit: 3,
+    });
+
+    expect(suggestions).toHaveLength(3);
+    expect(suggestions.map((suggestion) => suggestion.scope)).toEqual([
+      "notification:bancolombia:last4",
+      "notification:davivienda:last4",
+      "apple_pay:card_hint",
+    ]);
+  });
+});

--- a/apps/mobile/__tests__/capture-sources/apple-pay-pipeline.test.ts
+++ b/apps/mobile/__tests__/capture-sources/apple-pay-pipeline.test.ts
@@ -33,6 +33,7 @@ const mockBuildApplePayCaptureEvidence = vi.fn().mockReturnValue([
   },
 ]);
 const mockSaveCaptureEvidenceRows = vi.fn();
+const mockFindMatchingFinancialAccountId = vi.fn().mockReturnValue(null);
 
 vi.mock("@/features/transactions/lib/repository", () => ({
   insertTransaction: (...args: any[]) => mockInsertTransaction(...args),
@@ -63,6 +64,10 @@ vi.mock("@/features/capture-sources/lib/repository", () => ({
 
 vi.mock("@/features/financial-accounts", () => ({
   ensureDefaultFinancialAccount: (...args: any[]) => mockEnsureDefaultFinancialAccount(...args),
+}));
+
+vi.mock("@/features/account-suggestions", () => ({
+  findMatchingFinancialAccountId: (...args: any[]) => mockFindMatchingFinancialAccountId(...args),
 }));
 
 vi.mock("@/features/capture-evidence", () => ({
@@ -118,6 +123,7 @@ describe("processApplePayIntent", () => {
         value: "visa *1234",
       },
     ]);
+    mockFindMatchingFinancialAccountId.mockReturnValue(null);
     mockSaveCaptureEvidenceRows.mockResolvedValue(undefined);
   });
 
@@ -225,6 +231,21 @@ describe("processApplePayIntent", () => {
       "farmatodo",
       "health",
       expect.any(String)
+    );
+  });
+
+  it("marks the transaction as inferred when evidence matches a known financial account", async () => {
+    mockFindMatchingFinancialAccountId.mockReturnValueOnce("fa-card-1");
+
+    const result = await processApplePayIntent(mockDb, USER_ID, makeIntent());
+
+    expect(result.saved).toBe(true);
+    expect(mockInsertTransaction).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        accountId: "fa-card-1",
+        accountAttributionState: "inferred",
+      })
     );
   });
 

--- a/apps/mobile/__tests__/capture-sources/notification-pipeline.test.ts
+++ b/apps/mobile/__tests__/capture-sources/notification-pipeline.test.ts
@@ -34,6 +34,7 @@ const mockBuildNotificationCaptureEvidence = vi.fn().mockReturnValue([
   },
 ]);
 const mockSaveCaptureEvidenceRows = vi.fn();
+const mockFindMatchingFinancialAccountId = vi.fn().mockReturnValue(null);
 
 vi.mock("@/features/transactions/lib/repository", () => ({
   insertTransaction: (...args: any[]) => mockInsertTransaction(...args),
@@ -68,6 +69,10 @@ vi.mock("@/features/email-capture/services/parse-email-api", () => ({
 
 vi.mock("@/features/financial-accounts", () => ({
   ensureDefaultFinancialAccount: (...args: any[]) => mockEnsureDefaultFinancialAccount(...args),
+}));
+
+vi.mock("@/features/account-suggestions", () => ({
+  findMatchingFinancialAccountId: (...args: any[]) => mockFindMatchingFinancialAccountId(...args),
 }));
 
 vi.mock("@/features/capture-evidence", () => ({
@@ -127,6 +132,7 @@ describe("processNotification", () => {
         value: "1234",
       },
     ]);
+    mockFindMatchingFinancialAccountId.mockReturnValue(null);
     mockSaveCaptureEvidenceRows.mockResolvedValue(undefined);
   });
 
@@ -253,6 +259,21 @@ describe("processNotification", () => {
     expect(mockInsertTransaction).toHaveBeenCalledWith(
       mockDb,
       expect.objectContaining({ categoryId: "transport" })
+    );
+  });
+
+  it("marks the transaction as inferred when evidence matches a known financial account", async () => {
+    mockFindMatchingFinancialAccountId.mockReturnValueOnce("fa-card-1");
+
+    const result = await processNotification(mockDb, USER_ID, makeNotification());
+
+    expect(result.saved).toBe(true);
+    expect(mockInsertTransaction).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        accountId: "fa-card-1",
+        accountAttributionState: "inferred",
+      })
     );
   });
 

--- a/apps/mobile/__tests__/sync/syncEngine.test.ts
+++ b/apps/mobile/__tests__/sync/syncEngine.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetQueuedSyncEntries = vi.fn().mockReturnValue([]);
 const mockClearSyncEntries = vi.fn();
+const mockGetAccountSuggestionDismissalById = vi.fn().mockReturnValue(null);
 const mockGetTransactionById = vi.fn().mockReturnValue(null);
 const mockGetFinancialAccountById = vi.fn().mockReturnValue(null);
 const mockGetFinancialAccountIdentifierById = vi.fn().mockReturnValue(null);
@@ -18,6 +19,7 @@ const mockGetSyncMeta = vi.fn().mockReturnValue(null);
 const mockSetSyncMeta = vi.fn();
 const mockUpsertTransaction = vi.fn();
 const mockInsertTransaction = vi.fn();
+const mockUpsertAccountSuggestionDismissal = vi.fn();
 const mockUpsertFinancialAccount = vi.fn();
 const mockUpsertFinancialAccountIdentifier = vi.fn();
 const mockUpsertOpeningBalance = vi.fn();
@@ -37,6 +39,13 @@ vi.mock("@/features/transactions/lib/repository", () => ({
   setSyncMeta: (...args: any[]) => mockSetSyncMeta(...args),
   insertTransaction: (...args: any[]) => mockInsertTransaction(...args),
   upsertTransaction: (...args: any[]) => mockUpsertTransaction(...args),
+}));
+
+vi.mock("@/features/account-suggestions", () => ({
+  getAccountSuggestionDismissalById: (...args: any[]) =>
+    mockGetAccountSuggestionDismissalById(...args),
+  upsertAccountSuggestionDismissal: (...args: any[]) =>
+    mockUpsertAccountSuggestionDismissal(...args),
 }));
 
 vi.mock("@/features/financial-accounts", () => ({
@@ -250,6 +259,46 @@ describe("syncEngine", () => {
         })
       );
       expect(mockClearSyncEntries).toHaveBeenCalledWith(mockDb, ["sq-accounts-1"]);
+    });
+
+    it("upserts account suggestion dismissal rows and clears the queue entry on success", async () => {
+      mockGetQueuedSyncEntries.mockReturnValueOnce([
+        {
+          id: "sq-dismissal-1",
+          tableName: "accountSuggestionDismissals",
+          rowId: "asd-1",
+          operation: "insert",
+          createdAt: "2026-04-19T10:00:00.000Z",
+        },
+      ]);
+      mockGetAccountSuggestionDismissalById.mockReturnValueOnce({
+        id: "asd-1",
+        userId: "user-1",
+        scope: "notification:bancolombia:last4",
+        value: "1234",
+        dismissedScore: 200,
+        createdAt: "2026-04-19T10:00:00.000Z",
+        updatedAt: "2026-04-19T10:00:00.000Z",
+        deletedAt: null,
+      });
+      mockUpsert.mockReturnValueOnce({ error: null });
+      const mockSupabase = createMockSupabase();
+
+      const { syncPush } = await import("@/features/sync/services/syncEngine");
+      await syncPush(mockDb, mockSupabase, "user-1");
+
+      expect(mockSupabase.from).toHaveBeenCalledWith("account_suggestion_dismissals");
+      expect(mockUpsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "asd-1",
+          user_id: "user-1",
+          scope: "notification:bancolombia:last4",
+          value: "1234",
+          dismissed_score: 200,
+        }),
+        { onConflict: "user_id,scope,value" }
+      );
+      expect(mockClearSyncEntries).toHaveBeenCalledWith(mockDb, ["sq-dismissal-1"]);
     });
 
     it("upserts transfer rows and clears the queue entry on success", async () => {
@@ -632,6 +681,54 @@ describe("syncEngine", () => {
       expect(JSON.parse(getLastSetSyncMetaValue("last_sync_at_capture_evidence")!)).toEqual({
         updatedAt: "2026-04-18T08:00:00.000Z",
         id: "ce-1",
+      });
+    });
+
+    it("pulls account suggestion dismissals and advances their cursor", async () => {
+      const mockSupabase = createMockSupabase({
+        account_suggestion_dismissals: {
+          data: [
+            {
+              id: "asd-1",
+              user_id: "user-1",
+              scope: "notification:bancolombia:last4",
+              value: "1234",
+              dismissed_score: 200,
+              created_at: "2026-04-19T10:00:00.000Z",
+              updated_at: "2026-04-19T11:00:00.000Z",
+              deleted_at: null,
+            },
+          ],
+          error: null,
+        },
+        capture_evidence: { data: [], error: null },
+        financial_accounts: { data: [], error: null },
+        transfers: { data: [], error: null },
+        opening_balances: { data: [], error: null },
+        financial_account_identifiers: { data: [], error: null },
+        transactions: { data: [], error: null },
+      });
+      mockGetAccountSuggestionDismissalById.mockReturnValueOnce(null);
+
+      const { syncPull } = await import("@/features/sync/services/syncEngine");
+      const result = await syncPull(mockDb, mockSupabase, "user-1");
+
+      expect(result).toBe(true);
+      expect(mockUpsertAccountSuggestionDismissal).toHaveBeenCalledWith(
+        mockDb,
+        expect.objectContaining({
+          id: "asd-1",
+          userId: "user-1",
+          scope: "notification:bancolombia:last4",
+          value: "1234",
+          dismissedScore: 200,
+        })
+      );
+      expect(
+        JSON.parse(getLastSetSyncMetaValue("last_sync_at_account_suggestion_dismissals")!)
+      ).toEqual({
+        updatedAt: "2026-04-19T11:00:00.000Z",
+        id: "asd-1",
       });
     });
 

--- a/apps/mobile/drizzle/0021_account_suggestion_dismissals.sql
+++ b/apps/mobile/drizzle/0021_account_suggestion_dismissals.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `account_suggestion_dismissals` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`scope` text NOT NULL,
+	`value` text NOT NULL,
+	`dismissed_score` integer NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	`deleted_at` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_account_suggestion_dismissals_scope` ON `account_suggestion_dismissals` (`user_id`,`scope`,`value`) WHERE `deleted_at` IS NULL;
+--> statement-breakpoint
+CREATE INDEX `idx_account_suggestion_dismissals_user_updated` ON `account_suggestion_dismissals` (`user_id`,`updated_at`);

--- a/apps/mobile/drizzle/meta/_journal.json
+++ b/apps/mobile/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1776593600000,
       "tag": "0020_tidy_husk",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1776600000000,
+      "tag": "0021_account_suggestion_dismissals",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/mobile/drizzle/migrations.js
+++ b/apps/mobile/drizzle/migrations.js
@@ -20,6 +20,7 @@ import m0017 from "./0017_nostalgic_blade.sql";
 import m0018 from "./0018_notification_dedup_partial.sql";
 import m0019 from "./0019_watery_leopardon.sql";
 import m0020 from "./0020_tidy_husk.sql";
+import m0021 from "./0021_account_suggestion_dismissals.sql";
 import journal from "./meta/_journal.json";
 
 export default {
@@ -46,5 +47,6 @@ export default {
     m0018,
     m0019,
     m0020,
+    m0021,
   },
 };

--- a/apps/mobile/features/account-suggestions/index.ts
+++ b/apps/mobile/features/account-suggestions/index.ts
@@ -1,0 +1,18 @@
+export {
+  type AccountCreationSuggestion,
+  createAccountSuggestionFingerprint,
+  deriveAccountSuggestions,
+} from "./lib/derive-account-suggestions";
+export {
+  type AccountSuggestionDismissalRow,
+  getAccountSuggestionDismissalById,
+  getAccountSuggestionDismissalsForUser,
+  getActiveAccountSuggestionDismissal,
+  saveAccountSuggestionDismissal,
+  upsertAccountSuggestionDismissal,
+} from "./lib/dismissals-repository";
+export {
+  findMatchingFinancialAccountId,
+  matchFinancialAccountId,
+} from "./lib/match-financial-account";
+export { createAccountSuggestionService } from "./services/create-account-suggestion-service";

--- a/apps/mobile/features/account-suggestions/lib/derive-account-suggestions.ts
+++ b/apps/mobile/features/account-suggestions/lib/derive-account-suggestions.ts
@@ -1,0 +1,68 @@
+import type { CaptureEvidenceType } from "@/features/capture-evidence";
+
+type RepeatedCaptureEvidence = {
+  readonly scope: string;
+  readonly value: string;
+  readonly sourceFamily: string;
+  readonly evidenceType: string;
+  readonly occurrences: number;
+};
+
+type SuggestionEvidenceType = Extract<CaptureEvidenceType, "alias_token" | "card_hint" | "last4">;
+
+export type AccountCreationSuggestion = {
+  readonly fingerprint: string;
+  readonly scope: string;
+  readonly value: string;
+  readonly sourceFamily: string;
+  readonly evidenceType: SuggestionEvidenceType;
+  readonly occurrences: number;
+  readonly confidenceScore: number;
+};
+
+function isSuggestionEvidenceType(value: string): value is SuggestionEvidenceType {
+  return value === "last4" || value === "card_hint" || value === "alias_token";
+}
+
+export function createAccountSuggestionFingerprint(scope: string, value: string) {
+  return JSON.stringify([scope, value]);
+}
+
+function toConfidenceScore(evidenceType: SuggestionEvidenceType, occurrences: number) {
+  const baseScore = evidenceType === "last4" ? 100 : evidenceType === "card_hint" ? 80 : 60;
+
+  return baseScore * occurrences;
+}
+
+function compareSuggestions(left: AccountCreationSuggestion, right: AccountCreationSuggestion) {
+  return (
+    right.confidenceScore - left.confidenceScore ||
+    right.occurrences - left.occurrences ||
+    left.scope.localeCompare(right.scope) ||
+    left.value.localeCompare(right.value)
+  );
+}
+
+export function deriveAccountSuggestions(
+  rows: readonly RepeatedCaptureEvidence[]
+): readonly AccountCreationSuggestion[] {
+  const suggestionRows = Array.from(rows).filter(
+    (
+      row
+    ): row is RepeatedCaptureEvidence & {
+      readonly evidenceType: SuggestionEvidenceType;
+    } => isSuggestionEvidenceType(row.evidenceType)
+  );
+
+  return suggestionRows
+    .map((row) => ({
+      fingerprint: createAccountSuggestionFingerprint(row.scope, row.value),
+      scope: row.scope,
+      value: row.value,
+      sourceFamily: row.sourceFamily,
+      evidenceType: row.evidenceType,
+      occurrences: row.occurrences,
+      confidenceScore: toConfidenceScore(row.evidenceType, row.occurrences),
+    }))
+    .sort(compareSuggestions);
+}

--- a/apps/mobile/features/account-suggestions/lib/dismissals-repository.ts
+++ b/apps/mobile/features/account-suggestions/lib/dismissals-repository.ts
@@ -1,0 +1,142 @@
+import { and, eq, isNull } from "drizzle-orm";
+import { type AnyDb, accountSuggestionDismissals, enqueueSync, syncQueue } from "@/shared/db";
+import { generateSyncQueueId } from "@/shared/lib";
+
+export type AccountSuggestionDismissalRow = typeof accountSuggestionDismissals.$inferInsert;
+
+export function getAccountSuggestionDismissalById(
+  db: AnyDb,
+  id: AccountSuggestionDismissalRow["id"]
+) {
+  const rows = db
+    .select()
+    .from(accountSuggestionDismissals)
+    .where(eq(accountSuggestionDismissals.id, id))
+    .all();
+  return rows[0] ?? null;
+}
+
+export function getAccountSuggestionDismissalsForUser(
+  db: AnyDb,
+  userId: AccountSuggestionDismissalRow["userId"]
+) {
+  return db
+    .select()
+    .from(accountSuggestionDismissals)
+    .where(
+      and(
+        eq(accountSuggestionDismissals.userId, userId),
+        isNull(accountSuggestionDismissals.deletedAt)
+      )
+    )
+    .all();
+}
+
+export function getActiveAccountSuggestionDismissal(
+  db: AnyDb,
+  userId: AccountSuggestionDismissalRow["userId"],
+  scope: AccountSuggestionDismissalRow["scope"],
+  value: AccountSuggestionDismissalRow["value"]
+) {
+  const rows = db
+    .select()
+    .from(accountSuggestionDismissals)
+    .where(
+      and(
+        eq(accountSuggestionDismissals.userId, userId),
+        eq(accountSuggestionDismissals.scope, scope),
+        eq(accountSuggestionDismissals.value, value),
+        isNull(accountSuggestionDismissals.deletedAt)
+      )
+    )
+    .all();
+  return rows[0] ?? null;
+}
+
+function deleteDismissalDuplicate(db: AnyDb, duplicateId: AccountSuggestionDismissalRow["id"]) {
+  db.delete(syncQueue)
+    .where(
+      and(eq(syncQueue.tableName, "accountSuggestionDismissals"), eq(syncQueue.rowId, duplicateId))
+    )
+    .run();
+  db.delete(accountSuggestionDismissals)
+    .where(eq(accountSuggestionDismissals.id, duplicateId))
+    .run();
+}
+
+function persistAccountSuggestionDismissal(db: AnyDb, row: AccountSuggestionDismissalRow) {
+  db.insert(accountSuggestionDismissals)
+    .values(row)
+    .onConflictDoUpdate({
+      target: accountSuggestionDismissals.id,
+      set: {
+        userId: row.userId,
+        scope: row.scope,
+        value: row.value,
+        dismissedScore: row.dismissedScore,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+        deletedAt: row.deletedAt,
+      },
+    })
+    .run();
+}
+
+export function upsertAccountSuggestionDismissal(db: AnyDb, row: AccountSuggestionDismissalRow) {
+  db.transaction((tx) => {
+    const existingById = getAccountSuggestionDismissalById(tx, row.id);
+    const activeDuplicate =
+      row.deletedAt == null
+        ? getActiveAccountSuggestionDismissal(tx, row.userId, row.scope, row.value)
+        : null;
+    const duplicate = activeDuplicate?.id !== row.id ? activeDuplicate : null;
+
+    if (existingById && existingById.updatedAt >= row.updatedAt) {
+      return;
+    }
+
+    if (duplicate && duplicate.updatedAt >= row.updatedAt) {
+      return;
+    }
+
+    if (duplicate) {
+      deleteDismissalDuplicate(tx, duplicate.id);
+    }
+
+    persistAccountSuggestionDismissal(tx, row);
+  });
+}
+
+export function saveAccountSuggestionDismissal(db: AnyDb, row: AccountSuggestionDismissalRow) {
+  db.transaction((tx) => {
+    const existingById = getAccountSuggestionDismissalById(tx, row.id);
+    const activeDuplicate =
+      row.deletedAt == null
+        ? getActiveAccountSuggestionDismissal(tx, row.userId, row.scope, row.value)
+        : null;
+    const duplicate = activeDuplicate?.id !== row.id ? activeDuplicate : null;
+
+    if (existingById && duplicate) {
+      deleteDismissalDuplicate(tx, duplicate.id);
+    }
+
+    const persistedRow =
+      existingById == null && duplicate
+        ? {
+            ...row,
+            id: duplicate.id,
+            createdAt: duplicate.createdAt,
+          }
+        : row;
+
+    persistAccountSuggestionDismissal(tx, persistedRow);
+
+    enqueueSync(tx, {
+      id: generateSyncQueueId(),
+      tableName: "accountSuggestionDismissals",
+      rowId: persistedRow.id,
+      operation: existingById || duplicate ? "update" : "insert",
+      createdAt: row.updatedAt,
+    });
+  });
+}

--- a/apps/mobile/features/account-suggestions/lib/match-financial-account.ts
+++ b/apps/mobile/features/account-suggestions/lib/match-financial-account.ts
@@ -1,7 +1,9 @@
 import type { CaptureEvidenceSeed } from "@/features/capture-evidence";
 import {
   type FinancialAccountIdentifierRow,
+  type FinancialAccountRow,
   getFinancialAccountIdentifiersForUser,
+  getFinancialAccountsForUser,
 } from "@/features/financial-accounts";
 import type { AnyDb } from "@/shared/db";
 import type { FinancialAccountId, UserId } from "@/shared/types/branded";
@@ -25,10 +27,25 @@ export function matchFinancialAccountId(
   return matchedAccountIds.length === 1 ? (matchedAccountIds[0] ?? null) : null;
 }
 
+function filterIdentifiersForActiveAccounts(
+  identifiers: readonly Pick<FinancialAccountIdentifierRow, "accountId" | "scope" | "value">[],
+  accounts: readonly Pick<FinancialAccountRow, "id">[]
+) {
+  const activeAccountIds = new Set(accounts.map((account) => account.id));
+
+  return identifiers.filter((identifier) => activeAccountIds.has(identifier.accountId));
+}
+
 export function findMatchingFinancialAccountId(
   db: AnyDb,
   userId: UserId,
   evidence: readonly MatchableEvidence[]
 ) {
-  return matchFinancialAccountId(getFinancialAccountIdentifiersForUser(db, userId), evidence);
+  return matchFinancialAccountId(
+    filterIdentifiersForActiveAccounts(
+      getFinancialAccountIdentifiersForUser(db, userId),
+      getFinancialAccountsForUser(db, userId)
+    ),
+    evidence
+  );
 }

--- a/apps/mobile/features/account-suggestions/lib/match-financial-account.ts
+++ b/apps/mobile/features/account-suggestions/lib/match-financial-account.ts
@@ -1,0 +1,34 @@
+import type { CaptureEvidenceSeed } from "@/features/capture-evidence";
+import {
+  type FinancialAccountIdentifierRow,
+  getFinancialAccountIdentifiersForUser,
+} from "@/features/financial-accounts";
+import type { AnyDb } from "@/shared/db";
+import type { FinancialAccountId, UserId } from "@/shared/types/branded";
+
+type MatchableEvidence = Pick<CaptureEvidenceSeed, "scope" | "value">;
+
+export function matchFinancialAccountId(
+  identifiers: readonly Pick<FinancialAccountIdentifierRow, "accountId" | "scope" | "value">[],
+  evidence: readonly MatchableEvidence[]
+): FinancialAccountId | null {
+  const matchedAccountIds = Array.from(
+    new Set(
+      evidence.flatMap((row) =>
+        identifiers
+          .filter((identifier) => identifier.scope === row.scope && identifier.value === row.value)
+          .map((identifier) => identifier.accountId)
+      )
+    )
+  );
+
+  return matchedAccountIds.length === 1 ? (matchedAccountIds[0] ?? null) : null;
+}
+
+export function findMatchingFinancialAccountId(
+  db: AnyDb,
+  userId: UserId,
+  evidence: readonly MatchableEvidence[]
+) {
+  return matchFinancialAccountId(getFinancialAccountIdentifiersForUser(db, userId), evidence);
+}

--- a/apps/mobile/features/account-suggestions/services/create-account-suggestion-service.ts
+++ b/apps/mobile/features/account-suggestions/services/create-account-suggestion-service.ts
@@ -1,0 +1,236 @@
+import {
+  getCaptureEvidenceRowsForScopeValue,
+  getRepeatedCaptureEvidenceForUser,
+} from "@/features/capture-evidence";
+import {
+  type FinancialAccountIdentifierRow,
+  getFinancialAccountIdentifiersForUser,
+  saveFinancialAccountIdentifier,
+} from "@/features/financial-accounts";
+import { getTransactionById, upsertTransaction } from "@/features/transactions/lib/repository";
+import type { AnyDb } from "@/shared/db";
+import { enqueueSync } from "@/shared/db";
+import {
+  generateAccountSuggestionDismissalId,
+  generateFinancialAccountIdentifierId,
+  generateSyncQueueId,
+  toIsoDateTime,
+} from "@/shared/lib";
+import type {
+  AccountSuggestionDismissalId,
+  FinancialAccountId,
+  FinancialAccountIdentifierId,
+  IsoDateTime,
+  TransactionId,
+  UserId,
+} from "@/shared/types/branded";
+import {
+  type AccountCreationSuggestion,
+  createAccountSuggestionFingerprint,
+  deriveAccountSuggestions,
+} from "../lib/derive-account-suggestions";
+import {
+  type AccountSuggestionDismissalRow,
+  getAccountSuggestionDismissalsForUser,
+  saveAccountSuggestionDismissal,
+} from "../lib/dismissals-repository";
+
+type CreateAccountSuggestionServiceDeps = {
+  readonly getRepeatedCaptureEvidenceForUser?: typeof getRepeatedCaptureEvidenceForUser;
+  readonly getCaptureEvidenceRowsForScopeValue?: typeof getCaptureEvidenceRowsForScopeValue;
+  readonly getAccountSuggestionDismissalsForUser?: typeof getAccountSuggestionDismissalsForUser;
+  readonly saveAccountSuggestionDismissal?: typeof saveAccountSuggestionDismissal;
+  readonly getFinancialAccountIdentifiersForUser?: typeof getFinancialAccountIdentifiersForUser;
+  readonly saveFinancialAccountIdentifier?: typeof saveFinancialAccountIdentifier;
+  readonly getTransactionById?: typeof getTransactionById;
+  readonly upsertTransaction?: typeof upsertTransaction;
+  readonly enqueueSync?: typeof enqueueSync;
+  readonly now?: () => IsoDateTime;
+  readonly createDismissalId?: () => AccountSuggestionDismissalId;
+  readonly createIdentifierId?: () => FinancialAccountIdentifierId;
+};
+
+type ListSuggestionsInput = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly limit?: number;
+  readonly minimumOccurrences?: number;
+};
+
+type DismissSuggestionInput = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly suggestion: AccountCreationSuggestion;
+};
+
+type AcceptSuggestionInput = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly accountId: FinancialAccountId;
+  readonly suggestion: AccountCreationSuggestion;
+};
+
+type AcceptSuggestionResult = {
+  readonly accountId: FinancialAccountId;
+  readonly identifierScope: string;
+  readonly identifierValue: string;
+  readonly reprocessedTransactionIds: readonly TransactionId[];
+};
+
+function applyLimit<T>(rows: readonly T[], limit: number | undefined) {
+  return typeof limit === "number" ? rows.slice(0, limit) : rows;
+}
+
+function filterAlreadyLinkedSuggestions(
+  suggestions: readonly AccountCreationSuggestion[],
+  identifiers: readonly FinancialAccountIdentifierRow[]
+) {
+  const linkedFingerprints = new Set(
+    identifiers.map((row) => createAccountSuggestionFingerprint(row.scope, row.value))
+  );
+
+  return suggestions.filter((suggestion) => !linkedFingerprints.has(suggestion.fingerprint));
+}
+
+function filterDismissedSuggestions(
+  suggestions: readonly AccountCreationSuggestion[],
+  dismissals: readonly AccountSuggestionDismissalRow[]
+) {
+  const dismissalScoreByFingerprint = new Map(
+    dismissals.map((row) => [
+      createAccountSuggestionFingerprint(row.scope, row.value),
+      row.dismissedScore,
+    ])
+  );
+
+  return suggestions.filter((suggestion) => {
+    const dismissedScore = dismissalScoreByFingerprint.get(suggestion.fingerprint);
+    return dismissedScore == null || suggestion.confidenceScore > dismissedScore;
+  });
+}
+
+export function createAccountSuggestionService({
+  getRepeatedCaptureEvidenceForUser:
+    loadRepeatedCaptureEvidenceForUser = getRepeatedCaptureEvidenceForUser,
+  getCaptureEvidenceRowsForScopeValue:
+    loadCaptureEvidenceRowsForScopeValue = getCaptureEvidenceRowsForScopeValue,
+  getAccountSuggestionDismissalsForUser:
+    loadAccountSuggestionDismissalsForUser = getAccountSuggestionDismissalsForUser,
+  saveAccountSuggestionDismissal:
+    persistAccountSuggestionDismissal = saveAccountSuggestionDismissal,
+  getFinancialAccountIdentifiersForUser:
+    loadFinancialAccountIdentifiersForUser = getFinancialAccountIdentifiersForUser,
+  saveFinancialAccountIdentifier:
+    persistFinancialAccountIdentifier = saveFinancialAccountIdentifier,
+  getTransactionById: loadTransactionById = getTransactionById,
+  upsertTransaction: persistTransaction = upsertTransaction,
+  enqueueSync: enqueueSyncEntry = enqueueSync,
+  now = () => toIsoDateTime(new Date()),
+  createDismissalId = generateAccountSuggestionDismissalId,
+  createIdentifierId = generateFinancialAccountIdentifierId,
+}: CreateAccountSuggestionServiceDeps = {}) {
+  return {
+    listSuggestions({
+      db,
+      userId,
+      limit,
+      minimumOccurrences = 2,
+    }: ListSuggestionsInput): readonly AccountCreationSuggestion[] {
+      return applyLimit(
+        filterDismissedSuggestions(
+          filterAlreadyLinkedSuggestions(
+            deriveAccountSuggestions(
+              loadRepeatedCaptureEvidenceForUser(db, userId, minimumOccurrences)
+            ),
+            loadFinancialAccountIdentifiersForUser(db, userId)
+          ),
+          loadAccountSuggestionDismissalsForUser(db, userId)
+        ),
+        limit
+      );
+    },
+
+    dismissSuggestion({ db, userId, suggestion }: DismissSuggestionInput) {
+      const existingDismissal = loadAccountSuggestionDismissalsForUser(db, userId).find(
+        (row) => row.scope === suggestion.scope && row.value === suggestion.value
+      );
+      const updatedAt = now();
+
+      persistAccountSuggestionDismissal(db, {
+        id: existingDismissal?.id ?? createDismissalId(),
+        userId,
+        scope: suggestion.scope,
+        value: suggestion.value,
+        dismissedScore: suggestion.confidenceScore,
+        createdAt: existingDismissal?.createdAt ?? updatedAt,
+        updatedAt,
+        deletedAt: null,
+      });
+    },
+
+    acceptSuggestion({
+      db,
+      userId,
+      accountId,
+      suggestion,
+    }: AcceptSuggestionInput): AcceptSuggestionResult {
+      const updatedAt = now();
+
+      persistFinancialAccountIdentifier(db, {
+        id: createIdentifierId(),
+        userId,
+        accountId,
+        scope: suggestion.scope,
+        value: suggestion.value,
+        createdAt: updatedAt,
+        updatedAt,
+        deletedAt: null,
+      });
+
+      const reprocessedTransactionIds = Array.from(
+        new Set(
+          loadCaptureEvidenceRowsForScopeValue(db, userId, suggestion.scope, suggestion.value)
+            .map((row) => row.transactionId)
+            .filter((transactionId): transactionId is TransactionId => transactionId != null)
+            .filter((transactionId) => {
+              const transaction = loadTransactionById(db, transactionId);
+              return (
+                transaction?.userId === userId &&
+                transaction.deletedAt == null &&
+                transaction.accountAttributionState === "unresolved"
+              );
+            })
+        )
+      );
+
+      reprocessedTransactionIds.forEach((transactionId) => {
+        const transaction = loadTransactionById(db, transactionId);
+        if (!transaction) {
+          return;
+        }
+
+        persistTransaction(db, {
+          ...transaction,
+          accountId,
+          accountAttributionState: "inferred",
+          updatedAt,
+        });
+
+        enqueueSyncEntry(db, {
+          id: generateSyncQueueId(),
+          tableName: "transactions",
+          rowId: transactionId,
+          operation: "update",
+          createdAt: updatedAt,
+        });
+      });
+
+      return {
+        accountId,
+        identifierScope: suggestion.scope,
+        identifierValue: suggestion.value,
+        reprocessedTransactionIds,
+      };
+    },
+  };
+}

--- a/apps/mobile/features/capture-evidence/index.ts
+++ b/apps/mobile/features/capture-evidence/index.ts
@@ -7,6 +7,7 @@ export type { CaptureEvidenceRow } from "./lib/repository";
 export {
   countCaptureEvidenceOccurrences,
   getCaptureEvidenceById,
+  getCaptureEvidenceRowsForScopeValue,
   getRepeatedCaptureEvidenceForUser,
   linkCaptureEvidenceToTransaction,
   materializeCaptureEvidenceRows,

--- a/apps/mobile/features/capture-evidence/lib/repository.ts
+++ b/apps/mobile/features/capture-evidence/lib/repository.ts
@@ -158,6 +158,27 @@ export function countCaptureEvidenceOccurrences(
   return rows[0]?.total ?? 0;
 }
 
+export function getCaptureEvidenceRowsForScopeValue(
+  db: AnyDb,
+  userId: CaptureEvidenceRow["userId"],
+  scope: CaptureEvidenceRow["scope"],
+  value: CaptureEvidenceRow["value"]
+) {
+  return db
+    .select()
+    .from(captureEvidence)
+    .where(
+      and(
+        eq(captureEvidence.userId, userId),
+        eq(captureEvidence.scope, scope),
+        eq(captureEvidence.value, value),
+        isNull(captureEvidence.deletedAt)
+      )
+    )
+    .orderBy(desc(captureEvidence.updatedAt), captureEvidence.id)
+    .all();
+}
+
 export function getRepeatedCaptureEvidenceForUser(
   db: AnyDb,
   userId: CaptureEvidenceRow["userId"],

--- a/apps/mobile/features/capture-sources/services/apple-pay-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/apple-pay-pipeline.ts
@@ -1,3 +1,4 @@
+import { findMatchingFinancialAccountId } from "@/features/account-suggestions";
 import {
   buildApplePayCaptureEvidence,
   materializeCaptureEvidenceRows,
@@ -42,6 +43,7 @@ export async function processApplePayIntent(
   intent: ApplePayIntentData
 ): Promise<ApplePayPipelineResult> {
   assertUserId(userId);
+  const captureEvidence = buildApplePayCaptureEvidence(intent);
   const amount = Math.round(intent.amount);
   assertCopAmount(amount);
   const today = toIsoDate(new Date());
@@ -82,7 +84,7 @@ export async function processApplePayIntent(
       });
       await saveCaptureEvidenceRows(
         db,
-        materializeCaptureEvidenceRows(buildApplePayCaptureEvidence(intent), {
+        materializeCaptureEvidenceRows(captureEvidence, {
           userId,
           transactionId: existingTxId,
           processedEmailId: null,
@@ -111,6 +113,7 @@ export async function processApplePayIntent(
     const txId = generateTransactionId();
     const now = toIsoDateTime(new Date());
     const defaultAccount = ensureDefaultFinancialAccount(db, userId, { now });
+    const matchedAccountId = findMatchingFinancialAccountId(db, userId, captureEvidence);
 
     insertTransaction(db, {
       id: txId,
@@ -120,8 +123,8 @@ export async function processApplePayIntent(
       categoryId,
       description: intent.merchant,
       date: today,
-      accountId: defaultAccount.id,
-      accountAttributionState: "unresolved",
+      accountId: matchedAccountId ?? defaultAccount.id,
+      accountAttributionState: matchedAccountId ? "inferred" : "unresolved",
       source,
       createdAt: now,
       updatedAt: now,
@@ -150,7 +153,7 @@ export async function processApplePayIntent(
     });
     await saveCaptureEvidenceRows(
       db,
-      materializeCaptureEvidenceRows(buildApplePayCaptureEvidence(intent), {
+      materializeCaptureEvidenceRows(captureEvidence, {
         userId,
         transactionId: txId,
         processedEmailId: null,

--- a/apps/mobile/features/capture-sources/services/notification-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/notification-pipeline.ts
@@ -1,3 +1,4 @@
+import { findMatchingFinancialAccountId } from "@/features/account-suggestions";
 import {
   buildNotificationCaptureEvidence,
   materializeCaptureEvidenceRows,
@@ -46,6 +47,7 @@ export async function processNotification(
   notification: NotificationData
 ): Promise<NotificationPipelineResult> {
   assertUserId(userId);
+  const captureEvidence = buildNotificationCaptureEvidence(notification);
   const notificationText = notification.bigText ?? notification.text;
   const sanitizedText = stripPii(notificationText).slice(0, 500);
   const receivedAt = toIsoDateTime(new Date(notification.timestamp));
@@ -89,7 +91,7 @@ export async function processNotification(
     });
     await saveCaptureEvidenceRows(
       db,
-      materializeCaptureEvidenceRows(buildNotificationCaptureEvidence(notification), {
+      materializeCaptureEvidenceRows(captureEvidence, {
         userId,
         transactionId: null,
         processedEmailId: null,
@@ -169,7 +171,7 @@ export async function processNotification(
       });
       await saveCaptureEvidenceRows(
         db,
-        materializeCaptureEvidenceRows(buildNotificationCaptureEvidence(notification), {
+        materializeCaptureEvidenceRows(captureEvidence, {
           userId,
           transactionId: existingTxId,
           processedEmailId: null,
@@ -203,6 +205,7 @@ export async function processNotification(
     const txId = generateTransactionId();
     const now = toIsoDateTime(new Date());
     const defaultAccount = ensureDefaultFinancialAccount(db, userId, { now });
+    const matchedAccountId = findMatchingFinancialAccountId(db, userId, captureEvidence);
 
     insertTransaction(db, {
       id: txId,
@@ -212,8 +215,8 @@ export async function processNotification(
       categoryId: finalCategoryId,
       description: parsed.merchant,
       date: parsed.date,
-      accountId: defaultAccount.id,
-      accountAttributionState: "unresolved",
+      accountId: matchedAccountId ?? defaultAccount.id,
+      accountAttributionState: matchedAccountId ? "inferred" : "unresolved",
       source,
       createdAt: now,
       updatedAt: now,
@@ -242,7 +245,7 @@ export async function processNotification(
     });
     await saveCaptureEvidenceRows(
       db,
-      materializeCaptureEvidenceRows(buildNotificationCaptureEvidence(notification), {
+      materializeCaptureEvidenceRows(captureEvidence, {
         userId,
         transactionId: txId,
         processedEmailId: null,

--- a/apps/mobile/features/financial-accounts/index.ts
+++ b/apps/mobile/features/financial-accounts/index.ts
@@ -3,6 +3,7 @@ export {
   type FinancialAccountIdentifierRow,
   getFinancialAccountIdentifierById,
   getFinancialAccountIdentifiersForAccount,
+  getFinancialAccountIdentifiersForUser,
   saveFinancialAccountIdentifier,
   upsertFinancialAccountIdentifier,
 } from "./lib/identifiers-repository";

--- a/apps/mobile/features/financial-accounts/lib/identifiers-repository.ts
+++ b/apps/mobile/features/financial-accounts/lib/identifiers-repository.ts
@@ -32,6 +32,22 @@ export function getFinancialAccountIdentifiersForAccount(
     .all();
 }
 
+export function getFinancialAccountIdentifiersForUser(
+  db: AnyDb,
+  userId: FinancialAccountIdentifierRow["userId"]
+) {
+  return db
+    .select()
+    .from(financialAccountIdentifiers)
+    .where(
+      and(
+        eq(financialAccountIdentifiers.userId, userId),
+        isNull(financialAccountIdentifiers.deletedAt)
+      )
+    )
+    .all();
+}
+
 function findActiveFinancialAccountIdentifierByUniqueKey(
   db: AnyDb,
   row: FinancialAccountIdentifierRow

--- a/apps/mobile/features/sync/services/syncEngine.ts
+++ b/apps/mobile/features/sync/services/syncEngine.ts
@@ -1,5 +1,10 @@
 // biome-ignore-all lint/style/useNamingConvention: snake_case matches Supabase Postgres column names
+
 import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  getAccountSuggestionDismissalById,
+  upsertAccountSuggestionDismissal,
+} from "@/features/account-suggestions";
 import { getBudgetById } from "@/features/budget";
 import { getCaptureEvidenceById, upsertCaptureEvidence } from "@/features/capture-evidence";
 import {
@@ -37,6 +42,7 @@ import { insertConflict } from "../lib/conflict-repository";
 const LEGACY_LAST_SYNC_AT = "last_sync_at";
 const LAST_SYNC_AT_BY_TABLE = {
   transactions: "last_sync_at_transactions",
+  account_suggestion_dismissals: "last_sync_at_account_suggestion_dismissals",
   capture_evidence: "last_sync_at_capture_evidence",
   financial_accounts: "last_sync_at_financial_accounts",
   transfers: "last_sync_at_transfers",
@@ -119,6 +125,17 @@ type SupabaseCaptureEvidenceRow = {
   transaction_id: string | null;
   processed_email_id: string | null;
   processed_capture_id: string | null;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+};
+
+type SupabaseAccountSuggestionDismissalRow = {
+  id: string;
+  user_id: string;
+  scope: string;
+  value: string;
+  dismissed_score: number;
   created_at: string;
   updated_at: string;
   deleted_at: string | null;
@@ -257,6 +274,21 @@ function fromSupabaseCaptureEvidenceRow(
     updatedAt: row.updated_at,
     deletedAt: row.deleted_at,
   } as Parameters<typeof upsertCaptureEvidence>[1];
+}
+
+function fromSupabaseAccountSuggestionDismissalRow(
+  row: SupabaseAccountSuggestionDismissalRow
+): Parameters<typeof upsertAccountSuggestionDismissal>[1] {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    scope: row.scope,
+    value: row.value,
+    dismissedScore: row.dismissed_score,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    deletedAt: row.deleted_at,
+  } as Parameters<typeof upsertAccountSuggestionDismissal>[1];
 }
 
 type PullTableName = keyof typeof LAST_SYNC_AT_BY_TABLE;
@@ -602,6 +634,32 @@ async function processCaptureEvidenceEntry(
   return !error;
 }
 
+async function processAccountSuggestionDismissalEntry(
+  db: AnyDb,
+  supabase: SupabaseClient,
+  rowId: string
+): Promise<boolean> {
+  const row = getAccountSuggestionDismissalById(
+    db,
+    rowId as Parameters<typeof getAccountSuggestionDismissalById>[1]
+  );
+  if (!row) return true;
+  const { error } = await supabase.from("account_suggestion_dismissals").upsert(
+    {
+      id: row.id,
+      user_id: row.userId,
+      scope: row.scope,
+      value: row.value,
+      dismissed_score: row.dismissedScore,
+      created_at: row.createdAt,
+      updated_at: row.updatedAt,
+      deleted_at: row.deletedAt,
+    },
+    { onConflict: "user_id,scope,value" }
+  );
+  return !error;
+}
+
 async function processContributionEntry(
   db: AnyDb,
   supabase: SupabaseClient,
@@ -651,6 +709,14 @@ async function processEntry(
   if (entry.tableName === "financialAccounts") {
     const ok = await processFinancialAccountEntry(db, supabase, entry.rowId);
     if (!ok) captureWarning("sync_push_entry_failed", { tableName: "financialAccounts" });
+    return ok ? entry.id : null;
+  }
+
+  if (entry.tableName === "accountSuggestionDismissals") {
+    const ok = await processAccountSuggestionDismissalEntry(db, supabase, entry.rowId);
+    if (!ok) {
+      captureWarning("sync_push_entry_failed", { tableName: "accountSuggestionDismissals" });
+    }
     return ok ? entry.id : null;
   }
 
@@ -730,6 +796,7 @@ export async function syncPull(
   userId: string
 ): Promise<boolean> {
   const [
+    accountSuggestionDismissalsCursor,
     captureEvidenceCursor,
     financialAccountsCursor,
     transfersCursor,
@@ -737,6 +804,7 @@ export async function syncPull(
     financialAccountIdentifiersCursor,
     transactionsCursor,
   ] = await Promise.all([
+    getPullCursor(db, "account_suggestion_dismissals"),
     getPullCursor(db, "capture_evidence"),
     getPullCursor(db, "financial_accounts"),
     getPullCursor(db, "transfers"),
@@ -745,6 +813,7 @@ export async function syncPull(
     getPullCursor(db, "transactions"),
   ]);
   const [
+    accountSuggestionDismissalsFetchResult,
     captureEvidenceFetchResult,
     financialAccountsFetchResult,
     transfersFetchResult,
@@ -752,6 +821,12 @@ export async function syncPull(
     financialAccountIdentifiersFetchResult,
     transactionsFetchResult,
   ] = await Promise.allSettled([
+    fetchPullRows<SupabaseAccountSuggestionDismissalRow>(
+      supabase,
+      userId,
+      "account_suggestion_dismissals",
+      accountSuggestionDismissalsCursor
+    ),
     fetchPullRows<SupabaseCaptureEvidenceRow>(
       supabase,
       userId,
@@ -781,6 +856,7 @@ export async function syncPull(
   ]);
 
   const [
+    accountSuggestionDismissalsResult,
     captureEvidenceResult,
     financialAccountsResult,
     transfersResult,
@@ -788,6 +864,7 @@ export async function syncPull(
     financialAccountIdentifiersResult,
     transactionsResult,
   ] = [
+    toPullFetchOutcome("account_suggestion_dismissals", accountSuggestionDismissalsFetchResult),
     toPullFetchOutcome("capture_evidence", captureEvidenceFetchResult),
     toPullFetchOutcome("financial_accounts", financialAccountsFetchResult),
     toPullFetchOutcome("transfers", transfersFetchResult),
@@ -797,6 +874,7 @@ export async function syncPull(
   ];
 
   const failedFetches = [
+    accountSuggestionDismissalsResult,
     captureEvidenceResult,
     financialAccountsResult,
     transfersResult,
@@ -813,6 +891,7 @@ export async function syncPull(
     });
   }
 
+  const accountSuggestionDismissalRows = accountSuggestionDismissalsResult.rows;
   const financialAccountRows = financialAccountsResult.rows;
   const captureEvidenceRows = captureEvidenceResult.rows;
   const transferRows = transfersResult.rows;
@@ -820,6 +899,7 @@ export async function syncPull(
   const financialAccountIdentifierRows = financialAccountIdentifiersResult.rows;
   const transactionRows = transactionsResult.rows;
   const allUpdatedAts = [
+    ...accountSuggestionDismissalRows.map((row) => row.updated_at),
     ...captureEvidenceRows.map((row) => row.updated_at),
     ...financialAccountRows.map((row) => row.updated_at),
     ...transferRows.map((row) => row.updated_at),
@@ -830,6 +910,16 @@ export async function syncPull(
   // FP exemption: each row may depend on prior upserts for conflict detection.
   let failedCount = 0;
   let conflictCount = 0;
+  const accountSuggestionDismissalsOutcome = applyServerRows(db, accountSuggestionDismissalRows, {
+    getLocalRow: (database, rowId) =>
+      getAccountSuggestionDismissalById(
+        database,
+        rowId as Parameters<typeof getAccountSuggestionDismissalById>[1]
+      ),
+    upsertLocalRow: upsertAccountSuggestionDismissal,
+    mapServerRow: fromSupabaseAccountSuggestionDismissalRow,
+  });
+  failedCount += accountSuggestionDismissalsOutcome.failedCount;
   const captureEvidenceOutcome = applyServerRows(db, captureEvidenceRows, {
     getLocalRow: (database, rowId) =>
       getCaptureEvidenceById(database, rowId as Parameters<typeof getCaptureEvidenceById>[1]),
@@ -935,6 +1025,11 @@ export async function syncPull(
   });
 
   await Promise.all([
+    advancePullCursor(
+      db,
+      "account_suggestion_dismissals",
+      accountSuggestionDismissalsOutcome.safeCursor
+    ),
     advancePullCursor(db, "capture_evidence", captureEvidenceOutcome.safeCursor),
     advancePullCursor(db, "financial_accounts", financialAccountsOutcome.safeCursor),
     advancePullCursor(db, "transfers", transfersOutcome.safeCursor),

--- a/apps/mobile/shared/db/enqueue-sync.ts
+++ b/apps/mobile/shared/db/enqueue-sync.ts
@@ -5,6 +5,7 @@ import { syncQueue } from "./schema";
 export type SyncOperation = "insert" | "update" | "delete";
 export type SyncTableName =
   | "transactions"
+  | "accountSuggestionDismissals"
   | "captureEvidence"
   | "financialAccounts"
   | "financialAccountIdentifiers"

--- a/apps/mobile/shared/db/index.ts
+++ b/apps/mobile/shared/db/index.ts
@@ -3,6 +3,7 @@ export { getDb, resetDb, tryGetDb } from "./client";
 export type { SyncOperation, SyncQueueEntry, SyncTableName } from "./enqueue-sync";
 export { enqueueSync } from "./enqueue-sync";
 export {
+  accountSuggestionDismissals,
   billPayments,
   bills,
   budgets,

--- a/apps/mobile/shared/db/schema.ts
+++ b/apps/mobile/shared/db/schema.ts
@@ -9,6 +9,7 @@ import {
   uniqueIndex,
 } from "drizzle-orm/sqlite-core";
 import type {
+  AccountSuggestionDismissalId,
   BillId,
   BillPaymentId,
   BudgetId,
@@ -219,6 +220,26 @@ export const captureEvidence = sqliteTable(
     index("idx_capture_evidence_processed_email").on(table.processedEmailId),
     index("idx_capture_evidence_processed_capture").on(table.processedCaptureId),
     index("idx_capture_evidence_user_updated").on(table.userId, table.updatedAt),
+  ]
+);
+
+export const accountSuggestionDismissals = sqliteTable(
+  "account_suggestion_dismissals",
+  {
+    id: text("id").$type<AccountSuggestionDismissalId>().primaryKey(),
+    userId: text("user_id").$type<UserId>().notNull(),
+    scope: text("scope").notNull(),
+    value: text("value").notNull(),
+    dismissedScore: integer("dismissed_score").notNull(),
+    createdAt: text("created_at").$type<IsoDateTime>().notNull(),
+    updatedAt: text("updated_at").$type<IsoDateTime>().notNull(),
+    deletedAt: text("deleted_at").$type<IsoDateTime>(),
+  },
+  (table) => [
+    uniqueIndex("uq_account_suggestion_dismissals_scope")
+      .on(table.userId, table.scope, table.value)
+      .where(sql`${table.deletedAt} is null`),
+    index("idx_account_suggestion_dismissals_user_updated").on(table.userId, table.updatedAt),
   ]
 );
 

--- a/apps/mobile/shared/lib/generate-id.ts
+++ b/apps/mobile/shared/lib/generate-id.ts
@@ -1,4 +1,5 @@
 import type {
+  AccountSuggestionDismissalId,
   BillId,
   BillPaymentId,
   BudgetId,
@@ -41,6 +42,10 @@ export function generateTransactionId(): TransactionId {
 
 export function generateBudgetId(): BudgetId {
   return generateId("budget") as BudgetId;
+}
+
+export function generateAccountSuggestionDismissalId(): AccountSuggestionDismissalId {
+  return generateId("asd") as AccountSuggestionDismissalId;
 }
 
 export function generateCaptureEvidenceId(): CaptureEvidenceId {

--- a/apps/mobile/shared/lib/index.ts
+++ b/apps/mobile/shared/lib/index.ts
@@ -38,6 +38,7 @@ export {
   parseDigitsToAmount,
 } from "./format-money";
 export {
+  generateAccountSuggestionDismissalId,
   generateBillId,
   generateBillPaymentId,
   generateBudgetId,

--- a/apps/mobile/shared/types/branded.ts
+++ b/apps/mobile/shared/types/branded.ts
@@ -6,6 +6,7 @@ export type BudgetId = Brand<string, "BudgetId">;
 export type BillId = Brand<string, "BillId">;
 export type BillPaymentId = Brand<string, "BillPaymentId">;
 export type CategoryId = Brand<string, "CategoryId">;
+export type AccountSuggestionDismissalId = Brand<string, "AccountSuggestionDismissalId">;
 export type CaptureEvidenceId = Brand<string, "CaptureEvidenceId">;
 export type FinancialAccountId = Brand<string, "FinancialAccountId">;
 export type FinancialAccountIdentifierId = Brand<string, "FinancialAccountIdentifierId">;

--- a/apps/mobile/supabase/migrations/20260419120000_account_suggestion_dismissals.sql
+++ b/apps/mobile/supabase/migrations/20260419120000_account_suggestion_dismissals.sql
@@ -1,0 +1,34 @@
+create table public.account_suggestion_dismissals (
+  id text primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  scope text not null,
+  value text not null,
+  dismissed_score integer not null,
+  created_at text not null,
+  updated_at text not null,
+  deleted_at text
+);
+
+create unique index uq_account_suggestion_dismissals_scope
+  on public.account_suggestion_dismissals (user_id, scope, value);
+
+create index idx_account_suggestion_dismissals_user_updated
+  on public.account_suggestion_dismissals (user_id, updated_at);
+
+alter table public.account_suggestion_dismissals enable row level security;
+
+create policy "Users can read own account suggestion dismissals"
+  on public.account_suggestion_dismissals for select
+  using (auth.uid() = user_id);
+
+create policy "Users can insert own account suggestion dismissals"
+  on public.account_suggestion_dismissals for insert
+  with check (auth.uid() = user_id);
+
+create policy "Users can update own account suggestion dismissals"
+  on public.account_suggestion_dismissals for update
+  using (auth.uid() = user_id);
+
+create policy "Users can delete own account suggestion dismissals"
+  on public.account_suggestion_dismissals for delete
+  using (auth.uid() = user_id);


### PR DESCRIPTION
- derive ranked account suggestions
- persist dismissal suppression
- reprocess matching unresolved records
- infer accounts for future captures
- sync suggestion dismissal rows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an account suggestion engine that ranks repeated capture evidence to link financial accounts. Users can dismiss or accept suggestions; acceptance creates identifiers, reprocesses unresolved transactions, and future captures auto-assign the right account while ignoring identifiers from deleted accounts.

- **New Features**
  - Derive ranked suggestions from repeated evidence: `last4`, `card_hint`, `alias_token` (stable order, limitable).
  - Persist dismissal suppression and resurface only when confidence increases.
  - Accepting a suggestion saves a financial account identifier and reprocesses matching unresolved transactions to `inferred`.
  - Capture pipelines (`notification`, `apple_pay`) match identifiers to auto-assign the account, ignore deleted accounts, and mark transactions as `inferred`.
  - Sync push/pull for suggestion dismissals via Supabase table `account_suggestion_dismissals`.

- **Migration**
  - Run Drizzle migration `0021_account_suggestion_dismissals`.
  - Apply Supabase migration `20260419120000_account_suggestion_dismissals.sql` (includes RLS and indexes).

<sup>Written for commit 969ca05a8947793b10bc9eb8604eefd829caa92b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

