### PR TITLE
fix(mobile): restore deep link params

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,10 @@ At the repo root, `bun test scripts/check-branded-boundaries.test.ts` can fail w
 
 Importing `@/shared/db` from a supposedly pure repository/query module also loads `shared/db/client.ts`, which reaches `shared/lib` and mobile-only runtime dependencies like `@sentry/react-native` and toast code. That can break isolated Bun imports and make data-layer tests unexpectedly depend on the React Native runtime. Fix: in pure repository/query modules and DB-heavy tests, prefer deep imports from `shared/db/schema`, `shared/db/enqueue-sync`, and `shared/db/client` instead of the `shared/db` barrel.
 
+### Notification deep-link params can drift from screen expectations (⚠️ AGENT SURPRISE)
+
+This repo has already had one mismatch where notification routes used legacy params like `/search?category=...` and `/goal-detail?id=...` while the destination screens expected different boundaries. The current app accepts both the legacy params and the normalized forms (`categoryId`, `goalId`) so existing queued notifications still work. Fix: when adding or refactoring notification deep links, update both the route builders and the destination route-param readers together, and keep a regression probe for notification taps in QA.
+
 ### Rebased PR branches can replay already-merged slice commits (⚠️ AGENT SURPRISE)
 
 When a new slice branch is created from an older feature branch and that parent PR later merges to `main`, the standard `git pull --rebase --autostash origin main` flow can try to replay those already-merged commits and produce conflicts in unrelated files. In this repo, the safer recovery is: stash the current work, create a fresh branch from `origin/main`, then reapply the stash there before opening the next PR.

--- a/apps/mobile/__tests__/goals/route-params.test.ts
+++ b/apps/mobile/__tests__/goals/route-params.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { resolveGoalDetailGoalId } from "@/features/goals/lib/route-params";
+
+describe("resolveGoalDetailGoalId", () => {
+  it("prefers the normalized goalId param", () => {
+    expect(resolveGoalDetailGoalId({ goalId: "goal_123", id: "legacy_goal" })).toBe("goal_123");
+  });
+
+  it("falls back to the legacy id param", () => {
+    expect(resolveGoalDetailGoalId({ id: "legacy_goal" })).toBe("legacy_goal");
+  });
+
+  it("ignores empty params", () => {
+    expect(resolveGoalDetailGoalId({ goalId: "   ", id: "" })).toBeNull();
+  });
+});

