### PR TITLE
test(mobile): trim capture-source complexity

### DIFF
--- a/apps/mobile/__tests__/capture-sources/apple-pay-pipeline.test.ts
+++ b/apps/mobile/__tests__/capture-sources/apple-pay-pipeline.test.ts
@@ -34,6 +34,25 @@ const mockBuildApplePayCaptureEvidence = vi.fn().mockReturnValue([
 ]);
 const mockSaveCaptureEvidenceRows = vi.fn();
 const mockFindMatchingFinancialAccountId = vi.fn().mockReturnValue(null);
+const DEFAULT_APPLE_PAY_CAPTURE_EVIDENCE = {
+  sourceFamily: "apple_pay",
+  evidenceType: "card_hint",
+  scope: "apple_pay:card_hint",
+  value: "visa *1234",
+};
+
+function materializeCaptureEvidenceRow(link: Record<string, unknown>, row: any, index: number) {
+  return {
+    id: `ce-${index + 1}`,
+    ...row,
+    ...link,
+    deletedAt: null,
+  };
+}
+
+function materializeCaptureEvidenceRows(evidence: any[], link: Record<string, unknown>) {
+  return evidence.map((row, index) => materializeCaptureEvidenceRow(link, row, index));
+}
 
 vi.mock("@/features/transactions/lib/repository", () => ({
   insertTransaction: (...args: any[]) => mockInsertTransaction(...args),
@@ -72,13 +91,7 @@ vi.mock("@/features/account-suggestions", () => ({
 
 vi.mock("@/features/capture-evidence", () => ({
   buildApplePayCaptureEvidence: (...args: any[]) => mockBuildApplePayCaptureEvidence(...args),
-  materializeCaptureEvidenceRows: (evidence: any[], link: Record<string, unknown>) =>
-    evidence.map((row, index) => ({
-      id: `ce-${index + 1}`,
-      ...row,
-      ...link,
-      deletedAt: null,
-    })),
+  materializeCaptureEvidenceRows,
   saveCaptureEvidenceRows: (...args: any[]) => mockSaveCaptureEvidenceRows(...args),
 }));
 
@@ -101,6 +114,39 @@ function makeIntent(overrides: Partial<ApplePayIntentData> = {}): ApplePayIntent
   };
 }
 
+function expectSavedApplePayTransaction(transactionId: string) {
+  expect(mockInsertTransaction).toHaveBeenCalledWith(
+    mockDb,
+    expect.objectContaining({
+      userId: USER_ID,
+      type: "expense",
+      amount: 50000,
+      description: "Farmatodo",
+      accountId: "fa-default-user-1",
+      accountAttributionState: "unresolved",
+      source: "apple_pay",
+    })
+  );
+  expect(mockEnqueueSync).toHaveBeenCalled();
+  expect(transactionId).toBe("tx-1");
+}
+
+function expectSavedApplePayEvidence(transactionId: string) {
+  expect(mockSaveCaptureEvidenceRows).toHaveBeenCalledWith(
+    mockDb,
+    expect.arrayContaining([
+      expect.objectContaining({
+        userId: USER_ID,
+        processedCaptureId: expect.any(String),
+        processedEmailId: null,
+        transactionId,
+        scope: "apple_pay:card_hint",
+        value: "visa *1234",
+      }),
+    ])
+  );
+}
+
 describe("processApplePayIntent", () => {
   let idCounter: number;
 
@@ -115,14 +161,7 @@ describe("processApplePayIntent", () => {
     mockFindDuplicateTransaction.mockResolvedValue(null);
     mockLookupMerchantRule.mockResolvedValue(null);
     mockClassifyMerchantApi.mockResolvedValue("other");
-    mockBuildApplePayCaptureEvidence.mockReturnValue([
-      {
-        sourceFamily: "apple_pay",
-        evidenceType: "card_hint",
-        scope: "apple_pay:card_hint",
-        value: "visa *1234",
-      },
-    ]);
+    mockBuildApplePayCaptureEvidence.mockReturnValue([DEFAULT_APPLE_PAY_CAPTURE_EVIDENCE]);
     mockFindMatchingFinancialAccountId.mockReturnValue(null);
     mockSaveCaptureEvidenceRows.mockResolvedValue(undefined);
   });
@@ -131,33 +170,8 @@ describe("processApplePayIntent", () => {
     const result = await processApplePayIntent(mockDb, USER_ID, makeIntent());
 
     expect(result.saved).toBe(true);
-    expect(result.transactionId).toBe("tx-1");
-    expect(mockInsertTransaction).toHaveBeenCalledWith(
-      mockDb,
-      expect.objectContaining({
-        userId: USER_ID,
-        type: "expense",
-        amount: 50000,
-        description: "Farmatodo",
-        accountId: "fa-default-user-1",
-        accountAttributionState: "unresolved",
-        source: "apple_pay",
-      })
-    );
-    expect(mockEnqueueSync).toHaveBeenCalled();
-    expect(mockSaveCaptureEvidenceRows).toHaveBeenCalledWith(
-      mockDb,
-      expect.arrayContaining([
-        expect.objectContaining({
-          userId: USER_ID,
-          processedCaptureId: expect.any(String),
-          processedEmailId: null,
-          transactionId: "tx-1",
-          scope: "apple_pay:card_hint",
-          value: "visa *1234",
-        }),
-      ])
-    );
+    expectSavedApplePayTransaction(result.transactionId ?? "");
+    expectSavedApplePayEvidence("tx-1");
   });
 
   it("converts amount to pesos correctly", async () => {

--- a/apps/mobile/__tests__/capture-sources/notification-pipeline.test.ts
+++ b/apps/mobile/__tests__/capture-sources/notification-pipeline.test.ts
@@ -35,6 +35,25 @@ const mockBuildNotificationCaptureEvidence = vi.fn().mockReturnValue([
 ]);
 const mockSaveCaptureEvidenceRows = vi.fn();
 const mockFindMatchingFinancialAccountId = vi.fn().mockReturnValue(null);
+const DEFAULT_NOTIFICATION_CAPTURE_EVIDENCE = {
+  sourceFamily: "bancolombia",
+  evidenceType: "last4",
+  scope: "notification:bancolombia:last4",
+  value: "1234",
+};
+
+function materializeCaptureEvidenceRow(link: Record<string, unknown>, row: any, index: number) {
+  return {
+    id: `ce-${index + 1}`,
+    ...row,
+    ...link,
+    deletedAt: null,
+  };
+}
+
+function materializeCaptureEvidenceRows(evidence: any[], link: Record<string, unknown>) {
+  return evidence.map((row, index) => materializeCaptureEvidenceRow(link, row, index));
+}
 
 vi.mock("@/features/transactions/lib/repository", () => ({
   insertTransaction: (...args: any[]) => mockInsertTransaction(...args),
@@ -78,13 +97,7 @@ vi.mock("@/features/account-suggestions", () => ({
 vi.mock("@/features/capture-evidence", () => ({
   buildNotificationCaptureEvidence: (...args: any[]) =>
     mockBuildNotificationCaptureEvidence(...args),
-  materializeCaptureEvidenceRows: (evidence: any[], link: Record<string, unknown>) =>
-    evidence.map((row, index) => ({
-      id: `ce-${index + 1}`,
-      ...row,
-      ...link,
-      deletedAt: null,
-    })),
+  materializeCaptureEvidenceRows,
   saveCaptureEvidenceRows: (...args: any[]) => mockSaveCaptureEvidenceRows(...args),
 }));
 
@@ -108,6 +121,45 @@ function makeNotification(overrides: Partial<NotificationData> = {}): Notificati
   };
 }
 
+function expectSavedNotificationTransaction(transactionId: string) {
+  expect(mockInsertTransaction).toHaveBeenCalledWith(
+    mockDb,
+    expect.objectContaining({
+      userId: USER_ID,
+      type: "expense",
+      amount: 50000,
+      description: "EDS LA CASTELLANA",
+      accountId: "fa-default-user-1",
+      accountAttributionState: "unresolved",
+      source: "notification_android",
+    })
+  );
+  expect(mockEnqueueSync).toHaveBeenCalled();
+  expect(mockInsertProcessedCapture).toHaveBeenCalledWith(
+    mockDb,
+    expect.objectContaining({
+      status: "success",
+      transactionId,
+    })
+  );
+}
+
+function expectSavedNotificationEvidence(transactionId: string) {
+  expect(mockSaveCaptureEvidenceRows).toHaveBeenCalledWith(
+    mockDb,
+    expect.arrayContaining([
+      expect.objectContaining({
+        userId: USER_ID,
+        processedCaptureId: expect.any(String),
+        processedEmailId: null,
+        transactionId,
+        scope: "notification:bancolombia:last4",
+        value: "1234",
+      }),
+    ])
+  );
+}
+
 describe("processNotification", () => {
   let idCounter: number;
 
@@ -124,14 +176,7 @@ describe("processNotification", () => {
     mockParseNotificationApi.mockResolvedValue(null);
     mockCaptureFingerprint.mockReturnValue("test-fingerprint");
     mockStripPii.mockImplementation((t: string) => t);
-    mockBuildNotificationCaptureEvidence.mockReturnValue([
-      {
-        sourceFamily: "bancolombia",
-        evidenceType: "last4",
-        scope: "notification:bancolombia:last4",
-        value: "1234",
-      },
-    ]);
+    mockBuildNotificationCaptureEvidence.mockReturnValue([DEFAULT_NOTIFICATION_CAPTURE_EVIDENCE]);
     mockFindMatchingFinancialAccountId.mockReturnValue(null);
     mockSaveCaptureEvidenceRows.mockResolvedValue(undefined);
   });
@@ -142,39 +187,8 @@ describe("processNotification", () => {
     expect(result.saved).toBe(true);
     expect(result.skippedDuplicate).toBe(false);
     expect(result.transactionId).toBe("tx-1");
-    expect(mockInsertTransaction).toHaveBeenCalledWith(
-      mockDb,
-      expect.objectContaining({
-        userId: USER_ID,
-        type: "expense",
-        amount: 50000,
-        description: "EDS LA CASTELLANA",
-        accountId: "fa-default-user-1",
-        accountAttributionState: "unresolved",
-        source: "notification_android",
-      })
-    );
-    expect(mockEnqueueSync).toHaveBeenCalled();
-    expect(mockInsertProcessedCapture).toHaveBeenCalledWith(
-      mockDb,
-      expect.objectContaining({
-        status: "success",
-        transactionId: "tx-1",
-      })
-    );
-    expect(mockSaveCaptureEvidenceRows).toHaveBeenCalledWith(
-      mockDb,
-      expect.arrayContaining([
-        expect.objectContaining({
-          userId: USER_ID,
-          processedCaptureId: expect.any(String),
-          processedEmailId: null,
-          transactionId: "tx-1",
-          scope: "notification:bancolombia:last4",
-          value: "1234",
-        }),
-      ])
-    );
+    expectSavedNotificationTransaction("tx-1");
+    expectSavedNotificationEvidence("tx-1");
   });
 
   it("falls through to LLM when local regex fails", async () => {

--- a/apps/mobile/__tests__/capture-sources/repository-sms-events.test.ts
+++ b/apps/mobile/__tests__/capture-sources/repository-sms-events.test.ts
@@ -25,6 +25,7 @@ let db: ReturnType<typeof drizzle>;
 
 const USER_ID = "user-1" as UserId;
 const CREATED_AT = "2026-04-01T00:00:00.000Z" as IsoDateTime;
+const OTHER_USER_ID = "user-2" as UserId;
 
 beforeEach(() => {
   sqlite = new Database(":memory:");
@@ -96,44 +97,46 @@ const insertNotificationSourceRow = (
     CREATED_AT
   );
 
+type NotificationSourceSeed = NonNullable<Parameters<typeof insertNotificationSourceRow>[0]>;
+
+const insertNotificationSources = (sources: readonly NotificationSourceSeed[]) =>
+  Promise.all(sources.map(insertNotificationSourceRow));
+
+const mapNotificationSourceSummary = ({
+  packageName,
+  label,
+  isEnabled,
+}: {
+  packageName: string;
+  label: string;
+  isEnabled: boolean;
+}) => ({ packageName, label, isEnabled });
+
+function expectNotificationSourceSummaries(
+  sources: Awaited<ReturnType<typeof getNotificationSources>>,
+  expected: readonly ReturnType<typeof mapNotificationSourceSummary>[]
+) {
+  expect(sources).toHaveLength(expected.length);
+  expect(sources.map(mapNotificationSourceSummary)).toEqual(expect.arrayContaining([...expected]));
+}
+
 describe("capture-sources repository SMS events", () => {
   it("returns all notification sources for the requested user only", async () => {
-    await insertNotificationSourceRow({
-      packageName: "com.bank.app",
-      label: "Bank App",
-      isEnabled: true,
-    });
-    await insertNotificationSourceRow({
-      packageName: "com.wallet.app",
-      label: "Wallet App",
-      isEnabled: false,
-    });
-    await insertNotificationSourceRow({
-      userId: "user-2" as UserId,
-      packageName: "com.other.bank",
-      label: "Other User App",
-      isEnabled: true,
-    });
+    await insertNotificationSources([
+      { packageName: "com.bank.app", label: "Bank App", isEnabled: true },
+      { packageName: "com.wallet.app", label: "Wallet App", isEnabled: false },
+      {
+        userId: OTHER_USER_ID,
+        packageName: "com.other.bank",
+        label: "Other User App",
+        isEnabled: true,
+      },
+    ]);
 
-    const sources = await getNotificationSources(db as any, USER_ID);
-
-    expect(sources).toHaveLength(2);
-    expect(
-      sources.map(({ packageName, label, isEnabled }) => ({ packageName, label, isEnabled }))
-    ).toEqual(
-      expect.arrayContaining([
-        {
-          packageName: "com.bank.app",
-          label: "Bank App",
-          isEnabled: true,
-        },
-        {
-          packageName: "com.wallet.app",
-          label: "Wallet App",
-          isEnabled: false,
-        },
-      ])
-    );
+    expectNotificationSourceSummaries(await getNotificationSources(db as any, USER_ID), [
+      { packageName: "com.bank.app", label: "Bank App", isEnabled: true },
+      { packageName: "com.wallet.app", label: "Wallet App", isEnabled: false },
+    ]);
   });
 
   it("returns only undismissed events for the current user in newest-first order", async () => {
@@ -155,7 +158,7 @@ describe("capture-sources repository SMS events", () => {
     });
     await insertSmsEventRow({
       id: "sms-4" as DetectedSmsEventId,
-      userId: "user-2" as UserId,
+      userId: OTHER_USER_ID,
       senderLabel: "Other user event",
       detectedAt: "2026-04-10T13:00:00.000Z" as IsoDateTime,
     });

--- a/apps/mobile/__tests__/capture-sources/widget-pipeline.test.ts
+++ b/apps/mobile/__tests__/capture-sources/widget-pipeline.test.ts
@@ -13,6 +13,10 @@ const mockGetPendingTransactions = vi.fn();
 const mockRemovePendingTransactions = vi.fn();
 const mockIsAvailable = vi.fn();
 const mockGenerateProcessedCaptureId = vi.fn();
+type CaptureFingerprintArgs = readonly [string, number, string, string];
+
+const buildFingerprint = ([source, amount, date, merchant]: CaptureFingerprintArgs) =>
+  `fp:${source}:${amount}:${date}:${merchant}`;
 
 vi.mock("@/features/transactions/lib/repository", () => ({
   insertTransaction: (...args: any[]) => mockInsertTransaction(...args),
@@ -40,8 +44,7 @@ vi.mock("@/shared/db/enqueue-sync", () => ({
 vi.mock("@/features/capture-sources/lib/dedup", () => ({
   isCaptureProcessed: (...args: any[]) => mockIsCaptureProcessed(...args),
   findDuplicateTransaction: (...args: any[]) => mockFindDuplicateTransaction(...args),
-  captureFingerprint: (source: string, amount: number, date: string, merchant: string) =>
-    `fp:${source}:${amount}:${date}:${merchant}`,
+  captureFingerprint: (...args: CaptureFingerprintArgs) => buildFingerprint(args),
 }));
 
 vi.mock("@/features/capture-sources/lib/repository", () => ({


### PR DESCRIPTION
- extract capture-source assertions
- reuse evidence fixtures
- tuple-wrap fingerprint mock


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified and de-duplicated capture-source tests to make them easier to read and maintain, with shared fixtures and helpers. No production code changes.

- **Refactors**
  - Extracted shared assertions for Apple Pay and notification pipelines (e.g., saved transaction/evidence checks).
  - Centralized capture evidence fixtures and `materializeCaptureEvidenceRows` helper to reduce repetition.
  - Streamlined SMS repository tests with small helpers (`insertNotificationSources`, summary mapper) and `OTHER_USER_ID` constant.
  - Tuple-wrapped and typed the fingerprint mock (`buildFingerprint`) to prevent param order mistakes in widget pipeline tests.

<sup>Written for commit 2b45c9a3e093bc3e802ca94f2685ac10e2ee3abe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

