### PR TITLE
refactor(mobile): split sync engine stages

### DIFF
--- a/apps/mobile/features/sync/services/syncEngine.ts
+++ b/apps/mobile/features/sync/services/syncEngine.ts
@@ -151,57 +151,40 @@ type SupabaseAccountSuggestionDismissalRow = {
   deleted_at: string | null;
 };
 
-function toSupabaseRow(row: {
-  id: string;
-  userId: string;
-  type: string;
-  amount: number;
-  categoryId: string;
-  accountId?: string;
-  accountAttributionState?: string;
-  supersededAt?: string | null;
-  description?: string | null;
-  date: string;
-  createdAt: string;
-  updatedAt: string;
-  deletedAt?: string | null;
-}): SupabaseTransactionRow {
+const shouldUpdateLocal = (serverUpdatedAt: string, localUpdatedAt: string | undefined): boolean =>
+  !localUpdatedAt || serverUpdatedAt > localUpdatedAt;
+
+function fromSupabaseTransactionAccountDefaults(row: SupabaseTransactionRow) {
   return {
-    id: row.id,
-    user_id: row.userId,
-    type: row.type,
-    amount: row.amount,
-    category_id: row.categoryId,
-    account_id: row.accountId ?? buildDefaultFinancialAccountId(row.userId),
-    account_attribution_state: row.accountAttributionState ?? "confirmed",
-    superseded_at: row.supersededAt ?? null,
-    description: row.description ?? null,
-    date: row.date,
-    created_at: row.createdAt,
-    updated_at: row.updatedAt,
-    deleted_at: row.deletedAt ?? null,
+    accountId: row.account_id ?? buildDefaultFinancialAccountId(row.user_id),
+    accountAttributionState: row.account_attribution_state ?? "confirmed",
   };
 }
 
-function shouldUpdateLocal(serverUpdatedAt: string, localUpdatedAt: string | undefined): boolean {
-  return !localUpdatedAt || serverUpdatedAt > localUpdatedAt;
+function fromSupabaseTransactionNullableFields(row: SupabaseTransactionRow) {
+  return {
+    supersededAt: row.superseded_at ?? null,
+    deletedAt: row.deleted_at ?? null,
+  };
 }
 
-function fromSupabaseRow(row: SupabaseTransactionRow) {
+function fromSupabaseTransactionRow(row: SupabaseTransactionRow) {
+  const accountDefaults = fromSupabaseTransactionAccountDefaults(row);
+  const nullableFields = fromSupabaseTransactionNullableFields(row);
   return {
     id: row.id,
     userId: row.user_id,
     type: row.type,
     amount: row.amount,
     categoryId: row.category_id,
-    accountId: row.account_id ?? buildDefaultFinancialAccountId(row.user_id),
-    accountAttributionState: row.account_attribution_state ?? "confirmed",
-    supersededAt: row.superseded_at ?? null,
+    accountId: accountDefaults.accountId,
+    accountAttributionState: accountDefaults.accountAttributionState,
+    supersededAt: nullableFields.supersededAt,
     description: row.description,
     date: row.date,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
-    deletedAt: row.deleted_at,
+    deletedAt: nullableFields.deletedAt,
   };
 }
 
@@ -315,30 +298,71 @@ type PullFetchOutcome<TRow extends { updated_at: string; id: string }> = {
   rows: TRow[];
   error: { message: string; code: string } | null;
 };
+type PushEntryContext = {
+  db: AnyDb;
+  supabase: SupabaseClient;
+  rowId: string;
+};
+type PushEntryOutcome = { ok: true } | { ok: false; errorMessage: string; errorCode: string };
+type PushEntryHandler = (context: PushEntryContext) => Promise<PushEntryOutcome>;
+type UpsertPushSpec<TRow, TSupabaseRow> = {
+  tableName: string;
+  getRow: (db: AnyDb, rowId: string) => TRow | null | Promise<TRow | null>;
+  mapRow: (row: TRow) => TSupabaseRow;
+  upsertOptions?: { onConflict: string };
+};
+type PullFetchRequest = {
+  supabase: SupabaseClient;
+  userId: string;
+  tableName: string;
+  lastSyncAt: PullCursor | null;
+};
+type ApplyServerRowsRequest<
+  TRow extends { id: string; updated_at: string },
+  TMappedRow,
+  TLocalRow extends { updatedAt: string } | null,
+> = {
+  db: AnyDb;
+  rows: readonly TRow[];
+  getLocalRow: (db: AnyDb, rowId: string) => TLocalRow;
+  upsertLocalRow: (db: AnyDb, row: TMappedRow) => void;
+  mapServerRow: (row: TRow) => TMappedRow;
+};
+type LocalTransactionRow = NonNullable<Awaited<ReturnType<typeof getTransactionById>>>;
+type LocalBudgetRow = NonNullable<ReturnType<typeof getBudgetById>>;
+type LocalGoalRow = NonNullable<ReturnType<typeof getGoalById>>;
+type LocalFinancialAccountRow = NonNullable<ReturnType<typeof getFinancialAccountById>>;
+type LocalTransferRow = NonNullable<ReturnType<typeof getTransferById>>;
+type LocalOpeningBalanceRow = NonNullable<ReturnType<typeof getOpeningBalanceById>>;
+type LocalFinancialAccountIdentifierRow = NonNullable<
+  ReturnType<typeof getFinancialAccountIdentifierById>
+>;
+type LocalCaptureEvidenceRow = NonNullable<ReturnType<typeof getCaptureEvidenceById>>;
+type LocalAccountSuggestionDismissalRow = NonNullable<
+  ReturnType<typeof getAccountSuggestionDismissalById>
+>;
+type LocalContributionRow = NonNullable<ReturnType<typeof getContributionById>>;
+const PUSH_ENTRY_PROCESSED: PushEntryOutcome = { ok: true };
 
-function rowToPullCursor(row: { updated_at: string; id: string }): PullCursor {
-  return {
-    updatedAt: row.updated_at,
-    id: row.id,
-  };
-}
+const rowToPullCursor = (row: { updated_at: string; id: string }): PullCursor => ({
+  updatedAt: row.updated_at,
+  id: row.id,
+});
 
-function serializePullCursor(cursor: PullCursor): string {
-  return JSON.stringify(cursor);
-}
+const serializePullCursor = (cursor: PullCursor): string => JSON.stringify(cursor);
 
 function parsePullCursor(value: string): PullCursor {
   try {
-    const parsed = JSON.parse(value);
-    if (
-      parsed &&
-      typeof parsed === "object" &&
-      typeof parsed.updatedAt === "string" &&
-      ("id" in parsed ? typeof parsed.id === "string" || parsed.id === null : true)
-    ) {
+    const parsed = JSON.parse(value) as {
+      updatedAt?: unknown;
+      id?: unknown;
+    };
+    const updatedAt = readParsedPullCursorUpdatedAt(parsed);
+    const id = readParsedPullCursorId(parsed);
+    if (updatedAt && id !== undefined) {
       return {
-        updatedAt: parsed.updatedAt,
-        id: parsed.id ?? null,
+        updatedAt,
+        id,
       };
     }
   } catch {
@@ -351,40 +375,103 @@ function parsePullCursor(value: string): PullCursor {
   };
 }
 
-function toCompositeCursorFilter(cursor: PullCursor): string {
-  return `updated_at.gt.${cursor.updatedAt},and(updated_at.eq.${cursor.updatedAt},id.gt.${cursor.id})`;
+function readParsedPullCursorUpdatedAt(parsed: { updatedAt?: unknown }) {
+  return typeof parsed.updatedAt === "string" ? parsed.updatedAt : null;
 }
 
+function readParsedPullCursorId(parsed: { id?: unknown }) {
+  return parsed.id == null || typeof parsed.id === "string" ? (parsed.id ?? null) : undefined;
+}
+
+const toCompositeCursorFilter = (cursor: PullCursor): string =>
+  `updated_at.gt.${cursor.updatedAt},and(updated_at.eq.${cursor.updatedAt},id.gt.${cursor.id})`;
+
 async function fetchPullRows<T extends { updated_at: string; id: string }>(
-  supabase: SupabaseClient,
-  userId: string,
-  tableName: string,
-  lastSyncAt: PullCursor | null
+  request: PullFetchRequest
 ) {
-  const baseQuery = supabase.from(tableName).select("*").eq("user_id", userId);
-  const query = !lastSyncAt
+  const baseQuery = request.supabase
+    .from(request.tableName)
+    .select("*")
+    .eq("user_id", request.userId);
+  const query = !request.lastSyncAt
     ? baseQuery
-    : lastSyncAt.id == null
-      ? baseQuery.gte("updated_at", lastSyncAt.updatedAt)
-      : baseQuery.or(toCompositeCursorFilter(lastSyncAt));
+    : request.lastSyncAt.id == null
+      ? baseQuery.gte("updated_at", request.lastSyncAt.updatedAt)
+      : baseQuery.or(toCompositeCursorFilter(request.lastSyncAt));
   return (await query
     .order("updated_at", { ascending: true })
     .order("id", { ascending: true })
     .limit(PULL_PAGE_SIZE)) as PullFetchResponse<T>;
 }
 
+function hasPullFetchErrorFields(error: unknown): error is { message?: unknown; code?: unknown } {
+  return typeof error === "object" && error !== null;
+}
+
+function readPullFetchErrorMessage(error: { message?: unknown }) {
+  return typeof error.message === "string" ? error.message : "unknown";
+}
+
+function readPullFetchErrorCode(error: { code?: unknown }) {
+  return typeof error.code === "string" ? error.code : "unknown";
+}
+
 function toPullFetchError(error: unknown) {
-  if (typeof error === "object" && error !== null) {
-    const message =
-      "message" in error && typeof error.message === "string" ? error.message : "unknown";
-    const code = "code" in error && typeof error.code === "string" ? error.code : "unknown";
-    return { message, code };
+  if (typeof error === "string") {
+    return {
+      message: error,
+      code: "unknown",
+    };
+  }
+
+  if (!hasPullFetchErrorFields(error)) {
+    return {
+      message: "unknown",
+      code: "unknown",
+    };
   }
 
   return {
-    message: typeof error === "string" ? error : "unknown",
-    code: "unknown",
+    message: readPullFetchErrorMessage(error),
+    code: readPullFetchErrorCode(error),
   };
+}
+
+function toMissingPullFetchError(response: PullFetchResponse<{ updated_at: string; id: string }>) {
+  return {
+    message: response.error?.message ?? "no_data",
+    code: response.error?.code ?? "unknown",
+  };
+}
+
+function getLocalAccountSuggestionDismissalRow(database: AnyDb, rowId: string) {
+  return getAccountSuggestionDismissalById(
+    database,
+    rowId as Parameters<typeof getAccountSuggestionDismissalById>[1]
+  );
+}
+
+function getLocalCaptureEvidenceRow(database: AnyDb, rowId: string) {
+  return getCaptureEvidenceById(database, rowId as Parameters<typeof getCaptureEvidenceById>[1]);
+}
+
+function getLocalFinancialAccountRow(database: AnyDb, rowId: string) {
+  return getFinancialAccountById(database, rowId as Parameters<typeof getFinancialAccountById>[1]);
+}
+
+function getLocalTransferRow(database: AnyDb, rowId: string) {
+  return getTransferById(database, rowId as Parameters<typeof getTransferById>[1]);
+}
+
+function getLocalOpeningBalanceRow(database: AnyDb, rowId: string) {
+  return getOpeningBalanceById(database, rowId as Parameters<typeof getOpeningBalanceById>[1]);
+}
+
+function getLocalFinancialAccountIdentifierRow(database: AnyDb, rowId: string) {
+  return getFinancialAccountIdentifierById(
+    database,
+    rowId as Parameters<typeof getFinancialAccountIdentifierById>[1]
+  );
 }
 
 function toPullFetchOutcome<TRow extends { updated_at: string; id: string }>(
@@ -403,10 +490,7 @@ function toPullFetchOutcome<TRow extends { updated_at: string; id: string }>(
     return {
       tableName,
       rows: [],
-      error: {
-        message: result.value.error?.message ?? "no_data",
-        code: result.value.error?.code ?? "unknown",
-      },
+      error: toMissingPullFetchError(result.value),
     };
   }
 
@@ -454,24 +538,16 @@ function applyServerRows<
   TRow extends { id: string; updated_at: string },
   TMappedRow,
   TLocalRow extends { updatedAt: string } | null,
->(
-  db: AnyDb,
-  rows: readonly TRow[],
-  options: {
-    getLocalRow: (db: AnyDb, rowId: string) => TLocalRow;
-    upsertLocalRow: (db: AnyDb, row: TMappedRow) => void;
-    mapServerRow: (row: TRow) => TMappedRow;
-  }
-) {
+>(request: ApplyServerRowsRequest<TRow, TMappedRow, TLocalRow>) {
   let failedCount = 0;
   let safeCursor: PullCursor | null = null;
   let sawFailure = false;
 
-  for (const serverRow of rows) {
+  for (const serverRow of request.rows) {
     try {
-      const localRow = options.getLocalRow(db, serverRow.id);
+      const localRow = request.getLocalRow(request.db, serverRow.id);
       if (shouldUpdateLocal(serverRow.updated_at, localRow?.updatedAt)) {
-        options.upsertLocalRow(db, options.mapServerRow(serverRow));
+        request.upsertLocalRow(request.db, request.mapServerRow(serverRow));
       }
       if (!sawFailure) {
         safeCursor = rowToPullCursor(serverRow);
@@ -486,215 +562,304 @@ function applyServerRows<
   return { failedCount, safeCursor };
 }
 
-async function processBudgetEntry(
-  db: AnyDb,
-  supabase: SupabaseClient,
-  rowId: string
-): Promise<boolean> {
-  const row = getBudgetById(db, requireBudgetId(rowId));
-  if (!row) return true;
-  const { error } = await supabase.from("budgets").upsert({
-    id: row.id,
-    user_id: row.userId,
-    category_id: row.categoryId,
-    amount: row.amount,
-    month: row.month,
-    created_at: row.createdAt,
-    updated_at: row.updatedAt,
-    deleted_at: row.deletedAt,
-  });
-  return !error;
+function toPushEntryFailure(error: { message?: string; code?: string }) {
+  return {
+    ok: false,
+    errorMessage: error.message ?? "unknown",
+    errorCode: error.code ?? "unknown",
+  };
 }
 
-async function processGoalEntry(
-  db: AnyDb,
-  supabase: SupabaseClient,
-  rowId: string
-): Promise<boolean> {
-  const row = getGoalById(db, rowId);
-  if (!row) return true; // row deleted locally, mark as processed
-  const { error } = await supabase.from("goals").upsert({
+function toSupabaseTransactionAccountDefaults(row: LocalTransactionRow) {
+  return {
+    accountId: row.accountId ?? buildDefaultFinancialAccountId(row.userId),
+    accountAttributionState: row.accountAttributionState ?? "confirmed",
+  };
+}
+
+function toSupabaseTransactionDeleteFields(row: LocalTransactionRow) {
+  return {
+    supersededAt: row.supersededAt ?? null,
+    deletedAt: row.deletedAt ?? null,
+  };
+}
+
+function toSupabaseTransactionDescription(row: LocalTransactionRow) {
+  return row.description ?? null;
+}
+
+function toSupabaseTransactionRow(row: LocalTransactionRow): SupabaseTransactionRow {
+  const accountDefaults = toSupabaseTransactionAccountDefaults(row);
+  const deleteFields = toSupabaseTransactionDeleteFields(row);
+  const description = toSupabaseTransactionDescription(row);
+  return {
     id: row.id,
     user_id: row.userId,
-    name: row.name,
     type: row.type,
-    target_amount: row.targetAmount,
-    target_date: row.targetDate,
-    interest_rate_percent: row.interestRatePercent,
-    icon_name: row.iconName,
-    color_hex: row.colorHex,
+    amount: row.amount,
+    category_id: row.categoryId,
+    account_id: accountDefaults.accountId,
+    account_attribution_state: accountDefaults.accountAttributionState,
+    superseded_at: deleteFields.supersededAt,
+    description,
+    date: row.date,
     created_at: row.createdAt,
     updated_at: row.updatedAt,
-    deleted_at: row.deletedAt,
-  });
-  return !error;
+    deleted_at: deleteFields.deletedAt,
+  };
 }
 
-async function processFinancialAccountEntry(
-  db: AnyDb,
-  supabase: SupabaseClient,
-  rowId: string
-): Promise<boolean> {
-  const row = getFinancialAccountById(db, rowId as Parameters<typeof getFinancialAccountById>[1]);
-  if (!row) return true;
-  const { error } = await supabase.from("financial_accounts").upsert({
+const toSupabaseBudgetRow = (row: LocalBudgetRow) => ({
+  id: row.id,
+  user_id: row.userId,
+  category_id: row.categoryId,
+  amount: row.amount,
+  month: row.month,
+  created_at: row.createdAt,
+  updated_at: row.updatedAt,
+  deleted_at: row.deletedAt,
+});
+
+const toSupabaseGoalRow = (row: LocalGoalRow) => ({
+  id: row.id,
+  user_id: row.userId,
+  name: row.name,
+  type: row.type,
+  target_amount: row.targetAmount,
+  target_date: row.targetDate,
+  interest_rate_percent: row.interestRatePercent,
+  icon_name: row.iconName,
+  color_hex: row.colorHex,
+  created_at: row.createdAt,
+  updated_at: row.updatedAt,
+  deleted_at: row.deletedAt,
+});
+
+const toSupabaseFinancialAccountDays = (row: LocalFinancialAccountRow) => ({
+  statementClosingDay: row.statementClosingDay ?? null,
+  paymentDueDay: row.paymentDueDay ?? null,
+});
+
+const toSupabaseFinancialAccountRow = (row: LocalFinancialAccountRow) => {
+  const days = toSupabaseFinancialAccountDays(row);
+  return {
     id: row.id,
     user_id: row.userId,
     name: row.name,
     kind: row.kind,
     is_default: row.isDefault,
-    statement_closing_day: row.statementClosingDay ?? null,
-    payment_due_day: row.paymentDueDay ?? null,
+    statement_closing_day: days.statementClosingDay,
+    payment_due_day: days.paymentDueDay,
     created_at: row.createdAt,
     updated_at: row.updatedAt,
     deleted_at: row.deletedAt,
+  };
+};
+
+const toSupabaseTransferRow = (row: LocalTransferRow) => ({
+  id: row.id,
+  user_id: row.userId,
+  amount: row.amount,
+  from_account_id: row.fromAccountId,
+  to_account_id: row.toAccountId,
+  from_external_label: row.fromExternalLabel,
+  to_external_label: row.toExternalLabel,
+  description: row.description,
+  date: row.date,
+  created_at: row.createdAt,
+  updated_at: row.updatedAt,
+  deleted_at: row.deletedAt,
+});
+
+const toSupabaseOpeningBalanceRow = (row: LocalOpeningBalanceRow) => ({
+  id: row.id,
+  user_id: row.userId,
+  account_id: row.accountId,
+  amount: row.amount,
+  effective_date: row.effectiveDate,
+  created_at: row.createdAt,
+  updated_at: row.updatedAt,
+  deleted_at: row.deletedAt,
+});
+
+const toSupabaseFinancialAccountIdentifierRow = (row: LocalFinancialAccountIdentifierRow) => ({
+  id: row.id,
+  user_id: row.userId,
+  account_id: row.accountId,
+  scope: row.scope,
+  value: row.value,
+  created_at: row.createdAt,
+  updated_at: row.updatedAt,
+  deleted_at: row.deletedAt,
+});
+
+const toSupabaseCaptureEvidenceRow = (row: LocalCaptureEvidenceRow) => ({
+  id: row.id,
+  user_id: row.userId,
+  source_family: row.sourceFamily,
+  evidence_type: row.evidenceType,
+  scope: row.scope,
+  value: row.value,
+  transaction_id: row.transactionId,
+  transfer_id: row.transferId ?? null,
+  processed_email_id: row.processedEmailId,
+  processed_capture_id: row.processedCaptureId,
+  created_at: row.createdAt,
+  updated_at: row.updatedAt,
+  deleted_at: row.deletedAt,
+});
+
+const toSupabaseAccountSuggestionDismissalRow = (row: LocalAccountSuggestionDismissalRow) => ({
+  id: row.id,
+  user_id: row.userId,
+  scope: row.scope,
+  value: row.value,
+  dismissed_score: row.dismissedScore,
+  created_at: row.createdAt,
+  updated_at: row.updatedAt,
+  deleted_at: row.deletedAt,
+});
+
+const toSupabaseContributionRow = (row: LocalContributionRow) => ({
+  id: row.id,
+  goal_id: row.goalId,
+  user_id: row.userId,
+  amount: row.amount,
+  note: row.note,
+  date: row.date,
+  created_at: row.createdAt,
+  updated_at: row.updatedAt,
+  deleted_at: row.deletedAt,
+});
+
+async function upsertPushRow<TRow, TSupabaseRow>(
+  context: PushEntryContext,
+  spec: UpsertPushSpec<TRow, TSupabaseRow>
+): Promise<PushEntryOutcome> {
+  const row = await spec.getRow(context.db, context.rowId);
+  if (!row) {
+    return PUSH_ENTRY_PROCESSED;
+  }
+
+  const query = context.supabase.from(spec.tableName);
+  const payload = spec.mapRow(row);
+  const response = spec.upsertOptions
+    ? await query.upsert(payload, spec.upsertOptions)
+    : await query.upsert(payload);
+
+  return response.error ? toPushEntryFailure(response.error) : PUSH_ENTRY_PROCESSED;
+}
+
+const processTransactionEntry: PushEntryHandler = (context) =>
+  upsertPushRow(context, {
+    tableName: "transactions",
+    getRow: (db, rowId) => getTransactionById(db, requireTransactionId(rowId)),
+    mapRow: toSupabaseTransactionRow,
   });
-  return !error;
-}
 
-async function processTransferEntry(
-  db: AnyDb,
-  supabase: SupabaseClient,
-  rowId: string
-): Promise<boolean> {
-  const row = getTransferById(db, rowId as Parameters<typeof getTransferById>[1]);
-  if (!row) return true;
-  const { error } = await supabase.from("transfers").upsert({
-    id: row.id,
-    user_id: row.userId,
-    amount: row.amount,
-    from_account_id: row.fromAccountId,
-    to_account_id: row.toAccountId,
-    from_external_label: row.fromExternalLabel,
-    to_external_label: row.toExternalLabel,
-    description: row.description,
-    date: row.date,
-    created_at: row.createdAt,
-    updated_at: row.updatedAt,
-    deleted_at: row.deletedAt,
+const processBudgetEntry: PushEntryHandler = (context) =>
+  upsertPushRow(context, {
+    tableName: "budgets",
+    getRow: (db, rowId) => getBudgetById(db, requireBudgetId(rowId)),
+    mapRow: toSupabaseBudgetRow,
   });
-  return !error;
-}
 
-async function processOpeningBalanceEntry(
-  db: AnyDb,
-  supabase: SupabaseClient,
-  rowId: string
-): Promise<boolean> {
-  const row = getOpeningBalanceById(db, rowId as Parameters<typeof getOpeningBalanceById>[1]);
-  if (!row) return true;
-  const { error } = await supabase.from("opening_balances").upsert(
-    {
-      id: row.id,
-      user_id: row.userId,
-      account_id: row.accountId,
-      amount: row.amount,
-      effective_date: row.effectiveDate,
-      created_at: row.createdAt,
-      updated_at: row.updatedAt,
-      deleted_at: row.deletedAt,
-    },
-    { onConflict: "account_id" }
-  );
-  return !error;
-}
-
-async function processFinancialAccountIdentifierEntry(
-  db: AnyDb,
-  supabase: SupabaseClient,
-  rowId: string
-): Promise<boolean> {
-  const row = getFinancialAccountIdentifierById(
-    db,
-    rowId as Parameters<typeof getFinancialAccountIdentifierById>[1]
-  );
-  if (!row) return true;
-  const { error } = await supabase.from("financial_account_identifiers").upsert(
-    {
-      id: row.id,
-      user_id: row.userId,
-      account_id: row.accountId,
-      scope: row.scope,
-      value: row.value,
-      created_at: row.createdAt,
-      updated_at: row.updatedAt,
-      deleted_at: row.deletedAt,
-    },
-    { onConflict: "user_id,account_id,scope,value" }
-  );
-  return !error;
-}
-
-async function processCaptureEvidenceEntry(
-  db: AnyDb,
-  supabase: SupabaseClient,
-  rowId: string
-): Promise<boolean> {
-  const row = getCaptureEvidenceById(db, rowId as Parameters<typeof getCaptureEvidenceById>[1]);
-  if (!row) return true;
-  const { error } = await supabase.from("capture_evidence").upsert({
-    id: row.id,
-    user_id: row.userId,
-    source_family: row.sourceFamily,
-    evidence_type: row.evidenceType,
-    scope: row.scope,
-    value: row.value,
-    transaction_id: row.transactionId,
-    transfer_id: row.transferId ?? null,
-    processed_email_id: row.processedEmailId,
-    processed_capture_id: row.processedCaptureId,
-    created_at: row.createdAt,
-    updated_at: row.updatedAt,
-    deleted_at: row.deletedAt,
+const processGoalEntry: PushEntryHandler = (context) =>
+  upsertPushRow(context, {
+    tableName: "goals",
+    getRow: (db, rowId) => getGoalById(db, rowId),
+    mapRow: toSupabaseGoalRow,
   });
-  return !error;
-}
 
-async function processAccountSuggestionDismissalEntry(
-  db: AnyDb,
-  supabase: SupabaseClient,
-  rowId: string
-): Promise<boolean> {
-  const row = getAccountSuggestionDismissalById(
-    db,
-    rowId as Parameters<typeof getAccountSuggestionDismissalById>[1]
-  );
-  if (!row) return true;
-  const { error } = await supabase.from("account_suggestion_dismissals").upsert(
-    {
-      id: row.id,
-      user_id: row.userId,
-      scope: row.scope,
-      value: row.value,
-      dismissed_score: row.dismissedScore,
-      created_at: row.createdAt,
-      updated_at: row.updatedAt,
-      deleted_at: row.deletedAt,
-    },
-    { onConflict: "user_id,scope,value" }
-  );
-  return !error;
-}
-
-async function processContributionEntry(
-  db: AnyDb,
-  supabase: SupabaseClient,
-  rowId: string
-): Promise<boolean> {
-  const row = getContributionById(db, rowId);
-  if (!row) return true;
-  const { error } = await supabase.from("goal_contributions").upsert({
-    id: row.id,
-    goal_id: row.goalId,
-    user_id: row.userId,
-    amount: row.amount,
-    note: row.note,
-    date: row.date,
-    created_at: row.createdAt,
-    updated_at: row.updatedAt,
-    deleted_at: row.deletedAt,
+const processFinancialAccountEntry: PushEntryHandler = (context) =>
+  upsertPushRow(context, {
+    tableName: "financial_accounts",
+    getRow: (db, rowId) =>
+      getFinancialAccountById(db, rowId as Parameters<typeof getFinancialAccountById>[1]),
+    mapRow: toSupabaseFinancialAccountRow,
   });
-  return !error;
+
+const processTransferEntry: PushEntryHandler = (context) =>
+  upsertPushRow(context, {
+    tableName: "transfers",
+    getRow: (db, rowId) => getTransferById(db, rowId as Parameters<typeof getTransferById>[1]),
+    mapRow: toSupabaseTransferRow,
+  });
+
+const processOpeningBalanceEntry: PushEntryHandler = (context) =>
+  upsertPushRow(context, {
+    tableName: "opening_balances",
+    getRow: (db, rowId) =>
+      getOpeningBalanceById(db, rowId as Parameters<typeof getOpeningBalanceById>[1]),
+    mapRow: toSupabaseOpeningBalanceRow,
+    upsertOptions: { onConflict: "account_id" },
+  });
+
+const processFinancialAccountIdentifierEntry: PushEntryHandler = (context) =>
+  upsertPushRow(context, {
+    tableName: "financial_account_identifiers",
+    getRow: (db, rowId) =>
+      getFinancialAccountIdentifierById(
+        db,
+        rowId as Parameters<typeof getFinancialAccountIdentifierById>[1]
+      ),
+    mapRow: toSupabaseFinancialAccountIdentifierRow,
+    upsertOptions: { onConflict: "user_id,account_id,scope,value" },
+  });
+
+const processCaptureEvidenceEntry: PushEntryHandler = (context) =>
+  upsertPushRow(context, {
+    tableName: "capture_evidence",
+    getRow: (db, rowId) =>
+      getCaptureEvidenceById(db, rowId as Parameters<typeof getCaptureEvidenceById>[1]),
+    mapRow: toSupabaseCaptureEvidenceRow,
+  });
+
+const processAccountSuggestionDismissalEntry: PushEntryHandler = (context) =>
+  upsertPushRow(context, {
+    tableName: "account_suggestion_dismissals",
+    getRow: (db, rowId) =>
+      getAccountSuggestionDismissalById(
+        db,
+        rowId as Parameters<typeof getAccountSuggestionDismissalById>[1]
+      ),
+    mapRow: toSupabaseAccountSuggestionDismissalRow,
+    upsertOptions: { onConflict: "user_id,scope,value" },
+  });
+
+const processContributionEntry: PushEntryHandler = (context) =>
+  upsertPushRow(context, {
+    tableName: "goal_contributions",
+    getRow: (db, rowId) => getContributionById(db, rowId),
+    mapRow: toSupabaseContributionRow,
+  });
+
+const PUSH_ENTRY_HANDLERS = {
+  transactions: processTransactionEntry,
+  budgets: processBudgetEntry,
+  financialAccounts: processFinancialAccountEntry,
+  accountSuggestionDismissals: processAccountSuggestionDismissalEntry,
+  captureEvidence: processCaptureEvidenceEntry,
+  transfers: processTransferEntry,
+  openingBalances: processOpeningBalanceEntry,
+  financialAccountIdentifiers: processFinancialAccountIdentifierEntry,
+  goals: processGoalEntry,
+  goalContributions: processContributionEntry,
+} satisfies Record<string, PushEntryHandler>;
+
+function getPushEntryHandler(tableName: string): PushEntryHandler | null {
+  return PUSH_ENTRY_HANDLERS[tableName as keyof typeof PUSH_ENTRY_HANDLERS] ?? null;
+}
+
+function capturePushEntryFailure(
+  tableName: string,
+  outcome: Extract<PushEntryOutcome, { ok: false }>
+) {
+  captureWarning("sync_push_entry_failed", {
+    tableName,
+    errorMessage: outcome.errorMessage,
+    errorCode: outcome.errorCode,
+  });
 }
 
 async function processEntry(
@@ -702,81 +867,17 @@ async function processEntry(
   supabase: SupabaseClient,
   entry: { id: SyncQueueId; tableName: string; rowId: string }
 ): Promise<SyncQueueId | null> {
-  if (entry.tableName === "transactions") {
-    const row = await getTransactionById(db, requireTransactionId(entry.rowId));
-    if (!row) return entry.id;
-    const { error } = await supabase.from("transactions").upsert(toSupabaseRow(row));
-    if (error) {
-      captureWarning("sync_push_entry_failed", {
-        tableName: entry.tableName,
-        errorMessage: error.message,
-        errorCode: error.code ?? "unknown",
-      });
-    }
-    return error ? null : entry.id;
+  const handler = getPushEntryHandler(entry.tableName);
+  if (!handler) {
+    captureWarning("sync_push_unknown_table", { tableName: entry.tableName });
+    return null;
   }
 
-  if (entry.tableName === "budgets") {
-    const ok = await processBudgetEntry(db, supabase, entry.rowId);
-    if (!ok) captureWarning("sync_push_entry_failed", { tableName: "budgets" });
-    return ok ? entry.id : null;
+  const outcome = await handler({ db, supabase, rowId: entry.rowId });
+  if (!outcome.ok) {
+    capturePushEntryFailure(entry.tableName, outcome);
   }
-
-  if (entry.tableName === "financialAccounts") {
-    const ok = await processFinancialAccountEntry(db, supabase, entry.rowId);
-    if (!ok) captureWarning("sync_push_entry_failed", { tableName: "financialAccounts" });
-    return ok ? entry.id : null;
-  }
-
-  if (entry.tableName === "accountSuggestionDismissals") {
-    const ok = await processAccountSuggestionDismissalEntry(db, supabase, entry.rowId);
-    if (!ok) {
-      captureWarning("sync_push_entry_failed", { tableName: "accountSuggestionDismissals" });
-    }
-    return ok ? entry.id : null;
-  }
-
-  if (entry.tableName === "captureEvidence") {
-    const ok = await processCaptureEvidenceEntry(db, supabase, entry.rowId);
-    if (!ok) captureWarning("sync_push_entry_failed", { tableName: "captureEvidence" });
-    return ok ? entry.id : null;
-  }
-
-  if (entry.tableName === "transfers") {
-    const ok = await processTransferEntry(db, supabase, entry.rowId);
-    if (!ok) captureWarning("sync_push_entry_failed", { tableName: "transfers" });
-    return ok ? entry.id : null;
-  }
-
-  if (entry.tableName === "openingBalances") {
-    const ok = await processOpeningBalanceEntry(db, supabase, entry.rowId);
-    if (!ok) captureWarning("sync_push_entry_failed", { tableName: "openingBalances" });
-    return ok ? entry.id : null;
-  }
-
-  if (entry.tableName === "financialAccountIdentifiers") {
-    const ok = await processFinancialAccountIdentifierEntry(db, supabase, entry.rowId);
-    if (!ok) {
-      captureWarning("sync_push_entry_failed", { tableName: "financialAccountIdentifiers" });
-    }
-    return ok ? entry.id : null;
-  }
-
-  if (entry.tableName === "goals") {
-    const ok = await processGoalEntry(db, supabase, entry.rowId);
-    if (!ok) captureWarning("sync_push_entry_failed", { tableName: "goals" });
-    return ok ? entry.id : null;
-  }
-
-  if (entry.tableName === "goalContributions") {
-    const ok = await processContributionEntry(db, supabase, entry.rowId);
-    if (!ok) captureWarning("sync_push_entry_failed", { tableName: "goalContributions" });
-    return ok ? entry.id : null;
-  }
-
-  // Unknown table — keep in queue for future handler
-  captureWarning("sync_push_unknown_table", { tableName: entry.tableName });
-  return null;
+  return outcome.ok ? entry.id : null;
 }
 
 export async function syncPush(
@@ -806,19 +907,56 @@ export async function syncPush(
   });
 }
 
-export async function syncPull(
-  db: AnyDb,
-  supabase: SupabaseClient,
-  userId: string
-): Promise<boolean> {
+type PullCursorState = {
+  accountSuggestionDismissals: PullCursor | null;
+  captureEvidence: PullCursor | null;
+  financialAccounts: PullCursor | null;
+  transfers: PullCursor | null;
+  openingBalances: PullCursor | null;
+  financialAccountIdentifiers: PullCursor | null;
+  transactions: PullCursor | null;
+};
+
+type PullResults = {
+  accountSuggestionDismissals: PullFetchOutcome<SupabaseAccountSuggestionDismissalRow>;
+  captureEvidence: PullFetchOutcome<SupabaseCaptureEvidenceRow>;
+  financialAccounts: PullFetchOutcome<SupabaseFinancialAccountRow>;
+  transfers: PullFetchOutcome<SupabaseTransferRow>;
+  openingBalances: PullFetchOutcome<SupabaseOpeningBalanceRow>;
+  financialAccountIdentifiers: PullFetchOutcome<SupabaseFinancialAccountIdentifierRow>;
+  transactions: PullFetchOutcome<SupabaseTransactionRow>;
+};
+
+type NonTransactionPullOutcome = {
+  failedCount: number;
+  safeCursors: {
+    accountSuggestionDismissals: PullCursor | null;
+    captureEvidence: PullCursor | null;
+    financialAccounts: PullCursor | null;
+    transfers: PullCursor | null;
+    openingBalances: PullCursor | null;
+    financialAccountIdentifiers: PullCursor | null;
+  };
+};
+
+type TransactionPullOutcome = {
+  failedCount: number;
+  conflictCount: number;
+  safeCursor: PullCursor | null;
+};
+
+type ComparableTransactionRow = ReturnType<typeof fromSupabaseTransactionRow>;
+type MaybeLocalTransactionRow = Awaited<ReturnType<typeof getTransactionById>>;
+
+async function getAllPullCursors(db: AnyDb): Promise<PullCursorState> {
   const [
-    accountSuggestionDismissalsCursor,
-    captureEvidenceCursor,
-    financialAccountsCursor,
-    transfersCursor,
-    openingBalancesCursor,
-    financialAccountIdentifiersCursor,
-    transactionsCursor,
+    accountSuggestionDismissals,
+    captureEvidence,
+    financialAccounts,
+    transfers,
+    openingBalances,
+    financialAccountIdentifiers,
+    transactions,
   ] = await Promise.all([
     getPullCursor(db, "account_suggestion_dismissals"),
     getPullCursor(db, "capture_evidence"),
@@ -828,237 +966,441 @@ export async function syncPull(
     getPullCursor(db, "financial_account_identifiers"),
     getPullCursor(db, "transactions"),
   ]);
-  const [
-    accountSuggestionDismissalsFetchResult,
-    captureEvidenceFetchResult,
-    financialAccountsFetchResult,
-    transfersFetchResult,
-    openingBalancesFetchResult,
-    financialAccountIdentifiersFetchResult,
-    transactionsFetchResult,
-  ] = await Promise.allSettled([
-    fetchPullRows<SupabaseAccountSuggestionDismissalRow>(
-      supabase,
-      userId,
-      "account_suggestion_dismissals",
-      accountSuggestionDismissalsCursor
-    ),
-    fetchPullRows<SupabaseCaptureEvidenceRow>(
-      supabase,
-      userId,
-      "capture_evidence",
-      captureEvidenceCursor
-    ),
-    fetchPullRows<SupabaseFinancialAccountRow>(
-      supabase,
-      userId,
-      "financial_accounts",
-      financialAccountsCursor
-    ),
-    fetchPullRows<SupabaseTransferRow>(supabase, userId, "transfers", transfersCursor),
-    fetchPullRows<SupabaseOpeningBalanceRow>(
-      supabase,
-      userId,
-      "opening_balances",
-      openingBalancesCursor
-    ),
-    fetchPullRows<SupabaseFinancialAccountIdentifierRow>(
-      supabase,
-      userId,
-      "financial_account_identifiers",
-      financialAccountIdentifiersCursor
-    ),
-    fetchPullRows<SupabaseTransactionRow>(supabase, userId, "transactions", transactionsCursor),
+
+  return {
+    accountSuggestionDismissals,
+    captureEvidence,
+    financialAccounts,
+    transfers,
+    openingBalances,
+    financialAccountIdentifiers,
+    transactions,
+  };
+}
+
+async function fetchAllPullResults(input: {
+  supabase: SupabaseClient;
+  userId: string;
+  cursors: PullCursorState;
+}): Promise<PullResults> {
+  const settledResults = await Promise.allSettled([
+    fetchPullRows<SupabaseAccountSuggestionDismissalRow>({
+      supabase: input.supabase,
+      userId: input.userId,
+      tableName: "account_suggestion_dismissals",
+      lastSyncAt: input.cursors.accountSuggestionDismissals,
+    }),
+    fetchPullRows<SupabaseCaptureEvidenceRow>({
+      supabase: input.supabase,
+      userId: input.userId,
+      tableName: "capture_evidence",
+      lastSyncAt: input.cursors.captureEvidence,
+    }),
+    fetchPullRows<SupabaseFinancialAccountRow>({
+      supabase: input.supabase,
+      userId: input.userId,
+      tableName: "financial_accounts",
+      lastSyncAt: input.cursors.financialAccounts,
+    }),
+    fetchPullRows<SupabaseTransferRow>({
+      supabase: input.supabase,
+      userId: input.userId,
+      tableName: "transfers",
+      lastSyncAt: input.cursors.transfers,
+    }),
+    fetchPullRows<SupabaseOpeningBalanceRow>({
+      supabase: input.supabase,
+      userId: input.userId,
+      tableName: "opening_balances",
+      lastSyncAt: input.cursors.openingBalances,
+    }),
+    fetchPullRows<SupabaseFinancialAccountIdentifierRow>({
+      supabase: input.supabase,
+      userId: input.userId,
+      tableName: "financial_account_identifiers",
+      lastSyncAt: input.cursors.financialAccountIdentifiers,
+    }),
+    fetchPullRows<SupabaseTransactionRow>({
+      supabase: input.supabase,
+      userId: input.userId,
+      tableName: "transactions",
+      lastSyncAt: input.cursors.transactions,
+    }),
   ]);
+  const [dismissals, evidence, accounts, transfers, balances, identifiers, transactions] =
+    settledResults;
 
-  const [
-    accountSuggestionDismissalsResult,
-    captureEvidenceResult,
-    financialAccountsResult,
-    transfersResult,
-    openingBalancesResult,
-    financialAccountIdentifiersResult,
-    transactionsResult,
-  ] = [
-    toPullFetchOutcome("account_suggestion_dismissals", accountSuggestionDismissalsFetchResult),
-    toPullFetchOutcome("capture_evidence", captureEvidenceFetchResult),
-    toPullFetchOutcome("financial_accounts", financialAccountsFetchResult),
-    toPullFetchOutcome("transfers", transfersFetchResult),
-    toPullFetchOutcome("opening_balances", openingBalancesFetchResult),
-    toPullFetchOutcome("financial_account_identifiers", financialAccountIdentifiersFetchResult),
-    toPullFetchOutcome("transactions", transactionsFetchResult),
+  return {
+    accountSuggestionDismissals: toPullFetchOutcome("account_suggestion_dismissals", dismissals),
+    captureEvidence: toPullFetchOutcome("capture_evidence", evidence),
+    financialAccounts: toPullFetchOutcome("financial_accounts", accounts),
+    transfers: toPullFetchOutcome("transfers", transfers),
+    openingBalances: toPullFetchOutcome("opening_balances", balances),
+    financialAccountIdentifiers: toPullFetchOutcome("financial_account_identifiers", identifiers),
+    transactions: toPullFetchOutcome("transactions", transactions),
+  };
+}
+
+function listPullResults(results: PullResults) {
+  return [
+    results.accountSuggestionDismissals,
+    results.captureEvidence,
+    results.financialAccounts,
+    results.transfers,
+    results.openingBalances,
+    results.financialAccountIdentifiers,
+    results.transactions,
   ];
+}
 
-  const failedFetches = [
-    accountSuggestionDismissalsResult,
-    captureEvidenceResult,
-    financialAccountsResult,
-    transfersResult,
-    openingBalancesResult,
-    financialAccountIdentifiersResult,
-    transactionsResult,
-  ].filter((result) => result.error);
+function capturePullFetchWarnings(results: PullResults) {
+  for (const failedFetch of listPullResults(results)) {
+    if (!failedFetch.error) {
+      continue;
+    }
 
-  for (const failedFetch of failedFetches) {
-    captureWarning("sync_pull_fetch_failed", {
-      tableName: failedFetch.tableName,
-      errorMessage: failedFetch.error?.message ?? "no_data",
-      errorCode: failedFetch.error?.code ?? "unknown",
-    });
+    captureWarning("sync_pull_fetch_failed", toPullFetchWarningPayload(failedFetch));
   }
+}
 
-  const accountSuggestionDismissalRows = accountSuggestionDismissalsResult.rows;
-  const financialAccountRows = financialAccountsResult.rows;
-  const captureEvidenceRows = captureEvidenceResult.rows;
-  const transferRows = transfersResult.rows;
-  const openingBalanceRows = openingBalancesResult.rows;
-  const financialAccountIdentifierRows = financialAccountIdentifiersResult.rows;
-  const transactionRows = transactionsResult.rows;
-  const allUpdatedAts = [
-    ...accountSuggestionDismissalRows.map((row) => row.updated_at),
-    ...captureEvidenceRows.map((row) => row.updated_at),
-    ...financialAccountRows.map((row) => row.updated_at),
-    ...transferRows.map((row) => row.updated_at),
-    ...openingBalanceRows.map((row) => row.updated_at),
-    ...financialAccountIdentifierRows.map((row) => row.updated_at),
-    ...transactionRows.map((row) => row.updated_at),
-  ];
-  // FP exemption: each row may depend on prior upserts for conflict detection.
-  let failedCount = 0;
-  let conflictCount = 0;
-  const accountSuggestionDismissalsOutcome = applyServerRows(db, accountSuggestionDismissalRows, {
-    getLocalRow: (database, rowId) =>
-      getAccountSuggestionDismissalById(
-        database,
-        rowId as Parameters<typeof getAccountSuggestionDismissalById>[1]
-      ),
+function countFetchedRows(results: PullResults) {
+  return listPullResults(results).reduce((count, result) => count + result.rows.length, 0);
+}
+
+function toPullFetchWarningPayload(
+  failedFetch: Extract<
+    ReturnType<typeof listPullResults>[number],
+    { error: NonNullable<PullFetchOutcome<{ updated_at: string; id: string }>["error"]> | null }
+  >
+) {
+  return {
+    tableName: failedFetch.tableName,
+    errorMessage: failedFetch.error?.message ?? "no_data",
+    errorCode: failedFetch.error?.code ?? "unknown",
+  };
+}
+
+function applyAccountSuggestionDismissalRows(
+  db: AnyDb,
+  rows: SupabaseAccountSuggestionDismissalRow[]
+) {
+  return applyServerRows({
+    db,
+    rows,
+    getLocalRow: getLocalAccountSuggestionDismissalRow,
     upsertLocalRow: upsertAccountSuggestionDismissal,
     mapServerRow: fromSupabaseAccountSuggestionDismissalRow,
   });
-  failedCount += accountSuggestionDismissalsOutcome.failedCount;
-  const captureEvidenceOutcome = applyServerRows(db, captureEvidenceRows, {
-    getLocalRow: (database, rowId) =>
-      getCaptureEvidenceById(database, rowId as Parameters<typeof getCaptureEvidenceById>[1]),
+}
+
+function applyCaptureEvidenceRows(db: AnyDb, rows: SupabaseCaptureEvidenceRow[]) {
+  return applyServerRows({
+    db,
+    rows,
+    getLocalRow: getLocalCaptureEvidenceRow,
     upsertLocalRow: upsertCaptureEvidence,
     mapServerRow: fromSupabaseCaptureEvidenceRow,
   });
-  failedCount += captureEvidenceOutcome.failedCount;
-  const financialAccountsOutcome = applyServerRows(db, financialAccountRows, {
-    getLocalRow: (database, rowId) =>
-      getFinancialAccountById(database, rowId as Parameters<typeof getFinancialAccountById>[1]),
+}
+
+function applyFinancialAccountRows(db: AnyDb, rows: SupabaseFinancialAccountRow[]) {
+  return applyServerRows({
+    db,
+    rows,
+    getLocalRow: getLocalFinancialAccountRow,
     upsertLocalRow: upsertFinancialAccount,
     mapServerRow: fromSupabaseFinancialAccountRow,
   });
-  failedCount += financialAccountsOutcome.failedCount;
+}
 
-  const transfersOutcome = applyServerRows(db, transferRows, {
-    getLocalRow: (database, rowId) =>
-      getTransferById(database, rowId as Parameters<typeof getTransferById>[1]),
+function applyTransferRows(db: AnyDb, rows: SupabaseTransferRow[]) {
+  return applyServerRows({
+    db,
+    rows,
+    getLocalRow: getLocalTransferRow,
     upsertLocalRow: upsertTransfer,
     mapServerRow: fromSupabaseTransferRow,
   });
-  failedCount += transfersOutcome.failedCount;
+}
 
-  const openingBalancesOutcome = applyServerRows(db, openingBalanceRows, {
-    getLocalRow: (database, rowId) =>
-      getOpeningBalanceById(database, rowId as Parameters<typeof getOpeningBalanceById>[1]),
+function applyOpeningBalanceRows(db: AnyDb, rows: SupabaseOpeningBalanceRow[]) {
+  return applyServerRows({
+    db,
+    rows,
+    getLocalRow: getLocalOpeningBalanceRow,
     upsertLocalRow: upsertOpeningBalance,
     mapServerRow: fromSupabaseOpeningBalanceRow,
   });
-  failedCount += openingBalancesOutcome.failedCount;
+}
 
-  const financialAccountIdentifiersOutcome = applyServerRows(db, financialAccountIdentifierRows, {
-    getLocalRow: (database, rowId) =>
-      getFinancialAccountIdentifierById(
-        database,
-        rowId as Parameters<typeof getFinancialAccountIdentifierById>[1]
-      ),
+function applyFinancialAccountIdentifierRows(
+  db: AnyDb,
+  rows: SupabaseFinancialAccountIdentifierRow[]
+) {
+  return applyServerRows({
+    db,
+    rows,
+    getLocalRow: getLocalFinancialAccountIdentifierRow,
     upsertLocalRow: upsertFinancialAccountIdentifier,
     mapServerRow: fromSupabaseFinancialAccountIdentifierRow,
   });
-  failedCount += financialAccountIdentifiersOutcome.failedCount;
-  let transactionsFailedCount = 0;
-  let transactionsSafeCursor: PullCursor | null = null;
-  let transactionsSawFailure = false;
+}
 
-  for (const serverRow of transactionRows) {
-    try {
-      const transactionId = requireTransactionId(serverRow.id);
-      const localRow = await getTransactionById(db, transactionId);
-      const mappedServerRow = fromSupabaseRow(serverRow);
+type NonTransactionRowOutcomes = {
+  accountSuggestionDismissals: ReturnType<typeof applyAccountSuggestionDismissalRows>;
+  captureEvidence: ReturnType<typeof applyCaptureEvidenceRows>;
+  financialAccounts: ReturnType<typeof applyFinancialAccountRows>;
+  transfers: ReturnType<typeof applyTransferRows>;
+  openingBalances: ReturnType<typeof applyOpeningBalanceRows>;
+  financialAccountIdentifiers: ReturnType<typeof applyFinancialAccountIdentifierRows>;
+};
 
-      if (shouldUpdateLocal(serverRow.updated_at, localRow?.updatedAt)) {
-        const comparableLocalRow =
-          localRow == null
-            ? null
-            : {
-                ...localRow,
-                description: localRow.description ?? null,
-                deletedAt: localRow.deletedAt ?? null,
-              };
-        const comparableServerRow = {
-          ...mappedServerRow,
-          description: mappedServerRow.description ?? null,
-          deletedAt: mappedServerRow.deletedAt ?? null,
-        };
-        const isConflict =
-          comparableLocalRow != null && hasDataConflict(comparableLocalRow, comparableServerRow);
-        await upsertTransaction(db, mappedServerRow as Parameters<typeof upsertTransaction>[1]);
-        // Log conflict after successful upsert to avoid duplicates on retry.
-        // Own try/catch so a conflict-logging failure doesn't affect the sync flow.
-        if (isConflict) {
-          conflictCount++;
-          try {
-            insertConflict(db, {
-              id: generateSyncConflictId(),
-              transactionId,
-              localData: JSON.stringify(localRow),
-              serverData: JSON.stringify(mappedServerRow),
-              detectedAt: toIsoDateTime(new Date()),
-            });
-          } catch (conflictErr) {
-            captureError(conflictErr);
-          }
-        }
-      }
-      if (!transactionsSawFailure) {
-        transactionsSafeCursor = rowToPullCursor(serverRow);
-      }
-    } catch (error) {
-      captureError(error);
-      transactionsFailedCount++;
-      transactionsSawFailure = true;
-    }
+function countNonTransactionFailedRows(outcomes: NonTransactionRowOutcomes) {
+  return (
+    outcomes.accountSuggestionDismissals.failedCount +
+    outcomes.captureEvidence.failedCount +
+    outcomes.financialAccounts.failedCount +
+    outcomes.transfers.failedCount +
+    outcomes.openingBalances.failedCount +
+    outcomes.financialAccountIdentifiers.failedCount
+  );
+}
+
+function getNonTransactionSafeCursors(outcomes: NonTransactionRowOutcomes) {
+  return {
+    accountSuggestionDismissals: outcomes.accountSuggestionDismissals.safeCursor,
+    captureEvidence: outcomes.captureEvidence.safeCursor,
+    financialAccounts: outcomes.financialAccounts.safeCursor,
+    transfers: outcomes.transfers.safeCursor,
+    openingBalances: outcomes.openingBalances.safeCursor,
+    financialAccountIdentifiers: outcomes.financialAccountIdentifiers.safeCursor,
+  };
+}
+
+function applyNonTransactionPullRows(db: AnyDb, results: PullResults): NonTransactionPullOutcome {
+  const outcomes: NonTransactionRowOutcomes = {
+    accountSuggestionDismissals: applyAccountSuggestionDismissalRows(
+      db,
+      results.accountSuggestionDismissals.rows
+    ),
+    captureEvidence: applyCaptureEvidenceRows(db, results.captureEvidence.rows),
+    financialAccounts: applyFinancialAccountRows(db, results.financialAccounts.rows),
+    transfers: applyTransferRows(db, results.transfers.rows),
+    openingBalances: applyOpeningBalanceRows(db, results.openingBalances.rows),
+    financialAccountIdentifiers: applyFinancialAccountIdentifierRows(
+      db,
+      results.financialAccountIdentifiers.rows
+    ),
+  };
+
+  return {
+    failedCount: countNonTransactionFailedRows(outcomes),
+    safeCursors: getNonTransactionSafeCursors(outcomes),
+  };
+}
+
+function toComparableTransactionRow(row: ComparableTransactionRow) {
+  return {
+    ...row,
+    description: row.description ?? null,
+    deletedAt: row.deletedAt ?? null,
+  };
+}
+
+function toComparableLocalTransactionRow(row: LocalTransactionRow) {
+  return {
+    ...row,
+    accountId: row.accountId ?? buildDefaultFinancialAccountId(row.userId),
+    accountAttributionState: row.accountAttributionState ?? "confirmed",
+    supersededAt: row.supersededAt ?? null,
+    description: row.description ?? null,
+    deletedAt: row.deletedAt ?? null,
+  };
+}
+
+function hasTransactionPullConflict(
+  localRow: MaybeLocalTransactionRow,
+  mappedServerRow: ComparableTransactionRow
+) {
+  return (
+    localRow != null &&
+    hasDataConflict(
+      toComparableLocalTransactionRow(localRow),
+      toComparableTransactionRow(mappedServerRow)
+    )
+  );
+}
+
+function captureTransactionPullConflict(input: {
+  db: AnyDb;
+  transactionId: ReturnType<typeof requireTransactionId>;
+  localRow: MaybeLocalTransactionRow;
+  mappedServerRow: ComparableTransactionRow;
+}) {
+  const conflict = buildTransactionPullConflict(input);
+  try {
+    insertConflict(input.db, conflict);
+  } catch (conflictError) {
+    captureError(conflictError);
   }
-  failedCount += transactionsFailedCount;
+}
 
+const buildTransactionPullConflict = (input: {
+  transactionId: ReturnType<typeof requireTransactionId>;
+  localRow: MaybeLocalTransactionRow;
+  mappedServerRow: ComparableTransactionRow;
+}) => ({
+  id: generateSyncConflictId(),
+  transactionId: input.transactionId,
+  localData: JSON.stringify(input.localRow),
+  serverData: JSON.stringify(input.mappedServerRow),
+  detectedAt: toIsoDateTime(new Date()),
+});
+
+async function applyTransactionPullRow(input: { db: AnyDb; serverRow: SupabaseTransactionRow }) {
+  try {
+    const transactionId = requireTransactionId(input.serverRow.id);
+    const localRow = await getTransactionById(input.db, transactionId);
+    const mappedServerRow = fromSupabaseTransactionRow(input.serverRow);
+    if (!shouldUpdateLocal(input.serverRow.updated_at, localRow?.updatedAt)) {
+      return { failed: false, conflict: false };
+    }
+
+    const conflict = hasTransactionPullConflict(localRow, mappedServerRow);
+    await upsertTransaction(input.db, mappedServerRow as Parameters<typeof upsertTransaction>[1]);
+    if (conflict) {
+      captureTransactionPullConflict({
+        db: input.db,
+        transactionId,
+        localRow,
+        mappedServerRow,
+      });
+    }
+    return { failed: false, conflict };
+  } catch (error) {
+    captureError(error);
+    return { failed: true, conflict: false };
+  }
+}
+
+type TransactionPullProgress = TransactionPullOutcome & { sawFailure: boolean };
+
+function nextTransactionPullProgress(
+  progress: TransactionPullProgress,
+  outcome: { failed: boolean; conflict: boolean },
+  serverRow: SupabaseTransactionRow
+): TransactionPullProgress {
+  const sawFailure = progress.sawFailure || outcome.failed;
+  return {
+    failedCount: progress.failedCount + Number(outcome.failed),
+    conflictCount: progress.conflictCount + Number(outcome.conflict),
+    safeCursor: sawFailure ? progress.safeCursor : rowToPullCursor(serverRow),
+    sawFailure,
+  };
+}
+
+async function applyTransactionPullRows(
+  db: AnyDb,
+  rows: SupabaseTransactionRow[]
+): Promise<TransactionPullOutcome> {
+  let progress: TransactionPullProgress = {
+    failedCount: 0,
+    conflictCount: 0,
+    safeCursor: null,
+    sawFailure: false,
+  };
+
+  for (const serverRow of rows) {
+    const outcome = await applyTransactionPullRow({ db, serverRow });
+    progress = nextTransactionPullProgress(progress, outcome, serverRow);
+  }
+
+  return {
+    failedCount: progress.failedCount,
+    conflictCount: progress.conflictCount,
+    safeCursor: progress.safeCursor,
+  };
+}
+
+function captureSyncPullEvent(input: {
+  results: PullResults;
+  nonTransactionOutcome: NonTransactionPullOutcome;
+  transactionOutcome: TransactionPullOutcome;
+}) {
   capturePipelineEvent({
     source: "sync_pull",
-    rowsFetched: allUpdatedAts.length,
-    rowsApplied: allUpdatedAts.length - failedCount,
-    conflicts: conflictCount,
-    failed: failedCount,
+    rowsFetched: countFetchedRows(input.results),
+    rowsApplied:
+      countFetchedRows(input.results) -
+      input.nonTransactionOutcome.failedCount -
+      input.transactionOutcome.failedCount,
+    conflicts: input.transactionOutcome.conflictCount,
+    failed: input.nonTransactionOutcome.failedCount + input.transactionOutcome.failedCount,
+  });
+}
+
+async function advanceSyncPullCursors(input: {
+  db: AnyDb;
+  nonTransactionOutcome: NonTransactionPullOutcome;
+  transactionSafeCursor: PullCursor | null;
+}) {
+  const cursorAdvancements = getSyncPullCursorAdvancements(input);
+  await Promise.all(
+    cursorAdvancements.map(({ tableName, cursor }) =>
+      advancePullCursor(input.db, tableName, cursor)
+    )
+  );
+}
+
+function getSyncPullCursorAdvancements(input: {
+  nonTransactionOutcome: NonTransactionPullOutcome;
+  transactionSafeCursor: PullCursor | null;
+}) {
+  return [
+    {
+      tableName: "account_suggestion_dismissals" as const,
+      cursor: input.nonTransactionOutcome.safeCursors.accountSuggestionDismissals,
+    },
+    {
+      tableName: "capture_evidence" as const,
+      cursor: input.nonTransactionOutcome.safeCursors.captureEvidence,
+    },
+    {
+      tableName: "financial_accounts" as const,
+      cursor: input.nonTransactionOutcome.safeCursors.financialAccounts,
+    },
+    { tableName: "transfers" as const, cursor: input.nonTransactionOutcome.safeCursors.transfers },
+    {
+      tableName: "opening_balances" as const,
+      cursor: input.nonTransactionOutcome.safeCursors.openingBalances,
+    },
+    {
+      tableName: "financial_account_identifiers" as const,
+      cursor: input.nonTransactionOutcome.safeCursors.financialAccountIdentifiers,
+    },
+    { tableName: "transactions" as const, cursor: input.transactionSafeCursor },
+  ];
+}
+
+export async function syncPull(
+  db: AnyDb,
+  supabase: SupabaseClient,
+  userId: string
+): Promise<boolean> {
+  const cursors = await getAllPullCursors(db);
+  const results = await fetchAllPullResults({ supabase, userId, cursors });
+  const nonTransactionOutcome = applyNonTransactionPullRows(db, results);
+  const transactionOutcome = await applyTransactionPullRows(db, results.transactions.rows);
+
+  capturePullFetchWarnings(results);
+  captureSyncPullEvent({ results, nonTransactionOutcome, transactionOutcome });
+  await advanceSyncPullCursors({
+    db,
+    nonTransactionOutcome,
+    transactionSafeCursor: transactionOutcome.safeCursor,
   });
 
-  await Promise.all([
-    advancePullCursor(
-      db,
-      "account_suggestion_dismissals",
-      accountSuggestionDismissalsOutcome.safeCursor
-    ),
-    advancePullCursor(db, "capture_evidence", captureEvidenceOutcome.safeCursor),
-    advancePullCursor(db, "financial_accounts", financialAccountsOutcome.safeCursor),
-    advancePullCursor(db, "transfers", transfersOutcome.safeCursor),
-    advancePullCursor(db, "opening_balances", openingBalancesOutcome.safeCursor),
-    advancePullCursor(
-      db,
-      "financial_account_identifiers",
-      financialAccountIdentifiersOutcome.safeCursor
-    ),
-    advancePullCursor(db, "transactions", transactionsSafeCursor),
-  ]);
-
-  return transactionsResult.error == null;
+  return results.transactions.error == null;
 }
 
 export async function fullSync(


### PR DESCRIPTION
- registry push handlers
- staged sync pull flow
- full verify passed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the mobile sync engine into staged push/pull flows with a registry of push handlers and per-table pull cursors to improve reliability, debuggability, and conflict handling.

- **Refactors**
  - Added a generic `upsertPushRow` and a registry of push handlers for transactions, budgets, accounts, transfers, openings, identifiers, goals, and contributions.
  - Reworked pull into stages: fetch all tables, apply non-transaction rows with per-table safe cursors, then apply transactions with conflict detection and logging.
  - Extracted clear mappers for Supabase/local rows and cursor utilities; improved null/default handling for transactions.
  - Centralized error parsing and warnings; added pipeline metrics (rows fetched/applied, conflicts, failures).

<sup>Written for commit a3ef855a4715197ce0a815a6df4e7c97de9855f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

