### PR TITLE
refactor(goals): slim goal store

### DIFF
--- a/apps/mobile/__tests__/goals/service.test.ts
+++ b/apps/mobile/__tests__/goals/service.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, expect, it, vi } from "vitest";
+import { createGoalMutationService } from "@/features/goals/services/create-goal-mutation-service";
 import { createGoalQueryService } from "@/features/goals/services/create-goal-query-service";
 import type { UserId } from "@/shared/types/branded";
 
@@ -8,103 +9,226 @@ const mockGetMonthlyTotalsByType = vi.fn();
 const mockGetContributionMonthCount = vi.fn();
 const mockGetContributionsForGoal = vi.fn();
 
-describe("goal query service", () => {
-  it("builds goal progress snapshots for the active user", async () => {
-    mockGetGoalsForUser.mockReturnValue([
-      {
-        id: "goal-1",
-        userId: "user-1",
-        name: "Trip",
-        type: "savings",
-        targetAmount: 900000,
-        targetDate: "2026-12-31",
-        interestRatePercent: null,
-        iconName: null,
-        colorHex: null,
-        createdAt: "2026-01-01T00:00:00.000Z",
-        updatedAt: "2026-01-01T00:00:00.000Z",
-        deletedAt: null,
-      },
-    ]);
-    mockGetGoalCurrentAmount.mockReturnValue(300000);
-    mockGetMonthlyTotalsByType.mockReturnValue([
-      { month: "2026-03", type: "income", total: 1200000 },
-      { month: "2026-03", type: "expense", total: 300000 },
-      { month: "2026-02", type: "income", total: 1100000 },
-      { month: "2026-02", type: "expense", total: 400000 },
-      { month: "2026-01", type: "income", total: 1000000 },
-      { month: "2026-01", type: "expense", total: 350000 },
-    ]);
-    mockGetContributionMonthCount.mockReturnValue(2);
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
-    const service = createGoalQueryService({
-      getGoalsForUser: mockGetGoalsForUser,
-      getGoalCurrentAmount: mockGetGoalCurrentAmount,
-      getMonthlyTotalsByType: mockGetMonthlyTotalsByType,
-      getContributionMonthCount: mockGetContributionMonthCount,
-      getContributionsForGoal: mockGetContributionsForGoal,
-      getToday: () => new Date("2026-03-15T00:00:00.000Z"),
-    });
+const goalRow = {
+  id: "goal-1",
+  userId: "user-1",
+  name: "Trip",
+  type: "savings" as const,
+  targetAmount: 900000,
+  targetDate: "2026-12-31",
+  interestRatePercent: null,
+  iconName: null,
+  colorHex: null,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  deletedAt: null,
+};
 
-    const snapshot = await service.loadGoals({
+const contributionRow = {
+  id: "contrib-1",
+  goalId: "goal-1",
+  userId: "user-1",
+  amount: 50000,
+  note: "bonus",
+  date: "2026-03-10",
+  createdAt: "2026-03-10T00:00:00.000Z",
+  updatedAt: "2026-03-10T00:00:00.000Z",
+  deletedAt: null,
+};
+
+const monthlyTotals = [
+  { month: "2026-03", type: "income" as const, total: 1200000 },
+  { month: "2026-03", type: "expense" as const, total: 300000 },
+  { month: "2026-02", type: "income" as const, total: 1100000 },
+  { month: "2026-02", type: "expense" as const, total: 400000 },
+  { month: "2026-01", type: "income" as const, total: 1000000 },
+  { month: "2026-01", type: "expense" as const, total: 350000 },
+];
+
+const expectedGoalSnapshot = [
+  expect.objectContaining({
+    goal: expect.objectContaining({ id: "goal-1", name: "Trip" }),
+    currentAmount: 300000,
+    progress: expect.objectContaining({
+      percentComplete: 33,
+      remaining: 600000,
+      isComplete: false,
+    }),
+    projection: expect.objectContaining({
+      confidence: "high",
+      monthsToGo: 1,
+      netMonthlySavings: 750000,
+      projectedDate: expect.any(Date),
+    }),
+    installments: {
+      current: 2,
+      total: 2,
+    },
+  }),
+];
+
+const expectedGoalSaveCommand = {
+  kind: "goal.save",
+  row: {
+    id: "goal-generated",
+    userId: "user-1",
+    name: "Trip",
+    type: "savings",
+    targetAmount: 900000,
+    targetDate: null,
+    interestRatePercent: null,
+    iconName: null,
+    colorHex: null,
+    createdAt: "2026-04-20T12:30:00.000Z",
+    updatedAt: "2026-04-20T12:30:00.000Z",
+    deletedAt: null,
+  },
+};
+
+function createQueryService() {
+  return createGoalQueryService({
+    getGoalsForUser: mockGetGoalsForUser,
+    getGoalCurrentAmount: mockGetGoalCurrentAmount,
+    getMonthlyTotalsByType: mockGetMonthlyTotalsByType,
+    getContributionMonthCount: mockGetContributionMonthCount,
+    getContributionsForGoal: mockGetContributionsForGoal,
+    getToday: () => new Date("2026-03-15T00:00:00.000Z"),
+  });
+}
+
+function createMilestoneService() {
+  const insertNotification = vi.fn();
+  const schedulePush = vi.fn();
+  const trackMilestoneReached = vi.fn();
+
+  return {
+    insertNotification,
+    schedulePush,
+    trackMilestoneReached,
+    service: createGoalMutationService({
       db: {} as never,
       userId: "user-1" as UserId,
-    });
+      commit: vi.fn().mockResolvedValue(true),
+      insertNotification,
+      schedulePush,
+      translateMilestoneTitle: ({ goalName, milestone }) => `${goalName}:${milestone}`,
+      translateMilestoneBody: ({ milestone }) => `Reached ${milestone}`,
+      trackMilestoneReached,
+    }),
+  };
+}
 
-    expect(mockGetGoalsForUser).toHaveBeenCalledWith(expect.anything(), "user-1");
-    expect(mockGetMonthlyTotalsByType).toHaveBeenCalledWith(expect.anything(), "user-1", 3);
-    expect(snapshot).toEqual([
-      expect.objectContaining({
-        goal: expect.objectContaining({ id: "goal-1", name: "Trip" }),
-        currentAmount: 300000,
-        progress: expect.objectContaining({
-          percentComplete: 33,
-          remaining: 600000,
-          isComplete: false,
-        }),
-        projection: expect.objectContaining({
-          confidence: "high",
-          monthsToGo: 1,
-          netMonthlySavings: 750000,
-          projectedDate: expect.any(Date),
-        }),
-        installments: {
-          current: 2,
-          total: 2,
-        },
-      }),
-    ]);
-  });
-
-  it("loads contribution history for the selected goal", async () => {
-    mockGetContributionsForGoal.mockReturnValue([
-      {
-        id: "contrib-1",
-        goalId: "goal-1",
-        userId: "user-1",
-        amount: 50000,
-        note: "bonus",
-        date: "2026-03-10",
-        createdAt: "2026-03-10T00:00:00.000Z",
-        updatedAt: "2026-03-10T00:00:00.000Z",
-        deletedAt: null,
-      },
-    ]);
-
-    const service = createGoalQueryService({
-      getGoalsForUser: mockGetGoalsForUser,
-      getGoalCurrentAmount: mockGetGoalCurrentAmount,
-      getMonthlyTotalsByType: mockGetMonthlyTotalsByType,
-      getContributionMonthCount: mockGetContributionMonthCount,
-      getContributionsForGoal: mockGetContributionsForGoal,
-    });
-
-    const contributions = await service.loadGoalContributions({
-      db: {} as never,
+function expectMilestoneNotifications(insertNotification: ReturnType<typeof vi.fn>) {
+  expect(insertNotification).toHaveBeenNthCalledWith(
+    1,
+    expect.anything(),
+    "user-1",
+    expect.objectContaining({
+      dedupKey: "goal_milestone:goal-1:25",
       goalId: "goal-1",
-    });
+    })
+  );
+  expect(insertNotification).toHaveBeenNthCalledWith(
+    2,
+    expect.anything(),
+    "user-1",
+    expect.objectContaining({
+      dedupKey: "goal_milestone:goal-1:50",
+      goalId: "goal-1",
+    })
+  );
+}
 
-    expect(mockGetContributionsForGoal).toHaveBeenCalledWith(expect.anything(), "goal-1");
-    expect(contributions).toEqual([expect.objectContaining({ id: "contrib-1", note: "bonus" })]);
+function expectMilestonePushes(
+  schedulePush: ReturnType<typeof vi.fn>,
+  trackMilestoneReached: ReturnType<typeof vi.fn>
+) {
+  expect(schedulePush).toHaveBeenNthCalledWith(
+    1,
+    expect.objectContaining({
+      title: "Trip:25",
+      body: "Reached 25",
+      data: { route: "/goal-detail?goalId=goal-1" },
+      preferenceKey: "goalMilestones",
+    })
+  );
+  expect(schedulePush).toHaveBeenNthCalledWith(
+    2,
+    expect.objectContaining({
+      title: "Trip:50",
+      body: "Reached 50",
+    })
+  );
+  expect(trackMilestoneReached).toHaveBeenCalledTimes(2);
+}
+
+it("builds goal progress snapshots for the active user", async () => {
+  mockGetGoalsForUser.mockReturnValue([goalRow]);
+  mockGetGoalCurrentAmount.mockReturnValue(300000);
+  mockGetMonthlyTotalsByType.mockReturnValue(monthlyTotals);
+  mockGetContributionMonthCount.mockReturnValue(2);
+
+  const snapshot = await createQueryService().loadGoals({
+    db: {} as never,
+    userId: "user-1" as UserId,
   });
+
+  expect(mockGetGoalsForUser).toHaveBeenCalledWith(expect.anything(), "user-1");
+  expect(mockGetMonthlyTotalsByType).toHaveBeenCalledWith(expect.anything(), "user-1", 3);
+  expect(snapshot).toEqual(expectedGoalSnapshot);
+});
+
+it("loads contribution history for the selected goal", async () => {
+  mockGetContributionsForGoal.mockReturnValue([contributionRow]);
+
+  const contributions = await createQueryService().loadGoalContributions({
+    db: {} as never,
+    goalId: "goal-1",
+  });
+
+  expect(mockGetContributionsForGoal).toHaveBeenCalledWith(expect.anything(), "goal-1");
+  expect(contributions).toEqual([expect.objectContaining({ id: "contrib-1", note: "bonus" })]);
+});
+
+it("commits normalized goal saves and tracks successful creates", async () => {
+  const commit = vi.fn().mockResolvedValue(true);
+  const trackCreated = vi.fn();
+
+  const service = createGoalMutationService({
+    db: {} as never,
+    userId: "user-1" as UserId,
+    commit,
+    now: () => new Date("2026-04-20T12:30:00.000Z"),
+    createGoalId: () => "goal-generated",
+    trackCreated,
+  });
+
+  await expect(
+    service.createGoal({
+      name: "Trip",
+      type: "savings",
+      targetAmount: 900000,
+    })
+  ).resolves.toBe(true);
+
+  expect(commit).toHaveBeenCalledWith(expectedGoalSaveCommand);
+  expect(trackCreated).toHaveBeenCalledTimes(1);
+});
+
+it("publishes milestone notifications through the injected side-effect boundary", () => {
+  const { insertNotification, schedulePush, trackMilestoneReached, service } =
+    createMilestoneService();
+
+  service.notifyMilestones({
+    goalId: "goal-1",
+    goalName: "Trip",
+    milestones: [25, 50],
+  });
+
+  expectMilestoneNotifications(insertNotification);
+  expectMilestonePushes(schedulePush, trackMilestoneReached);
 });

--- a/apps/mobile/features/goals/components/GoalEditSheet.tsx
+++ b/apps/mobile/features/goals/components/GoalEditSheet.tsx
@@ -85,14 +85,17 @@ export function GoalEditSheet() {
         const normalizedRate = interestRate.replace(",", ".");
         const isValidRate = /^\d+(\.\d+)?$/.test(normalizedRate);
         const parsedRate = isValidRate ? Number.parseFloat(normalizedRate) : null;
-        const success = await updateGoal(db, userId, selectedGoalId, {
-          name: name.trim(),
-          targetAmount: parsedAmount,
-          targetDate: targetDate ? toIsoDate(targetDate) : null,
-          interestRatePercent:
-            goalType === "debt" && parsedRate != null && Number.isFinite(parsedRate)
-              ? parsedRate
-              : null,
+        const success = await updateGoal(db, userId, {
+          id: selectedGoalId,
+          data: {
+            name: name.trim(),
+            targetAmount: parsedAmount,
+            targetDate: targetDate ? toIsoDate(targetDate) : null,
+            interestRatePercent:
+              goalType === "debt" && parsedRate != null && Number.isFinite(parsedRate)
+                ? parsedRate
+                : null,
+          },
         });
         if (success) back();
       }),

--- a/apps/mobile/features/goals/services/create-goal-mutation-service.ts
+++ b/apps/mobile/features/goals/services/create-goal-mutation-service.ts
@@ -1,0 +1,205 @@
+import { insertNotificationRecord, scheduleLocalPush } from "@/features/notifications";
+import { createWriteThroughMutationModule } from "@/mutations";
+import type { AnyDb } from "@/shared/db";
+import { i18n } from "@/shared/i18n";
+import {
+  generateId,
+  toIsoDateTime,
+  trackGoalContributionAdded,
+  trackGoalCreated,
+  trackGoalMilestoneReached,
+} from "@/shared/lib";
+import type { MutationCommand } from "@/shared/mutations/write-through";
+import type { UserId } from "@/shared/types/branded";
+import type { AddContributionInput, CreateGoalInput, Goal } from "../schema";
+import { addContributionSchema, createGoalSchema } from "../schema";
+
+type CommitGoalMutation = (command: MutationCommand) => Promise<boolean>;
+
+export type GoalUpdateInput = Partial<
+  Pick<
+    Goal,
+    "name" | "targetAmount" | "targetDate" | "interestRatePercent" | "iconName" | "colorHex"
+  >
+>;
+
+type GoalMilestone = {
+  readonly goalId: string;
+  readonly goalName: string;
+  readonly milestone: number;
+};
+
+type GoalMilestoneEffect = {
+  readonly goalId: string;
+  readonly goalName: string;
+  readonly milestones: readonly number[];
+};
+
+type CreateGoalMutationServiceDeps = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly commit?: CommitGoalMutation;
+  readonly now?: () => Date;
+  readonly createGoalId?: () => string;
+  readonly createContributionId?: () => string;
+  readonly insertNotification?: typeof insertNotificationRecord;
+  readonly schedulePush?: typeof scheduleLocalPush;
+  readonly translateMilestoneTitle?: (input: GoalMilestone) => string;
+  readonly translateMilestoneBody?: (input: GoalMilestone) => string;
+  readonly trackCreated?: () => void;
+  readonly trackContributionAdded?: () => void;
+  readonly trackMilestoneReached?: () => void;
+};
+
+function publishGoalMilestone(input: {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly milestone: GoalMilestone;
+  readonly insertNotification: typeof insertNotificationRecord;
+  readonly schedulePush: typeof scheduleLocalPush;
+  readonly translateMilestoneTitle: (input: GoalMilestone) => string;
+  readonly translateMilestoneBody: (input: GoalMilestone) => string;
+  readonly trackMilestoneReached: () => void;
+}): void {
+  void input.insertNotification(input.db, input.userId, {
+    type: "goal_milestone",
+    dedupKey: `goal_milestone:${input.milestone.goalId}:${input.milestone.milestone}`,
+    categoryId: null,
+    goalId: input.milestone.goalId,
+    titleKey: "notifications.goalMilestone",
+    messageKey: "notifications.goalMilestoneMsg",
+    params: JSON.stringify({
+      goalName: input.milestone.goalName,
+      percent: input.milestone.milestone,
+    }),
+  });
+  input.trackMilestoneReached();
+  void input.schedulePush({
+    title: input.translateMilestoneTitle(input.milestone),
+    body: input.translateMilestoneBody(input.milestone),
+    data: { route: `/goal-detail?goalId=${input.milestone.goalId}` },
+    preferenceKey: "goalMilestones",
+  });
+}
+
+export function createGoalMutationService({
+  db,
+  userId,
+  commit,
+  now = () => new Date(),
+  createGoalId = () => generateId("gl"),
+  createContributionId = () => generateId("gc"),
+  insertNotification = insertNotificationRecord,
+  schedulePush = scheduleLocalPush,
+  translateMilestoneTitle = ({ goalName, milestone }) =>
+    i18n.t("notifications.goalMilestone", { goalName, percent: milestone }),
+  translateMilestoneBody = ({ milestone }) =>
+    i18n.t("notifications.goalMilestoneMsg", { percent: milestone }),
+  trackCreated = trackGoalCreated,
+  trackContributionAdded = trackGoalContributionAdded,
+  trackMilestoneReached = trackGoalMilestoneReached,
+}: CreateGoalMutationServiceDeps) {
+  const mutations = createWriteThroughMutationModule(db);
+  const commitGoalMutation =
+    commit ??
+    (async (command: MutationCommand): Promise<boolean> => {
+      try {
+        const result = await mutations.commit(command);
+        return result.success;
+      } catch {
+        return false;
+      }
+    });
+
+  return {
+    createGoal: async (input: CreateGoalInput): Promise<boolean> => {
+      const validation = createGoalSchema.safeParse(input);
+      if (!validation.success) return false;
+
+      const timestamp = toIsoDateTime(now());
+      const didCommit = await commitGoalMutation({
+        kind: "goal.save",
+        row: {
+          id: createGoalId(),
+          userId,
+          name: validation.data.name,
+          type: validation.data.type,
+          targetAmount: validation.data.targetAmount,
+          targetDate: validation.data.targetDate ?? null,
+          interestRatePercent: validation.data.interestRatePercent ?? null,
+          iconName: validation.data.iconName ?? null,
+          colorHex: validation.data.colorHex ?? null,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+          deletedAt: null,
+        },
+      });
+      if (!didCommit) return false;
+
+      trackCreated();
+      return true;
+    },
+
+    updateGoal: (goalId: string, data: GoalUpdateInput): Promise<boolean> =>
+      commitGoalMutation({
+        kind: "goal.update",
+        goalId,
+        data,
+        now: toIsoDateTime(now()),
+      }),
+
+    deleteGoal: (goalId: string): Promise<boolean> =>
+      commitGoalMutation({
+        kind: "goal.delete",
+        goalId,
+        now: toIsoDateTime(now()),
+      }),
+
+    addContribution: async (input: AddContributionInput): Promise<boolean> => {
+      const validation = addContributionSchema.safeParse(input);
+      if (!validation.success) return false;
+
+      const timestamp = toIsoDateTime(now());
+      const didCommit = await commitGoalMutation({
+        kind: "goalContribution.save",
+        row: {
+          id: createContributionId(),
+          goalId: validation.data.goalId,
+          userId,
+          amount: validation.data.amount,
+          note: validation.data.note ?? null,
+          date: validation.data.date,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+          deletedAt: null,
+        },
+      });
+      if (!didCommit) return false;
+
+      trackContributionAdded();
+      return true;
+    },
+
+    deleteContribution: (id: string): Promise<boolean> =>
+      commitGoalMutation({
+        kind: "goalContribution.delete",
+        contributionId: id,
+        now: toIsoDateTime(now()),
+      }),
+
+    notifyMilestones: ({ goalId, goalName, milestones }: GoalMilestoneEffect): void => {
+      milestones.forEach((milestone) => {
+        publishGoalMilestone({
+          db,
+          userId,
+          milestone: { goalId, goalName, milestone },
+          insertNotification,
+          schedulePush,
+          translateMilestoneTitle,
+          translateMilestoneBody,
+          trackMilestoneReached,
+        });
+      });
+    },
+  };
+}

--- a/apps/mobile/features/goals/store.ts
+++ b/apps/mobile/features/goals/store.ts
@@ -1,19 +1,11 @@
 import { create } from "zustand";
-import { insertNotificationRecord, scheduleLocalPush } from "@/features/notifications";
-import { createWriteThroughMutationModule } from "@/mutations";
 import type { AnyDb } from "@/shared/db";
-import { i18n } from "@/shared/i18n";
-import {
-  generateId,
-  toIsoDateTime,
-  trackGoalContributionAdded,
-  trackGoalCreated,
-  trackGoalMilestoneReached,
-} from "@/shared/lib";
-import type { MutationCommand } from "@/shared/mutations/write-through";
 import type { UserId } from "@/shared/types/branded";
-import type { GoalContribution } from "./schema";
-import { addContributionSchema, createGoalSchema } from "./schema";
+import type { AddContributionInput, CreateGoalInput, GoalContribution } from "./schema";
+import {
+  createGoalMutationService,
+  type GoalUpdateInput,
+} from "./services/create-goal-mutation-service";
 import { createGoalQueryService } from "./services/create-goal-query-service";
 import type { GoalWithProgress } from "./types";
 
@@ -40,6 +32,34 @@ type GoalActions = {
   clearSelectedGoal: () => void;
   setIsLoading: (isLoading: boolean) => void;
 };
+
+type GoalSessionSnapshot = {
+  readonly userId: UserId;
+  readonly sessionId: number;
+};
+
+type GoalRequestSnapshot = GoalSessionSnapshot & {
+  readonly requestId: number;
+};
+
+type GoalSelectionSnapshot = GoalRequestSnapshot & {
+  readonly goalId: string;
+};
+
+type GoalRefreshSnapshot = GoalSessionSnapshot & {
+  readonly db: AnyDb;
+};
+
+type GoalSelectionRefreshSnapshot = GoalRefreshSnapshot & {
+  readonly goalId: string;
+};
+
+type GoalUpdateRequest = {
+  readonly id: string;
+  readonly data: GoalUpdateInput;
+};
+
+type GoalMutationService = ReturnType<typeof createGoalMutationService>;
 
 export const useGoalStore = create<GoalState & GoalActions>((set) => ({
   activeUserId: null,
@@ -68,83 +88,51 @@ export const useGoalStore = create<GoalState & GoalActions>((set) => ({
   setIsLoading: (isLoading) => set({ isLoading }),
 }));
 
-function isCurrentGoalsRequest(requestId: number, userId: UserId, sessionId: number): boolean {
-  return (
-    loadGoalsRequestId === requestId &&
-    useGoalStore.getState().activeUserId === userId &&
-    goalsSessionId === sessionId
-  );
+function isActiveGoalSession(session: GoalSessionSnapshot): boolean {
+  const { activeUserId } = useGoalStore.getState();
+  return [goalsSessionId === session.sessionId, activeUserId === session.userId].every(Boolean);
 }
 
-function isCurrentGoalSelection(
-  requestId: number,
-  userId: UserId,
-  goalId: string,
-  sessionId: number
-): boolean {
-  return (
-    loadGoalContributionsRequestId === requestId &&
-    useGoalStore.getState().activeUserId === userId &&
-    useGoalStore.getState().selectedGoalId === goalId &&
-    goalsSessionId === sessionId
-  );
+function isCurrentGoalsRequest(request: GoalRequestSnapshot): boolean {
+  return [loadGoalsRequestId === request.requestId, isActiveGoalSession(request)].every(Boolean);
 }
 
-function isActiveGoalSession(userId: UserId, sessionId: number): boolean {
-  return goalsSessionId === sessionId && useGoalStore.getState().activeUserId === userId;
+function isCurrentGoalSelection(request: GoalSelectionSnapshot): boolean {
+  const { selectedGoalId } = useGoalStore.getState();
+  return [
+    loadGoalContributionsRequestId === request.requestId,
+    selectedGoalId === request.goalId,
+    isActiveGoalSession(request),
+  ].every(Boolean);
 }
 
-function getCrossedMilestones(percentBefore: number, percentAfter: number) {
-  return GOAL_MILESTONES.filter(
-    (milestone) => percentBefore < milestone && percentAfter >= milestone
-  );
-}
-
-async function commitGoalMutation(db: AnyDb, command: MutationCommand): Promise<boolean> {
-  const mutations = createWriteThroughMutationModule(db);
-
-  try {
-    const result = await mutations.commit(command);
-    return result.success;
-  } catch {
-    return false;
+function clearGoalsLoadingIfCurrent(requestId: number): void {
+  if (loadGoalsRequestId === requestId) {
+    useGoalStore.getState().setIsLoading(false);
   }
 }
 
-async function refreshGoalsForActiveSession(
-  db: AnyDb,
-  userId: UserId,
-  sessionId: number
-): Promise<boolean> {
-  if (!isActiveGoalSession(userId, sessionId)) return false;
-  await loadGoalsForUser(db, userId);
-  return isActiveGoalSession(userId, sessionId);
+async function refreshGoalsForActiveSession(input: GoalRefreshSnapshot): Promise<boolean> {
+  if (!isActiveGoalSession(input)) return false;
+  await loadGoalsForUser(input.db, input.userId);
+  return isActiveGoalSession(input);
 }
 
 async function refreshSelectedGoalContributions(
-  db: AnyDb,
-  userId: UserId,
-  goalId: string,
-  sessionId: number
+  input: GoalSelectionRefreshSnapshot
 ): Promise<boolean> {
-  if (!isActiveGoalSession(userId, sessionId)) return false;
-  await selectGoal(db, userId, goalId);
-  return isActiveGoalSession(userId, sessionId);
+  if (!isActiveGoalSession(input)) return false;
+  await selectGoal(input.db, input.userId, input.goalId);
+  return isActiveGoalSession(input);
 }
 
-function buildGoalMilestoneNotification(goalName: string, goalId: string, milestone: number) {
-  return {
-    type: "goal_milestone" as const,
-    dedupKey: `goal_milestone:${goalId}:${milestone}`,
-    categoryId: null,
-    goalId,
-    titleKey: "notifications.goalMilestone",
-    messageKey: "notifications.goalMilestoneMsg",
-    params: JSON.stringify({
-      goalName,
-      percent: milestone,
-    }),
-  };
+function getGoalById(goalId: string): GoalWithProgress | null {
+  return useGoalStore.getState().goals.find((goal) => goal.goal.id === goalId) ?? null;
+}
+
+function getGoalPercentComplete(goalId: string): number {
+  const goal = getGoalById(goalId);
+  return goal == null ? 0 : goal.progress.percentComplete;
 }
 
 export function initializeGoalSession(userId: UserId): void {
@@ -155,29 +143,28 @@ export function initializeGoalSession(userId: UserId): void {
 }
 
 export async function loadGoalsForUser(db: AnyDb, userId: UserId): Promise<void> {
-  const requestId = ++loadGoalsRequestId;
-  const sessionId = goalsSessionId;
+  const request: GoalRequestSnapshot = {
+    userId,
+    sessionId: goalsSessionId,
+    requestId: ++loadGoalsRequestId,
+  };
   useGoalStore.getState().setIsLoading(true);
 
   try {
     const goals = await goalQueryService.loadGoals({ db, userId });
-    if (!isCurrentGoalsRequest(requestId, userId, sessionId)) {
-      if (loadGoalsRequestId === requestId) {
-        useGoalStore.getState().setIsLoading(false);
-      }
+    if (!isCurrentGoalsRequest(request)) {
+      clearGoalsLoadingIfCurrent(request.requestId);
       return;
     }
     useGoalStore.getState().setGoals(goals);
   } catch {
-    if (loadGoalsRequestId === requestId) {
-      useGoalStore.getState().setIsLoading(false);
-    }
+    clearGoalsLoadingIfCurrent(request.requestId);
   }
 }
 
 export async function selectGoal(db: AnyDb, userId: UserId, goalId: string | null): Promise<void> {
   const requestId = ++loadGoalContributionsRequestId;
-  const sessionId = goalsSessionId;
+  const session: GoalSessionSnapshot = { userId, sessionId: goalsSessionId };
   useGoalStore.getState().setSelectedGoalId(goalId);
 
   if (goalId == null) {
@@ -187,7 +174,7 @@ export async function selectGoal(db: AnyDb, userId: UserId, goalId: string | nul
 
   try {
     const contributions = await goalQueryService.loadGoalContributions({ db, goalId });
-    if (!isCurrentGoalSelection(requestId, userId, goalId, sessionId)) {
+    if (!isCurrentGoalSelection({ ...session, goalId, requestId })) {
       return;
     }
     useGoalStore.getState().setSelectedGoalContributions(contributions);
@@ -199,170 +186,96 @@ export async function selectGoal(db: AnyDb, userId: UserId, goalId: string | nul
 export async function createGoal(
   db: AnyDb,
   userId: UserId,
-  input: {
-    readonly name: string;
-    readonly type: "savings" | "debt";
-    readonly targetAmount: number;
-    readonly targetDate?: string;
-    readonly interestRatePercent?: number;
-    readonly iconName?: string;
-    readonly colorHex?: string;
-  }
+  input: CreateGoalInput
 ): Promise<boolean> {
-  const validation = createGoalSchema.safeParse(input);
-  if (!validation.success) return false;
-
-  const sessionId = goalsSessionId;
-  const now = toIsoDateTime(new Date());
-  const didCommit = await commitGoalMutation(db, {
-    kind: "goal.save",
-    row: {
-      id: generateId("gl"),
-      userId,
-      name: input.name,
-      type: input.type,
-      targetAmount: input.targetAmount,
-      targetDate: input.targetDate ?? null,
-      interestRatePercent: input.interestRatePercent ?? null,
-      iconName: input.iconName ?? null,
-      colorHex: input.colorHex ?? null,
-      createdAt: now,
-      updatedAt: now,
-      deletedAt: null,
-    },
-  });
-  if (!didCommit) return false;
-  trackGoalCreated();
-
-  return refreshGoalsForActiveSession(db, userId, sessionId);
+  const session: GoalSessionSnapshot = { userId, sessionId: goalsSessionId };
+  const didCreate = await createGoalMutationService({ db, userId }).createGoal(input);
+  if (!didCreate) return false;
+  return refreshGoalsForActiveSession({ db, ...session });
 }
 
 export async function updateGoal(
   db: AnyDb,
   userId: UserId,
-  id: string,
-  data: {
-    readonly name?: string;
-    readonly targetAmount?: number;
-    readonly targetDate?: string | null;
-    readonly interestRatePercent?: number | null;
-    readonly iconName?: string | null;
-    readonly colorHex?: string | null;
-  }
+  input: GoalUpdateRequest
 ): Promise<boolean> {
-  const sessionId = goalsSessionId;
-  const didCommit = await commitGoalMutation(db, {
-    kind: "goal.update",
-    goalId: id,
-    data,
-    now: toIsoDateTime(new Date()),
-  });
-  if (!didCommit) return false;
-
-  return refreshGoalsForActiveSession(db, userId, sessionId);
+  const session: GoalSessionSnapshot = { userId, sessionId: goalsSessionId };
+  const didUpdate = await createGoalMutationService({ db, userId }).updateGoal(
+    input.id,
+    input.data
+  );
+  if (!didUpdate) return false;
+  return refreshGoalsForActiveSession({ db, ...session });
 }
 
 export async function deleteGoal(db: AnyDb, userId: UserId, id: string): Promise<boolean> {
-  const sessionId = goalsSessionId;
-  const didCommit = await commitGoalMutation(db, {
-    kind: "goal.delete",
-    goalId: id,
-    now: toIsoDateTime(new Date()),
-  });
-  if (!didCommit) return false;
-  if (!isActiveGoalSession(userId, sessionId)) return false;
+  const session: GoalSessionSnapshot = { userId, sessionId: goalsSessionId };
+  const didDelete = await createGoalMutationService({ db, userId }).deleteGoal(id);
+  if (!didDelete) return false;
+  if (!isActiveGoalSession(session)) return false;
 
   if (useGoalStore.getState().selectedGoalId === id) {
     useGoalStore.getState().clearSelectedGoal();
   }
+  return refreshGoalsForActiveSession({ db, ...session });
+}
 
-  return refreshGoalsForActiveSession(db, userId, sessionId);
+function getCrossedMilestones(percentBefore: number, percentAfter: number) {
+  return GOAL_MILESTONES.filter(
+    (milestone) => percentBefore < milestone && percentAfter >= milestone
+  );
+}
+
+function notifyGoalMilestones(
+  goalMutations: GoalMutationService,
+  goalId: string,
+  percentBefore: number
+): void {
+  const goal = getGoalById(goalId);
+  if (goal == null) return;
+
+  const milestones = getCrossedMilestones(percentBefore, goal.progress.percentComplete);
+  if (milestones.length === 0) return;
+
+  goalMutations.notifyMilestones({
+    goalId,
+    goalName: goal.goal.name,
+    milestones,
+  });
 }
 
 export async function addContribution(
   db: AnyDb,
   userId: UserId,
-  input: {
-    readonly goalId: string;
-    readonly amount: number;
-    readonly note?: string;
-    readonly date: string;
-  }
+  input: AddContributionInput
 ): Promise<boolean> {
-  const validation = addContributionSchema.safeParse(input);
-  if (!validation.success) return false;
+  const session: GoalSessionSnapshot = { userId, sessionId: goalsSessionId };
+  const goalMutations: GoalMutationService = createGoalMutationService({ db, userId });
+  const percentBefore = getGoalPercentComplete(input.goalId);
+  const didAdd = await goalMutations.addContribution(input);
+  if (!didAdd) return false;
 
-  const sessionId = goalsSessionId;
-  const now = toIsoDateTime(new Date());
-  const percentBefore =
-    useGoalStore.getState().goals.find((goal) => goal.goal.id === input.goalId)?.progress
-      .percentComplete ?? 0;
-  const didCommit = await commitGoalMutation(db, {
-    kind: "goalContribution.save",
-    row: {
-      id: generateId("gc"),
-      goalId: input.goalId,
-      userId,
-      amount: input.amount,
-      note: input.note ?? null,
-      date: input.date,
-      createdAt: now,
-      updatedAt: now,
-      deletedAt: null,
-    },
-  });
-  if (!didCommit) return false;
-  trackGoalContributionAdded();
-
-  const didRefreshGoals = await refreshGoalsForActiveSession(db, userId, sessionId);
+  const didRefreshGoals = await refreshGoalsForActiveSession({ db, ...session });
   if (!didRefreshGoals) return false;
 
-  const selectedGoal = useGoalStore.getState().goals.find((goal) => goal.goal.id === input.goalId);
-  if (selectedGoal == null) return true;
-
-  getCrossedMilestones(percentBefore, selectedGoal.progress.percentComplete).forEach(
-    (milestone) => {
-      void insertNotificationRecord(
-        db,
-        userId,
-        buildGoalMilestoneNotification(selectedGoal.goal.name, input.goalId, milestone)
-      );
-      trackGoalMilestoneReached();
-      void scheduleLocalPush({
-        title: i18n.t("notifications.goalMilestone", {
-          goalName: selectedGoal.goal.name,
-          percent: milestone,
-        }),
-        body: i18n.t("notifications.goalMilestoneMsg", { percent: milestone }),
-        data: { route: `/goal-detail?goalId=${input.goalId}` },
-        preferenceKey: "goalMilestones",
-      });
-    }
-  );
-
-  if (useGoalStore.getState().selectedGoalId !== input.goalId) {
-    return true;
-  }
-
-  return refreshSelectedGoalContributions(db, userId, input.goalId, sessionId);
+  notifyGoalMilestones(goalMutations, input.goalId, percentBefore);
+  return useGoalStore.getState().selectedGoalId === input.goalId
+    ? refreshSelectedGoalContributions({ db, ...session, goalId: input.goalId })
+    : true;
 }
 
 export async function deleteContribution(db: AnyDb, userId: UserId, id: string): Promise<boolean> {
-  const sessionId = goalsSessionId;
-  const didCommit = await commitGoalMutation(db, {
-    kind: "goalContribution.delete",
-    contributionId: id,
-    now: toIsoDateTime(new Date()),
-  });
-  if (!didCommit) return false;
+  const session: GoalSessionSnapshot = { userId, sessionId: goalsSessionId };
+  const didDelete = await createGoalMutationService({ db, userId }).deleteContribution(id);
+  if (!didDelete) return false;
 
-  const didRefreshGoals = await refreshGoalsForActiveSession(db, userId, sessionId);
+  const didRefreshGoals = await refreshGoalsForActiveSession({ db, ...session });
   if (!didRefreshGoals) return false;
 
-  const selectedGoalId = useGoalStore.getState().selectedGoalId;
+  const { selectedGoalId } = useGoalStore.getState();
   if (selectedGoalId == null) {
     return true;
   }
 
-  return refreshSelectedGoalContributions(db, userId, selectedGoalId, sessionId);
+  return refreshSelectedGoalContributions({ db, ...session, goalId: selectedGoalId });
 }


### PR DESCRIPTION
- extract goal mutation service
- narrow goal update payload
- add goal mutation tests


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted goal mutations into a dedicated service and slimmed the goals store for clearer boundaries and easier testing. Narrowed the update API and added tests for commits and milestone notifications.

- **Refactors**
  - Added `features/goals/services/create-goal-mutation-service` to handle create/update/delete goal and contributions with injectable side effects (commit, notifications, push, analytics).
  - Reworked `features/goals/store` to delegate mutations to the service, reduce state code, and improve request/session guards and loading handling.
  - Store now computes crossed milestones and calls the service to publish notifications after contributions.

- **Migration**
  - `updateGoal` now takes `{ id, data }` instead of `(id, data)`. Call sites should pass an object with `id` and a `data` payload.

<sup>Written for commit 1e2b8cd1b681543f64f7b2adfb1cc50f29e6455f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

