### PR TITLE
refactor(mobile): isolate calendar bill commands

### DIFF
--- a/apps/mobile/__tests__/calendar/store.test.ts
+++ b/apps/mobile/__tests__/calendar/store.test.ts
@@ -62,6 +62,43 @@ function createDeferred<T>() {
   return { promise, resolve, reject };
 }
 
+const db = {} as never;
+const bill = {
+  id: "bill-1" as BillId,
+  name: "Netflix",
+  amount: 35000 as CopAmount,
+  frequency: "monthly" as const,
+  categoryId: "services" as CategoryId,
+  startDate: new Date("2026-01-15T00:00:00.000Z"),
+  isActive: true,
+};
+const billDraft = {
+  name: bill.name,
+  amount: "35000",
+  frequency: bill.frequency,
+  categoryId: bill.categoryId,
+  startDate: bill.startDate,
+};
+const unpaidPayment = {
+  id: "pay-1" as BillPaymentId,
+  billId: bill.id,
+  dueDate: "2026-03-15" as IsoDate,
+  paidAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
+  transactionId: null,
+  createdAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
+};
+const paidPayment = {
+  ...unpaidPayment,
+  transactionId: "txn-1" as TransactionId,
+};
+
+const actor = (userId: UserId) => ({ db, userId });
+const paymentCommand = (userId: UserId) => ({
+  ...actor(userId),
+  billId: bill.id,
+  dueDate: unpaidPayment.dueDate,
+});
+
 describe("calendar store boundary", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -93,17 +130,7 @@ describe("calendar store boundary", () => {
     const load = loadBills({} as never, "user-1" as UserId);
 
     initializeCalendarSession("user-2" as UserId);
-    deferred.resolve([
-      {
-        id: "bill-1" as BillId,
-        name: "Netflix",
-        amount: 35000 as CopAmount,
-        frequency: "monthly",
-        categoryId: "services" as CategoryId,
-        startDate: new Date("2026-01-15T00:00:00.000Z"),
-        isActive: true,
-      },
-    ]);
+    deferred.resolve([bill]);
 
     await load;
 
@@ -154,15 +181,10 @@ describe("calendar store boundary", () => {
     });
     initializeCalendarSession("user-1" as UserId);
 
-    const result = await addBill(
-      {} as never,
-      "user-1" as UserId,
-      "Netflix",
-      "35000",
-      "monthly",
-      "services" as CategoryId,
-      new Date("2026-01-15T00:00:00.000Z")
-    );
+    const result = await addBill({
+      ...actor("user-1" as UserId),
+      draft: billDraft,
+    });
 
     expect(result).toBe(true);
     expect(useCalendarStore.getState().bills).toEqual([
@@ -189,28 +211,15 @@ describe("calendar store boundary", () => {
     mockAddBill.mockReturnValueOnce(deferred.promise);
 
     initializeCalendarSession("user-1" as UserId);
-    const add = addBill(
-      {} as never,
-      "user-1" as UserId,
-      "Netflix",
-      "35000",
-      "monthly",
-      "services" as CategoryId,
-      new Date("2026-01-15T00:00:00.000Z")
-    );
+    const add = addBill({
+      ...actor("user-1" as UserId),
+      draft: billDraft,
+    });
 
     initializeCalendarSession("user-2" as UserId);
     deferred.resolve({
       success: true,
-      bill: {
-        id: "bill-1" as BillId,
-        name: "Netflix",
-        amount: 35000 as CopAmount,
-        frequency: "monthly",
-        categoryId: "services" as CategoryId,
-        startDate: new Date("2026-01-15T00:00:00.000Z"),
-        isActive: true,
-      },
+      bill,
     });
 
     await expect(add).resolves.toBe(false);
@@ -223,23 +232,13 @@ describe("calendar store boundary", () => {
   it("drops stale update results after the active user changes", async () => {
     const deferred = createDeferred<boolean>();
     mockUpdateBill.mockReturnValueOnce(deferred.promise);
-    useCalendarStore.setState({
-      bills: [
-        {
-          id: "bill-1" as BillId,
-          name: "Netflix",
-          amount: 35000 as CopAmount,
-          frequency: "monthly",
-          categoryId: "services" as CategoryId,
-          startDate: new Date("2026-01-15T00:00:00.000Z"),
-          isActive: true,
-        },
-      ],
-    });
+    useCalendarStore.setState({ bills: [bill] });
 
     initializeCalendarSession("user-1" as UserId);
-    const update = updateBill({} as never, "user-1" as UserId, "bill-1" as BillId, {
-      name: "Hulu",
+    const update = updateBill({
+      ...actor("user-1" as UserId),
+      billId: bill.id,
+      changes: { name: "Hulu" },
     });
 
     initializeCalendarSession("user-2" as UserId);
@@ -254,32 +253,13 @@ describe("calendar store boundary", () => {
 
   it("removes a deleted bill and its payments from state", async () => {
     initializeCalendarSession("user-1" as UserId);
-    useCalendarStore.setState({
-      bills: [
-        {
-          id: "bill-1" as BillId,
-          name: "Netflix",
-          amount: 35000 as CopAmount,
-          frequency: "monthly",
-          categoryId: "services" as CategoryId,
-          startDate: new Date("2026-01-15T00:00:00.000Z"),
-          isActive: true,
-        },
-      ],
-      payments: [
-        {
-          id: "pay-1" as BillPaymentId,
-          billId: "bill-1" as BillId,
-          dueDate: "2026-03-15" as IsoDate,
-          paidAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
-          transactionId: null,
-          createdAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
-        },
-      ],
-    });
+    useCalendarStore.setState({ bills: [bill], payments: [unpaidPayment] });
     mockDeleteBill.mockResolvedValueOnce(true);
 
-    await deleteBill({} as never, "user-1" as UserId, "bill-1" as BillId);
+    await deleteBill({
+      ...actor("user-1" as UserId),
+      billId: bill.id,
+    });
 
     expect(useCalendarStore.getState()).toMatchObject({
       bills: [],
@@ -288,39 +268,15 @@ describe("calendar store boundary", () => {
   });
 
   it("updates payment state through the paid and unpaid boundaries", async () => {
-    useCalendarStore.setState({
-      bills: [
-        {
-          id: "bill-1" as BillId,
-          name: "Netflix",
-          amount: 35000 as CopAmount,
-          frequency: "monthly",
-          categoryId: "services" as CategoryId,
-          startDate: new Date("2026-01-15T00:00:00.000Z"),
-          isActive: true,
-        },
-      ],
-    });
+    useCalendarStore.setState({ bills: [bill] });
     mockMarkBillPaid.mockResolvedValueOnce({
       success: true,
-      payment: {
-        id: "pay-1" as BillPaymentId,
-        billId: "bill-1" as BillId,
-        dueDate: "2026-03-15" as IsoDate,
-        paidAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
-        transactionId: "txn-1" as TransactionId,
-        createdAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
-      },
+      payment: paidPayment,
     });
     mockUnmarkBillPaid.mockResolvedValueOnce({ success: true });
     initializeCalendarSession("user-1" as UserId);
 
-    await markBillPaid(
-      {} as never,
-      "user-1" as UserId,
-      "bill-1" as BillId,
-      "2026-03-15" as IsoDate
-    );
+    await markBillPaid(paymentCommand("user-1" as UserId));
     expect(useCalendarStore.getState().payments).toEqual([
       expect.objectContaining({
         id: "pay-1",
@@ -328,12 +284,7 @@ describe("calendar store boundary", () => {
       }),
     ]);
 
-    await unmarkBillPaid(
-      {} as never,
-      "user-1" as UserId,
-      "bill-1" as BillId,
-      "2026-03-15" as IsoDate
-    );
+    await unmarkBillPaid(paymentCommand("user-1" as UserId));
     expect(useCalendarStore.getState().payments).toEqual([]);
   });
 
@@ -349,40 +300,16 @@ describe("calendar store boundary", () => {
         createdAt: IsoDateTime;
       };
     }>();
-    useCalendarStore.setState({
-      bills: [
-        {
-          id: "bill-1" as BillId,
-          name: "Netflix",
-          amount: 35000 as CopAmount,
-          frequency: "monthly",
-          categoryId: "services" as CategoryId,
-          startDate: new Date("2026-01-15T00:00:00.000Z"),
-          isActive: true,
-        },
-      ],
-    });
+    useCalendarStore.setState({ bills: [bill] });
     mockMarkBillPaid.mockReturnValueOnce(deferred.promise);
 
     initializeCalendarSession("user-1" as UserId);
-    const mark = markBillPaid(
-      {} as never,
-      "user-1" as UserId,
-      "bill-1" as BillId,
-      "2026-03-15" as IsoDate
-    );
+    const mark = markBillPaid(paymentCommand("user-1" as UserId));
 
     initializeCalendarSession("user-2" as UserId);
     deferred.resolve({
       success: true,
-      payment: {
-        id: "pay-1" as BillPaymentId,
-        billId: "bill-1" as BillId,
-        dueDate: "2026-03-15" as IsoDate,
-        paidAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
-        transactionId: "txn-1" as TransactionId,
-        createdAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
-      },
+      payment: paidPayment,
     });
 
     await mark;

--- a/apps/mobile/app/add-bill.tsx
+++ b/apps/mobile/app/add-bill.tsx
@@ -33,10 +33,13 @@ import { useAsyncGuard, useThemeColor, useTranslation } from "@/shared/hooks";
 import { getCategoryLabel } from "@/shared/i18n";
 import { parseDigitsToAmount } from "@/shared/lib";
 import { requireBillId } from "@/shared/types/assertions";
-import type { BillId, UserId } from "@/shared/types/branded";
+import type { UserId } from "@/shared/types/branded";
 import migrations from "../drizzle/migrations";
 
 const DEFAULT_BILL_CATEGORY_ID = getBuiltInCategoryId("services");
+
+type AddBillDraft = Parameters<typeof addBill>[0]["draft"];
+type UpdateBillInput = Omit<Parameters<typeof updateBill>[0], "db" | "userId">;
 
 function AddBillForm({
   existingBill,
@@ -46,19 +49,8 @@ function AddBillForm({
   canSubmit,
 }: {
   readonly existingBill: Bill | undefined;
-  readonly onAddBill: (
-    name: string,
-    amount: string,
-    frequency: BillFrequency,
-    categoryId: CategoryId,
-    startDate: Date
-  ) => Promise<boolean>;
-  readonly onUpdateBill: (
-    id: BillId,
-    data: Partial<
-      Pick<Bill, "name" | "amount" | "frequency" | "categoryId" | "startDate" | "isActive">
-    >
-  ) => Promise<boolean>;
+  readonly onAddBill: (draft: AddBillDraft) => Promise<boolean>;
+  readonly onUpdateBill: (input: UpdateBillInput) => Promise<boolean>;
   readonly onDone: () => void;
   readonly canSubmit: boolean;
 }) {
@@ -95,16 +87,25 @@ function AddBillForm({
       if (existingBill) {
         const amountValue = parseDigitsToAmount(amount);
         if (amountValue <= 0) return;
-        const success = await onUpdateBill(requireBillId(existingBill.id), {
+        const success = await onUpdateBill({
+          billId: requireBillId(existingBill.id),
+          changes: {
+            name: trimmedName,
+            amount: amountValue,
+            frequency,
+            categoryId: category,
+            startDate,
+          },
+        });
+        if (success) onDone();
+      } else {
+        const success = await onAddBill({
           name: trimmedName,
-          amount: amountValue,
+          amount,
           frequency,
           categoryId: category,
           startDate,
         });
-        if (success) onDone();
-      } else {
-        const success = await onAddBill(trimmedName, amount, frequency, category, startDate);
         if (success) onDone();
       }
     });
@@ -272,13 +273,13 @@ function AuthenticatedAddBillForm({
       key={existingBill?.id ?? "new"}
       existingBill={existingBill}
       canSubmit={migrationsReady}
-      onAddBill={(name, amount, frequency, categoryId, startDate) => {
+      onAddBill={(draft) => {
         if (!migrationsReady) return Promise.resolve(false);
-        return addBill(db, userId, name, amount, frequency, categoryId, startDate);
+        return addBill({ db, userId, draft });
       }}
-      onUpdateBill={(id, data) => {
+      onUpdateBill={(input) => {
         if (!migrationsReady) return Promise.resolve(false);
-        return updateBill(db, userId, id, data);
+        return updateBill({ db, userId, ...input });
       }}
       onDone={onDone}
     />

--- a/apps/mobile/app/day-detail.tsx
+++ b/apps/mobile/app/day-detail.tsx
@@ -47,9 +47,9 @@ export default function DayDetailScreen() {
     if (!userId) return;
     const existing = isPaymentPaid(billId);
     if (existing) {
-      await unmarkBillPaid(getDb(userId), userId, billId, dueDateStr);
+      await unmarkBillPaid({ db: getDb(userId), userId, billId, dueDate: dueDateStr });
     } else {
-      await markBillPaid(getDb(userId), userId, billId, dueDateStr);
+      await markBillPaid({ db: getDb(userId), userId, billId, dueDate: dueDateStr });
     }
   };
 
@@ -65,7 +65,7 @@ export default function DayDetailScreen() {
         style: "destructive",
         onPress: () => {
           if (!userId) return;
-          void deleteBill(getDb(userId), userId, billId).catch(captureError);
+          void deleteBill({ db: getDb(userId), userId, billId }).catch(captureError);
         },
       },
     ]);

--- a/apps/mobile/features/calendar/store.ts
+++ b/apps/mobile/features/calendar/store.ts
@@ -16,6 +16,46 @@ let calendarSessionId = 0;
 
 const calendarQueryService = createCalendarQueryService();
 
+type BillDraft = {
+  readonly name: string;
+  readonly amount: string;
+  readonly frequency: BillFrequency;
+  readonly categoryId: CategoryId;
+  readonly startDate: Date;
+};
+
+type BillChanges = Partial<
+  Pick<Bill, "name" | "amount" | "frequency" | "categoryId" | "startDate" | "isActive">
+>;
+
+type CalendarActor = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+};
+
+type AddBillCommand = CalendarActor & {
+  readonly draft: BillDraft;
+};
+
+type UpdateBillCommand = CalendarActor & {
+  readonly billId: BillId;
+  readonly changes: BillChanges;
+};
+
+type DeleteBillCommand = CalendarActor & {
+  readonly billId: BillId;
+};
+
+type BillPaymentCommand = CalendarActor & {
+  readonly billId: BillId;
+  readonly dueDate: IsoDate;
+};
+
+type CalendarMutationSession = {
+  readonly userId: UserId;
+  readonly sessionId: number;
+};
+
 type CalendarState = {
   readonly activeUserId: UserId | null;
   readonly currentMonth: Date;
@@ -31,12 +71,7 @@ type CalendarActions = {
   setPayments: (payments: readonly BillPayment[]) => void;
   setIsLoading: (isLoading: boolean) => void;
   appendBill: (bill: Bill) => void;
-  replaceBill: (
-    id: BillId,
-    fields: Partial<
-      Pick<Bill, "name" | "amount" | "frequency" | "categoryId" | "startDate" | "isActive">
-    >
-  ) => void;
+  replaceBill: (id: BillId, fields: BillChanges) => void;
   removeBill: (id: BillId) => void;
   appendPayment: (payment: BillPayment) => void;
   removePayment: (billId: BillId, dueDate: IsoDate) => void;
@@ -114,7 +149,23 @@ function isActiveCalendarSession(userId: UserId, sessionId: number): boolean {
   return calendarSessionId === sessionId && useCalendarStore.getState().activeUserId === userId;
 }
 
-function createLiveCalendarBillMutations(db: AnyDb, userId: UserId) {
+function captureMutationSession(userId: UserId): CalendarMutationSession {
+  return { userId, sessionId: calendarSessionId };
+}
+
+function applyMutationIfSessionIsActive(
+  session: CalendarMutationSession,
+  apply: () => void
+): boolean {
+  if (!isActiveCalendarSession(session.userId, session.sessionId)) {
+    return false;
+  }
+
+  apply();
+  return true;
+}
+
+function createLiveCalendarBillMutations({ db, userId }: CalendarActor) {
   const mutations = createWriteThroughMutationModule(db);
 
   return createCalendarBillMutationService({
@@ -192,88 +243,68 @@ export async function prevMonth(db: AnyDb): Promise<void> {
   await loadPaymentsForMonth(db);
 }
 
-export async function addBill(
-  db: AnyDb,
-  userId: UserId,
-  name: string,
-  amount: string,
-  frequency: BillFrequency,
-  categoryId: CategoryId,
-  startDate: Date
-): Promise<boolean> {
-  const sessionId = calendarSessionId;
-  const result = await createLiveCalendarBillMutations(db, userId).addBill({
-    name,
-    amount,
-    frequency,
-    categoryId,
-    startDate,
-  });
+export async function addBill(command: AddBillCommand): Promise<boolean> {
+  const { db, userId, draft } = command;
+  const session = captureMutationSession(userId);
+  const result = await createLiveCalendarBillMutations({ db, userId }).addBill(draft);
   if (!result.success) return false;
-  if (!isActiveCalendarSession(userId, sessionId)) return false;
 
-  useCalendarStore.getState().appendBill(result.bill);
-  return true;
+  return applyMutationIfSessionIsActive(session, () => {
+    useCalendarStore.getState().appendBill(result.bill);
+  });
 }
 
-export async function updateBill(
-  db: AnyDb,
-  userId: UserId,
-  id: BillId,
-  fields: Partial<
-    Pick<Bill, "name" | "amount" | "frequency" | "categoryId" | "startDate" | "isActive">
-  >
-): Promise<boolean> {
-  const sessionId = calendarSessionId;
-  const didUpdate = await createLiveCalendarBillMutations(db, userId).updateBill(id, fields);
+export async function updateBill(command: UpdateBillCommand): Promise<boolean> {
+  const { db, userId, billId, changes } = command;
+  const session = captureMutationSession(userId);
+  const didUpdate = await createLiveCalendarBillMutations({ db, userId }).updateBill(
+    billId,
+    changes
+  );
   if (!didUpdate) return false;
-  if (!isActiveCalendarSession(userId, sessionId)) return false;
 
-  useCalendarStore.getState().replaceBill(id, fields);
-  return true;
+  return applyMutationIfSessionIsActive(session, () => {
+    useCalendarStore.getState().replaceBill(billId, changes);
+  });
 }
 
-export async function deleteBill(db: AnyDb, userId: UserId, id: BillId): Promise<void> {
-  const sessionId = calendarSessionId;
-  const didDelete = await createLiveCalendarBillMutations(db, userId).deleteBill(id);
+export async function deleteBill(command: DeleteBillCommand): Promise<void> {
+  const { db, userId, billId } = command;
+  const session = captureMutationSession(userId);
+  const didDelete = await createLiveCalendarBillMutations({ db, userId }).deleteBill(billId);
   if (!didDelete) return;
-  if (!isActiveCalendarSession(userId, sessionId)) return;
 
-  useCalendarStore.getState().removeBill(id);
+  applyMutationIfSessionIsActive(session, () => {
+    useCalendarStore.getState().removeBill(billId);
+  });
 }
 
-export async function markBillPaid(
-  db: AnyDb,
-  userId: UserId,
-  billId: BillId,
-  dueDate: IsoDate
-): Promise<void> {
-  const sessionId = calendarSessionId;
-  const result = await createLiveCalendarBillMutations(db, userId).markBillPaid(
+export async function markBillPaid(command: BillPaymentCommand): Promise<void> {
+  const { db, userId, billId, dueDate } = command;
+  const session = captureMutationSession(userId);
+  const result = await createLiveCalendarBillMutations({ db, userId }).markBillPaid(
     useCalendarStore.getState().bills,
     billId,
     dueDate
   );
   if (!result.success) return;
-  if (!isActiveCalendarSession(userId, sessionId)) return;
 
-  useCalendarStore.getState().appendPayment(result.payment);
+  applyMutationIfSessionIsActive(session, () => {
+    useCalendarStore.getState().appendPayment(result.payment);
+  });
 }
 
-export async function unmarkBillPaid(
-  db: AnyDb,
-  userId: UserId,
-  billId: BillId,
-  dueDate: IsoDate
-): Promise<void> {
-  const sessionId = calendarSessionId;
-  const result = await createLiveCalendarBillMutations(db, userId).unmarkBillPaid(
+export async function unmarkBillPaid(command: BillPaymentCommand): Promise<void> {
+  const { db, userId, billId, dueDate } = command;
+  const session = captureMutationSession(userId);
+  const result = await createLiveCalendarBillMutations({ db, userId }).unmarkBillPaid(
     useCalendarStore.getState().payments,
     billId,
     dueDate
   );
   if (!result.success) return;
-  if (!isActiveCalendarSession(userId, sessionId)) return;
 
-  useCalendarStore.getState().removePayment(billId, dueDate);
+  applyMutationIfSessionIsActive(session, () => {
+    useCalendarStore.getState().removePayment(billId, dueDate);
+  });
 }


### PR DESCRIPTION
- narrow calendar store mutation APIs
- guard state updates by session
- align calendar screens and tests


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors calendar bill mutations to use object-based commands and guards state updates by the active session to avoid stale writes when the user changes. Updates `add-bill` and day detail screens and tests to the new API.

- **Refactors**
  - Replace positional APIs with commands: `addBill({ db, userId, draft })`, `updateBill({ db, userId, billId, changes })`, `deleteBill({ db, userId, billId })`, `markBillPaid({ db, userId, billId, dueDate })`, `unmarkBillPaid({ db, userId, billId, dueDate })`.
  - Capture session on mutation and apply results only if the same user/session is still active.

<sup>Written for commit 11a510ec64d301d7f6a469dff0d7d281f2a10c15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

