### PR TITLE
refactor(mobile): split slice 6b helpers

### DIFF
--- a/apps/mobile/__tests__/transactions/build-transaction.test.ts
+++ b/apps/mobile/__tests__/transactions/build-transaction.test.ts
@@ -29,7 +29,12 @@ describe("buildTransaction", () => {
   };
 
   test("returns success with valid input", () => {
-    const result = buildTransaction(validInput, "user-1" as UserId, "tx-1" as TransactionId, NOW);
+    const result = buildTransaction({
+      input: validInput,
+      userId: "user-1" as UserId,
+      id: "tx-1" as TransactionId,
+      now: NOW,
+    });
     expect(result.success).toBe(true);
     if (!result.success) return;
     expect(result.transaction.id).toBe("tx-1");
@@ -44,44 +49,44 @@ describe("buildTransaction", () => {
   });
 
   test("returns error for zero amount", () => {
-    const result = buildTransaction(
-      { ...validInput, digits: "0" },
-      "user-1" as UserId,
-      "tx-2" as TransactionId,
-      NOW
-    );
+    const result = buildTransaction({
+      input: { ...validInput, digits: "0" },
+      userId: "user-1" as UserId,
+      id: "tx-2" as TransactionId,
+      now: NOW,
+    });
     expect(result.success).toBe(false);
   });
 
   test("defaults categoryId to 'other' when null", () => {
-    const result = buildTransaction(
-      { ...validInput, categoryId: null },
-      "user-1" as UserId,
-      "tx-3" as TransactionId,
-      NOW
-    );
+    const result = buildTransaction({
+      input: { ...validInput, categoryId: null },
+      userId: "user-1" as UserId,
+      id: "tx-3" as TransactionId,
+      now: NOW,
+    });
     expect(result.success).toBe(true);
     if (!result.success) return;
     expect(result.transaction.categoryId).toBe("other");
   });
 
   test("returns error for non-numeric digits", () => {
-    const result = buildTransaction(
-      { ...validInput, digits: "abc" },
-      "user-1" as UserId,
-      "tx-4" as TransactionId,
-      NOW
-    );
+    const result = buildTransaction({
+      input: { ...validInput, digits: "abc" },
+      userId: "user-1" as UserId,
+      id: "tx-4" as TransactionId,
+      now: NOW,
+    });
     expect(result.success).toBe(false);
   });
 
   test("returns error when the owning account is missing", () => {
-    const result = buildTransaction(
-      { ...validInput, accountId: null },
-      "user-1" as UserId,
-      "tx-5" as TransactionId,
-      NOW
-    );
+    const result = buildTransaction({
+      input: { ...validInput, accountId: null },
+      userId: "user-1" as UserId,
+      id: "tx-5" as TransactionId,
+      now: NOW,
+    });
     expect(result.success).toBe(false);
   });
 });

--- a/apps/mobile/features/email-capture/services/gmail-adapter.ts
+++ b/apps/mobile/features/email-capture/services/gmail-adapter.ts
@@ -2,101 +2,87 @@
 import { captureError, captureWarning } from "@/shared/lib";
 import type { RawEmail } from "../schema";
 
-export async function fetchGmailEmailsWithToken(
-  token: string,
-  since: string,
-  senderEmails: string[]
-): Promise<RawEmail[]> {
-  const epoch = Math.floor(new Date(since).getTime() / 1000);
-  const fromQuery = senderEmails.map((e) => `from:${e}`).join(" OR ");
-  const query = `(${fromQuery}) after:${epoch}`;
-
-  const listResponse = await fetch(
-    `https://gmail.googleapis.com/gmail/v1/users/me/messages?q=${encodeURIComponent(query)}`,
-    { headers: { Authorization: `Bearer ${token}` } }
-  );
-
-  if (!listResponse.ok) {
-    captureWarning("gmail_api_list_failed", { httpStatus: listResponse.status });
-    return [];
-  }
-
-  const listData = (await listResponse.json()) as { messages?: { id: string }[] };
-  const messageIds: string[] = (listData.messages ?? []).map((m) => m.id);
-
-  if (messageIds.length === 0) return [];
-
-  const Concurrency = 5;
-  const chunks = Array.from({ length: Math.ceil(messageIds.length / Concurrency) }, (_, i) =>
-    messageIds.slice(i * Concurrency, (i + 1) * Concurrency)
-  );
-
-  // Batches must be sequential to respect Gmail API rate limits.
-  const emails = await chunks.reduce<Promise<RawEmail[]>>(async (accPromise, batch) => {
-    const acc = await accPromise;
-    const results = await Promise.allSettled(
-      batch.map(async (id) => {
-        const msgResponse = await fetch(
-          `https://gmail.googleapis.com/gmail/v1/users/me/messages/${id}?format=full`,
-          { headers: { Authorization: `Bearer ${token}` } }
-        );
-        if (!msgResponse.ok) return null;
-        const msg = (await msgResponse.json()) as { payload: GmailPayload };
-        return parseGmailMessage(id, msg);
-      })
-    );
-    const fulfilled = results
-      .filter((r): r is PromiseFulfilledResult<RawEmail | null> => r.status === "fulfilled")
-      .map((r) => r.value)
-      .filter((v): v is RawEmail => v != null);
-    return [...acc, ...fulfilled];
-  }, Promise.resolve([]));
-
-  return emails;
-}
-
 type GmailHeader = { name: string; value: string };
 type GmailPart = { mimeType: string; body?: { data?: string }; parts?: GmailPart[] };
 type GmailPayload = { headers: GmailHeader[]; parts?: GmailPart[]; body?: { data?: string } };
+type GmailListResponse = { messages?: { id: string }[] };
+type GmailMessageResponse = { payload: GmailPayload };
+type GmailJsonResult<T> = { ok: true; data: T } | { ok: false; status: number };
 
-function getHeader(headers: GmailHeader[], name: string): string {
-  return headers.find((h) => h.name.toLowerCase() === name.toLowerCase())?.value ?? "";
-}
+const GMAIL_MESSAGES_URL = "https://gmail.googleapis.com/gmail/v1/users/me/messages";
+const GMAIL_BATCH_SIZE = 5;
 
-function extractBodyText(payload: GmailPayload): string {
-  // Try top-level body first
+const toAuthorizationHeaders = (token: string) => ({ Authorization: `Bearer ${token}` });
+
+const fetchGmailJson = async <T>(url: string, token: string): Promise<GmailJsonResult<T>> => {
+  const response = await fetch(url, { headers: toAuthorizationHeaders(token) });
+  if (!response.ok) {
+    return { ok: false, status: response.status };
+  }
+
+  return { ok: true, data: (await response.json()) as T };
+};
+
+const toMessageQuery = (since: string, senderEmails: string[]): string => {
+  const epoch = Math.floor(new Date(since).getTime() / 1000);
+  const senders = senderEmails.map((email) => `from:${email}`).join(" OR ");
+  return `(${senders}) after:${epoch}`;
+};
+
+const toListUrl = (query: string): string => `${GMAIL_MESSAGES_URL}?q=${encodeURIComponent(query)}`;
+
+const toMessageUrl = (id: string): string => `${GMAIL_MESSAGES_URL}/${id}?format=full`;
+
+const toMessageIds = (listData: GmailListResponse): string[] =>
+  (listData.messages ?? []).map((message) => message.id);
+
+const chunkMessageIds = (messageIds: string[]): string[][] =>
+  Array.from({ length: Math.ceil(messageIds.length / GMAIL_BATCH_SIZE) }, (_, index) =>
+    messageIds.slice(index * GMAIL_BATCH_SIZE, (index + 1) * GMAIL_BATCH_SIZE)
+  );
+
+const isFulfilled = <T>(result: PromiseSettledResult<T>): result is PromiseFulfilledResult<T> =>
+  result.status === "fulfilled";
+
+const isNonNull = <T>(value: T | null): value is T => value != null;
+
+const getHeader = (headers: GmailHeader[], name: string): string =>
+  headers.find((header) => header.name.toLowerCase() === name.toLowerCase())?.value ?? "";
+
+const getMatchingPartData = (part: GmailPart, mime: string): string | null =>
+  part.mimeType === mime && part.body?.data ? decodeBase64Url(part.body.data) : null;
+
+const getNestedPartData = (part: GmailPart, mime: string): string | null =>
+  part.parts ? findPartByMime(part.parts, mime) : null;
+
+const findPartByMime = (parts: GmailPart[], mime: string): string | null => {
+  for (const part of parts) {
+    const directMatch = getMatchingPartData(part, mime);
+    if (directMatch) return directMatch;
+
+    const nestedMatch = getNestedPartData(part, mime);
+    if (nestedMatch) return nestedMatch;
+  }
+
+  return null;
+};
+
+const extractBodyText = (payload: GmailPayload): string => {
   if (payload.body?.data) {
     return decodeBase64Url(payload.body.data);
   }
 
   if (!payload.parts) return "";
 
-  // Prefer text/plain
   const plain = findPartByMime(payload.parts, "text/plain");
   if (plain) return plain;
 
-  // Fall back to text/html with tags stripped (bank emails are often HTML-only)
   const html = findPartByMime(payload.parts, "text/html");
-  if (html) return stripHtml(html);
+  return html ? stripHtml(html) : "";
+};
 
-  return "";
-}
-
-function findPartByMime(parts: GmailPart[], mime: string): string | null {
-  for (const part of parts) {
-    if (part.mimeType === mime && part.body?.data) {
-      return decodeBase64Url(part.body.data);
-    }
-    if (part.parts) {
-      const nested = findPartByMime(part.parts, mime);
-      if (nested) return nested;
-    }
-  }
-  return null;
-}
-
-function stripHtml(html: string): string {
-  return html
+const stripHtml = (html: string): string =>
+  html
     .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "")
     .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "")
     .replace(/<[^>]+>/g, " ")
