### PR TITLE
refactor(mobile): split notification parser

### DIFF
--- a/apps/mobile/__tests__/email-capture/fetch-service.test.ts
+++ b/apps/mobile/__tests__/email-capture/fetch-service.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createEmailFetchClientIds,
+  fetchEmailAccountBatch,
+} from "@/features/email-capture/services/email-capture-fetch-service";
+import type { EmailAccountRow } from "@/features/email-capture/lib/repository";
+import type { EmailAccountId, IsoDateTime, UserId } from "@/shared/types/branded";
+
+const { mockFetchEmails, mockEnsureBankSenders } = vi.hoisted(() => ({
+  mockFetchEmails: vi.fn(),
+  mockEnsureBankSenders: vi.fn(),
+}));
+
+vi.mock("@/features/capture-sources/ingestion.public", () => ({
+  createCaptureIngestionPort: vi.fn(),
+}));
+
+vi.mock("@/features/email-capture/lib/repository", () => ({
+  getFailedEmails: vi.fn(),
+  getNeedsReviewEmails: vi.fn(),
+  updateLastFetchedAt: vi.fn(),
+}));
+
+vi.mock("@/features/email-capture/pipeline.public", () => ({
+  processEmails: vi.fn(),
+  processRetries: vi.fn(),
+}));
+
+vi.mock("@/features/email-capture/queries/bank-senders", () => ({
+  ensureBankSenders: mockEnsureBankSenders,
+}));
+
+vi.mock("@/features/email-capture/services/email-adapter", () => ({
+  getAdapter: vi.fn(() => ({
+    fetchEmails: mockFetchEmails,
+  })),
+}));
+
+vi.mock("@/shared/query", () => ({
+  queryClient: {},
+}));
+
+const makeAccount = (overrides: Partial<EmailAccountRow> = {}): EmailAccountRow => ({
+  id: "ea-1" as EmailAccountId,
+  userId: "user-1" as UserId,
+  provider: "gmail",
+  email: "alerts@example.com",
+  createdAt: "2026-04-01T00:00:00.000Z" as IsoDateTime,
+  lastFetchedAt: null,
+  ...overrides,
+});
+
+describe("fetchEmailAccountBatch", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-20T12:00:00.000Z"));
+    vi.clearAllMocks();
+    mockFetchEmails.mockResolvedValue([]);
+    mockEnsureBankSenders.mockResolvedValue([{ email: "bank@example.com" }]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("uses the account lastFetchedAt when it is newer than the lookback boundary", async () => {
+    await fetchEmailAccountBatch({
+      accounts: [makeAccount({ lastFetchedAt: "2026-04-15T09:00:00.000Z" as IsoDateTime })],
+      clientIds: createEmailFetchClientIds("gmail-client", "outlook-client"),
+    });
+
+    expect(mockFetchEmails).toHaveBeenCalledWith("gmail-client", "2026-04-15T09:00:00.000Z", [
+      "bank@example.com",
+    ]);
+  });
+
+  it("clamps older lastFetchedAt values to the 30-day lookback boundary", async () => {
+    await fetchEmailAccountBatch({
+      accounts: [makeAccount({ lastFetchedAt: "2026-02-10T09:00:00.000Z" as IsoDateTime })],
+      clientIds: createEmailFetchClientIds("gmail-client", "outlook-client"),
+    });
+
+    expect(mockFetchEmails).toHaveBeenCalledWith("gmail-client", "2026-03-21T12:00:00.000Z", [
+      "bank@example.com",
+    ]);
+  });
+});

--- a/apps/mobile/__tests__/email-capture/fetch-service.test.ts
+++ b/apps/mobile/__tests__/email-capture/fetch-service.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { EmailAccountRow } from "@/features/email-capture/lib/repository";
 import {
   createEmailFetchClientIds,
   fetchEmailAccountBatch,
 } from "@/features/email-capture/services/email-capture-fetch-service";