--- a/apps/mobile/__tests__/notifications/display.test.ts
+++ b/apps/mobile/__tests__/notifications/display.test.ts
@@ -71,7 +71,7 @@ describe("deriveNotificationDisplay", () => {
     expect(result.iconName).toBe("utensils");
     expect(result.iconColor).toBe("#7CB243");
     expect(result.iconBgColor).toBe("#E8F5E9");
-    expect(result.route).toBe("/search?category=food");
+    expect(result.route).toBe("/search?categoryId=food");
   });
 
   it("resolves spending_anomaly for transport category", () => {
@@ -106,7 +106,7 @@ describe("deriveNotificationDisplay", () => {
     expect(result.iconName).toBe("trophy");
     expect(result.iconColor).toBe("#7CB243");
     expect(result.iconBgColor).toBe("#E8F5E9");
-    expect(result.route).toBe("/goal-detail?id=goal-42");
+    expect(result.route).toBe("/goal-detail?goalId=goal-42");
   });
 
   it("resolves goal_milestone with null goalId to null route", () => {

--- a/apps/mobile/__tests__/search/route-params.test.ts
+++ b/apps/mobile/__tests__/search/route-params.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { resolveSearchRouteFilters } from "@/features/search/lib/route-params";
+
+describe("resolveSearchRouteFilters", () => {
+  it("prefers the normalized categoryId param", () => {
+    expect(resolveSearchRouteFilters({ categoryId: "food", category: "transport" })).toEqual({
+      categoryIds: ["food"],
+    });
+  });
+
+  it("falls back to the legacy category param", () => {
+    expect(resolveSearchRouteFilters({ category: "transport" })).toEqual({
+      categoryIds: ["transport"],
+    });
+  });
+
+  it("returns an empty partial when no category filter exists", () => {
+    expect(resolveSearchRouteFilters({ category: "   " })).toEqual({});
+  });
+});

--- a/apps/mobile/features/goals/components/GoalDetail.tsx
+++ b/apps/mobile/features/goals/components/GoalDetail.tsx
@@ -1,15 +1,18 @@
 import { format } from "date-fns";
-import { Stack, useRouter } from "expo-router";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { memo, useCallback, useRef, useState } from "react";
 import Svg, { Circle as SvgCircle } from "react-native-svg";
+import { useOptionalUserId } from "@/features/auth";
 import { Platform, Pressable, ScrollView, StyleSheet, Text, View } from "@/shared/components/rn";
+import { tryGetDb } from "@/shared/db";
 import { useSubscription, useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatDateDisplay, formatMoney } from "@/shared/lib";
 import { requireIsoDate } from "@/shared/types/assertions";
 import type { GoalProjection, Milestone } from "../lib/derive";
 import { deriveMonthlyMilestones } from "../lib/derive";
+import { resolveGoalDetailGoalId } from "../lib/route-params";
 import type { GoalContribution } from "../schema";
-import { useGoalStore } from "../store";
+import { selectGoal, useGoalStore } from "../store";
 import type { CelebrationMilestone } from "./CelebrationModal";
 import { CelebrationModal } from "./CelebrationModal";
 
@@ -266,8 +269,14 @@ const MilestoneRow = memo(MilestoneRowInner);
 // ---------------------------------------------------------------------------
 
 export function GoalDetailScreen() {
+  const routeParams = useLocalSearchParams<{
+    goalId?: string | string[];
+    id?: string | string[];
+  }>();
   const { t } = useTranslation();
   const { push } = useRouter();
+  const userId = useOptionalUserId();
+  const db = userId ? tryGetDb(userId) : null;
   const accentGreen = useThemeColor("accentGreen");
   const accentGreenLight = useThemeColor("accentGreenLight");
   const primaryColor = useThemeColor("primary");
@@ -280,9 +289,12 @@ export function GoalDetailScreen() {
     null
   );
 
+  const routeGoalId = resolveGoalDetailGoalId(routeParams);
   const selectedGoalId = useGoalStore((s) => s.selectedGoalId);
   const goals = useGoalStore((s) => s.goals);
   const contributions = useGoalStore((s) => s.selectedGoalContributions);
+  const activeGoalId = routeGoalId ?? selectedGoalId;
+  const visibleContributions = activeGoalId === selectedGoalId ? contributions : [];
 
   const handleTabChange = useCallback((tab: TabType) => {
     setActiveTab(tab);
@@ -304,8 +316,19 @@ export function GoalDetailScreen() {
     push("/(tabs)/(ai)" as never);
   }, [push]);
 
-  // Find the selected goal
-  const goalData = goals.find((g) => g.goal.id === selectedGoalId);
+  useSubscription(
+    () => {
+      if (!db || !userId || routeGoalId == null) {
+        return;
+      }
+
+      void selectGoal(db, userId, routeGoalId);
+    },
+    [db, userId, routeGoalId],
+    db != null && userId != null && routeGoalId != null && routeGoalId !== selectedGoalId
+  );
+
+  const goalData = goals.find((g) => g.goal.id === activeGoalId);
 
   // Track previous progress percent to detect milestone crossings.
   const prevPercentRef = useRef<number | null>(null);
@@ -333,7 +356,7 @@ export function GoalDetailScreen() {
   // Compute running totals for contribution history
   const contributionsWithRunning: { contribution: GoalContribution; runningTotal: number }[] =
     (() => {
-      const reversed = [...contributions].reverse();
+      const reversed = [...visibleContributions].reverse();
       const result: { contribution: GoalContribution; runningTotal: number }[] = [];
       reversed.forEach((c) => {
         const prevTotal = result.length > 0 ? (result[result.length - 1]?.runningTotal ?? 0) : 0;

--- a/apps/mobile/features/goals/lib/route-params.ts
+++ b/apps/mobile/features/goals/lib/route-params.ts
@@ -1,0 +1,17 @@
+type GoalDetailRouteParams = {
+  readonly goalId?: string | readonly string[];
+  readonly id?: string | readonly string[];
+};
+
+function getFirstNonEmptyRouteParam(value: string | readonly string[] | undefined): string | null {
+  if (typeof value === "string") {
+    const trimmedValue = value.trim();
+    return trimmedValue.length > 0 ? trimmedValue : null;
+  }
+
+  return value?.find((entry) => entry.trim().length > 0)?.trim() ?? null;
+}
+
+export function resolveGoalDetailGoalId(params: GoalDetailRouteParams): string | null {
+  return getFirstNonEmptyRouteParam(params.goalId) ?? getFirstNonEmptyRouteParam(params.id);
+}

--- a/apps/mobile/features/goals/store.ts
+++ b/apps/mobile/features/goals/store.ts
@@ -334,7 +334,7 @@ export async function addContribution(
           percent: milestone,
         }),
         body: i18n.t("notifications.goalMilestoneMsg", { percent: milestone }),
-        data: { route: `/goal-detail?id=${input.goalId}` },
+        data: { route: `/goal-detail?goalId=${input.goalId}` },
         preferenceKey: "goalMilestones",
       });
     }

--- a/apps/mobile/features/notifications/lib/display.ts
+++ b/apps/mobile/features/notifications/lib/display.ts
@@ -96,7 +96,7 @@ export const deriveNotificationDisplay = (
       case "spending_anomaly":
         return {
           ...getCategoryVisuals(notification.categoryId),
-          route: `/search?category=${notification.categoryId ?? "other"}` as string | null,
+          route: `/search?categoryId=${notification.categoryId ?? "other"}` as string | null,
         };
       case "budget_pace":
         return {
@@ -109,7 +109,7 @@ export const deriveNotificationDisplay = (
           iconColor: "#7CB243",
           iconBgColor: "#E8F5E9",
           route: notification.goalId
-            ? (`/goal-detail?id=${notification.goalId}` as string | null)
+            ? (`/goal-detail?goalId=${notification.goalId}` as string | null)
             : null,
         };
       default:

--- a/apps/mobile/features/search/components/SearchScreen.tsx
+++ b/apps/mobile/features/search/components/SearchScreen.tsx
@@ -1,4 +1,4 @@
-import { useRouter } from "expo-router";
+import { useLocalSearchParams, useRouter } from "expo-router";
 import { memo, useCallback, useMemo, useRef, useState } from "react";
 import { useOptionalUserId } from "@/features/auth";
 import { CATEGORY_MAP, makeDateLabel, type StoredTransaction } from "@/features/transactions";
@@ -11,6 +11,7 @@ import { getCategoryLabel, getDateFnsLocale } from "@/shared/i18n";
 import { formatSignedMoney, toIsoDate } from "@/shared/lib";
 import { amountDigitsToAmount } from "../lib/amount-utils";
 import { hasActiveFilters } from "../lib/filters";
+import { resolveSearchRouteFilters } from "../lib/route-params";
 import type { SearchFilters } from "../lib/types";
 import {
   clearSearchFilters,
@@ -67,6 +68,10 @@ const SearchTransactionItem = memo(function SearchTransactionItem({
 });
 
 export const SearchScreen = () => {
+  const routeParams = useLocalSearchParams<{
+    category?: string | string[];
+    categoryId?: string | string[];
+  }>();
   const { back } = useRouter();
   const { t } = useTranslation();
   const primary = useThemeColor("primary");
@@ -80,6 +85,8 @@ export const SearchScreen = () => {
   const hasMore = useSearchStore((s) => s.hasMore);
   const summary = useSearchStore((s) => s.summary);
   const reset = useSearchStore((s) => s.reset);
+  const initialRouteFilters = resolveSearchRouteFilters(routeParams);
+  const shouldAutoFocusInput = initialRouteFilters.categoryIds == null;
 
   const [ready, setReady] = useState(false);
   const [inputText, setInputText] = useState("");
@@ -93,9 +100,15 @@ export const SearchScreen = () => {
     const handle = InteractionManager.runAfterInteractions(() => {
       setReady(true);
       if (db && userId) {
-        executeSearch(db, userId);
+        if (initialRouteFilters.categoryIds != null) {
+          updateSearchFilters(db, userId, initialRouteFilters);
+        } else {
+          executeSearch(db, userId);
+        }
       }
-      inputRef.current?.focus();
+      if (shouldAutoFocusInput) {
+        inputRef.current?.focus();
+      }
     });
     return () => {
       handle.cancel();

--- a/apps/mobile/features/search/lib/route-params.ts
+++ b/apps/mobile/features/search/lib/route-params.ts
@@ -1,0 +1,22 @@
+import type { SearchFilters } from "./types";
+
+type SearchRouteParams = {
+  readonly categoryId?: string | readonly string[];
+  readonly category?: string | readonly string[];
+};
+
+function getFirstNonEmptyRouteParam(value: string | readonly string[] | undefined): string | null {
+  if (typeof value === "string") {
+    const trimmedValue = value.trim();
+    return trimmedValue.length > 0 ? trimmedValue : null;
+  }
+
+  return value?.find((entry) => entry.trim().length > 0)?.trim() ?? null;
+}
+
+export function resolveSearchRouteFilters(params: SearchRouteParams): Partial<SearchFilters> {
+  const categoryId =
+    getFirstNonEmptyRouteParam(params.categoryId) ?? getFirstNonEmptyRouteParam(params.category);
+
+  return categoryId ? { categoryIds: [categoryId] } : {};
+}


### PR DESCRIPTION
- normalize notification routes
- support legacy goal and search params
- add route param coverage


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores working deep links in the mobile app by normalizing notification routes and supporting legacy query params so existing notifications and URLs continue to open the correct screens.

- **Bug Fixes**
  - Normalize routes to `/search?categoryId=...` and `/goal-detail?goalId=...`.
  - Accept legacy params `category` and `id` in Search and Goal Detail (backward compatible).
  - Goal Detail reads `goalId` from route and auto-selects the goal if different from current.
  - Search preloads category filter from route and only auto-focuses input when no filter.
  - Update milestone notifications to emit normalized routes.
  - Add tests for route param resolution and notification routes; document the mismatch risk in AGENTS.md.

<sup>Written for commit f28d08e62b405c764f80da86a49b805aca626423. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