@@ -107,9 +93,8 @@ function stripHtml(html: string): string {
     .replace(/&#?\w+;/gi, "")
     .replace(/\s+/g, " ")
     .trim();
-}
 
-function decodeBase64Url(data: string): string {
+const decodeBase64Url = (data: string): string => {
   try {
     const base64 = data.replace(/-/g, "+").replace(/_/g, "/");
     const binary = atob(base64);
@@ -119,31 +104,79 @@ function decodeBase64Url(data: string): string {
     captureError(error);
     return "";
   }
-}
+};
 
-function parseGmailMessage(id: string, msg: { payload: GmailPayload }): RawEmail | null {
+const normalizeSender = (from: string): string => from.match(/<(.+?)>/)?.[1] ?? from;
+
+const normalizeReceivedAt = (date: string): string => {
+  const parsedDate = new Date(date);
+  return Number.isNaN(parsedDate.getTime()) ? new Date().toISOString() : parsedDate.toISOString();
+};
+
+const fetchGmailMessage = async (token: string, id: string): Promise<RawEmail | null> => {
+  const result = await fetchGmailJson<GmailMessageResponse>(toMessageUrl(id), token);
+  return result.ok ? parseGmailMessage(id, result.data) : null;
+};
+
+const toBatchEmails = (results: PromiseSettledResult<RawEmail | null>[]): RawEmail[] =>
+  results
+    .filter(isFulfilled)
+    .map((result) => result.value)
+    .filter(isNonNull);
+
+const collectBatchEmails = async (token: string, batch: string[]): Promise<RawEmail[]> =>
+  toBatchEmails(await Promise.allSettled(batch.map((id) => fetchGmailMessage(token, id))));
+
+const appendBatchEmails = async (
+  token: string,
+  accPromise: Promise<RawEmail[]>,
+  batch: string[]
+): Promise<RawEmail[]> => {
+  const acc = await accPromise;
+  const emails = await collectBatchEmails(token, batch);
+  return [...acc, ...emails];
+};
+
+const collectSequentialEmails = (token: string, messageIds: string[]): Promise<RawEmail[]> =>
+  chunkMessageIds(messageIds).reduce<Promise<RawEmail[]>>(
+    // Batches must be sequential to respect Gmail API rate limits.
+    (accPromise, batch) => appendBatchEmails(token, accPromise, batch),
+    Promise.resolve([])
+  );
+
+export const fetchGmailEmailsWithToken = async (
+  token: string,
+  since: string,
+  senderEmails: string[]
+): Promise<RawEmail[]> => {
+  const listResult = await fetchGmailJson<GmailListResponse>(
+    toListUrl(toMessageQuery(since, senderEmails)),
+    token
+  );
+
+  if (!listResult.ok) {
+    captureWarning("gmail_api_list_failed", { httpStatus: listResult.status });
+    return [];
+  }
+
+  const messageIds = toMessageIds(listResult.data);
+  return messageIds.length === 0 ? [] : collectSequentialEmails(token, messageIds);
+};
+
+const parseGmailMessage = (id: string, msg: GmailMessageResponse): RawEmail | null => {
   const headers = msg.payload.headers;
   const from = getHeader(headers, "From");
   const subject = getHeader(headers, "Subject");
-  const dateStr = getHeader(headers, "Date");
-  const body = extractBodyText(msg.payload);
-
   if (!from || !subject) return null;
 
-  const emailMatch = from.match(/<(.+?)>/);
-  const emailAddress = emailMatch?.[1] ?? from;
-
-  const parsedDate = new Date(dateStr);
-  const receivedAt = Number.isNaN(parsedDate.getTime())
-    ? new Date().toISOString()
-    : parsedDate.toISOString();
-
+  const body = extractBodyText(msg.payload);
+  const receivedAt = normalizeReceivedAt(getHeader(headers, "Date"));
   return {
     externalId: id,
-    from: emailAddress,
+    from: normalizeSender(from),
     subject,
     body,
     receivedAt,
     provider: "gmail",
   };
-}
+};

--- a/apps/mobile/features/email-capture/services/parse-email-api.ts
+++ b/apps/mobile/features/email-capture/services/parse-email-api.ts
@@ -1,36 +1,45 @@
 import type { LlmParsedTransaction } from "./llm-parser";
 import { liveParseEmailService } from "./parse-email-service";
 
-export function stripPii(text: string): string {
-  return (
-    text
-      .replace(/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g, "[EMAIL]")
-      .replace(/\+\d[\d\s-]{8,14}\d/g, "[PHONE]")
-      // ID patterns must run before local phone — cedulas starting with 601-608 would otherwise match phones
-      .replace(
-        /\b(?:C\.?\s?C\.?|T\.?\s?I\.?|C\.?\s?E\.?|[Cc][eé]dula)\s*:?\s*#?\s*\d{6,11}\b/gi,
-        "[ID]"
-      )
-      .replace(/\bNIT\s*:?\s*\d{3}\.?\d{3}\.?\d{3,4}-?\d?\b/gi, "[ID]")
-      .replace(
-        /(?:(?:No\.?\s*)?Cuenta|Cta\.?)\s*(?:(?:de\s+)?(?:Ahorros|Corriente)\s*)?(?:No\.?\s*)?#?\s{0,3}\d{8,20}/gi,
-        "[ACCOUNT]"
-      )
-      .replace(/(?<!\d)\(?60[1-8]\)?[\s-]?\d{3}[\s-]?\d{4}\b/g, "[PHONE]")
-      .replace(/\b\d{4}[\s-]\d{4}[\s-]\d{4}[\s-]\d{4}\b/g, "[CARD]")
-      .replace(/\b\d{15,16}\b/g, "[CARD]")
-      .replace(/\d{4}[\s-]*[*Xx]{2,}[\s-]*[*Xx]{2,}[\s-]*\d{4}/g, "[CARD]")
-      .replace(/[*Xx]{2,4}[\s.-]*[*Xx]{2,4}[\s.-]*[*Xx]{2,4}[\s.-]*\d{4}/g, "[CARD]")
-      .replace(/\*{1,4}\d{4}/g, "[CARD]")
-  );
-}
+type RedactionRule = {
+  pattern: RegExp;
+  replacement: string;
+};
 
-export async function classifyMerchantApi(merchant: string): Promise<string> {
-  return liveParseEmailService.classifyMerchant(merchant);
-}
+const REDACTION_RULES: readonly RedactionRule[] = [
+  { pattern: /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g, replacement: "[EMAIL]" },
+  { pattern: /\+\d[\d\s-]{8,14}\d/g, replacement: "[PHONE]" },
+  // ID patterns must run before local phone — cedulas starting with 601-608 would otherwise match phones
+  {
+    pattern: /\b(?:C\.?\s?C\.?|T\.?\s?I\.?|C\.?\s?E\.?|[Cc][eé]dula)\s*:?\s*#?\s*\d{6,11}\b/gi,
+    replacement: "[ID]",
+  },
+  { pattern: /\bNIT\s*:?\s*\d{3}\.?\d{3}\.?\d{3,4}-?\d?\b/gi, replacement: "[ID]" },
+  {
+    pattern:
+      /(?:(?:No\.?\s*)?Cuenta|Cta\.?)\s*(?:(?:de\s+)?(?:Ahorros|Corriente)\s*)?(?:No\.?\s*)?#?\s{0,3}\d{8,20}/gi,
+    replacement: "[ACCOUNT]",
+  },
+  { pattern: /(?<!\d)\(?60[1-8]\)?[\s-]?\d{3}[\s-]?\d{4}\b/g, replacement: "[PHONE]" },
+  { pattern: /\b\d{4}[\s-]\d{4}[\s-]\d{4}[\s-]\d{4}\b/g, replacement: "[CARD]" },
+  { pattern: /\b\d{15,16}\b/g, replacement: "[CARD]" },
+  { pattern: /\d{4}[\s-]*[*Xx]{2,}[\s-]*[*Xx]{2,}[\s-]*\d{4}/g, replacement: "[CARD]" },
+  { pattern: /[*Xx]{2,4}[\s.-]*[*Xx]{2,4}[\s.-]*[*Xx]{2,4}[\s.-]*\d{4}/g, replacement: "[CARD]" },
+  { pattern: /\*{1,4}\d{4}/g, replacement: "[CARD]" },
+];
 
-export async function parseEmailApi(emailBody: string): Promise<LlmParsedTransaction | null> {
-  const stripped = stripPii(emailBody);
-  const truncated = stripped.slice(0, 2000);
-  return liveParseEmailService.parseEmail(truncated);
-}
+const applyRedactionRule = (text: string, rule: RedactionRule): string =>
+  text.replace(rule.pattern, rule.replacement);
+
+const truncateEmailBody = (text: string): string => text.slice(0, 2000);
+
+const sanitizeEmailBody = (text: string): string =>
+  truncateEmailBody(REDACTION_RULES.reduce(applyRedactionRule, text));
+
+export const stripPii = (text: string): string => REDACTION_RULES.reduce(applyRedactionRule, text);
+
+export const classifyMerchantApi = async (merchant: string): Promise<string> =>
+  liveParseEmailService.classifyMerchant(merchant);
+
+export const parseEmailApi = async (emailBody: string): Promise<LlmParsedTransaction | null> =>
+  liveParseEmailService.parseEmail(sanitizeEmailBody(emailBody));

--- a/apps/mobile/features/transactions/lib/build-transaction.ts
+++ b/apps/mobile/features/transactions/lib/build-transaction.ts
@@ -1,7 +1,12 @@
-import { buildDefaultFinancialAccountId } from "@/features/financial-accounts";
+import { buildDefaultFinancialAccountId } from "@/features/financial-accounts/lib/default-account";
 import { parseDigitsToAmount, parseIsoDate, toIsoDate, toIsoDateTime } from "@/shared/lib";
 import type { CategoryId, FinancialAccountId, TransactionId, UserId } from "@/shared/types/branded";
-import type { AccountAttributionState, StoredTransaction, TransactionType } from "../schema";
+import type {
+  AccountAttributionState,
+  CreateTransactionInput,
+  StoredTransaction,
+  TransactionType,
+} from "../schema";
 import { createTransactionSchema } from "../schema";
 import { getBuiltInCategoryId, isValidCategoryId } from "./categories";
 import type { TransactionRow } from "./repository";
@@ -15,112 +20,178 @@ type BuildInput = {
   date: Date;
 };
 
+type BuildTransactionArgs = {
+  input: BuildInput;
+  userId: UserId;
+  id: TransactionId;
+  now: Date;
+  existing?: StoredTransaction | null;
+};
+
+type TransactionBuildResult =
+  | { success: true; transaction: StoredTransaction }
+  | { success: false; error: string };
+
+type TransactionDraft = {
+  type: TransactionType;
+  amount: number;
+  categoryId: string;
+  accountId: FinancialAccountId | "";
+  description?: string;
+  date: Date;
+};
+
+type BuildTransactionContext = {
+  validated: CreateTransactionInput;
+  userId: UserId;
+  id: TransactionId;
+  now: Date;
+  existing: StoredTransaction | null;
+};
+
 const OTHER_CATEGORY_ID = getBuiltInCategoryId("other");
 const TRANSACTION_SOURCES_WITH_CONFIRMED_DEFAULT = new Set(["manual"]);
 
-function getDefaultAccountAttributionState(source: string | undefined): AccountAttributionState {
-  return TRANSACTION_SOURCES_WITH_CONFIRMED_DEFAULT.has(source ?? "manual")
-    ? "confirmed"
-    : "unresolved";
-}
+const toTransactionSource = (source: string | undefined | null): string => source ?? "manual";
 
-function normalizeAccountAttributionState(
-  state: string | undefined,
-  source: string | undefined
-): AccountAttributionState {
-  if (state === "confirmed" || state === "inferred" || state === "unresolved") {
-    return state;
-  }
+const isAccountAttributionState = (state: string | undefined): state is AccountAttributionState =>
+  state === "confirmed" || state === "inferred" || state === "unresolved";
 
-  return getDefaultAccountAttributionState(source);
-}
+const getDefaultAccountAttributionState = (
+  source: string | undefined | null
+): AccountAttributionState =>
+  TRANSACTION_SOURCES_WITH_CONFIRMED_DEFAULT.has(source ?? "manual") ? "confirmed" : "unresolved";
 
-export function buildTransaction(
-  input: BuildInput,
-  userId: UserId,
-  id: TransactionId,
-  now: Date,
-  existing: StoredTransaction | null = null
-): { success: true; transaction: StoredTransaction } | { success: false; error: string } {
-  const amount = parseDigitsToAmount(input.digits);
+const normalizeAccountAttributionState = ({
+  state,
+  source,
+}: {
+  state: string | undefined;
+  source: string | undefined | null;
+}): AccountAttributionState =>
+  isAccountAttributionState(state) ? state : getDefaultAccountAttributionState(source);
 
-  const raw = {
-    type: input.type,
-    amount: amount as number,
-    categoryId: (input.categoryId ?? "other") as string,
-    accountId: input.accountId ?? "",
-    description: input.description || undefined,
-    date: input.date,
-  };
+const toNullableDate = (value: string | null | undefined): Date | null =>
+  value ? new Date(value) : null;
 
-  const result = createTransactionSchema.safeParse(raw);
+const toOptionalDescription = (description: string): string | undefined => description || undefined;
+
+const toNullableDescription = (description: string): string | null => description || null;
+
+const toTransactionDraft = (input: BuildInput): TransactionDraft => ({
+  type: input.type,
+  amount: parseDigitsToAmount(input.digits) as number,
+  categoryId: (input.categoryId ?? OTHER_CATEGORY_ID) as string,
+  accountId: input.accountId ?? "",
+  description: toOptionalDescription(input.description),
+  date: input.date,
+});
+
+const parseTransactionDraft = (input: BuildInput) =>
+  createTransactionSchema.safeParse(toTransactionDraft(input));
+
+const getBuildError = (error: string): TransactionBuildResult => ({ success: false, error });
+
+const resolveCreatedAt = (existing: StoredTransaction | null, now: Date): Date =>
+  existing?.createdAt ?? now;
+
+const resolveDeletedAt = (existing: StoredTransaction | null): Date | null =>
+  existing?.deletedAt ?? null;
+
+const resolveSupersededAt = (existing: StoredTransaction | null): Date | null =>
+  existing?.supersededAt ?? null;
+
+const resolveAccountAttribution = (existing: StoredTransaction | null): AccountAttributionState =>
+  existing?.accountAttributionState ?? getDefaultAccountAttributionState(existing?.source);
+
+const mapBuiltTransaction = ({
+  validated,
+  userId,
+  id,
+  now,
+  existing,
+}: BuildTransactionContext): StoredTransaction => ({
+  id,
+  userId,
+  type: validated.type,
+  amount: validated.amount,
+  categoryId: validated.categoryId,
+  description: validated.description ?? "",
+  date: validated.date,
+  createdAt: resolveCreatedAt(existing, now),
+  updatedAt: now,
+  deletedAt: resolveDeletedAt(existing),
+  accountId: validated.accountId,
+  accountAttributionState: resolveAccountAttribution(existing),
+  supersededAt: resolveSupersededAt(existing),
+  source: toTransactionSource(existing?.source),
+});
+
+const getRowAccountId = (row: TransactionRow): FinancialAccountId =>
+  row.accountId ?? buildDefaultFinancialAccountId(row.userId);
+
+const getRowCategoryId = (categoryId: string): CategoryId =>
+  isValidCategoryId(categoryId) ? categoryId : OTHER_CATEGORY_ID;
+
+const getRowAttributionState = (row: TransactionRow): AccountAttributionState =>
+  normalizeAccountAttributionState({
+    state: row.accountAttributionState,
+    source: row.source,
+  });
+
+const serializeNullableDate = (
+  value: Date | null | undefined
+): ReturnType<typeof toIsoDateTime> | null => (value ? toIsoDateTime(value) : null);
+
+export const buildTransaction = ({
+  input,
+  userId,
+  id,
+  now,
+  existing = null,
+}: BuildTransactionArgs): TransactionBuildResult => {
+  const result = parseTransactionDraft(input);
   if (!result.success) {
-    return {
-      success: false,
-      error: result.error.issues[0]?.message ?? "Invalid input",
-    };
+    return getBuildError(result.error.issues[0]?.message ?? "Invalid input");
   }
 
+  const context: BuildTransactionContext = { validated: result.data, userId, id, now, existing };
   return {
     success: true,
-    transaction: {
-      id,
-      userId,
-      type: result.data.type,
-      amount: result.data.amount,
-      categoryId: result.data.categoryId,
-      description: result.data.description ?? "",
-      date: result.data.date,
-      createdAt: existing?.createdAt ?? now,
-      updatedAt: now,
-      deletedAt: existing?.deletedAt ?? null,
-      accountId: result.data.accountId,
-      accountAttributionState:
-        existing?.accountAttributionState ?? getDefaultAccountAttributionState(existing?.source),
-      supersededAt: existing?.supersededAt ?? null,
-      source: existing?.source ?? "manual",
-    },
+    transaction: mapBuiltTransaction(context),
   };
-}
+};
 
-export function toStoredTransaction(row: TransactionRow): StoredTransaction {
-  return {
-    id: row.id,
-    userId: row.userId,
-    type: row.type as TransactionType,
-    amount: row.amount,
-    categoryId: isValidCategoryId(row.categoryId) ? row.categoryId : OTHER_CATEGORY_ID,
-    description: row.description ?? "",
-    date: parseIsoDate(row.date),
-    createdAt: new Date(row.createdAt),
-    updatedAt: new Date(row.updatedAt),
-    deletedAt: row.deletedAt ? new Date(row.deletedAt) : null,
-    accountId: row.accountId ?? buildDefaultFinancialAccountId(row.userId),
-    accountAttributionState: normalizeAccountAttributionState(
-      row.accountAttributionState,
-      row.source
-    ),
-    supersededAt: row.supersededAt ? new Date(row.supersededAt) : null,
-    source: row.source ?? "manual",
-  };
-}
+export const toStoredTransaction = (row: TransactionRow): StoredTransaction => ({
+  id: row.id,
+  userId: row.userId,
+  type: row.type as TransactionType,
+  amount: row.amount,
+  categoryId: getRowCategoryId(row.categoryId),
+  description: row.description ?? "",
+  date: parseIsoDate(row.date),
+  createdAt: new Date(row.createdAt),
+  updatedAt: new Date(row.updatedAt),
+  deletedAt: toNullableDate(row.deletedAt),
+  accountId: getRowAccountId(row),
+  accountAttributionState: getRowAttributionState(row),
+  supersededAt: toNullableDate(row.supersededAt),
+  source: toTransactionSource(row.source),
+});
 
-export function toTransactionRow(tx: StoredTransaction): TransactionRow {
-  const source = tx.source ?? "manual";
-  return {
-    id: tx.id,
-    userId: tx.userId,
-    type: tx.type,
-    amount: tx.amount,
-    categoryId: tx.categoryId,
-    description: tx.description || null,
-    date: toIsoDate(tx.date),
-    accountId: tx.accountId,
-    accountAttributionState: tx.accountAttributionState,
-    supersededAt: tx.supersededAt ? toIsoDateTime(tx.supersededAt) : null,
-    createdAt: toIsoDateTime(tx.createdAt),
-    updatedAt: toIsoDateTime(tx.updatedAt),
-    deletedAt: tx.deletedAt ? toIsoDateTime(tx.deletedAt) : null,
-    source,
-  };
-}
+export const toTransactionRow = (tx: StoredTransaction): TransactionRow => ({
+  id: tx.id,
+  userId: tx.userId,
+  type: tx.type,
+  amount: tx.amount,
+  categoryId: tx.categoryId,
+  description: toNullableDescription(tx.description),
+  date: toIsoDate(tx.date),
+  accountId: tx.accountId,
+  accountAttributionState: tx.accountAttributionState,
+  supersededAt: serializeNullableDate(tx.supersededAt),
+  createdAt: toIsoDateTime(tx.createdAt),
+  updatedAt: toIsoDateTime(tx.updatedAt),
+  deletedAt: serializeNullableDate(tx.deletedAt),
+  source: toTransactionSource(tx.source),
+});

--- a/apps/mobile/features/transactions/lib/mutation-service.ts
+++ b/apps/mobile/features/transactions/lib/mutation-service.ts
@@ -75,7 +75,7 @@ function buildMutationTransaction(
     return fail("Store not initialized");
   }
 
-  const result = buildTransaction(input, userId, id, now, existing);
+  const result = buildTransaction({ input, userId, id, now, existing });
   return result.success ? result : fail(result.error);
 }
 


### PR DESCRIPTION
- stage transaction builder mapping
- stage email parse helpers
- stage gmail adapter flow
- verify with bun run verify


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored transaction and email helpers to improve safety and reuse. Key changes include a new object-arg API for `buildTransaction`, a cleaner Gmail adapter, and consistent PII redaction with truncation.

- **Refactors**
  - Switched `buildTransaction` to object params: `{ input, userId, id, now, existing }`; extracted mapping helpers and updated tests and `mutation-service`.
  - Reworked Gmail adapter into small helpers with sequential batching, robust multipart parsing, HTML stripping, and normalized headers.
  - Centralized PII redaction rules and truncated email input to 2000 chars before parsing.

- **Bug Fixes**
  - Normalized Gmail dates (fallback to current ISO on invalid) and normalized “From” to the email address.
  - Consistent fallbacks: category to built-in “other”, `source` to “manual”, and default account when missing.
  - Safer account attribution state normalization to avoid invalid states.

<sup>Written for commit df663673b9680f8e830588aee0de8fdecc678b02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

