### PR TITLE
refactor(notifications): reduce complexity

### DIFF
--- a/apps/mobile/__tests__/notifications/display.test.ts
+++ b/apps/mobile/__tests__/notifications/display.test.ts
@@ -153,6 +153,17 @@ describe("deriveNotificationDisplay", () => {
     expect(result.iconBgColor).toBe("#F3E5F5");
   });
 
+  it("falls back to 'other' category visuals when categoryId is unsupported", () => {
+    const n = makeNotification({
+      type: "spending_anomaly",
+      categoryId: "unknown-category" as CategoryId,
+    });
+    const result = deriveNotificationDisplay(n, mockT);
+    expect(result.iconName).toBe("ellipsis");
+    expect(result.iconColor).toBe("#B8A9D4");
+    expect(result.iconBgColor).toBe("#F3E5F5");
+  });
+
   it("defaults budget_alert with no params to threshold 100 visuals", () => {
     const n = makeNotification({
       type: "budget_alert",

--- a/apps/mobile/features/notifications/lib/derive.ts
+++ b/apps/mobile/features/notifications/lib/derive.ts
@@ -27,6 +27,18 @@ type BudgetPaceMove = {
 
 export type WeeklyMove = AnomalyMove | BudgetPaceMove;
 
+type AnomalyCandidate = {
+  readonly categoryId: CategoryId;
+  readonly priorCount: number;
+  readonly thisWeekSpend: CopAmount;
+  readonly weeklyTotals: readonly CopAmount[];
+};
+
+type AnomalyContext = {
+  readonly priorCountByCategory: ReadonlyMap<CategoryId, number>;
+  readonly currentWeekByCategory: ReadonlyMap<CategoryId, CopAmount>;
+};
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
@@ -65,6 +77,41 @@ const groupPriorWeeksByCategory = (
     return acc;
   }, new Map());
 
+const buildAnomalyCandidate = (
+  categoryId: CategoryId,
+  weekTotalsMap: ReadonlyMap<number, CopAmount>,
+  context: AnomalyContext
+): AnomalyCandidate => ({
+  categoryId,
+  priorCount: context.priorCountByCategory.get(categoryId) ?? 0,
+  thisWeekSpend: (context.currentWeekByCategory.get(categoryId) ?? 0) as CopAmount,
+  weeklyTotals: Array.from(weekTotalsMap.values()),
+});
+
+const buildAnomalyMove = ({
+  categoryId,
+  priorCount,
+  thisWeekSpend,
+  weeklyTotals,
+}: AnomalyCandidate): AnomalyMove | null => {
+  if (priorCount < 5) return null;
+
+  const medianWeeklySpend = computeMedian(weeklyTotals);
+
+  if (!Number.isFinite(medianWeeklySpend)) return null;
+  if (thisWeekSpend <= 1.5 * medianWeeklySpend) return null;
+
+  return {
+    type: "anomaly" as const,
+    categoryId,
+    weeklySpend: thisWeekSpend as CopAmount,
+    medianWeeklySpend: Math.round(medianWeeklySpend) as CopAmount,
+    impact: Math.round(thisWeekSpend - medianWeeklySpend) as CopAmount,
+  };
+};
+
+const isPresent = <T>(value: T | null): value is T => value !== null;
+
 /**
  * Detects spending anomalies per category using median weekly spend of prior weeks.
  * Emits an AnomalyMove when this-week spend > 1.5 × medianWeeklySpend.
@@ -85,29 +132,13 @@ const detectAnomalies = (
     return acc;
   }, new Map());
 
-  return Array.from(priorWeeksByCategory.entries()).flatMap(([categoryId, weekTotalsMap]) => {
-    const priorCount = priorCountByCategory.get(categoryId) ?? 0;
-    if (priorCount < 5) return [];
+  const anomalyContext: AnomalyContext = { priorCountByCategory, currentWeekByCategory };
 
-    const weeklyTotals = Array.from(weekTotalsMap.values());
-    const medianWeeklySpend = computeMedian(weeklyTotals);
-
-    if (!Number.isFinite(medianWeeklySpend)) return [];
-
-    const thisWeekSpend = currentWeekByCategory.get(categoryId) ?? 0;
-
-    if (thisWeekSpend <= 1.5 * medianWeeklySpend) return [];
-
-    return [
-      {
-        type: "anomaly" as const,
-        categoryId,
-        weeklySpend: thisWeekSpend as CopAmount,
-        medianWeeklySpend: Math.round(medianWeeklySpend) as CopAmount,
-        impact: Math.round(thisWeekSpend - medianWeeklySpend) as CopAmount,
-      },
-    ];
-  });
+  return Array.from(priorWeeksByCategory.entries())
+    .map(([categoryId, weekTotalsMap]) =>
+      buildAnomalyMove(buildAnomalyCandidate(categoryId, weekTotalsMap, anomalyContext))
+    )
+    .filter(isPresent);
 };
 
 /**

--- a/apps/mobile/features/notifications/lib/display.ts
+++ b/apps/mobile/features/notifications/lib/display.ts
@@ -6,43 +6,65 @@ import type { NotificationDisplay, NotificationSection, StoredNotification } fro
 // Constants
 // ---------------------------------------------------------------------------
 
-const CATEGORY_ICON_NAMES: Record<string, string> = {
-  food: "utensils",
-  transport: "car",
-  entertainment: "clapperboard",
-  health: "heart-pulse",
-  education: "graduation-cap",
-  home: "house",
-  clothing: "shirt",
-  services: "wrench",
-  transfer: "arrow-left-right",
-  other: "ellipsis",
+type CategoryVisuals = {
+  readonly iconName: string;
+  readonly iconColor: string;
+  readonly iconBgColor: string;
 };
 
-const CATEGORY_CHART_COLORS: Record<string, string> = {
-  food: "#7CB243",
-  transport: "#E8A090",
-  entertainment: "#F5C842",
-  health: "#E06060",
-  education: "#5B9BD5",
-  home: "#8BBAE8",
-  clothing: "#1A1A1A",
-  services: "#F0A04B",
-  transfer: "#6DC4B0",
-  other: "#B8A9D4",
+const DEFAULT_CATEGORY_VISUALS: CategoryVisuals = {
+  iconName: "ellipsis",
+  iconColor: "#B8A9D4",
+  iconBgColor: "#F3E5F5",
 };
 
-const CATEGORY_BG_COLORS: Record<string, string> = {
-  food: "#E8F5E9",
-  transport: "#FFF0ED",
-  entertainment: "#FFFDE7",
-  health: "#FFEBEE",
-  education: "#E3F2FD",
-  home: "#E3F2FD",
-  clothing: "#F5F5F5",
-  services: "#FFF3E0",
-  transfer: "#E0F2F1",
-  other: "#F3E5F5",
+const CATEGORY_VISUALS: Record<string, CategoryVisuals> = {
+  food: {
+    iconName: "utensils",
+    iconColor: "#7CB243",
+    iconBgColor: "#E8F5E9",
+  },
+  transport: {
+    iconName: "car",
+    iconColor: "#E8A090",
+    iconBgColor: "#FFF0ED",
+  },
+  entertainment: {
+    iconName: "clapperboard",
+    iconColor: "#F5C842",
+    iconBgColor: "#FFFDE7",
+  },
+  health: {
+    iconName: "heart-pulse",
+    iconColor: "#E06060",
+    iconBgColor: "#FFEBEE",
+  },
+  education: {
+    iconName: "graduation-cap",
+    iconColor: "#5B9BD5",
+    iconBgColor: "#E3F2FD",
+  },
+  home: {
+    iconName: "house",
+    iconColor: "#8BBAE8",
+    iconBgColor: "#E3F2FD",
+  },
+  clothing: {
+    iconName: "shirt",
+    iconColor: "#1A1A1A",
+    iconBgColor: "#F5F5F5",
+  },
+  services: {
+    iconName: "wrench",
+    iconColor: "#F0A04B",
+    iconBgColor: "#FFF3E0",
+  },
+  transfer: {
+    iconName: "arrow-left-right",
+    iconColor: "#6DC4B0",
+    iconBgColor: "#E0F2F1",
+  },
+  other: DEFAULT_CATEGORY_VISUALS,
 };
 
 // ---------------------------------------------------------------------------
@@ -60,14 +82,8 @@ const parseParams = (params: string | null): Record<string, unknown> => {
   }
 };
 
-const getCategoryVisuals = (categoryId: CategoryId | null) => {
-  const key = categoryId ?? "other";
-  return {
-    iconName: CATEGORY_ICON_NAMES[key] ?? CATEGORY_ICON_NAMES.other ?? "ellipsis",
-    iconColor: CATEGORY_CHART_COLORS[key] ?? CATEGORY_CHART_COLORS.other ?? "#B8A9D4",
-    iconBgColor: CATEGORY_BG_COLORS[key] ?? CATEGORY_BG_COLORS.other ?? "#F3E5F5",
-  };
-};
+const getCategoryVisuals = (categoryId: CategoryId | null): CategoryVisuals =>
+  CATEGORY_VISUALS[categoryId ?? "other"] ?? DEFAULT_CATEGORY_VISUALS;
 
 // ---------------------------------------------------------------------------
 // deriveNotificationDisplay


### PR DESCRIPTION
- collapse category visual lookup
- extract anomaly move builder
- add fallback coverage


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored notification visuals and anomaly detection to reduce complexity and improve reliability. Adds a safe fallback for unknown categories and keeps display logic concise.

- **Refactors**
  - Collapsed category visuals into a single `CATEGORY_VISUALS` map with `DEFAULT_CATEGORY_VISUALS`.
  - Extracted anomaly helpers (`buildAnomalyCandidate`, `buildAnomalyMove`) and shared context to streamline `detectAnomalies`.
  - Simplified null checks with `isPresent` and reduced branching.

- **Bug Fixes**
  - Unsupported `categoryId` now reliably falls back to “other” visuals; added test coverage.

<sup>Written for commit 392d843413e18459386068d85b6ae5e30b06658a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

