### PR TITLE
fix(mobile): tighten branded boundaries

### DIFF
--- a/apps/mobile/__tests__/ai-chat/parse-action.test.ts
+++ b/apps/mobile/__tests__/ai-chat/parse-action.test.ts
@@ -63,6 +63,20 @@ describe("parseActionFromResponse", () => {
     expect(parseActionFromResponse(text)).toBeNull();
   });
 
+  it("returns null for impossible calendar dates", () => {
+    const text =
+      '[ACTION]{"type":"add","data":{"type":"expense","amount":10000,"categoryId":"food","description":"test","date":"2026-02-31"}}[/ACTION]';
+
+    expect(parseActionFromResponse(text)).toBeNull();
+  });
+
+  it("returns null for empty transaction ids", () => {
+    const text =
+      '[ACTION]{"type":"delete","transactionId":"","description":"Uber","amount":15000,"date":"2026-03-01"}[/ACTION]';
+
+    expect(parseActionFromResponse(text)).toBeNull();
+  });
+
   it("extracts text content without action block", () => {
     const text =
       'Here is the result. [ACTION]{"type":"add","data":{"type":"expense","amount":10000,"categoryId":"food","description":"test","date":"2026-03-01"}}[/ACTION] All done.';

--- a/apps/mobile/__tests__/ai-chat/schema.test.ts
+++ b/apps/mobile/__tests__/ai-chat/schema.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { chatActionSchema } from "@/features/ai-chat/schema";
+
+describe("chatActionSchema", () => {
+  it("returns a validation error for impossible ISO dates instead of throwing", () => {
+    expect(() =>
+      chatActionSchema.safeParse({
+        type: "add",
+        data: {
+          type: "expense",
+          amount: 10000,
+          categoryId: "food",
+          description: "Lunch",
+          date: "2026-02-31",
+        },
+      })
+    ).not.toThrow();
+
+    const result = chatActionSchema.safeParse({
+      type: "add",
+      data: {
+        type: "expense",
+        amount: 10000,
+        categoryId: "food",
+        description: "Lunch",
+        date: "2026-02-31",
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("returns a validation error for whitespace transaction ids instead of throwing", () => {
+    expect(() =>
+      chatActionSchema.safeParse({
+        type: "delete",
+        transactionId: "   ",
+        description: "Uber",
+        amount: 15000,
+        date: "2026-03-01",
+      })
+    ).not.toThrow();
+
+    const result = chatActionSchema.safeParse({
+      type: "delete",
+      transactionId: "   ",
+      description: "Uber",
+      amount: 15000,
+      date: "2026-03-01",
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/mobile/__tests__/lib/format-money.test.ts
+++ b/apps/mobile/__tests__/lib/format-money.test.ts
@@ -6,33 +6,32 @@ import {
   formatSignedMoney,
   parseDigitsToAmount,
 } from "@/shared/lib/format-money";
-import type { CopAmount } from "@/shared/types/branded";
 
 describe("formatMoney", () => {
   it("formats thousands with dot separator", () => {
-    expect(formatMoney(50000 as CopAmount)).toBe("$50.000");
+    expect(formatMoney(50000)).toBe("$50.000");
   });
 
   it("formats zero", () => {
-    expect(formatMoney(0 as CopAmount)).toBe("$0");
+    expect(formatMoney(0)).toBe("$0");
   });
 
   it("formats millions", () => {
-    expect(formatMoney(1500000 as CopAmount)).toBe("$1.500.000");
+    expect(formatMoney(1500000)).toBe("$1.500.000");
   });
 
   it("formats small amounts without separator", () => {
-    expect(formatMoney(500 as CopAmount)).toBe("$500");
+    expect(formatMoney(500)).toBe("$500");
   });
 });
 
 describe("formatSignedMoney", () => {
   it("prepends minus for expenses", () => {
-    expect(formatSignedMoney(50000 as CopAmount, "expense")).toBe("-$50.000");
+    expect(formatSignedMoney(50000, "expense")).toBe("-$50.000");
   });
 
   it("prepends plus for income", () => {
-    expect(formatSignedMoney(50000 as CopAmount, "income")).toBe("+$50.000");
+    expect(formatSignedMoney(50000, "income")).toBe("+$50.000");
   });
 });
 

--- a/apps/mobile/__tests__/shared/assertions.test.ts
+++ b/apps/mobile/__tests__/shared/assertions.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "vitest";
-import { assertIsoDate, assertIsoDateTime } from "@/shared/types/assertions";
+import {
+  assertIsoDate,
+  assertIsoDateTime,
+  requireCopAmount,
+  requireFinancialAccountId,
+  requireMonth,
+} from "@/shared/types/assertions";
 
 describe("temporal assertions", () => {
   test("assertIsoDate accepts valid calendar dates", () => {
@@ -32,5 +38,25 @@ describe("temporal assertions", () => {
     expect(() => assertIsoDateTime("2024-01-01T24:00:00Z")).toThrow(
       "datetime must be a valid ISO 8601 timestamp"
     );
+  });
+});
+
+describe("boundary require helpers", () => {
+  test("requireMonth accepts calendar months", () => {
+    expect(requireMonth("2026-04")).toBe("2026-04");
+  });
+
+  test("requireMonth rejects invalid months", () => {
+    expect(() => requireMonth("2026-13")).toThrow("month must be a valid YYYY-MM string");
+  });
+
+  test("requireFinancialAccountId rejects empty values", () => {
+    expect(() => requireFinancialAccountId("")).toThrow(
+      "financialAccountId must be a non-empty string"
+    );
+  });
+
+  test("requireCopAmount rejects negative numbers", () => {
+    expect(() => requireCopAmount(-1)).toThrow("amount must be a non-negative integer");
   });
 });

--- a/apps/mobile/__tests__/transactions/schema.test.ts
+++ b/apps/mobile/__tests__/transactions/schema.test.ts
@@ -97,4 +97,20 @@ describe("createTransactionSchema", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it("returns a validation error for whitespace account ids instead of throwing", () => {
+    expect(() =>
+      createTransactionSchema.safeParse({
+        ...validInput,
+        accountId: "   ",
+      })
+    ).not.toThrow();
+
+    const result = createTransactionSchema.safeParse({
+      ...validInput,
+      accountId: "   ",
+    });
+
+    expect(result.success).toBe(false);
+  });
 });

--- a/apps/mobile/app/day-detail.tsx
+++ b/apps/mobile/app/day-detail.tsx
@@ -16,7 +16,7 @@ import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { getDateFnsLocale } from "@/shared/i18n";
 import { captureError, formatMoney, toIsoDate } from "@/shared/lib";
 import { requireBillId } from "@/shared/types/assertions";
-import type { BillId, CopAmount } from "@/shared/types/branded";
+import type { BillId } from "@/shared/types/branded";
 
 export default function DayDetailScreen() {
   const { date } = useLocalSearchParams<{ date: string }>();
@@ -107,7 +107,7 @@ export default function DayDetailScreen() {
                     {bill.name}
                   </Text>
                   <Text style={[styles.billAmount, { color: secondaryColor }]}>
-                    {formatMoney(bill.amount as CopAmount)}
+                    {formatMoney(bill.amount)}
                   </Text>
                 </View>
 

--- a/apps/mobile/features/ai-chat/components/ActionCard.tsx
+++ b/apps/mobile/features/ai-chat/components/ActionCard.tsx
@@ -2,7 +2,6 @@ import { Trash2 } from "@/shared/components/icons";
 import { Pressable, Text, View } from "@/shared/components/rn";
 import { useThemeColor } from "@/shared/hooks";
 import { formatMoney } from "@/shared/lib";
-import type { CopAmount } from "@/shared/types/branded";
 import type { ChatAction } from "../schema";
 
 type ActionCardProps = {
@@ -35,7 +34,7 @@ export function ActionCard({ action, onConfirm, onDismiss }: ActionCardProps) {
             Delete transaction
           </Text>
           <Text className="font-poppins-medium text-label text-secondary dark:text-secondary-dark">
-            {formatMoney(action.amount as CopAmount)} — {action.description}
+            {formatMoney(action.amount)} — {action.description}
           </Text>
           <Text className="font-poppins-medium text-caption text-tertiary dark:text-tertiary-dark">
             {action.date}

--- a/apps/mobile/features/ai-chat/schema.ts
+++ b/apps/mobile/features/ai-chat/schema.ts
@@ -1,10 +1,9 @@
 import { z } from "zod";
+import { requireIsoDate, requireTransactionId } from "@/shared/types/assertions";
 import type {
   ChatMessageId,
   ChatSessionId,
-  IsoDate,
   IsoDateTime,
-  TransactionId,
   UserId,
   UserMemoryId,
 } from "@/shared/types/branded";
@@ -19,6 +18,26 @@ export type ChatRole = z.infer<typeof chatRoleSchema>;
 export const actionStatusSchema = z.enum(["pending", "confirmed", "dismissed"]);
 export type ActionStatus = z.infer<typeof actionStatusSchema>;
 
+const actionIsoDateSchema = z
+  .string()
+  .refine(
+    (value) => {
+      try {
+        requireIsoDate(value);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    { message: "Invalid ISO date" }
+  )
+  .transform((value) => requireIsoDate(value));
+
+const actionTransactionIdSchema = z
+  .string()
+  .min(1, "Transaction ID is required")
+  .transform((value) => requireTransactionId(value));
+
 export const addActionSchema = z.object({
   type: z.literal("add"),
   data: z.object({
@@ -26,37 +45,27 @@ export const addActionSchema = z.object({
     amount: z.number().int().positive(),
     categoryId: categoryIdSchema,
     description: z.string(),
-    date: z
-      .string()
-      .regex(/^\d{4}-\d{2}-\d{2}$/)
-      .transform((s) => s as IsoDate),
+    date: actionIsoDateSchema,
   }),
 });
 
 export const editActionSchema = z.object({
   type: z.literal("edit"),
-  transactionId: z.string().transform((s) => s as TransactionId),
+  transactionId: actionTransactionIdSchema,
   data: z.object({
     amount: z.number().int().positive().optional(),
     categoryId: categoryIdSchema.optional(),
     description: z.string().optional(),
-    date: z
-      .string()
-      .regex(/^\d{4}-\d{2}-\d{2}$/)
-      .transform((s) => s as IsoDate)
-      .optional(),
+    date: actionIsoDateSchema.optional(),
   }),
 });
 
 export const deleteActionSchema = z.object({
   type: z.literal("delete"),
-  transactionId: z.string().transform((s) => s as TransactionId),
+  transactionId: actionTransactionIdSchema,
   description: z.string(),
   amount: z.number().int().positive(),
-  date: z
-    .string()
-    .regex(/^\d{4}-\d{2}-\d{2}$/)
-    .transform((s) => s as IsoDate),
+  date: actionIsoDateSchema,
 });
 
 export const chatActionSchema = z.discriminatedUnion("type", [

--- a/apps/mobile/features/ai-chat/schema.ts
+++ b/apps/mobile/features/ai-chat/schema.ts
@@ -18,25 +18,27 @@ export type ChatRole = z.infer<typeof chatRoleSchema>;
 export const actionStatusSchema = z.enum(["pending", "confirmed", "dismissed"]);
 export type ActionStatus = z.infer<typeof actionStatusSchema>;
 
-const actionIsoDateSchema = z
-  .string()
-  .refine(
-    (value) => {
-      try {
-        requireIsoDate(value);
-        return true;
-      } catch {
-        return false;
-      }
-    },
-    { message: "Invalid ISO date" }
-  )
-  .transform((value) => requireIsoDate(value));
+const actionIsoDateSchema = z.string().transform((value, ctx) => {
+  try {
+    return requireIsoDate(value);
+  } catch {
+    ctx.addIssue({ code: "custom", message: "Invalid ISO date" });
+    return z.NEVER;
+  }
+});
 
 const actionTransactionIdSchema = z
   .string()
+  .trim()
   .min(1, "Transaction ID is required")
-  .transform((value) => requireTransactionId(value));
+  .transform((value, ctx) => {
+    try {
+      return requireTransactionId(value);
+    } catch {
+      ctx.addIssue({ code: "custom", message: "Transaction ID is required" });
+      return z.NEVER;
+    }
+  });
 
 export const addActionSchema = z.object({
   type: z.literal("add"),

--- a/apps/mobile/features/analytics/components/IncomeExpenseCard.tsx
+++ b/apps/mobile/features/analytics/components/IncomeExpenseCard.tsx
@@ -2,7 +2,6 @@ import { memo } from "react";
 import { StyleSheet, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatMoney } from "@/shared/lib";
-import type { CopAmount } from "@/shared/types/branded";
 import type { IncomeExpenseResult } from "../lib/derive";
 
 type IncomeExpenseCardProps = {
@@ -28,7 +27,7 @@ const IncomeExpenseCard = memo(function IncomeExpenseCard({ data }: IncomeExpens
 
   const netPrefix = t("analytics.netPrefix");
   const netSign = netIsPositive ? "+" : "-";
-  const netAbsolute = Math.abs(net) as CopAmount;
+  const netAbsolute = Math.abs(net);
   const netText = `${netPrefix}${netSign}${formatMoney(netAbsolute)}`;
   const netColor = netIsPositive ? accentGreen : accentRed;
 

--- a/apps/mobile/features/analytics/components/PeriodDeltaCard.tsx
+++ b/apps/mobile/features/analytics/components/PeriodDeltaCard.tsx
@@ -4,7 +4,6 @@ import { StyleSheet, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { getCategoryLabel } from "@/shared/i18n";
 import { formatMoney } from "@/shared/lib";
-import type { CopAmount } from "@/shared/types/branded";
 import type { AnalyticsPeriod, PeriodDelta } from "../lib/derive";
 
 type PeriodDeltaCardProps = {
@@ -13,9 +12,9 @@ type PeriodDeltaCardProps = {
 };
 
 /** Format a delta amount + percent: "+$45.000 (+7%)" or "-$30.000 (-9%)" */
-const formatDelta = (delta: CopAmount, deltaPercent: number): string => {
+const formatDelta = (delta: number, deltaPercent: number): string => {
   const sign = delta >= 0 ? "+" : "-";
-  const absAmount = Math.abs(delta) as CopAmount;
+  const absAmount = Math.abs(delta);
   const absPercent = Math.abs(deltaPercent);
   return `${sign}${formatMoney(absAmount)} (${sign}${absPercent}%)`;
 };

--- a/apps/mobile/features/budget/components/BudgetAlertBanner.tsx
+++ b/apps/mobile/features/budget/components/BudgetAlertBanner.tsx
@@ -4,7 +4,7 @@ import { Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
 import { useMountEffect, useThemeColor, useTranslation } from "@/shared/hooks";
 import { getCategoryLabel } from "@/shared/i18n";
 import { formatMoney, trackBudgetAlertViewed } from "@/shared/lib";
-import type { BudgetId, CopAmount } from "@/shared/types/branded";
+import type { BudgetId } from "@/shared/types/branded";
 import type { BudgetAlert } from "../lib/derive";
 
 type Props = {
@@ -36,7 +36,7 @@ export function BudgetAlertBanner({ alert, onDismiss }: Props) {
     ? t("budgets.alerts.overBudget", { category: categoryLabel, percent: alert.percentUsed })
     : t("budgets.alerts.nearLimit", { category: categoryLabel, percent: alert.percentUsed });
 
-  const remaining = formatMoney(Math.abs(alert.remainingAmount) as CopAmount);
+  const remaining = formatMoney(Math.abs(alert.remainingAmount));
   const overAmount = remaining;
 
   const handleDismiss = () => onDismiss(alert.budgetId, alert.threshold);

--- a/apps/mobile/features/budget/components/BudgetCard.tsx
+++ b/apps/mobile/features/budget/components/BudgetCard.tsx
@@ -5,7 +5,6 @@ import { Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { getCategoryLabel } from "@/shared/i18n";
 import { formatMoney } from "@/shared/lib";
-import type { CopAmount } from "@/shared/types/branded";
 import type { BudgetProgress } from "../lib/derive";
 
 type Props = {
@@ -28,7 +27,7 @@ function BudgetCardInner({ progress, onPress }: Props) {
   const badgeColor = progress.isOverBudget ? accentRed : accentGreen;
 
   const remainingText = progress.isOverBudget
-    ? t("budgets.card.over", { amount: formatMoney(Math.abs(progress.remaining) as CopAmount) })
+    ? t("budgets.card.over", { amount: formatMoney(Math.abs(progress.remaining)) })
     : t("budgets.card.remaining", { amount: formatMoney(progress.remaining) });
 
   const handlePress = () => onPress(progress.budgetId);

--- a/apps/mobile/features/budget/components/BudgetSummaryCard.tsx
+++ b/apps/mobile/features/budget/components/BudgetSummaryCard.tsx
@@ -2,7 +2,6 @@ import { ProgressBar } from "@/shared/components";
 import { StyleSheet, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatMoney } from "@/shared/lib";
-import type { CopAmount } from "@/shared/types/branded";
 
 type Props = {
   readonly totalBudget: number;
@@ -23,16 +22,14 @@ export function BudgetSummaryCard({ totalBudget, totalSpent, percentUsed }: Prop
         <Text style={[styles.label, { color: secondaryColor }]}>
           {t("budgets.summary.totalBudget")}
         </Text>
-        <Text style={[styles.amount, { color: primaryColor }]}>
-          {formatMoney(totalBudget as CopAmount)}
-        </Text>
+        <Text style={[styles.amount, { color: primaryColor }]}>{formatMoney(totalBudget)}</Text>
       </View>
 
       <ProgressBar percent={percentUsed} />
 
       <View style={styles.footer}>
         <Text style={[styles.spentText, { color: secondaryColor }]}>
-          {formatMoney(totalSpent as CopAmount)} / {formatMoney(totalBudget as CopAmount)}
+          {formatMoney(totalSpent)} / {formatMoney(totalBudget)}
         </Text>
         <Text style={[styles.usedText, { color: secondaryColor }]}>
           {t("budgets.summary.used", { percent: percentUsed })}

--- a/apps/mobile/features/budget/components/UpcomingBillsSection.tsx
+++ b/apps/mobile/features/budget/components/UpcomingBillsSection.tsx
@@ -6,7 +6,6 @@ import { Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { getCategoryLabel } from "@/shared/i18n";
 import { formatMoney } from "@/shared/lib";
-import type { CopAmount } from "@/shared/types/branded";
 
 const MAX_UPCOMING_BILLS = 3;
 
@@ -83,7 +82,7 @@ export function UpcomingBillsSection() {
                   </View>
                 </View>
                 <Text style={[styles.billAmount, { color: primaryColor }]}>
-                  {formatMoney(bill.amount as CopAmount)}
+                  {formatMoney(bill.amount)}
                 </Text>
               </View>
             );

--- a/apps/mobile/features/budget/schema.ts
+++ b/apps/mobile/features/budget/schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { categoryIdSchema } from "@/features/transactions";
+import { requireMonth } from "@/shared/types/assertions";
 import type {
   BudgetId,
   CategoryId,
@@ -13,7 +14,7 @@ import type {
 export const monthSchema = z
   .string()
   .regex(/^\d{4}-(0[1-9]|1[0-2])$/)
-  .transform((s) => s as Month);
+  .transform((value) => requireMonth(value));
 
 export const createBudgetSchema = z.object({
   categoryId: categoryIdSchema,

--- a/apps/mobile/features/budget/store.ts
+++ b/apps/mobile/features/budget/store.ts
@@ -1,4 +1,4 @@
-import { addMonths, format, subMonths } from "date-fns";
+import { addMonths, subMonths } from "date-fns";
 import { create } from "zustand";
 import { insertNotificationRecord } from "@/features/notifications";
 import { useSettingsStore } from "@/features/settings";
@@ -6,7 +6,7 @@ import { CATEGORY_MAP } from "@/features/transactions";
 import { createWriteThroughMutationModule } from "@/mutations";
 import type { AnyDb } from "@/shared/db";
 import { getCategoryLabel, useLocaleStore } from "@/shared/i18n";
-import { generateBudgetId, toIsoDateTime, trackBudgetCreated } from "@/shared/lib";
+import { generateBudgetId, toIsoDateTime, toMonth, trackBudgetCreated } from "@/shared/lib";
 import type { BudgetId, CategoryId, CopAmount, Month, UserId } from "@/shared/types/branded";
 import type { BudgetAlert, BudgetProgress, BudgetSuggestion } from "./lib/derive";
 import type { BudgetMonthSnapshot } from "./lib/monitoring";
@@ -18,7 +18,7 @@ import { createBudgetSchema } from "./schema";
 let budgetSessionId = 0;
 let loadBudgetsRequestId = 0;
 
-const formatMonth = (date: Date): Month => format(date, "yyyy-MM") as Month;
+const formatMonth = (date: Date): Month => toMonth(date);
 
 /** Parse "YYYY-MM" to a local-time Date (1st of month). Avoids UTC date-only parsing pitfall. */
 const parseMonth = (month: Month): Date => {

--- a/apps/mobile/features/calendar/schema.ts
+++ b/apps/mobile/features/calendar/schema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { categoryIdSchema } from "@/features/transactions";
 import { toIsoDate } from "@/shared/lib";
-import { requireBillId, requireCategoryId } from "@/shared/types/assertions";
+import { requireBillId, requireCategoryId, requireCopAmount } from "@/shared/types/assertions";
 import type {
   BillId,
   BillPaymentId,
@@ -77,7 +77,7 @@ export function toBillRow(
     id: requireBillId(bill.id),
     userId,
     name: bill.name,
-    amount: bill.amount as CopAmount,
+    amount: requireCopAmount(bill.amount),
     frequency: bill.frequency,
     categoryId: bill.categoryId,
     startDate: toIsoDate(bill.startDate),

--- a/apps/mobile/features/dashboard/components/BalanceSection.tsx
+++ b/apps/mobile/features/dashboard/components/BalanceSection.tsx
@@ -1,7 +1,6 @@
 import { Text, View } from "@/shared/components/rn";
 import { useTranslation } from "@/shared/hooks";
 import { formatMoney } from "@/shared/lib";
-import type { CopAmount } from "@/shared/types/branded";
 
 type BalanceSectionProps = {
   readonly balance: number;
@@ -16,7 +15,7 @@ export const BalanceSection = ({ balance }: BalanceSectionProps) => {
         {t("dashboard.spentThisMonth")}
       </Text>
       <Text className="font-poppins-bold text-balance text-primary dark:text-primary-dark">
-        {formatMoney(balance as CopAmount)}
+        {formatMoney(balance)}
       </Text>
     </View>
   );

--- a/apps/mobile/features/dashboard/components/ChartSection.tsx
+++ b/apps/mobile/features/dashboard/components/ChartSection.tsx
@@ -12,7 +12,6 @@ import {
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { getCategoryLabel } from "@/shared/i18n";
 import { formatMoney } from "@/shared/lib";
-import type { CopAmount } from "@/shared/types/branded";
 import { CategoryRow } from "./CategoryRow";
 import { DonutChart } from "./DonutChart";
 import { SpendingLineChart } from "./SpendingLineChart";
@@ -50,7 +49,7 @@ const toCategoryRows = (categories: readonly CategorySpendingItem[], locale: str
       categoryId: c.categoryId,
       color: cat?.color ?? "#B8A9D4",
       name: cat ? getCategoryLabel(cat, locale) : c.categoryId,
-      amount: formatMoney(c.total as CopAmount),
+      amount: formatMoney(c.total),
     };
   });
 
@@ -138,7 +137,7 @@ export const ChartSection = ({
             <View style={{ width: slideWidth }} className="flex-row gap-4">
               <DonutChart
                 segments={segments}
-                centerLabel={formatMoney(totalSpent as CopAmount)}
+                centerLabel={formatMoney(totalSpent)}
                 centerSubLabel={t("chart.spent")}
               />
               <View className="flex-1 justify-center gap-2.5">
@@ -154,7 +153,7 @@ export const ChartSection = ({
                   <CategoryRow
                     color={OTHERS_COLOR}
                     name={t("chart.moreCategories", { count: remaining.length })}
-                    amount={formatMoney(remainingTotal as CopAmount)}
+                    amount={formatMoney(remainingTotal)}
                   />
                 )}
               </View>
@@ -181,7 +180,7 @@ export const ChartSection = ({
                     {t("chart.avgPerDay")}
                   </Text>
                   <Text className="font-poppins-bold text-body text-primary dark:text-primary-dark">
-                    {formatMoney(avgPerDay as CopAmount)}
+                    {formatMoney(avgPerDay)}
                   </Text>
                 </View>
                 <View className="mt-1 gap-1">
@@ -192,7 +191,7 @@ export const ChartSection = ({
                     {t("chart.thisMonthTotal")}
                   </Text>
                   <Text className="font-poppins-bold text-body text-primary dark:text-primary-dark">
-                    {formatMoney(totalSpent as CopAmount)}
+                    {formatMoney(totalSpent)}
                   </Text>
                 </View>
               </View>

--- a/apps/mobile/features/financial-accounts/lib/default-account.ts
+++ b/apps/mobile/features/financial-accounts/lib/default-account.ts
@@ -1,5 +1,6 @@
+import { requireFinancialAccountId } from "@/shared/types/assertions";
 import type { FinancialAccountId } from "@/shared/types/branded";
 
 export function buildDefaultFinancialAccountId(userId: string): FinancialAccountId {
-  return `fa-default-${userId}` as FinancialAccountId;
+  return requireFinancialAccountId(`fa-default-${userId}`);
 }

--- a/apps/mobile/features/goals/components/AddPaymentSheet.tsx
+++ b/apps/mobile/features/goals/components/AddPaymentSheet.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from "expo-router";
 import { useCallback, useRef, useState } from "react";
 import Animated from "react-native-reanimated";
-import { useAuthStore } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth";
 import { handleNumpadPress } from "@/features/transactions";
 import { FidyNumpad } from "@/shared/components";
 import {
@@ -16,7 +16,6 @@ import {
 import { tryGetDb } from "@/shared/db";
 import { useAsyncGuard, useBlinkingCursor, useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatInputDisplay, parseDigitsToAmount, toIsoDate } from "@/shared/lib";
-import type { UserId } from "@/shared/types/branded";
 import { addContribution, useGoalStore } from "../store";
 
 export function AddPaymentSheet() {
@@ -24,7 +23,7 @@ export function AddPaymentSheet() {
   const { t } = useTranslation();
 
   const selectedGoalId = useGoalStore((s) => s.selectedGoalId);
-  const userId = useAuthStore((s) => s.session?.user.id ?? null) as UserId | null;
+  const userId = useOptionalUserId();
 
   const cardBg = useThemeColor("card");
   const primaryColor = useThemeColor("primary");

--- a/apps/mobile/features/goals/components/CelebrationModal.tsx
+++ b/apps/mobile/features/goals/components/CelebrationModal.tsx
@@ -2,7 +2,6 @@ import { memo } from "react";
 import { Modal, Pressable, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatMoney } from "@/shared/lib";
-import type { CopAmount } from "@/shared/types/branded";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -124,7 +123,7 @@ export const CelebrationModal = memo(function CelebrationModal({
               color: accentGreen,
             }}
           >
-            {formatMoney(displayAmount as CopAmount)}
+            {formatMoney(displayAmount)}
           </Text>
 
           {/* Continue button */}

--- a/apps/mobile/features/goals/components/GoalCard.tsx
+++ b/apps/mobile/features/goals/components/GoalCard.tsx
@@ -2,7 +2,6 @@ import { memo } from "react";
 import { Pressable, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatMoney } from "@/shared/lib";
-import type { CopAmount } from "@/shared/types/branded";
 import { deriveGoalCardStatus } from "../lib/derive";
 import type { GoalWithProgress } from "../types";
 
@@ -90,7 +89,7 @@ function GoalCardInner({ goalWithProgress, onPress, onAddPayment }: GoalCardProp
           {goal.name}
         </Text>
         <Text style={{ fontFamily: "Poppins_600SemiBold", fontSize: 13, color: accentGreen }}>
-          {formatMoney(goal.targetAmount as CopAmount)}
+          {formatMoney(goal.targetAmount)}
         </Text>
       </View>
 
@@ -137,7 +136,7 @@ function GoalCardInner({ goalWithProgress, onPress, onAddPayment }: GoalCardProp
           }}
           numberOfLines={1}
         >
-          {formatMoney(currentAmount as CopAmount)}
+          {formatMoney(currentAmount)}
         </Text>
       </View>
 

--- a/apps/mobile/features/goals/components/GoalCreateSheet.tsx
+++ b/apps/mobile/features/goals/components/GoalCreateSheet.tsx
@@ -2,7 +2,7 @@ import DateTimePicker from "@react-native-community/datetimepicker";
 import { useRouter } from "expo-router";
 import { useCallback, useRef, useState } from "react";
 import Animated from "react-native-reanimated";
-import { useAuthStore } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth";
 import { handleNumpadPress } from "@/features/transactions";
 import { FidyNumpad } from "@/shared/components";
 import {
@@ -18,7 +18,6 @@ import {
 import { tryGetDb } from "@/shared/db";
 import { useAsyncGuard, useBlinkingCursor, useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatInputDisplay, parseDigitsToAmount, toIsoDate } from "@/shared/lib";
-import type { UserId } from "@/shared/types/branded";
 import type { GoalType } from "../schema";
 import { createGoal, useGoalStore } from "../store";
 
@@ -26,7 +25,7 @@ export function GoalCreateSheet() {
   const { back } = useRouter();
   const { t, locale } = useTranslation();
   const goals = useGoalStore((s) => s.goals);
-  const userId = useAuthStore((s) => s.session?.user.id ?? null) as UserId | null;
+  const userId = useOptionalUserId();
 
   const cardBg = useThemeColor("card");
   const primaryColor = useThemeColor("primary");

--- a/apps/mobile/features/goals/components/GoalDetail.tsx
+++ b/apps/mobile/features/goals/components/GoalDetail.tsx
@@ -6,7 +6,6 @@ import { Platform, Pressable, ScrollView, StyleSheet, Text, View } from "@/share
 import { useSubscription, useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatDateDisplay, formatMoney } from "@/shared/lib";
 import { requireIsoDate } from "@/shared/types/assertions";
-import type { CopAmount } from "@/shared/types/branded";
 import type { GoalProjection, Milestone } from "../lib/derive";
 import { deriveMonthlyMilestones } from "../lib/derive";
 import type { GoalContribution } from "../schema";
@@ -218,10 +217,10 @@ function ContributionRowInner({
         </Text>
       </View>
       <Text style={[styles.contributionAmount, { color: accentGreen }]}>
-        +{formatMoney(contribution.amount as CopAmount)}
+        +{formatMoney(contribution.amount)}
       </Text>
       <Text style={[styles.contributionRunning, { color: secondaryColor }]}>
-        {formatMoney(runningTotal as CopAmount)}
+        {formatMoney(runningTotal)}
       </Text>
     </View>
   );
@@ -253,7 +252,7 @@ function MilestoneRowInner({ milestone }: { readonly milestone: Milestone }) {
           {format(milestone.month, "MMMM")}
         </Text>
         <Text style={[styles.milestoneAmount, { color: secondaryColor }]}>
-          {formatMoney(milestone.cumulativeTarget as CopAmount)}
+          {formatMoney(milestone.cumulativeTarget)}
         </Text>
       </View>
     </View>
@@ -357,11 +356,11 @@ export function GoalDetailScreen() {
   const recommendationText =
     projection.projectedDate != null
       ? t("goals.detail.recommendationText", {
-          amount: formatMoney(Math.round(projection.netMonthlySavings) as CopAmount),
+          amount: formatMoney(Math.round(projection.netMonthlySavings)),
           date: format(projection.projectedDate, "MMMM yyyy"),
         })
       : t("goals.detail.recommendationTextNoDate", {
-          amount: formatMoney(Math.round(projection.netMonthlySavings) as CopAmount),
+          amount: formatMoney(Math.round(projection.netMonthlySavings)),
         });
 
   return (
@@ -391,11 +390,11 @@ export function GoalDetailScreen() {
           <ProgressRing percent={Math.min(progress.percentComplete, 100)} />
           <View style={styles.amountRow}>
             <Text style={[styles.currentAmount, { color: primaryColor }]}>
-              {formatMoney(currentAmount as CopAmount)}
+              {formatMoney(currentAmount)}
             </Text>
             <Text style={[styles.amountDivider, { color: secondaryColor }]}>/</Text>
             <Text style={[styles.targetAmount, { color: secondaryColor }]}>
-              {formatMoney(goal.targetAmount as CopAmount)}
+              {formatMoney(goal.targetAmount)}
             </Text>
           </View>
         </View>

--- a/apps/mobile/features/goals/components/GoalSmartCard.tsx
+++ b/apps/mobile/features/goals/components/GoalSmartCard.tsx
@@ -1,11 +1,10 @@
 import { useRouter } from "expo-router";
 import { memo, useCallback, useMemo } from "react";
-import { useAuthStore } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth";
 import { Pressable, Text, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatMoney } from "@/shared/lib";
-import type { CopAmount, UserId } from "@/shared/types/branded";
 import { selectGoal, useGoalStore } from "../store";
 
 export const GoalSmartCard = memo(function GoalSmartCard() {
@@ -13,7 +12,7 @@ export const GoalSmartCard = memo(function GoalSmartCard() {
   const { t } = useTranslation();
   const goals = useGoalStore((s) => s.goals);
   const accentGreen = useThemeColor("accentGreen");
-  const userId = useAuthStore((s) => s.session?.user.id ?? null) as UserId | null;
+  const userId = useOptionalUserId();
 
   // Find best goal to display: highest progress % among active (non-complete) goals
   // Fallback: most recently created
@@ -104,8 +103,7 @@ export const GoalSmartCard = memo(function GoalSmartCard() {
             opacity: 0.8,
           }}
         >
-          {formatMoney(topGoal.currentAmount as CopAmount)} /{" "}
-          {formatMoney(topGoal.goal.targetAmount as CopAmount)}
+          {formatMoney(topGoal.currentAmount)} / {formatMoney(topGoal.goal.targetAmount)}
         </Text>
         {moreCount > 0 ? (
           <Text

--- a/apps/mobile/features/goals/components/GoalsListScreen.tsx
+++ b/apps/mobile/features/goals/components/GoalsListScreen.tsx
@@ -1,12 +1,11 @@
 import { useRouter } from "expo-router";
 import { useCallback } from "react";
-import { useAuthStore } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth";
 import { ScreenLayout, TAB_BAR_CLEARANCE } from "@/shared/components";
 import { Plus, Target } from "@/shared/components/icons";
 import { FlatList, Platform, Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
-import type { UserId } from "@/shared/types/branded";
 import { selectGoal, useGoalStore } from "../store";
 import { GoalCard } from "./GoalCard";
 
@@ -62,7 +61,7 @@ export function GoalsListScreen() {
   const { t } = useTranslation();
   const goals = useGoalStore((s) => s.goals);
   const isLoading = useGoalStore((s) => s.isLoading);
-  const userId = useAuthStore((s) => s.session?.user.id ?? null) as UserId | null;
+  const userId = useOptionalUserId();
 
   const handleCreateGoal = useCallback(() => {
     router.push("/create-goal");

--- a/apps/mobile/features/search/components/ResultsSummary.tsx
+++ b/apps/mobile/features/search/components/ResultsSummary.tsx
@@ -1,7 +1,6 @@
 import { Text, View } from "@/shared/components/rn";
 import { useTranslation } from "@/shared/hooks";
 import { formatMoney } from "@/shared/lib";
-import type { CopAmount } from "@/shared/types/branded";
 import type { SearchSummary } from "../lib/types";
 
 type ResultsSummaryProps = {
@@ -16,7 +15,7 @@ export const ResultsSummary = ({ summary }: ResultsSummaryProps) => {
       <Text className="font-poppins-medium text-caption text-secondary dark:text-secondary-dark">
         {t("search.resultsSummary", {
           count: summary.count,
-          total: formatMoney(summary.total as CopAmount),
+          total: formatMoney(summary.total),
         })}
       </Text>
     </View>

--- a/apps/mobile/features/search/lib/repository.ts
+++ b/apps/mobile/features/search/lib/repository.ts
@@ -1,8 +1,8 @@
 import { and, count, desc, eq, gte, inArray, isNull, like, lte, sql } from "drizzle-orm";
 import type { AnyDb } from "@/shared/db";
 import { transactions } from "@/shared/db";
-import { requireCategoryId, requireIsoDate } from "@/shared/types/assertions";
-import type { CopAmount, UserId } from "@/shared/types/branded";
+import { requireCategoryId, requireCopAmount, requireIsoDate } from "@/shared/types/assertions";
+import type { UserId } from "@/shared/types/branded";
 import type { SearchFilters, SearchSummary } from "./types";
 
 function buildSearchConditions(userId: UserId, filters: SearchFilters) {
@@ -20,10 +20,10 @@ function buildSearchConditions(userId: UserId, filters: SearchFilters) {
       : []),
     ...(filters.dateTo !== null ? [lte(transactions.date, requireIsoDate(filters.dateTo))] : []),
     ...(filters.amountMin !== null
-      ? [gte(transactions.amount, filters.amountMin as CopAmount)]
+      ? [gte(transactions.amount, requireCopAmount(filters.amountMin))]
       : []),
     ...(filters.amountMax !== null
-      ? [lte(transactions.amount, filters.amountMax as CopAmount)]
+      ? [lte(transactions.amount, requireCopAmount(filters.amountMax))]
       : []),
     ...(filters.type !== "all" ? [eq(transactions.type, filters.type)] : []),
   ];

--- a/apps/mobile/features/sync/components/ConflictCard.tsx
+++ b/apps/mobile/features/sync/components/ConflictCard.tsx
@@ -4,7 +4,6 @@ import { Pressable, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { getCategoryLabel } from "@/shared/i18n";
 import { formatSignedMoney } from "@/shared/lib";
-import type { CopAmount } from "@/shared/types/branded";
 import type { SyncConflict } from "../store";
 
 type ConflictCardProps = {
@@ -73,14 +72,8 @@ export const ConflictCard = memo(function ConflictCard({
     [
       localData.amount !== serverData.amount && {
         label: t("common.amount"),
-        localValue: formatSignedMoney(
-          localData.amount as CopAmount,
-          localData.type as "expense" | "income"
-        ),
-        serverValue: formatSignedMoney(
-          serverData.amount as CopAmount,
-          serverData.type as "expense" | "income"
-        ),
+        localValue: formatSignedMoney(localData.amount, localData.type as "expense" | "income"),
+        serverValue: formatSignedMoney(serverData.amount, serverData.type as "expense" | "income"),
       },
       localData.categoryId !== serverData.categoryId && {
         label: t("common.category"),

--- a/apps/mobile/features/sync/services/sync.ts
+++ b/apps/mobile/features/sync/services/sync.ts
@@ -4,7 +4,7 @@ import { enqueueSync } from "@/shared/db";
 import { liveAppNetwork } from "@/shared/effect/network";
 import { liveAppSupabase } from "@/shared/effect/supabase";
 import { generateSyncQueueId } from "@/shared/lib";
-import type { UserId } from "@/shared/types/branded";
+import { requireUserId } from "@/shared/types/assertions";
 import {
   getUnresolvedConflicts,
   resolveConflict as resolveConflictDb,
@@ -24,7 +24,7 @@ const syncService = createSyncService({
   syncPull,
   syncPush,
   refreshTransactions: async ({ db, userId }) => {
-    await refreshTransactions(db, userId as UserId);
+    await refreshTransactions(db, requireUserId(userId));
   },
   getConflictRows: async ({ db }) => getUnresolvedConflicts(db),
   upsertTransaction: async (db, row) => {

--- a/apps/mobile/features/transactions/lib/build-transaction.ts
+++ b/apps/mobile/features/transactions/lib/build-transaction.ts
@@ -1,12 +1,6 @@
 import { buildDefaultFinancialAccountId } from "@/features/financial-accounts";
 import { parseDigitsToAmount, parseIsoDate, toIsoDate, toIsoDateTime } from "@/shared/lib";
-import type {
-  CategoryId,
-  CopAmount,
-  FinancialAccountId,
-  TransactionId,
-  UserId,
-} from "@/shared/types/branded";
+import type { CategoryId, FinancialAccountId, TransactionId, UserId } from "@/shared/types/branded";
 import type { AccountAttributionState, StoredTransaction, TransactionType } from "../schema";
 import { createTransactionSchema } from "../schema";
 import { getBuiltInCategoryId, isValidCategoryId } from "./categories";
@@ -73,7 +67,7 @@ export function buildTransaction(
       id,
       userId,
       type: result.data.type,
-      amount: result.data.amount as CopAmount,
+      amount: result.data.amount,
       categoryId: result.data.categoryId,
       description: result.data.description ?? "",
       date: result.data.date,

--- a/apps/mobile/features/transactions/schema.ts
+++ b/apps/mobile/features/transactions/schema.ts
@@ -1,4 +1,9 @@
 import { z } from "zod";
+import {
+  requireCategoryId,
+  requireCopAmount,
+  requireFinancialAccountId,
+} from "@/shared/types/assertions";
 import type {
   CategoryId,
   CopAmount,
@@ -17,13 +22,13 @@ export type AccountAttributionState = z.infer<typeof accountAttributionStateSche
 export const financialAccountIdSchema = z
   .string()
   .min(1, "Account is required")
-  .transform((value) => value as FinancialAccountId);
+  .transform((value) => requireFinancialAccountId(value));
 
 export function makeCategoryIdSchema(isValid: (id: string) => boolean) {
   return z
     .string()
     .refine(isValid, { message: "Invalid category ID" })
-    .transform((s) => s as CategoryId);
+    .transform((value) => requireCategoryId(value));
 }
 
 export const categoryIdSchema = makeCategoryIdSchema(isValidCategoryId);
@@ -31,7 +36,11 @@ export const categoryIdSchema = makeCategoryIdSchema(isValidCategoryId);
 export const createTransactionSchema = z.object({
   type: transactionTypeSchema,
   /** Amount in whole currency units — must be positive */
-  amount: z.number().int().positive(),
+  amount: z
+    .number()
+    .int()
+    .positive()
+    .transform((value) => requireCopAmount(value)),
   categoryId: categoryIdSchema,
   accountId: financialAccountIdSchema,
   description: z.string().trim().max(200).optional(),

--- a/apps/mobile/features/transactions/schema.ts
+++ b/apps/mobile/features/transactions/schema.ts
@@ -21,8 +21,16 @@ export type AccountAttributionState = z.infer<typeof accountAttributionStateSche
 
 export const financialAccountIdSchema = z
   .string()
+  .trim()
   .min(1, "Account is required")
-  .transform((value) => requireFinancialAccountId(value));
+  .transform((value, ctx) => {
+    try {
+      return requireFinancialAccountId(value);
+    } catch {
+      ctx.addIssue({ code: "custom", message: "Account is required" });
+      return z.NEVER;
+    }
+  });
 
 export function makeCategoryIdSchema(isValid: (id: string) => boolean) {
   return z

--- a/apps/mobile/shared/lib/format-money.ts
+++ b/apps/mobile/shared/lib/format-money.ts
@@ -38,7 +38,7 @@ export const parseDigitsToAmount = (digits: string): CopAmount => {
  * Formats a numeric amount as a currency display string.
  * 50000 → "$50.000", 0 → "$0"
  */
-export const formatMoney = (amount: CopAmount, config?: CurrencyConfig): string =>
+export const formatMoney = (amount: number, config?: CurrencyConfig): string =>
   stripCurrencySpace(getFormatter(config).format(amount));
 
 /**
@@ -46,7 +46,7 @@ export const formatMoney = (amount: CopAmount, config?: CurrencyConfig): string 
  * (50000, "expense") → "-$50.000", (50000, "income") → "+$50.000"
  */
 export const formatSignedMoney = (
-  amount: CopAmount,
+  amount: number,
   type: "expense" | "income",
   config?: CurrencyConfig
 ): string => {

--- a/apps/mobile/shared/types/assertions.ts
+++ b/apps/mobile/shared/types/assertions.ts
@@ -5,8 +5,10 @@ import type {
   CopAmount,
   DetectedSmsEventId,
   EmailAccountId,
+  FinancialAccountId,
   IsoDate,
   IsoDateTime,
+  Month,
   ProcessedEmailId,
   SyncConflictId,
   SyncQueueId,
@@ -16,6 +18,7 @@ import type {
 } from "@/shared/types/branded";
 
 const ISO_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+const MONTH_PATTERN = /^(\d{4})-(0[1-9]|1[0-2])$/;
 const ISO_DATE_TIME_PATTERN =
   /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,9}))?(Z|([+-])(\d{2}):(\d{2}))$/;
 
@@ -129,6 +132,10 @@ export function assertEmailAccountId(value: string): asserts value is EmailAccou
   assertNonEmptyString(value, "emailAccountId");
 }
 
+export function assertFinancialAccountId(value: string): asserts value is FinancialAccountId {
+  assertNonEmptyString(value, "financialAccountId");
+}
+
 export function assertProcessedEmailId(value: string): asserts value is ProcessedEmailId {
   assertNonEmptyString(value, "processedEmailId");
 }
@@ -148,6 +155,12 @@ export function assertUserMemoryId(value: string): asserts value is UserMemoryId
 export function assertCopAmount(value: number): asserts value is CopAmount {
   if (!Number.isInteger(value) || value < 0) {
     throw new Error("amount must be a non-negative integer");
+  }
+}
+
+export function assertMonth(value: string): asserts value is Month {
+  if (!MONTH_PATTERN.test(value)) {
+    throw new Error("month must be a valid YYYY-MM string");
   }
 }
 
@@ -173,6 +186,11 @@ export function requireTransactionId(value: string): TransactionId {
   return value;
 }
 
+export function requireCopAmount(value: number): CopAmount {
+  assertCopAmount(value);
+  return value;
+}
+
 export function requireBillId(value: string): BillId {
   assertBillId(value);
   return value;
@@ -190,6 +208,16 @@ export function requireCategoryId(value: string): CategoryId {
 
 export function requireDetectedSmsEventId(value: string): DetectedSmsEventId {
   assertDetectedSmsEventId(value);
+  return value;
+}
+
+export function requireFinancialAccountId(value: string): FinancialAccountId {
+  assertFinancialAccountId(value);
+  return value;
+}
+
+export function requireMonth(value: string): Month {
+  assertMonth(value);
   return value;
 }
 


### PR DESCRIPTION
- harden action schema validation
- add boundary require helpers
- remove ui branded casts
- keep money formatting numeric

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthened mobile validation. We now enforce boundary checks, handle Zod transform failures safely, trim IDs before branding, and drop unsafe UI casts. Money formatting accepts plain numbers. AI chat and transactions reject invalid dates and empty/whitespace IDs without throwing.

- **Bug Fixes**
  - AI chat: impossible ISO dates and blank `transactionId` return validation errors; parser returns null instead of crashing.
  - Transactions: trim `accountId` before branding; whitespace IDs and invalid amounts fail validation instead of throwing.

- **Refactors**
  - Added `require*` helpers (`requireCopAmount`, `requireFinancialAccountId`, `requireMonth`, `requireIsoDate`, etc.) and applied across `transactions`, `budget`, `calendar`, `search`, `ai-chat`, default account, and sync.
  - `formatMoney`/`formatSignedMoney` now take `number`; removed UI `CopAmount` casts and switched goals screens to `useOptionalUserId`.

<sup>Written for commit 840c0dfbd139a7742e1936c5b164c33e9330134a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