-import type { EmailAccountRow } from "@/features/email-capture/lib/repository";
 import type { EmailAccountId, IsoDateTime, UserId } from "@/shared/types/branded";
 
 const { mockFetchEmails, mockEnsureBankSenders } = vi.hoisted(() => ({

--- a/apps/mobile/__tests__/goals/service.test.ts
+++ b/apps/mobile/__tests__/goals/service.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, expect, it, vi } from "vitest";
 import { createGoalMutationService } from "@/features/goals/services/create-goal-mutation-service";
 import { createGoalQueryService } from "@/features/goals/services/create-goal-query-service";
+import type { GoalUpdateInput } from "@/features/goals/schema";
 import type { UserId } from "@/shared/types/branded";
 
 const mockGetGoalsForUser = vi.fn();
@@ -101,7 +102,7 @@ function createQueryService() {
 }
 
 function createMilestoneService() {
-  const insertNotification = vi.fn();
+  const insertNotification = vi.fn().mockResolvedValue(true);
   const schedulePush = vi.fn();
   const trackMilestoneReached = vi.fn();
 
@@ -219,11 +220,53 @@ it("commits normalized goal saves and tracks successful creates", async () => {
   expect(trackCreated).toHaveBeenCalledTimes(1);
 });
 
-it("publishes milestone notifications through the injected side-effect boundary", () => {
+it("commits validated goal updates", async () => {
+  const commit = vi.fn().mockResolvedValue(true);
+  const service = createGoalMutationService({
+    db: {} as never,
+    userId: "user-1" as UserId,
+    commit,
+    now: () => new Date("2026-04-20T12:30:00.000Z"),
+  });
+
+  await expect(
+    service.updateGoal("goal-1", {
+      targetDate: null,
+      colorHex: "#00AAFF",
+    })
+  ).resolves.toBe(true);
+
+  expect(commit).toHaveBeenCalledWith({
+    kind: "goal.update",
+    goalId: "goal-1",
+    data: {
+      targetDate: null,
+      colorHex: "#00AAFF",
+    },
+    now: "2026-04-20T12:30:00.000Z",
+  });
+});
+
+it("rejects invalid goal updates before they reach the mutation boundary", async () => {
+  const commit = vi.fn().mockResolvedValue(true);
+  const service = createGoalMutationService({
+    db: {} as never,
+    userId: "user-1" as UserId,
+    commit,
+  });
+
+  await expect(service.updateGoal("goal-1", { colorHex: "blue" } as GoalUpdateInput)).resolves.toBe(
+    false
+  );
+
+  expect(commit).not.toHaveBeenCalled();
+});
+
+it("publishes milestone notifications through the injected side-effect boundary", async () => {
   const { insertNotification, schedulePush, trackMilestoneReached, service } =
     createMilestoneService();
 
-  service.notifyMilestones({
+  await service.notifyMilestones({
     goalId: "goal-1",
     goalName: "Trip",
     milestones: [25, 50],
@@ -231,4 +274,20 @@ it("publishes milestone notifications through the injected side-effect boundary"
 
   expectMilestoneNotifications(insertNotification);
   expectMilestonePushes(schedulePush, trackMilestoneReached);
+});
+
+it("skips milestone push and analytics when the notification insert is deduped", async () => {
+  const { insertNotification, schedulePush, trackMilestoneReached, service } =
+    createMilestoneService();
+  insertNotification.mockResolvedValue(false);
+
+  await service.notifyMilestones({
+    goalId: "goal-1",
+    goalName: "Trip",
+    milestones: [25],
+  });
+
+  expect(insertNotification).toHaveBeenCalledTimes(1);
+  expect(schedulePush).not.toHaveBeenCalled();
+  expect(trackMilestoneReached).not.toHaveBeenCalled();
 });

--- a/apps/mobile/__tests__/goals/service.test.ts
+++ b/apps/mobile/__tests__/goals/service.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, expect, it, vi } from "vitest";
+import type { GoalUpdateInput } from "@/features/goals/schema";
 import { createGoalMutationService } from "@/features/goals/services/create-goal-mutation-service";
 import { createGoalQueryService } from "@/features/goals/services/create-goal-query-service";
-import type { GoalUpdateInput } from "@/features/goals/schema";
 import type { UserId } from "@/shared/types/branded";
 
 const mockGetGoalsForUser = vi.fn();

--- a/apps/mobile/__tests__/goals/service.test.ts
+++ b/apps/mobile/__tests__/goals/service.test.ts
@@ -291,3 +291,21 @@ it("skips milestone push and analytics when the notification insert is deduped",
   expect(schedulePush).not.toHaveBeenCalled();
   expect(trackMilestoneReached).not.toHaveBeenCalled();
 });
+
+it("squashes milestone notification failures", async () => {
+  const { insertNotification, schedulePush, trackMilestoneReached, service } =
+    createMilestoneService();
+  insertNotification.mockRejectedValue(new Error("notification unavailable"));
+
+  await expect(
+    service.notifyMilestones({
+      goalId: "goal-1",
+      goalName: "Trip",
+      milestones: [25],
+    })
+  ).resolves.toBeUndefined();
+
+  expect(insertNotification).toHaveBeenCalledTimes(1);
+  expect(schedulePush).not.toHaveBeenCalled();
+  expect(trackMilestoneReached).not.toHaveBeenCalled();
+});

--- a/apps/mobile/__tests__/goals/store.test.ts
+++ b/apps/mobile/__tests__/goals/store.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { insertNotificationRecord } from "@/features/notifications";
 import {
   addContribution,
   createGoal,
@@ -9,6 +8,7 @@ import {
   useGoalStore,
 } from "@/features/goals/store";
 import type { GoalWithProgress } from "@/features/goals/types";
+import { insertNotificationRecord } from "@/features/notifications";
 import type { UserId } from "@/shared/types/branded";
 
 const mockLoadGoals = vi.fn();

--- a/apps/mobile/__tests__/goals/store.test.ts
+++ b/apps/mobile/__tests__/goals/store.test.ts
@@ -1,16 +1,46 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { insertNotificationRecord } from "@/features/notifications";
 import {
+  addContribution,
   createGoal,
   initializeGoalSession,
   loadGoalsForUser,
   selectGoal,
   useGoalStore,
 } from "@/features/goals/store";
+import type { GoalWithProgress } from "@/features/goals/types";
 import type { UserId } from "@/shared/types/branded";
 
 const mockLoadGoals = vi.fn();
 const mockLoadGoalContributions = vi.fn();
 const mockCommit = vi.fn();
+
+const baseGoalSnapshot: GoalWithProgress = {
+  goal: {
+    id: "goal-1",
+    userId: "user-1",
+    name: "Trip",
+    type: "savings",
+    targetAmount: 1000000,
+    targetDate: null,
+    interestRatePercent: null,
+    iconName: null,
+    colorHex: null,
+    createdAt: "2026-04-01T00:00:00.000Z",
+    updatedAt: "2026-04-01T00:00:00.000Z",
+    deletedAt: null,
+  },
+  currentAmount: 250000,
+  progress: { percentComplete: 25, remaining: 750000, isComplete: false },
+  projection: {
+    monthsToGo: 2,
+    projectedDate: new Date("2026-06-01T00:00:00.000Z"),
+    confidence: "high",
+    netMonthlySavings: 400000,
+  },
+  installments: { current: 1, total: 3 },
+  paceGuidance: null,
+};
 
 vi.mock("@/features/goals/services/create-goal-query-service", () => ({
   createGoalQueryService: () => ({
@@ -53,6 +83,26 @@ function createDeferred<T>() {
   return { promise, resolve, reject };
 }
 
+const createGoalSnapshot = (progress: GoalWithProgress["progress"]): GoalWithProgress => ({
+  ...baseGoalSnapshot,
+  currentAmount: baseGoalSnapshot.goal.targetAmount - progress.remaining,
+  progress,
+});
+
+const initialGoalSnapshot = createGoalSnapshot({
+  percentComplete: 20,
+  remaining: 800000,
+  isComplete: false,
+});
+
+const updatedGoalSnapshot = createGoalSnapshot({
+  percentComplete: 50,
+  remaining: 500000,
+  isComplete: false,
+});
+
+const createGoalLoadDeferred = () => createDeferred<readonly GoalWithProgress[]>();
+
 describe("goal store boundary", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -66,55 +116,14 @@ describe("goal store boundary", () => {
   });
 
   it("drops stale goal results after the active user changes", async () => {
-    const deferred =
-      createDeferred<
-        readonly [
-          {
-            readonly goal: {
-              readonly id: string;
-              readonly name: string;
-            };
-            readonly currentAmount: number;
-            readonly progress: {
-              readonly percentComplete: number;
-              readonly remaining: number;
-              readonly isComplete: boolean;
-            };
-            readonly projection: {
-              readonly monthsToGo: number | null;
-              readonly projectedDate: Date | null;
-              readonly confidence: "none" | "low" | "medium" | "high";
-              readonly netMonthlySavings: number;
-            };
-            readonly installments: {
-              readonly current: number;
-              readonly total: number;
-            };
-            readonly paceGuidance: null;
-          },
-        ]
-      >();
+    const deferred = createGoalLoadDeferred();
     mockLoadGoals.mockReturnValueOnce(deferred.promise);
 
     initializeGoalSession("user-1" as UserId);
     const load = loadGoalsForUser({} as never, "user-1" as UserId);
 
     initializeGoalSession("user-2" as UserId);
-    deferred.resolve([
-      {
-        goal: { id: "goal-1", name: "Trip" },
-        currentAmount: 250000,
-        progress: { percentComplete: 25, remaining: 750000, isComplete: false },
-        projection: {
-          monthsToGo: 2,
-          projectedDate: new Date("2026-06-01T00:00:00.000Z"),
-          confidence: "high",
-          netMonthlySavings: 400000,
-        },
-        installments: { current: 1, total: 3 },
-        paceGuidance: null,
-      },
-    ]);
+    deferred.resolve([baseGoalSnapshot]);
 
     await load;
 
@@ -173,5 +182,33 @@ describe("goal store boundary", () => {
       activeUserId: "user-2",
       goals: [],
     });
+  });
+
+  it("does not fail addContribution when milestone notification publishing rejects", async () => {
+    mockCommit.mockResolvedValueOnce({ success: true });
+    mockLoadGoals.mockResolvedValueOnce([updatedGoalSnapshot]);
+    vi.mocked(insertNotificationRecord).mockRejectedValue(new Error("notifications offline"));
+
+    initializeGoalSession("user-1" as UserId);
+    useGoalStore.setState({
+      activeUserId: "user-1" as UserId,
+      goals: [initialGoalSnapshot],
+      selectedGoalId: null,
+      selectedGoalContributions: [],
+      isLoading: false,
+    });
+
+    await expect(
+      addContribution({} as never, "user-1" as UserId, {
+        goalId: "goal-1",
+        amount: 250000,
+        date: "2026-04-18",
+      })
+    ).resolves.toBe(true);
+
+    expect(mockCommit).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "goalContribution.save" })
+    );
+    expect(useGoalStore.getState().goals).toEqual([updatedGoalSnapshot]);
   });
 });

--- a/apps/mobile/features/capture-sources/lib/notification-parser.ts
+++ b/apps/mobile/features/capture-sources/lib/notification-parser.ts
@@ -4,13 +4,39 @@ export type LocalParseResult = {
   type: "expense" | "income";
 };
 
-function parseAmount(raw: string): number | null {
+type MerchantResolver = (match: RegExpMatchArray) => string;
+
+function parseAmount(raw: string | undefined): number | null {
+  if (typeof raw !== "string") return null;
   const cleaned = raw.replace(/[$\s]/g, "");
   const normalized = cleaned.replace(/[.,](?=\d{3}(?:\D|$))/g, "");
   const match = normalized.match(/^(\d+)(?:[.,](\d{1,2}))?$/);
   if (!match) return null;
-  const pesos = parseInt(match[1] ?? "", 10);
+  const pesosText = match[1];
+  if (typeof pesosText !== "string") return null;
+  const pesos = parseInt(pesosText, 10);
   return pesos;
+}
+
+function parseMatchedAmount(match: RegExpMatchArray, amountGroup: number): number | null {
+  const amount = parseAmount(match[amountGroup]);
+  if (amount === null) return null;
+  if (amount <= 0) return null;
+  return amount;
+}
+
+function trimCapturedMerchant(match: RegExpMatchArray, merchantGroup: number): string {
+  const merchant = match[merchantGroup];
+  if (typeof merchant !== "string") return "";
+  return merchant.trim().replace(/[.\s]+$/, "");
+}
+
+function merchantFromGroup(merchantGroup: number): MerchantResolver {
+  return (match) => trimCapturedMerchant(match, merchantGroup);
+}
+
+function staticMerchant(merchant: string): MerchantResolver {
+  return () => merchant;
 }
 
 const BANCOLOMBIA_PURCHASE = /compra\s+por\s+\$?([\d.,]+)\s+en\s+(.+?)(?:\.\s|$)/i;
@@ -35,40 +61,90 @@ type PatternEntry = {
   pattern: RegExp;
   type: "expense" | "income";
   amountGroup: number;
-  merchantGroup: number;
+  merchantResolver: MerchantResolver;
 };
 
 const PATTERNS: readonly PatternEntry[] = [
-  { pattern: BANCOLOMBIA_PURCHASE, type: "expense", amountGroup: 1, merchantGroup: 2 },
-  { pattern: BANCOLOMBIA_TRANSFER_OUT, type: "expense", amountGroup: 1, merchantGroup: 2 },
-  { pattern: BANCOLOMBIA_TRANSFER_IN, type: "income", amountGroup: 1, merchantGroup: 2 },
-  { pattern: BANCOLOMBIA_DEPOSIT, type: "income", amountGroup: 1, merchantGroup: -1 },
-  { pattern: BBVA_PURCHASE, type: "expense", amountGroup: 1, merchantGroup: 2 },
-  { pattern: NEQUI_SENT, type: "expense", amountGroup: 1, merchantGroup: 2 },
-  { pattern: NEQUI_RECEIVED, type: "income", amountGroup: 1, merchantGroup: 2 },
-  { pattern: DAVIPLATA_PURCHASE, type: "expense", amountGroup: 1, merchantGroup: 2 },
-  { pattern: DAVIPLATA_RECEIVED, type: "income", amountGroup: 1, merchantGroup: 2 },
-  { pattern: GOOGLE_WALLET_EN, type: "expense", amountGroup: 1, merchantGroup: 2 },
-  { pattern: GOOGLE_WALLET_ES, type: "expense", amountGroup: 1, merchantGroup: 2 },
-  { pattern: GENERIC_PURCHASE, type: "expense", amountGroup: 1, merchantGroup: 2 },
+  {
+    pattern: BANCOLOMBIA_PURCHASE,
+    type: "expense",
+    amountGroup: 1,
+    merchantResolver: merchantFromGroup(2),
+  },
+  {
+    pattern: BANCOLOMBIA_TRANSFER_OUT,
+    type: "expense",
+    amountGroup: 1,
+    merchantResolver: merchantFromGroup(2),
+  },
+  {
+    pattern: BANCOLOMBIA_TRANSFER_IN,
+    type: "income",
+    amountGroup: 1,
+    merchantResolver: merchantFromGroup(2),
+  },
+  {
+    pattern: BANCOLOMBIA_DEPOSIT,
+    type: "income",
+    amountGroup: 1,
+    merchantResolver: staticMerchant("Depósito"),
+  },
+  {
+    pattern: BBVA_PURCHASE,
+    type: "expense",
+    amountGroup: 1,
+    merchantResolver: merchantFromGroup(2),
+  },
+  { pattern: NEQUI_SENT, type: "expense", amountGroup: 1, merchantResolver: merchantFromGroup(2) },
+  {
+    pattern: NEQUI_RECEIVED,
+    type: "income",
+    amountGroup: 1,
+    merchantResolver: merchantFromGroup(2),
+  },
+  {
+    pattern: DAVIPLATA_PURCHASE,
+    type: "expense",
+    amountGroup: 1,
+    merchantResolver: merchantFromGroup(2),
+  },
+  {
+    pattern: DAVIPLATA_RECEIVED,
+    type: "income",
+    amountGroup: 1,
+    merchantResolver: merchantFromGroup(2),
+  },
+  {
+    pattern: GOOGLE_WALLET_EN,
+    type: "expense",
+    amountGroup: 1,
+    merchantResolver: merchantFromGroup(2),
+  },
+  {
+    pattern: GOOGLE_WALLET_ES,
+    type: "expense",
+    amountGroup: 1,
+    merchantResolver: merchantFromGroup(2),
+  },
+  {
+    pattern: GENERIC_PURCHASE,
+    type: "expense",
+    amountGroup: 1,
+    merchantResolver: merchantFromGroup(2),
+  },
 ];
 
 function tryParseEntry(combined: string, entry: PatternEntry): LocalParseResult | null {
   const match = combined.match(entry.pattern);
   if (!match) return null;
 
-  const rawAmount = match[entry.amountGroup] ?? "";
-  const amount = parseAmount(rawAmount);
-  if (!amount || amount <= 0) return null;
+  const amount = parseMatchedAmount(match, entry.amountGroup);
+  if (amount === null) return null;
 
-  const rawMerchant =
-    entry.merchantGroup === -1
-      ? "Depósito"
-      : (match[entry.merchantGroup] ?? "").trim().replace(/[.\s]+$/, "");
+  const merchant = entry.merchantResolver(match);
+  if (merchant.length === 0) return null;
 
-  if (rawMerchant.length === 0) return null;
-
-  return { amount, merchant: rawMerchant, type: entry.type };
+  return { amount, merchant, type: entry.type };
 }
 
 export function parseNotificationLocally(text: string): LocalParseResult | null {

--- a/apps/mobile/features/email-capture/services/email-capture-fetch-service.ts
+++ b/apps/mobile/features/email-capture/services/email-capture-fetch-service.ts
@@ -90,7 +90,7 @@ const isSupportedEmailProvider = (provider: string): provider is EmailProvider =
   provider === "gmail" || provider === "outlook";
 
 const resolveFetchSince = (account: EmailAccountRow, minSince: string): string =>
-  account.lastFetchedAt && account.lastFetchedAt < minSince ? account.lastFetchedAt : minSince;
+  account.lastFetchedAt && account.lastFetchedAt > minSince ? account.lastFetchedAt : minSince;
 
 const loadSenderEmails = async (): Promise<readonly string[]> => {
   const senders = await ensureBankSenders(queryClient);

--- a/apps/mobile/features/goals/schema.ts
+++ b/apps/mobile/features/goals/schema.ts
@@ -1,33 +1,49 @@
 import { z } from "zod";
 
 const goalTypeSchema = z.enum(["savings", "debt"]);
+const goalNameSchema = z.string().min(1).max(100);
+const targetAmountSchema = z.number().int().positive();
+const interestRatePercentSchema = z.number().min(0).max(100);
+const iconNameSchema = z.string();
+const colorHexSchema = z.string().regex(/^#[0-9a-fA-F]{6}$/);
+
+function isValidCalendarDate(value: string): boolean {
+  const [year = 0, month = 1, day = 1] = value.split("-").map(Number);
+  const date = new Date(year, month - 1, day);
+  return [date.getFullYear() === year, date.getMonth() === month - 1, date.getDate() === day].every(
+    Boolean
+  );
+}
 
 const isoDateSchema = z
   .string()
   .regex(/^\d{4}-\d{2}-\d{2}$/)
-  .refine((val) => {
-    const parts = val.split("-").map(Number);
-    const y = parts[0] ?? 0;
-    const m = parts[1] ?? 1;
-    const d = parts[2] ?? 1;
-    const date = new Date(y, m - 1, d);
-    return date.getFullYear() === y && date.getMonth() === m - 1 && date.getDate() === d;
-  }, "Invalid calendar date");
+  .refine(isValidCalendarDate, "Invalid calendar date");
 
 export const createGoalSchema = z.object({
-  name: z.string().min(1).max(100),
+  name: goalNameSchema,
   type: goalTypeSchema,
-  targetAmount: z.number().int().positive(),
+  targetAmount: targetAmountSchema,
   targetDate: isoDateSchema.optional(),
-  interestRatePercent: z.number().min(0).max(100).optional(),
-  iconName: z.string().optional(),
-  colorHex: z
-    .string()
-    .regex(/^#[0-9a-fA-F]{6}$/)
-    .optional(),
+  interestRatePercent: interestRatePercentSchema.optional(),
+  iconName: iconNameSchema.optional(),
+  colorHex: colorHexSchema.optional(),
 });
 
 export type CreateGoalInput = z.infer<typeof createGoalSchema>;
+
+export const updateGoalSchema = z
+  .object({
+    name: goalNameSchema.optional(),
+    targetAmount: targetAmountSchema.optional(),
+    targetDate: isoDateSchema.nullable().optional(),
+    interestRatePercent: interestRatePercentSchema.nullable().optional(),
+    iconName: iconNameSchema.nullable().optional(),
+    colorHex: colorHexSchema.nullable().optional(),
+  })
+  .strict();
+
+export type GoalUpdateInput = z.infer<typeof updateGoalSchema>;
 
 export const addContributionSchema = z.object({
   goalId: z.string().min(1),

--- a/apps/mobile/features/goals/services/create-goal-mutation-service.ts
+++ b/apps/mobile/features/goals/services/create-goal-mutation-service.ts
@@ -11,17 +11,11 @@ import {
 } from "@/shared/lib";
 import type { MutationCommand } from "@/shared/mutations/write-through";
 import type { UserId } from "@/shared/types/branded";
-import type { AddContributionInput, CreateGoalInput, Goal } from "../schema";
-import { addContributionSchema, createGoalSchema } from "../schema";
+import type { AddContributionInput, CreateGoalInput, GoalUpdateInput } from "../schema";
+import { addContributionSchema, createGoalSchema, updateGoalSchema } from "../schema";
 
 type CommitGoalMutation = (command: MutationCommand) => Promise<boolean>;
-
-export type GoalUpdateInput = Partial<
-  Pick<
-    Goal,
-    "name" | "targetAmount" | "targetDate" | "interestRatePercent" | "iconName" | "colorHex"
-  >
->;
+export type { GoalUpdateInput } from "../schema";
 
 type GoalMilestone = {
   readonly goalId: string;
@@ -60,26 +54,31 @@ function publishGoalMilestone(input: {
   readonly translateMilestoneTitle: (input: GoalMilestone) => string;
   readonly translateMilestoneBody: (input: GoalMilestone) => string;
   readonly trackMilestoneReached: () => void;
-}): void {
-  void input.insertNotification(input.db, input.userId, {
-    type: "goal_milestone",
-    dedupKey: `goal_milestone:${input.milestone.goalId}:${input.milestone.milestone}`,
-    categoryId: null,
-    goalId: input.milestone.goalId,
-    titleKey: "notifications.goalMilestone",
-    messageKey: "notifications.goalMilestoneMsg",
-    params: JSON.stringify({
-      goalName: input.milestone.goalName,
-      percent: input.milestone.milestone,
-    }),
-  });
-  input.trackMilestoneReached();
-  void input.schedulePush({
-    title: input.translateMilestoneTitle(input.milestone),
-    body: input.translateMilestoneBody(input.milestone),
-    data: { route: `/goal-detail?goalId=${input.milestone.goalId}` },
-    preferenceKey: "goalMilestones",
-  });
+}): Promise<void> {
+  return input
+    .insertNotification(input.db, input.userId, {
+      type: "goal_milestone",
+      dedupKey: `goal_milestone:${input.milestone.goalId}:${input.milestone.milestone}`,
+      categoryId: null,
+      goalId: input.milestone.goalId,
+      titleKey: "notifications.goalMilestone",
+      messageKey: "notifications.goalMilestoneMsg",
+      params: JSON.stringify({
+        goalName: input.milestone.goalName,
+        percent: input.milestone.milestone,
+      }),
+    })
+    .then((didInsert) => {
+      if (!didInsert) return;
+
+      input.trackMilestoneReached();
+      void input.schedulePush({
+        title: input.translateMilestoneTitle(input.milestone),
+        body: input.translateMilestoneBody(input.milestone),
+        data: { route: `/goal-detail?goalId=${input.milestone.goalId}` },
+        preferenceKey: "goalMilestones",
+      });
+    });
 }
 
 export function createGoalMutationService({
@@ -140,13 +139,17 @@ export function createGoalMutationService({
       return true;
     },
 
-    updateGoal: (goalId: string, data: GoalUpdateInput): Promise<boolean> =>
-      commitGoalMutation({
+    updateGoal: async (goalId: string, data: GoalUpdateInput): Promise<boolean> => {
+      const validation = updateGoalSchema.safeParse(data);
+      if (!validation.success) return false;
+
+      return commitGoalMutation({
         kind: "goal.update",
         goalId,
-        data,
+        data: validation.data,
         now: toIsoDateTime(now()),
-      }),
+      });
+    },
 
     deleteGoal: (goalId: string): Promise<boolean> =>
       commitGoalMutation({
@@ -187,19 +190,25 @@ export function createGoalMutationService({
         now: toIsoDateTime(now()),
       }),
 
-    notifyMilestones: ({ goalId, goalName, milestones }: GoalMilestoneEffect): void => {
-      milestones.forEach((milestone) => {
-        publishGoalMilestone({
-          db,
-          userId,
-          milestone: { goalId, goalName, milestone },
-          insertNotification,
-          schedulePush,
-          translateMilestoneTitle,
-          translateMilestoneBody,
-          trackMilestoneReached,
-        });
-      });
+    notifyMilestones: async ({
+      goalId,
+      goalName,
+      milestones,
+    }: GoalMilestoneEffect): Promise<void> => {
+      await Promise.all(
+        milestones.map((milestone) =>
+          publishGoalMilestone({
+            db,
+            userId,
+            milestone: { goalId, goalName, milestone },
+            insertNotification,
+            schedulePush,
+            translateMilestoneTitle,
+            translateMilestoneBody,
+            trackMilestoneReached,
+          })
+        )
+      );
     },
   };
 }

--- a/apps/mobile/features/goals/services/create-goal-mutation-service.ts
+++ b/apps/mobile/features/goals/services/create-goal-mutation-service.ts
@@ -3,6 +3,7 @@ import { createWriteThroughMutationModule } from "@/mutations";
 import type { AnyDb } from "@/shared/db";
 import { i18n } from "@/shared/i18n";
 import {
+  captureWarning,
   generateId,
   toIsoDateTime,
   trackGoalContributionAdded,
@@ -46,6 +47,32 @@ type CreateGoalMutationServiceDeps = {
   readonly trackMilestoneReached?: () => void;
 };
 
+function logMilestoneNotificationFailure(milestone: GoalMilestone, error: unknown): void {
+  captureWarning("goal_milestone_notification_failed", {
+    goalId: milestone.goalId,
+    milestone: milestone.milestone,
+    errorMessage: error instanceof Error ? error.message : "unknown",
+  });
+}
+
+function scheduleMilestonePush(input: {
+  readonly milestone: GoalMilestone;
+  readonly schedulePush: typeof scheduleLocalPush;
+  readonly translateMilestoneTitle: (input: GoalMilestone) => string;
+  readonly translateMilestoneBody: (input: GoalMilestone) => string;
+}): void {
+  void input
+    .schedulePush({
+      title: input.translateMilestoneTitle(input.milestone),
+      body: input.translateMilestoneBody(input.milestone),
+      data: { route: `/goal-detail?goalId=${input.milestone.goalId}` },
+      preferenceKey: "goalMilestones",
+    })
+    .catch((error) => {
+      logMilestoneNotificationFailure(input.milestone, error);
+    });
+}
+
 function publishGoalMilestone(input: {
   readonly db: AnyDb;
   readonly userId: UserId;
@@ -73,12 +100,10 @@ function publishGoalMilestone(input: {
       if (!didInsert) return;
 
       input.trackMilestoneReached();
-      void input.schedulePush({
-        title: input.translateMilestoneTitle(input.milestone),
-        body: input.translateMilestoneBody(input.milestone),
-        data: { route: `/goal-detail?goalId=${input.milestone.goalId}` },
-        preferenceKey: "goalMilestones",
-      });
+      scheduleMilestonePush(input);
+    })
+    .catch((error) => {
+      logMilestoneNotificationFailure(input.milestone, error);
     });
 }
 

--- a/apps/mobile/features/goals/services/create-goal-mutation-service.ts
+++ b/apps/mobile/features/goals/services/create-goal-mutation-service.ts
@@ -15,6 +15,7 @@ import type { AddContributionInput, CreateGoalInput, GoalUpdateInput } from "../
 import { addContributionSchema, createGoalSchema, updateGoalSchema } from "../schema";
 
 type CommitGoalMutation = (command: MutationCommand) => Promise<boolean>;
+
 export type { GoalUpdateInput } from "../schema";
 
 type GoalMilestone = {

--- a/apps/mobile/features/goals/store.ts
+++ b/apps/mobile/features/goals/store.ts
@@ -226,18 +226,18 @@ function getCrossedMilestones(percentBefore: number, percentAfter: number) {
   );
 }
 
-function notifyGoalMilestones(
+async function notifyGoalMilestones(
   goalMutations: GoalMutationService,
   goalId: string,
   percentBefore: number
-): void {
+) {
   const goal = getGoalById(goalId);
   if (goal == null) return;
 
   const milestones = getCrossedMilestones(percentBefore, goal.progress.percentComplete);
   if (milestones.length === 0) return;
 
-  goalMutations.notifyMilestones({
+  await goalMutations.notifyMilestones({
     goalId,
     goalName: goal.goal.name,
     milestones,
@@ -258,7 +258,7 @@ export async function addContribution(
   const didRefreshGoals = await refreshGoalsForActiveSession({ db, ...session });
   if (!didRefreshGoals) return false;
 
-  notifyGoalMilestones(goalMutations, input.goalId, percentBefore);
+  await notifyGoalMilestones(goalMutations, input.goalId, percentBefore);
   return useGoalStore.getState().selectedGoalId === input.goalId
     ? refreshSelectedGoalContributions({ db, ...session, goalId: input.goalId })
     : true;

--- a/apps/mobile/features/notifications/store.ts
+++ b/apps/mobile/features/notifications/store.ts
@@ -20,6 +20,12 @@ type InsertNotificationInput = {
   readonly params: string | null;
 };
 
+type InsertNotificationCommandInput = {
+  readonly userId: UserId;
+  readonly input: InsertNotificationInput;
+  readonly now: IsoDateTime;
+};
+
 type NotificationState = {
   notifications: readonly StoredNotification[];
   newCount: number;
@@ -65,6 +71,40 @@ function isActiveNotificationUser(userId: UserId): boolean {
   return useNotificationStore.getState().activeUserId === userId;
 }
 
+const createInsertNotificationCommand = ({
+  userId,
+  input,
+  now,
+}: InsertNotificationCommandInput) => ({
+  kind: "notification.insert" as const,
+  row: {
+    id: generateNotificationId(),
+    userId,
+    type: input.type,
+    dedupKey: input.dedupKey,
+    categoryId: input.categoryId,
+    goalId: input.goalId,
+    titleKey: input.titleKey,
+    messageKey: input.messageKey,
+    params: input.params,
+    createdAt: now,
+    updatedAt: now,
+    deletedAt: null,
+  },
+});
+
+const finalizeInsertedNotification = (userId: UserId, didMutate: boolean): boolean => {
+  if (!didMutate) {
+    return false;
+  }
+
+  if (isActiveNotificationUser(userId)) {
+    useNotificationStore.getState().incrementNewCount();
+  }
+
+  return true;
+};
+
 export async function initializeNotificationStore(db: AnyDb, userId: UserId): Promise<void> {
   useNotificationStore.getState().beginSession(userId);
 
@@ -100,32 +140,16 @@ export async function insertNotificationRecord(
   db: AnyDb,
   userId: UserId,
   input: InsertNotificationInput
-): Promise<void> {
+): Promise<boolean> {
   const now = toIsoDateTime(new Date());
-  const id = generateNotificationId();
   const mutations = createWriteThroughMutationModule(db);
+  const result = await mutations.commit(createInsertNotificationCommand({ userId, input, now }));
 
-  const result = await mutations.commit({
-    kind: "notification.insert",
-    row: {
-      id,
-      userId,
-      type: input.type,
-      dedupKey: input.dedupKey,
-      categoryId: input.categoryId,
-      goalId: input.goalId,
-      titleKey: input.titleKey,
-      messageKey: input.messageKey,
-      params: input.params,
-      createdAt: now,
-      updatedAt: now,
-      deletedAt: null,
-    },
-  });
-
-  if (result.success && result.didMutate && isActiveNotificationUser(userId)) {
-    useNotificationStore.getState().incrementNewCount();
+  if (!result.success) {
+    return false;
   }
+
+  return finalizeInsertedNotification(userId, result.didMutate);
 }
 
 export function markNotificationsVisited(userId: UserId): void {


### PR DESCRIPTION
- move merchant resolution into pattern entries
- extract smaller amount parsing helpers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the mobile notification parser and hardened milestone notifications so they don’t block goal contributions. Also clamped the email fetch window and validated goal updates.

- **Refactors**
  - Notification parser: added `MerchantResolver` (`merchantFromGroup`, `staticMerchant`), extracted `parseAmount`/`parseMatchedAmount`/`trimCapturedMerchant`, made `PATTERNS` self-contained, and tightened `tryParseEntry`.
  - Goals/notifications: validate updates via `updateGoalSchema`; make `notifyMilestones` async and only trigger push/analytics on real inserts; `insertNotificationRecord` returns a boolean and increments new count only on actual mutations.

- **Bug Fixes**
  - Email capture: clamp fetch start to the newer of account `lastFetchedAt` and the 30‑day lookback boundary.
  - Milestones: swallow notification failures (insert/push) to keep the contribution flow successful.

<sup>Written for commit 517462c604cf703b43c807aa5ccbc88b251d5872. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

