### PR TITLE
fix(mobile): migrate boundaries lint rule

### DIFF
--- a/apps/mobile/eslint.config.js
+++ b/apps/mobile/eslint.config.js
@@ -162,35 +162,39 @@ module.exports = defineConfig([
 
       // — Import rules —
       "import/no-cycle": "error",
-      "boundaries/element-types": [
+      "boundaries/dependencies": [
         "error",
         {
           default: "allow",
           rules: [
             {
-              from: ["feature-public", "feature-internal"],
-              disallow: ["app"],
+              from: { type: ["feature-public", "feature-internal"] },
+              disallow: { to: { type: "app" } },
             },
             {
-              from: "shared",
-              disallow: ["app", "feature-public", "feature-internal", "module"],
+              from: { type: "shared" },
+              disallow: {
+                to: { type: ["app", "feature-public", "feature-internal", "module"] },
+              },
             },
             {
-              from: "module",
-              disallow: ["app", "feature-public", "feature-internal", "shared"],
+              from: { type: "module" },
+              disallow: {
+                to: { type: ["app", "feature-public", "feature-internal", "shared"] },
+              },
             },
             {
               from: { category: "feature" },
               disallow: {
                 to: {
                   type: "feature-internal",
-                  captured: { featureName: "!{{from.featureName}}" },
+                  captured: { featureName: "!{{ from.captured.featureName }}" },
                 },
               },
             },
             {
-              from: "app",
-              disallow: ["feature-internal"],
+              from: { type: "app" },
+              disallow: { to: { type: "feature-internal" } },
             },
           ],
         },


### PR DESCRIPTION
- rename deprecated boundaries rule
- migrate selectors to v6 syntax
- update featureName template syntax
- verify repo gate passes
- existing locale warnings remain


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated mobile ESLint boundaries config to v6 to keep import constraints working and remove deprecations. Renamed the rule and updated selectors so the repo gate stays green.

- **Refactors**
  - Replaced `boundaries/element-types` with `boundaries/dependencies`.
  - Converted to v6 selector syntax (`from`, `disallow.to`, `type`).
  - Updated `featureName` capture to `{{ from.captured.featureName }}`; behavior unchanged and existing locale warnings remain.

<sup>Written for commit 641374c4bd8a23349e9ebc9b5e46ccf0169c4a66. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

