### PR TITLE
refactor(mobile): reduce wave 1 complexity

### DIFF
--- a/apps/mobile/__tests__/goals/derive.test.ts
+++ b/apps/mobile/__tests__/goals/derive.test.ts
@@ -435,14 +435,29 @@ describe("deriveBudgetNudges", () => {
     { categoryId: "utilities", total: 200_000 },
   ];
 
+  const makeBudgetNudgeInput = (
+    overrides: Partial<{
+      currentAmount: number;
+      targetAmount: number;
+      netMonthlySavings: number;
+      spendingByCategory: readonly { categoryId: string; total: number }[];
+    }> = {}
+  ) => ({
+    currentAmount: 0,
+    targetAmount: 5_000_000,
+    netMonthlySavings: 500_000,
+    spendingByCategory: spending,
+    ...overrides,
+  });
+
   it("returns top 3 categories by total spending", () => {
-    const result = deriveBudgetNudges(0, 5_000_000, 500_000, spending);
+    const result = deriveBudgetNudges(makeBudgetNudgeInput());
     expect(result).toHaveLength(3);
     expect(result[0]?.categoryId).toBe("food");
   });
 
   it("calculates 15% reduction for each category", () => {
-    const result = deriveBudgetNudges(0, 5_000_000, 500_000, spending);
+    const result = deriveBudgetNudges(makeBudgetNudgeInput());
     const foodNudge = result.find((n) => n.categoryId === "food");
     expect(foodNudge).toBeDefined();
     expect(foodNudge?.currentSpending).toBe(800_000);
@@ -454,31 +469,31 @@ describe("deriveBudgetNudges", () => {
     // baseline monthsToGo = 5M / 500k = 10
     // food reduction = 120k → new savings = 620k → 5M/620k = 8.06.. → ceil 9
     // monthsSaved = 10 - 9 = 1
-    const result = deriveBudgetNudges(0, 5_000_000, 500_000, spending);
+    const result = deriveBudgetNudges(makeBudgetNudgeInput());
     const foodNudge = result.find((n) => n.categoryId === "food");
     expect(foodNudge).toBeDefined();
     expect(foodNudge?.monthsSaved).toBe(1);
   });
 
   it("sorts by monthsSaved descending", () => {
-    const result = deriveBudgetNudges(0, 5_000_000, 500_000, spending);
+    const result = deriveBudgetNudges(makeBudgetNudgeInput());
     const monthsSaved = result.map((n) => n.monthsSaved);
     expect(monthsSaved).toEqual([...monthsSaved].sort((a, b) => b - a));
   });
 
   it("returns empty array when savings rate is zero", () => {
-    const result = deriveBudgetNudges(0, 5_000_000, 0, spending);
+    const result = deriveBudgetNudges(makeBudgetNudgeInput({ netMonthlySavings: 0 }));
     expect(result).toHaveLength(0);
   });
 
   it("returns empty array when savings rate is negative", () => {
-    const result = deriveBudgetNudges(0, 5_000_000, -100_000, spending);
+    const result = deriveBudgetNudges(makeBudgetNudgeInput({ netMonthlySavings: -100_000 }));
     expect(result).toHaveLength(0);
   });
 
   it("handles fewer than 3 categories", () => {
     const smallSpending = [{ categoryId: "food", total: 800_000 }];
-    const result = deriveBudgetNudges(0, 5_000_000, 500_000, smallSpending);
+    const result = deriveBudgetNudges(makeBudgetNudgeInput({ spendingByCategory: smallSpending }));
     expect(result).toHaveLength(1);
   });
 });

--- a/apps/mobile/__tests__/qa/devtools-store.test.ts
+++ b/apps/mobile/__tests__/qa/devtools-store.test.ts
@@ -34,6 +34,23 @@ describe("QA devtools store", () => {
     );
   });
 
+  it("fills missing persisted flags from defaults", async () => {
+    vi.mocked(getItem).mockReturnValueOnce(
+      JSON.stringify({
+        networkInspectorEnabled: false,
+      })
+    );
+
+    const { useQaDevtoolsStore } = await import("@/features/qa/devtools-store");
+
+    expect(useQaDevtoolsStore.getState().flags).toMatchObject({
+      networkInspectorEnabled: false,
+      logInspectorEnabled: true,
+      simulateOffline: false,
+      showQaBanner: false,
+    });
+  });
+
   it("records bounded QA log and network history", async () => {
     const { useQaDevtoolsStore } = await import("@/features/qa/devtools-store");
 

--- a/apps/mobile/features/auth/store.ts
+++ b/apps/mobile/features/auth/store.ts
@@ -29,6 +29,8 @@ type AuthActions = {
   signOut: () => Promise<void>;
 };
 
+type SetAuthState = (nextState: Partial<AuthState>) => void;
+
 const REDIRECT_URI = "fidy://auth/callback";
 let authTransitionVersion = 0;
 
@@ -41,6 +43,183 @@ function isCurrentAuthTransition(version: number) {
   return authTransitionVersion === version;
 }
 
+function isStaleAuthTransition(version: number) {
+  return !isCurrentAuthTransition(version);
+}
+
+function setSignedOutAuthState(set: SetAuthState) {
+  set({
+    session: null,
+    localQaSession: null,
+    isLoading: false,
+  });
+}
+
+function setLocalQaAuthState(set: SetAuthState, localQaSession: LocalQaSession) {
+  identifyUser(localQaSession.userId);
+  set({
+    session: null,
+    localQaSession,
+    isLoading: false,
+  });
+}
+
+function setRemoteAuthState(set: SetAuthState, session: Session) {
+  identifyUser(session.user.id);
+  set({
+    session,
+    localQaSession: null,
+    isLoading: false,
+  });
+}
+
+function clearLocalOnboardingState() {
+  useLocalOnboardingState.getState().setIsComplete(false);
+}
+
+async function clearOnboardingAndAuthState(set: SetAuthState) {
+  await clearOnboardingFromStore();
+  setSignedOutAuthState(set);
+  clearLocalOnboardingState();
+}
+
+function captureAuthFailure(event: string, err: unknown) {
+  captureWarning(event, {
+    errorType: err instanceof Error ? err.message : "unknown",
+  });
+}
+
+async function restoreStoredLocalQaSession(
+  set: SetAuthState,
+  transitionVersion: number
+): Promise<boolean> {
+  const persistedLocalQaSession = await loadLocalQaSession();
+  if (persistedLocalQaSession == null) return false;
+  if (isStaleAuthTransition(transitionVersion)) return true;
+  setLocalQaAuthState(set, persistedLocalQaSession);
+  return true;
+}
+
+async function handleMissingRemoteSession(
+  set: SetAuthState,
+  transitionVersion: number,
+  errorMessage?: string
+) {
+  if (errorMessage) {
+    captureWarning("auth_restore_failed", { errorMessage });
+  }
+  await clearOnboardingFromStore();
+  if (isStaleAuthTransition(transitionVersion)) return;
+  setSignedOutAuthState(set);
+  clearLocalOnboardingState();
+}
+
+async function restoreSupabaseSession(set: SetAuthState, transitionVersion: number) {
+  const supabase = getSupabase();
+  const { data, error } = await supabase.auth.getSession();
+  if (isStaleAuthTransition(transitionVersion)) return;
+  if (error || !data.session) {
+    await handleMissingRemoteSession(set, transitionVersion, error?.message);
+    return;
+  }
+  setRemoteAuthState(set, data.session);
+}
+
+async function handleRestoreSessionException(
+  set: SetAuthState,
+  transitionVersion: number,
+  err: unknown
+) {
+  if (isStaleAuthTransition(transitionVersion)) return;
+  captureAuthFailure("auth_restore_exception", err);
+  setSignedOutAuthState(set);
+  clearLocalOnboardingState();
+}
+
+type SupabaseAuthTokens = {
+  readonly accessToken: string;
+  readonly refreshToken: string;
+};
+
+async function requestOauthUrl(provider: OAuthProvider): Promise<string | null> {
+  await clearLocalQaSession().catch(() => undefined);
+  const supabase = getSupabase();
+  const { data, error } = await supabase.auth.signInWithOAuth({
+    provider,
+    options: { redirectTo: REDIRECT_URI, skipBrowserRedirect: true },
+  });
+  return error || !data.url ? null : data.url;
+}
+
+async function openOauthBrowser(url: string): Promise<string | null> {
+  const { openAuthSessionAsync } = await import("expo-web-browser");
+  const result = await openAuthSessionAsync(url, REDIRECT_URI);
+  return result.type === "success" && result.url ? result.url : null;
+}
+
+function getSupabaseSessionTokens(url: string): SupabaseAuthTokens | null {
+  const params = new URLSearchParams(new URL(url).hash.slice(1));
+  return createSupabaseAuthTokens(params.get("access_token"), params.get("refresh_token"));
+}
+
+async function signInWithProvider(provider: OAuthProvider): Promise<Session | null> {
+  const authUrl = await requestOauthUrl(provider);
+  if (authUrl === null) return null;
+
+  return restoreProviderSession(authUrl);
+}
+
+function createSupabaseAuthTokens(
+  accessToken: string | null,
+  refreshToken: string | null
+): SupabaseAuthTokens | null {
+  if (accessToken === null || refreshToken === null) return null;
+  return { accessToken, refreshToken };
+}
+
+async function restoreProviderSession(authUrl: string): Promise<Session | null> {
+  const sessionUrl = await openOauthBrowser(authUrl);
+  if (sessionUrl === null) return null;
+  return exchangeProviderSession(sessionUrl);
+}
+
+async function exchangeProviderSession(sessionUrl: string): Promise<Session | null> {
+  const sessionTokens = getSupabaseSessionTokens(sessionUrl);
+  if (sessionTokens === null) return null;
+  const supabase = getSupabase();
+  const { data } = await supabase.auth.setSession({
+    // biome-ignore lint/style/useNamingConvention: Supabase API
+    access_token: sessionTokens.accessToken,
+    // biome-ignore lint/style/useNamingConvention: Supabase API
+    refresh_token: sessionTokens.refreshToken,
+  });
+  return data.session ?? null;
+}
+
+async function signOutLocalQaSession(set: SetAuthState) {
+  await clearLocalQaSession().catch(() => undefined);
+  await clearOnboardingAndAuthState(set);
+  resetAnalyticsUser();
+}
+
+async function cleanupPushTokenBeforeSignOut() {
+  await Promise.race([
+    cleanupCurrentPushToken().catch((error) => {
+      captureAuthFailure("auth_signout_push_token_cleanup_failed", error);
+    }),
+    new Promise((resolve) => setTimeout(resolve, 2000)),
+  ]);
+}
+
+async function signOutRemoteSession() {
+  try {
+    const supabase = getSupabase();
+    await supabase.auth.signOut();
+  } catch {
+    // Clear local state regardless.
+  }
+}
+
 export const useAuthStore = create<AuthState & AuthActions>((set) => ({
   session: null,
   localQaSession: null,
@@ -51,47 +230,11 @@ export const useAuthStore = create<AuthState & AuthActions>((set) => ({
     const transitionVersion = beginAuthTransition();
 
     try {
-      const persistedLocalQaSession = await loadLocalQaSession();
-
-      if (persistedLocalQaSession) {
-        if (!isCurrentAuthTransition(transitionVersion)) return;
-        identifyUser(persistedLocalQaSession.userId);
-        set({ session: null, localQaSession: persistedLocalQaSession, isLoading: false });
-        return;
-      }
-
-      const supabase = getSupabase();
-      const { data, error } = await supabase.auth.getSession();
-      if (!isCurrentAuthTransition(transitionVersion)) return;
-      if (error || !data.session) {
-        if (error) captureWarning("auth_restore_failed", { errorMessage: error.message });
-        await clearOnboardingFromStore();
-        if (!isCurrentAuthTransition(transitionVersion)) return;
-        set({
-          session: null,
-          localQaSession: null,
-          isLoading: false,
-        });
-        useLocalOnboardingState.getState().setIsComplete(false);
-        return;
-      }
-      identifyUser(data.session.user.id);
-      set({
-        session: data.session,
-        localQaSession: null,
-        isLoading: false,
-      });
+      const didRestoreLocalQaSession = await restoreStoredLocalQaSession(set, transitionVersion);
+      if (didRestoreLocalQaSession) return;
+      await restoreSupabaseSession(set, transitionVersion);
     } catch (err) {
-      if (!isCurrentAuthTransition(transitionVersion)) return;
-      captureWarning("auth_restore_exception", {
-        errorType: err instanceof Error ? err.message : "unknown",
-      });
-      set({
-        session: null,
-        localQaSession: null,
-        isLoading: false,
-      });
-      useLocalOnboardingState.getState().setIsComplete(false);
+      await handleRestoreSessionException(set, transitionVersion, err);
     }
   },
 
@@ -129,43 +272,10 @@ export const useAuthStore = create<AuthState & AuthActions>((set) => ({
     beginAuthTransition();
     set({ isSigningIn: true });
     try {
-      const { openAuthSessionAsync } = await import("expo-web-browser");
-      await clearLocalQaSession().catch(() => undefined);
-      const supabase = getSupabase();
-      const { data, error } = await supabase.auth.signInWithOAuth({
-        provider,
-        options: { redirectTo: REDIRECT_URI, skipBrowserRedirect: true },
-      });
-      if (error || !data.url) {
-        return;
-      }
-      const result = await openAuthSessionAsync(data.url, REDIRECT_URI);
-      if (result.type === "success" && result.url) {
-        const url = new URL(result.url);
-        const params = new URLSearchParams(url.hash.slice(1));
-        const accessToken = params.get("access_token");
-        const refreshToken = params.get("refresh_token");
-        if (accessToken && refreshToken) {
-          const { data: sessionData } = await supabase.auth.setSession({
-            // biome-ignore lint/style/useNamingConvention: Supabase API
-            access_token: accessToken,
-            // biome-ignore lint/style/useNamingConvention: Supabase API
-            refresh_token: refreshToken,
-          });
-          if (sessionData.session) {
-            identifyUser(sessionData.session.user.id);
-            set({
-              session: sessionData.session,
-              localQaSession: null,
-              isLoading: false,
-            });
-          }
-        }
-      }
+      const session = await signInWithProvider(provider);
+      if (session !== null) setRemoteAuthState(set, session);
     } catch (err) {
-      captureWarning("auth_signin_failed", {
-        errorType: err instanceof Error ? err.message : "unknown",
-      });
+      captureAuthFailure("auth_signin_failed", err);
     } finally {
       set({ isSigningIn: false });
     }
@@ -175,42 +285,15 @@ export const useAuthStore = create<AuthState & AuthActions>((set) => ({
     beginAuthTransition();
 
     if (useAuthStore.getState().localQaSession) {
-      await clearLocalQaSession().catch(() => undefined);
-      await clearOnboardingFromStore();
-      resetAnalyticsUser();
-      set({
-        session: null,
-        localQaSession: null,
-        isLoading: false,
-      });
-      useLocalOnboardingState.getState().setIsComplete(false);
+      await signOutLocalQaSession(set);
       return;
     }
 
     // Clean up push token while session is still valid (RLS needs auth).
     // Capped at 2s so signout isn't blocked indefinitely by network issues.
-    await Promise.race([
-      cleanupCurrentPushToken().catch((error) => {
-        captureWarning("auth_signout_push_token_cleanup_failed", {
-          errorType: error instanceof Error ? error.message : "unknown",
-        });
-      }),
-      new Promise((resolve) => setTimeout(resolve, 2000)),
-    ]);
-
-    try {
-      const supabase = getSupabase();
-      await supabase.auth.signOut();
-    } catch {
-      // Clear local state regardless
-    }
-    await clearOnboardingFromStore();
+    await cleanupPushTokenBeforeSignOut();
+    await signOutRemoteSession();
+    await clearOnboardingAndAuthState(set);
     resetAnalyticsUser();
-    set({
-      session: null,
-      localQaSession: null,
-      isLoading: false,
-    });
-    useLocalOnboardingState.getState().setIsComplete(false);
   },
 }));

--- a/apps/mobile/features/calendar/lib/calendar-utils.ts
+++ b/apps/mobile/features/calendar/lib/calendar-utils.ts
@@ -22,6 +22,19 @@ export type CalendarDay = {
   date: Date | null;
 };
 
+type CalendarDateContext = {
+  readonly date: Date;
+  readonly year: number;
+  readonly month: number;
+  readonly day: number;
+  readonly dayOfWeek: number;
+};
+
+type OccurrenceContext = {
+  readonly start: Date;
+  readonly normalizedFrom: Date;
+};
+
 export const WEEKDAY_LABELS = ["M", "T", "W", "T", "F", "S", "S"] as const;
 
 /**
@@ -54,31 +67,8 @@ export function getMonthGrid(year: number, month: number): CalendarDay[][] {
  * Returns bills that occur on a specific date based on their frequency.
  */
 export function getBillsForDate(bills: Bill[], date: Date): Bill[] {
-  const y = date.getFullYear();
-  const m = date.getMonth();
-  const d = date.getDate();
-
-  return bills.filter((bill) => {
-    if (!bill.isActive) return false;
-    if (date < bill.startDate) return false;
-
-    switch (bill.frequency) {
-      case "monthly":
-        return clampDay(bill.startDate.getDate(), y, m) === d;
-      case "weekly":
-        return getDay(bill.startDate) === getDay(date);
-      case "biweekly": {
-        const weeksDiff = differenceInWeeks(date, bill.startDate);
-        return weeksDiff >= 0 && weeksDiff % 2 === 0 && getDay(bill.startDate) === getDay(date);
-      }
-      case "yearly": {
-        if (bill.startDate.getMonth() !== m) return false;
-        return clampDay(bill.startDate.getDate(), y, m) === d;
-      }
-      default:
-        return false;
-    }
-  });
+  const calendarDate = getCalendarDateContext(date);
+  return bills.filter((bill) => billOccursOnDate(bill, calendarDate));
 }
 
 export function formatMonthYear(date: Date, dateFnsLocale?: Locale): string {
@@ -89,35 +79,77 @@ export function formatMonthYear(date: Date, dateFnsLocale?: Locale): string {
  * Get the next occurrence of a bill from a given date.
  */
 export function getNextOccurrence(bill: Bill, from: Date): Date {
-  const start = bill.startDate;
-  // Normalize to midnight so a bill due today isn't skipped
-  const normalizedFrom = startOfDay(from);
-  switch (bill.frequency) {
-    case "weekly": {
-      const dayDiff = (getDay(start) - getDay(normalizedFrom) + 7) % 7;
-      const next = addDays(normalizedFrom, dayDiff === 0 ? 0 : dayDiff);
-      return next >= normalizedFrom ? next : addWeeks(next, 1);
-    }
-    case "biweekly": {
-      const daysDiff = differenceInCalendarDays(normalizedFrom, start);
-      const periods = daysDiff <= 0 ? 0 : Math.ceil(daysDiff / 14);
-      return addWeeks(start, periods * 2);
-    }
-    case "monthly": {
-      const day = start.getDate();
-      const y = normalizedFrom.getFullYear();
-      const m = normalizedFrom.getMonth();
-      const candidate = new Date(y, m, clampDay(day, y, m));
-      if (candidate >= normalizedFrom) return candidate;
-      return new Date(y, m + 1, clampDay(day, y, m + 1));
-    }
-    case "yearly": {
-      const day = start.getDate();
-      const sm = start.getMonth();
-      const y = normalizedFrom.getFullYear();
-      const candidate = new Date(y, sm, clampDay(day, y, sm));
-      if (candidate >= normalizedFrom) return candidate;
-      return new Date(y + 1, sm, clampDay(day, y + 1, sm));
-    }
-  }
+  return getNextOccurrenceForFrequency(bill.frequency, {
+    start: bill.startDate,
+    normalizedFrom: startOfDay(from),
+  });
+}
+
+function getCalendarDateContext(date: Date): CalendarDateContext {
+  return {
+    date,
+    year: date.getFullYear(),
+    month: date.getMonth(),
+    day: date.getDate(),
+    dayOfWeek: getDay(date),
+  };
+}
+
+function billOccursOnDate(bill: Bill, calendarDate: CalendarDateContext): boolean {
+  if (!bill.isActive) return false;
+  if (calendarDate.date < bill.startDate) return false;
+  const matcher = BILL_DATE_MATCHERS[bill.frequency as Bill["frequency"]];
+  return matcher ? matcher(bill, calendarDate) : false;
+}
+
+const BILL_DATE_MATCHERS = {
+  monthly: (bill: Bill, calendarDate: CalendarDateContext): boolean =>
+    clampDay(bill.startDate.getDate(), calendarDate.year, calendarDate.month) === calendarDate.day,
+  weekly: (bill: Bill, calendarDate: CalendarDateContext): boolean =>
+    getDay(bill.startDate) === calendarDate.dayOfWeek,
+  biweekly: (bill: Bill, calendarDate: CalendarDateContext): boolean => {
+    const weeksDiff = differenceInWeeks(calendarDate.date, bill.startDate);
+    return (
+      weeksDiff >= 0 && weeksDiff % 2 === 0 && getDay(bill.startDate) === calendarDate.dayOfWeek
+    );
+  },
+  yearly: (bill: Bill, calendarDate: CalendarDateContext): boolean =>
+    bill.startDate.getMonth() === calendarDate.month &&
+    clampDay(bill.startDate.getDate(), calendarDate.year, calendarDate.month) === calendarDate.day,
+} satisfies Record<Bill["frequency"], (bill: Bill, calendarDate: CalendarDateContext) => boolean>;
+
+const NEXT_OCCURRENCE_HANDLERS = {
+  weekly: ({ start, normalizedFrom }: OccurrenceContext): Date => {
+    const dayDiff = (getDay(start) - getDay(normalizedFrom) + 7) % 7;
+    const next = addDays(normalizedFrom, dayDiff === 0 ? 0 : dayDiff);
+    return next >= normalizedFrom ? next : addWeeks(next, 1);
+  },
+  biweekly: ({ start, normalizedFrom }: OccurrenceContext): Date => {
+    const daysDiff = differenceInCalendarDays(normalizedFrom, start);
+    const periods = daysDiff <= 0 ? 0 : Math.ceil(daysDiff / 14);
+    return addWeeks(start, periods * 2);
+  },
+  monthly: ({ start, normalizedFrom }: OccurrenceContext): Date => {
+    const year = normalizedFrom.getFullYear();
+    const month = normalizedFrom.getMonth();
+    const candidate = new Date(year, month, clampDay(start.getDate(), year, month));
+    return candidate >= normalizedFrom
+      ? candidate
+      : new Date(year, month + 1, clampDay(start.getDate(), year, month + 1));
+  },
+  yearly: ({ start, normalizedFrom }: OccurrenceContext): Date => {
+    const year = normalizedFrom.getFullYear();
+    const month = start.getMonth();
+    const candidate = new Date(year, month, clampDay(start.getDate(), year, month));
+    return candidate >= normalizedFrom
+      ? candidate
+      : new Date(year + 1, month, clampDay(start.getDate(), year + 1, month));
+  },
+} satisfies Record<Bill["frequency"], (context: OccurrenceContext) => Date>;
+
+function getNextOccurrenceForFrequency(
+  frequency: Bill["frequency"],
+  context: OccurrenceContext
+): Date {
+  return NEXT_OCCURRENCE_HANDLERS[frequency](context);
 }

--- a/apps/mobile/features/goals/lib/derive.ts
+++ b/apps/mobile/features/goals/lib/derive.ts
@@ -66,6 +66,28 @@ export type GoalAlert = {
   readonly shiftMonths: number;
 };
 
+type MonthSummary = {
+  readonly income: number;
+  readonly expense: number;
+};
+
+type GoalProjectionStats = {
+  readonly confidence: ConfidenceTier;
+  readonly netMonthlySavings: number;
+};
+
+type BudgetNudgeSpending = {
+  readonly categoryId: string;
+  readonly total: number;
+};
+
+type BudgetNudgeInput = {
+  readonly currentAmount: number;
+  readonly targetAmount: number;
+  readonly netMonthlySavings: number;
+  readonly spendingByCategory: readonly BudgetNudgeSpending[];
+};
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -73,21 +95,92 @@ export type GoalAlert = {
 /** Compute the median of a readonly numeric array. Pure, no mutation. */
 export function computeMedian(values: readonly number[]): number {
   if (values.length === 0) return 0;
-  if (values.length === 1) return values[0] ?? 0;
-
-  const sorted = [...values].sort((a, b) => a - b);
-  const mid = Math.floor(sorted.length / 2);
-
-  return sorted.length % 2 === 1
-    ? (sorted[mid] ?? 0)
-    : ((sorted[mid - 1] ?? 0) + (sorted[mid] ?? 0)) / 2;
+  const sorted = sortNumbers(values);
+  const mid = getMedianIndex(sorted.length);
+  return isEvenLength(sorted.length) ? getEvenMedian(sorted, mid) : getValueAt(sorted, mid);
 }
+
+const sortNumbers = (values: readonly number[]): readonly number[] =>
+  [...values].sort(compareNumbersAscending);
+
+const compareNumbersAscending = (left: number, right: number): number => left - right;
+
+const getMedianIndex = (length: number): number => Math.floor(length / 2);
+
+const isEvenLength = (length: number): boolean => length % 2 === 0;
+
+const getValueAt = (values: readonly number[], index: number): number => values[index] ?? 0;
+
+const getEvenMedian = (sorted: readonly number[], mid: number): number =>
+  (getValueAt(sorted, mid - 1) + getValueAt(sorted, mid)) / 2;
 
 const confidenceFromMonthCount = (count: number): ConfidenceTier => {
   if (count === 0) return "none";
   if (count === 1) return "low";
   if (count === 2) return "medium";
   return "high";
+};
+
+const updateMonthSummary = (summary: MonthSummary, total: MonthlyTotal): MonthSummary =>
+  total.type === "income"
+    ? { ...summary, income: summary.income + total.total }
+    : { ...summary, expense: summary.expense + total.total };
+
+const groupMonthlyTotals = (
+  monthlyTotals: readonly MonthlyTotal[]
+): ReadonlyMap<string, MonthSummary> =>
+  monthlyTotals.reduce<Map<string, MonthSummary>>((acc, total) => {
+    const current = acc.get(total.month) ?? { income: 0, expense: 0 };
+    acc.set(total.month, updateMonthSummary(current, total));
+    return acc;
+  }, new Map());
+
+const getNetMonthlySavings = (monthSummaries: readonly MonthSummary[]): number => {
+  const incomes = monthSummaries.map((entry) => entry.income);
+  const expenses = monthSummaries.map((entry) => entry.expense);
+  return computeMedian(incomes) - computeMedian(expenses);
+};
+
+const getGoalProjectionStats = (monthlyTotals: readonly MonthlyTotal[]): GoalProjectionStats => {
+  const monthGroups = groupMonthlyTotals(monthlyTotals);
+  return {
+    confidence: confidenceFromMonthCount(monthGroups.size),
+    netMonthlySavings: getNetMonthlySavings([...monthGroups.values()]),
+  };
+};
+
+const buildCompletedProjection = (
+  confidence: ConfidenceTier,
+  netMonthlySavings: number
+): GoalProjection => ({
+  monthsToGo: 0,
+  projectedDate: new Date(),
+  confidence,
+  netMonthlySavings,
+});
+
+const buildUnavailableProjection = (
+  confidence: ConfidenceTier,
+  netMonthlySavings: number
+): GoalProjection => ({
+  monthsToGo: null,
+  projectedDate: null,
+  confidence,
+  netMonthlySavings,
+});
+
+const buildProjectedGoalResult = (
+  remaining: number,
+  confidence: ConfidenceTier,
+  netMonthlySavings: number
+): GoalProjection => {
+  const monthsToGo = Math.ceil(remaining / netMonthlySavings);
+  return {
+    monthsToGo,
+    projectedDate: addMonths(new Date(), monthsToGo),
+    confidence,
+    netMonthlySavings,
+  };
 };
 
 // ---------------------------------------------------------------------------
@@ -120,54 +213,11 @@ export function deriveGoalProjection(
   currentAmount: number,
   monthlyTotals: readonly MonthlyTotal[]
 ): GoalProjection {
-  // Group by month, aggregate income and expense per month
-  const byMonth = monthlyTotals.reduce<Map<string, { income: number; expense: number }>>(
-    (acc, t) => {
-      const existing = acc.get(t.month) ?? { income: 0, expense: 0 };
-      const updated =
-        t.type === "income"
-          ? { ...existing, income: existing.income + t.total }
-          : { ...existing, expense: existing.expense + t.total };
-      acc.set(t.month, updated);
-      return acc;
-    },
-    new Map()
-  );
-
-  const distinctMonths = byMonth.size;
-  const confidence = confidenceFromMonthCount(distinctMonths);
-
-  const monthEntries = [...byMonth.values()];
-  const medianIncome = computeMedian(monthEntries.map((e) => e.income));
-  const medianExpense = computeMedian(monthEntries.map((e) => e.expense));
-  const netMonthlySavings = medianIncome - medianExpense;
-
+  const { confidence, netMonthlySavings } = getGoalProjectionStats(monthlyTotals);
   const remaining = goal.targetAmount - currentAmount;
-
-  // Already complete
-  if (remaining <= 0) {
-    return {
-      monthsToGo: 0,
-      projectedDate: new Date(),
-      confidence,
-      netMonthlySavings,
-    };
-  }
-
-  // Cannot project if no savings or no data
-  if (netMonthlySavings <= 0) {
-    return {
-      monthsToGo: null,
-      projectedDate: null,
-      confidence,
-      netMonthlySavings,
-    };
-  }
-
-  const monthsToGo = Math.ceil(remaining / netMonthlySavings);
-  const projectedDate = addMonths(new Date(), monthsToGo);
-
-  return { monthsToGo, projectedDate, confidence, netMonthlySavings };
+  if (remaining <= 0) return buildCompletedProjection(confidence, netMonthlySavings);
+  if (netMonthlySavings <= 0) return buildUnavailableProjection(confidence, netMonthlySavings);
+  return buildProjectedGoalResult(remaining, confidence, netMonthlySavings);
 }
 
 // ---------------------------------------------------------------------------
@@ -263,41 +313,40 @@ export function deriveInstallmentProgress(
 // 6. deriveBudgetNudges
 // ---------------------------------------------------------------------------
 
-export function deriveBudgetNudges(
-  currentAmount: number,
-  targetAmount: number,
-  netMonthlySavings: number,
-  spendingByCategory: readonly {
-    readonly categoryId: string;
-    readonly total: number;
-  }[]
-): readonly BudgetNudge[] {
-  if (netMonthlySavings <= 0) return [];
+export function deriveBudgetNudges(input: BudgetNudgeInput): readonly BudgetNudge[] {
+  if (input.netMonthlySavings <= 0) return [];
 
-  const remaining = targetAmount - currentAmount;
+  const remaining = input.targetAmount - input.currentAmount;
   if (remaining <= 0) return [];
 
-  const baselineMonths = Math.ceil(remaining / netMonthlySavings);
-
-  // Top 3 categories by total, sorted descending
-  const topCategories = [...spendingByCategory].sort((a, b) => b.total - a.total).slice(0, 3);
-
-  const nudges = topCategories.map((cat) => {
-    const suggestedReduction = Math.round(cat.total * 0.15);
-    const newSavings = netMonthlySavings + suggestedReduction;
-    const newMonths = newSavings > 0 ? Math.ceil(remaining / newSavings) : baselineMonths;
-    const monthsSaved = baselineMonths - newMonths;
-
-    return {
-      categoryId: cat.categoryId,
-      currentSpending: cat.total,
-      suggestedReduction,
-      monthsSaved,
-    };
-  });
-
-  return [...nudges].sort((a, b) => b.monthsSaved - a.monthsSaved);
+  const baselineMonths = Math.ceil(remaining / input.netMonthlySavings);
+  const nudges = getTopSpendingCategories(input.spendingByCategory).map((category) =>
+    buildBudgetNudge(category, remaining, baselineMonths, input.netMonthlySavings)
+  );
+  return nudges.sort((left, right) => right.monthsSaved - left.monthsSaved);
 }
+
+const getTopSpendingCategories = (
+  spendingByCategory: readonly BudgetNudgeSpending[]
+): readonly BudgetNudgeSpending[] =>
+  [...spendingByCategory].sort((left, right) => right.total - left.total).slice(0, 3);
+
+const buildBudgetNudge = (
+  category: BudgetNudgeSpending,
+  remaining: number,
+  baselineMonths: number,
+  netMonthlySavings: number
+): BudgetNudge => {
+  const suggestedReduction = Math.round(category.total * 0.15);
+  const newSavings = netMonthlySavings + suggestedReduction;
+  const newMonths = newSavings > 0 ? Math.ceil(remaining / newSavings) : baselineMonths;
+  return {
+    categoryId: category.categoryId,
+    currentSpending: category.total,
+    suggestedReduction,
+    monthsSaved: baselineMonths - newMonths,
+  };
+};
 
 // ---------------------------------------------------------------------------
 // 7. deriveGoalAlerts
@@ -387,19 +436,21 @@ export function deriveGoalCardStatus(
   progress: GoalProgress,
   paceGuidance: GoalPaceGuidance | null
 ): GoalCardStatus | null {
-  if (progress.isComplete) return { kind: "completed" };
-
-  if (paceGuidance !== null) {
-    if (paceGuidance.type === "pace_ahead") {
-      return { kind: "pace_ahead", amount: paceGuidance.amountAhead };
-    }
-    if (paceGuidance.reason === "no_contributions") {
-      return { kind: "start_saving" };
-    }
-    return { kind: "pace_behind", amount: paceGuidance.amountBehind };
-  }
-
-  if (progress.percentComplete >= 75) return { kind: "almost_there" };
-
-  return null;
+  const progressStatus = getProgressStatus(progress);
+  if (progressStatus?.kind === "completed") return progressStatus;
+  if (paceGuidance !== null) return getPaceStatus(paceGuidance);
+  return progressStatus;
 }
+
+const getProgressStatus = (progress: GoalProgress): GoalCardStatus | null => {
+  if (progress.isComplete) return { kind: "completed" };
+  if (progress.percentComplete >= 75) return { kind: "almost_there" };
+  return null;
+};
+
+const getPaceStatus = (paceGuidance: GoalPaceGuidance): GoalCardStatus =>
+  paceGuidance.type === "pace_ahead"
+    ? { kind: "pace_ahead", amount: paceGuidance.amountAhead }
+    : paceGuidance.reason === "no_contributions"
+      ? { kind: "start_saving" }
+      : { kind: "pace_behind", amount: paceGuidance.amountBehind };

--- a/apps/mobile/features/qa/devtools-store.ts
+++ b/apps/mobile/features/qa/devtools-store.ts
@@ -58,42 +58,47 @@ const DEFAULT_QA_FEATURE_FLAGS: QaFeatureFlags = {
   showQaBanner: false,
 };
 
+const QA_FEATURE_FLAG_NAMES = [
+  "networkInspectorEnabled",
+  "logInspectorEnabled",
+  "simulateOffline",
+  "showQaBanner",
+] as const satisfies readonly QaFeatureFlagName[];
+
 function buildStoredFlagsKey() {
   return QA_DEVTOOLS_FLAGS_KEY;
 }
 
-function parseStoredFlags(value: string | null): QaFeatureFlags {
-  if (!value) return DEFAULT_QA_FEATURE_FLAGS;
+function getParsedBooleanFlag(
+  parsed: Partial<Record<QaFeatureFlagName, unknown>>,
+  name: QaFeatureFlagName
+) {
+  return typeof parsed[name] === "boolean" ? parsed[name] : DEFAULT_QA_FEATURE_FLAGS[name];
+}
 
+function normalizeStoredFlags(parsed: Partial<Record<QaFeatureFlagName, unknown>>): QaFeatureFlags {
+  return {
+    networkInspectorEnabled: getParsedBooleanFlag(parsed, QA_FEATURE_FLAG_NAMES[0]),
+    logInspectorEnabled: getParsedBooleanFlag(parsed, QA_FEATURE_FLAG_NAMES[1]),
+    simulateOffline: getParsedBooleanFlag(parsed, QA_FEATURE_FLAG_NAMES[2]),
+    showQaBanner: getParsedBooleanFlag(parsed, QA_FEATURE_FLAG_NAMES[3]),
+  };
+}
+
+function tryParseStoredFlags(value: string): Partial<Record<QaFeatureFlagName, unknown>> | null {
   try {
-    const parsed = JSON.parse(value) as Partial<Record<QaFeatureFlagName, unknown>>;
-
-    return {
-      networkInspectorEnabled:
-        typeof parsed.networkInspectorEnabled === "boolean"
-          ? parsed.networkInspectorEnabled
-          : DEFAULT_QA_FEATURE_FLAGS.networkInspectorEnabled,
-      logInspectorEnabled:
-        typeof parsed.logInspectorEnabled === "boolean"
-          ? parsed.logInspectorEnabled
-          : DEFAULT_QA_FEATURE_FLAGS.logInspectorEnabled,
-      simulateOffline:
-        typeof parsed.simulateOffline === "boolean"
-          ? parsed.simulateOffline
-          : DEFAULT_QA_FEATURE_FLAGS.simulateOffline,
-      showQaBanner:
-        typeof parsed.showQaBanner === "boolean"
-          ? parsed.showQaBanner
-          : DEFAULT_QA_FEATURE_FLAGS.showQaBanner,
-    };
+    return JSON.parse(value) as Partial<Record<QaFeatureFlagName, unknown>>;
   } catch {
-    return DEFAULT_QA_FEATURE_FLAGS;
+    return null;
   }
 }
 
-function loadStoredFlags(): QaFeatureFlags {
-  if (!isLocalQaAvailable()) return DEFAULT_QA_FEATURE_FLAGS;
+function parseStoredFlags(value: string | null): QaFeatureFlags {
+  const parsed = value === null ? null : tryParseStoredFlags(value);
+  return parsed === null ? DEFAULT_QA_FEATURE_FLAGS : normalizeStoredFlags(parsed);
+}
 
+function readStoredFlags(): QaFeatureFlags {
   try {
     return parseStoredFlags(SecureStore.getItem(buildStoredFlagsKey()));
   } catch {
@@ -101,14 +106,8 @@ function loadStoredFlags(): QaFeatureFlags {
   }
 }
 
-function persistFlags(flags: QaFeatureFlags) {
-  if (!isLocalQaAvailable()) return;
-
-  try {
-    SecureStore.setItem(buildStoredFlagsKey(), JSON.stringify(flags));
-  } catch {
-    // Best-effort persistence only.
-  }
+function loadStoredFlags(): QaFeatureFlags {
+  return isLocalQaAvailable() ? readStoredFlags() : DEFAULT_QA_FEATURE_FLAGS;
 }
 
 function appendBounded<T>(current: readonly T[], next: T, maxItems: number) {
@@ -187,3 +186,16 @@ export const useQaDevtoolsStore = create<QaDevtoolsState & QaDevtoolsActions>((s
 export const qaFeatureFlags = {
   defaults: DEFAULT_QA_FEATURE_FLAGS,
 };
+
+function persistFlags(flags: QaFeatureFlags) {
+  if (!isLocalQaAvailable()) return;
+  writeStoredFlags(flags);
+}
+
+function writeStoredFlags(flags: QaFeatureFlags) {
+  try {
+    SecureStore.setItem(buildStoredFlagsKey(), JSON.stringify(flags));
+  } catch {
+    // Best-effort persistence only.
+  }
+}

--- a/apps/mobile/features/qa/network-inspector.ts
+++ b/apps/mobile/features/qa/network-inspector.ts
@@ -9,17 +9,21 @@ type FetchFn = typeof fetch;
 let originalFetch: FetchFn | null = null;
 let installedFetchWrapper: FetchFn | null = null;
 
-function getRequestUrl(input: FetchInput) {
-  if (typeof input === "string") return input;
-  if (typeof URL !== "undefined" && input instanceof URL) return input.toString();
-  if (typeof Request !== "undefined" && input instanceof Request) return input.url;
-  return String(input);
+type QaRecordNetworkEvent = ReturnType<typeof useQaDevtoolsStore.getState>["recordNetworkEvent"];
+
+type QaRequestDetails = {
+  readonly method: string;
+  readonly url: string;
+  readonly startedAt: number;
+};
+
+function isRequestInput(input: FetchInput): input is Request {
+  return typeof Request !== "undefined" && input instanceof Request;
 }
 
-function getRequestMethod(input: FetchInput, init?: FetchInit) {
-  if (typeof init?.method === "string") return init.method.toUpperCase();
-  if (typeof Request !== "undefined" && input instanceof Request) return input.method.toUpperCase();
-  return "GET";
+function getRequestUrl(input: FetchInput) {
+  if (typeof input === "string") return input;
+  return isRequestInput(input) ? input.url : String(input);
 }
 
 function getCurrentFetch(): FetchFn | null {
@@ -28,6 +32,90 @@ function getCurrentFetch(): FetchFn | null {
 
 function setGlobalFetch(nextFetch: FetchFn) {
   globalThis.fetch = nextFetch;
+}
+
+function getQaRequestDetails(input: FetchInput, init?: FetchInit): QaRequestDetails {
+  return {
+    method: getRequestMethod(input, init),
+    url: getRequestUrl(input),
+    startedAt: Date.now(),
+  };
+}
+
+function getRequestMethod(input: FetchInput, init?: FetchInit) {
+  if (typeof init?.method === "string") return init.method.toUpperCase();
+  if (isRequestInput(input)) return input.method.toUpperCase();
+  return "GET";
+}
+
+function recordBlockedRequest(details: QaRequestDetails, recordNetworkEvent: QaRecordNetworkEvent) {
+  recordNetworkEvent({
+    method: details.method,
+    url: details.url,
+    outcome: "blocked",
+    status: null,
+    durationMs: 0,
+    errorMessage: "QA simulateOffline is enabled",
+  });
+  recordQaLog("warn", "qa_simulate_offline_blocked_request", {
+    method: details.method,
+    url: details.url,
+  });
+}
+
+function recordSuccessfulRequest(
+  details: QaRequestDetails,
+  recordNetworkEvent: QaRecordNetworkEvent,
+  response: Response
+) {
+  recordNetworkEvent({
+    method: details.method,
+    url: details.url,
+    outcome: "success",
+    status: response.status,
+    durationMs: Date.now() - details.startedAt,
+    errorMessage: null,
+  });
+}
+
+function recordFailedRequest(
+  details: QaRequestDetails,
+  recordNetworkEvent: QaRecordNetworkEvent,
+  error: unknown
+) {
+  const errorMessage = error instanceof Error ? error.message : "unknown";
+  recordNetworkEvent({
+    method: details.method,
+    url: details.url,
+    outcome: "error",
+    status: null,
+    durationMs: Date.now() - details.startedAt,
+    errorMessage,
+  });
+}
+
+async function inspectFetchRequest(currentFetch: FetchFn, input: FetchInput, init?: FetchInit) {
+  const { flags, recordNetworkEvent } = useQaDevtoolsStore.getState();
+  const requestDetails = getQaRequestDetails(input, init);
+
+  if (flags.simulateOffline) {
+    recordBlockedRequest(requestDetails, recordNetworkEvent);
+    throw new TypeError("Network request failed (QA simulateOffline)");
+  }
+
+  try {
+    const response = await currentFetch(input, init);
+    recordSuccessfulRequest(requestDetails, recordNetworkEvent, response);
+    return response;
+  } catch (error) {
+    recordFailedRequest(requestDetails, recordNetworkEvent, error);
+    throw error;
+  }
+}
+
+function createQaFetchWrapper(currentFetch: FetchFn): FetchFn {
+  return ((input: FetchInput, init?: FetchInit) =>
+    inspectFetchRequest(currentFetch, input, init)) as FetchFn;
 }
 
 export function installQaFetchInspector() {
@@ -45,53 +133,7 @@ export function installQaFetchInspector() {
   }
 
   originalFetch = currentFetch;
-  installedFetchWrapper = (async (input: FetchInput, init?: FetchInit) => {
-    const { flags, recordNetworkEvent } = useQaDevtoolsStore.getState();
-    const url = getRequestUrl(input);
-    const method = getRequestMethod(input, init);
-    const startedAt = Date.now();
-
-    if (flags.simulateOffline) {
-      recordNetworkEvent({
-        method,
-        url,
-        outcome: "blocked",
-        status: null,
-        durationMs: 0,
-        errorMessage: "QA simulateOffline is enabled",
-      });
-      recordQaLog("warn", "qa_simulate_offline_blocked_request", { method, url });
-      throw new TypeError("Network request failed (QA simulateOffline)");
-    }
-
-    try {
-      const response = await currentFetch(input, init);
-
-      recordNetworkEvent({
-        method,
-        url,
-        outcome: "success",
-        status: response.status,
-        durationMs: Date.now() - startedAt,
-        errorMessage: null,
-      });
-
-      return response;
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : "unknown";
-
-      recordNetworkEvent({
-        method,
-        url,
-        outcome: "error",
-        status: null,
-        durationMs: Date.now() - startedAt,
-        errorMessage,
-      });
-
-      throw error;
-    }
-  }) as FetchFn;
+  installedFetchWrapper = createQaFetchWrapper(currentFetch);
 
   setGlobalFetch(installedFetchWrapper);
   recordQaLog("info", "qa_fetch_inspector_installed");

--- a/apps/mobile/plugins/withFidyWidget.js
+++ b/apps/mobile/plugins/withFidyWidget.js
@@ -90,213 +90,209 @@ const copyWidgetFiles = (projectRoot, config) => {
 
 const generateUuid = (project) => project.generateUuid();
 
+const BASE_EXTENSION_BUILD_SETTINGS = {
+  ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: '""',
+  ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME: '""',
+  CLANG_ANALYZER_NONNULL: "YES",
+  CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION: "YES_AGGRESSIVE",
+  CLANG_CXX_LANGUAGE_STANDARD: '"gnu++20"',
+  CLANG_ENABLE_OBJC_WEAK: "YES",
+  CLANG_WARN_DOCUMENTATION_COMMENTS: "YES",
+  CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER: "YES",
+  CLANG_WARN_UNGUARDED_AVAILABILITY: "YES_AGGRESSIVE",
+  CODE_SIGN_ENTITLEMENTS: `${EXTENSION_NAME}/widget.entitlements`,
+  CODE_SIGN_STYLE: "Automatic",
+  CURRENT_PROJECT_VERSION: "1",
+  DEBUG_INFORMATION_FORMAT: '"dwarf-with-dsym"',
+  GCC_C_LANGUAGE_STANDARD: "gnu17",
+  INFOPLIST_KEY_CFBundleDisplayName: EXTENSION_NAME,
+  INFOPLIST_KEY_NSHumanReadableCopyright: '""',
+  IPHONEOS_DEPLOYMENT_TARGET: DEPLOYMENT_TARGET,
+  LD_RUNPATH_SEARCH_PATHS:
+    '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
+  MARKETING_VERSION: "1.0",
+  PRODUCT_NAME: '"$(TARGET_NAME)"',
+  SKIP_INSTALL: "YES",
+  SWIFT_EMIT_LOC_STRINGS: "YES",
+  SWIFT_VERSION,
+  TARGETED_DEVICE_FAMILY: '"1,2"',
+};
+
+const isObject = (value) => typeof value === "object" && value !== null;
+const isNamedExtensionTarget = (target) => isObject(target) && target.name === EXTENSION_NAME;
+const getProductsGroupComment = () => `${EXTENSION_NAME}.appex`;
+const getEmbedPhaseComment = () => `${EXTENSION_NAME}.appex in Embed App Extensions`;
+const getXcodeObjects = (project) => project.hash.project.objects;
+
 // Xcode build setting keys use SCREAMING_SNAKE_CASE by convention.
 const buildSettings = (config) => {
   const developmentTeam = getDevelopmentTeam(config);
-  const extensionBundleId = getExtensionBundleId(config);
-
   const settings = {
-    ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: '""',
-    ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME: '""',
-    CLANG_ANALYZER_NONNULL: "YES",
-    CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION: "YES_AGGRESSIVE",
-    CLANG_CXX_LANGUAGE_STANDARD: '"gnu++20"',
-    CLANG_ENABLE_OBJC_WEAK: "YES",
-    CLANG_WARN_DOCUMENTATION_COMMENTS: "YES",
-    CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER: "YES",
-    CLANG_WARN_UNGUARDED_AVAILABILITY: "YES_AGGRESSIVE",
-    CODE_SIGN_ENTITLEMENTS: `${EXTENSION_NAME}/widget.entitlements`,
-    CODE_SIGN_STYLE: "Automatic",
-    CURRENT_PROJECT_VERSION: "1",
-    DEBUG_INFORMATION_FORMAT: '"dwarf-with-dsym"',
-    GCC_C_LANGUAGE_STANDARD: "gnu17",
-    INFOPLIST_KEY_CFBundleDisplayName: EXTENSION_NAME,
-    INFOPLIST_KEY_NSHumanReadableCopyright: '""',
-    IPHONEOS_DEPLOYMENT_TARGET: DEPLOYMENT_TARGET,
-    LD_RUNPATH_SEARCH_PATHS:
-      '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
-    MARKETING_VERSION: "1.0",
-    PRODUCT_BUNDLE_IDENTIFIER: extensionBundleId,
-    PRODUCT_NAME: '"$(TARGET_NAME)"',
-    SKIP_INSTALL: "YES",
-    SWIFT_EMIT_LOC_STRINGS: "YES",
-    SWIFT_VERSION,
-    TARGETED_DEVICE_FAMILY: '"1,2"',
+    ...BASE_EXTENSION_BUILD_SETTINGS,
+    PRODUCT_BUNDLE_IDENTIFIER: getExtensionBundleId(config),
   };
-
-  if (developmentTeam) {
-    settings.DEVELOPMENT_TEAM = developmentTeam;
-  }
-
-  return settings;
+  return developmentTeam ? { ...settings, DEVELOPMENT_TEAM: developmentTeam } : settings;
 };
 
 /** Reconcile build settings on the extension's Debug/Release configurations. */
+const getExtensionConfigListId = (project) =>
+  Object.values(project.pbxNativeTargetSection()).find(isNamedExtensionTarget)
+    ?.buildConfigurationList ?? null;
+
+const getConfigList = (project, configListId) =>
+  getXcodeObjects(project).XCConfigurationList?.[configListId] ?? null;
+
+const getBuildConfigurationRefs = (project, configListId) =>
+  getConfigList(project, configListId)?.buildConfigurations ?? [];
+
+const applySettingsToBuildConfig = (config, settings) => {
+  if (isObject(config) && config.buildSettings) {
+    config.buildSettings = { ...config.buildSettings, ...settings };
+  }
+};
+
+const applySettingsToConfigRefs = (project, configRefs, settings) => {
+  const buildConfigs = getXcodeObjects(project).XCBuildConfiguration;
+  for (const ref of configRefs) {
+    applySettingsToBuildConfig(buildConfigs?.[ref.value], settings);
+  }
+};
+
 const reconcileBuildSettings = (project, settings) => {
-  // Find the extension target's buildConfigurationList UUID
-  const nativeTargets = project.pbxNativeTargetSection();
-  let configListId = null;
-  for (const val of Object.values(nativeTargets)) {
-    if (typeof val === "object" && val !== null && val.name === EXTENSION_NAME) {
-      configListId = val.buildConfigurationList;
-      break;
-    }
-  }
+  const configListId = getExtensionConfigListId(project);
   if (!configListId) return;
+  applySettingsToConfigRefs(project, getBuildConfigurationRefs(project, configListId), settings);
+};
 
-  // Get the configuration UUIDs from the XCConfigurationList via direct hash access
-  const configLists = project.hash.project.objects.XCConfigurationList;
-  const configList = configLists?.[configListId];
-  if (!configList?.buildConfigurations) return;
+const targetExists = (project) =>
+  Object.values(project.pbxNativeTargetSection()).some(isNamedExtensionTarget);
 
-  const configUuids = new Set(configList.buildConfigurations.map((c) => c.value));
+const createWidgetTarget = (project, extensionBundleId) =>
+  project.addTarget(EXTENSION_NAME, "app_extension", EXTENSION_NAME, extensionBundleId);
 
-  // Apply build settings to those specific configurations
-  const buildConfigs = project.hash.project.objects.XCBuildConfiguration;
-  for (const uuid of configUuids) {
-    const config = buildConfigs?.[uuid];
-    if (typeof config === "object" && config.buildSettings) {
-      config.buildSettings = { ...config.buildSettings, ...settings };
-    }
-  }
+const applySettingsToTarget = (project, targetUuid, settings) => {
+  const nativeTarget = project.pbxNativeTargetSection()[targetUuid];
+  const configListId = nativeTarget?.buildConfigurationList;
+  if (!configListId) return;
+  applySettingsToConfigRefs(project, getBuildConfigurationRefs(project, configListId), settings);
+};
+
+const addWidgetSourcesBuildPhase = (project, targetUuid) =>
+  project.addBuildPhase(
+    SWIFT_FILES.map((file) => `${EXTENSION_NAME}/${file}`),
+    "PBXSourcesBuildPhase",
+    "Sources",
+    targetUuid,
+    undefined,
+    generateUuid(project)
+  );
+
+const addWidgetExtensionGroup = (project) => {
+  const extensionGroup = project.addPbxGroup(
+    [...STATIC_EXTENSION_FILES, "WidgetConfig.swift"],
+    EXTENSION_NAME,
+    EXTENSION_NAME,
+    '"<group>"',
+    { uuid: generateUuid(project) }
+  );
+  const mainGroupId = project.getFirstProject().firstProject.mainGroup;
+  project.addToPbxGroup(extensionGroup.uuid, mainGroupId);
+};
+
+const addFrameworkBuildPhase = (project, targetUuid) =>
+  project.addBuildPhase(
+    [],
+    "PBXFrameworksBuildPhase",
+    "Frameworks",
+    targetUuid,
+    undefined,
+    generateUuid(project)
+  );
+
+const addWidgetFrameworks = (project, targetUuid) => {
+  addFrameworkBuildPhase(project, targetUuid);
+  project.addFramework("WidgetKit.framework", { target: targetUuid, link: true });
+  project.addFramework("SwiftUI.framework", { target: targetUuid, link: true });
+};
+
+const createEmbedPhase = (project) => {
+  const embedPhaseUuid = generateUuid(project);
+  const mainTarget = project.getFirstTarget();
+  project.addBuildPhase(
+    [],
+    "PBXCopyFilesBuildPhase",
+    "Embed App Extensions",
+    mainTarget.firstTarget.uuid,
+    "app_extension",
+    embedPhaseUuid
+  );
+  return embedPhaseUuid;
+};
+
+const getProductReferenceUuid = (project, targetUuid) =>
+  project.pbxNativeTargetSection()[targetUuid]?.productReference ?? null;
+
+const getProductsGroup = (project) => {
+  const groups = getXcodeObjects(project).PBXGroup || {};
+  return (
+    Object.values(groups).find((group) => isObject(group) && group.name === "Products") ?? null
+  );
+};
+
+const addProductToProductsGroup = (project, productRefUuid) => {
+  const productsGroup = getProductsGroup(project);
+  if (!productsGroup) return;
+  const alreadyInGroup = productsGroup.children?.some((child) => child.value === productRefUuid);
+  if (alreadyInGroup) return;
+  productsGroup.children.push({
+    value: productRefUuid,
+    comment: getProductsGroupComment(),
+  });
+};
+
+const createEmbedBuildFile = (project, productRefUuid) => {
+  const buildFileUuid = generateUuid(project);
+  getXcodeObjects(project).PBXBuildFile[buildFileUuid] = {
+    isa: "PBXBuildFile",
+    fileRef: productRefUuid,
+    settings: { ATTRIBUTES: ["RemoveHeadersOnCopy"] },
+  };
+  getXcodeObjects(project).PBXBuildFile[`${buildFileUuid}_comment`] = getEmbedPhaseComment();
+  return buildFileUuid;
+};
+
+const addBuildFileToEmbedPhase = (project, embedPhaseUuid, buildFileUuid) => {
+  const embedPhase = getXcodeObjects(project).PBXCopyFilesBuildPhase?.[embedPhaseUuid];
+  if (!embedPhase) return;
+  embedPhase.files.push({
+    value: buildFileUuid,
+    comment: getEmbedPhaseComment(),
+  });
+};
+
+const embedWidgetExtension = (project, targetUuid) => {
+  const productRefUuid = getProductReferenceUuid(project, targetUuid);
+  if (!productRefUuid) return;
+  const embedPhaseUuid = createEmbedPhase(project);
+  addProductToProductsGroup(project, productRefUuid);
+  addBuildFileToEmbedPhase(project, embedPhaseUuid, createEmbedBuildFile(project, productRefUuid));
+};
+
+const createWidgetExtensionStructure = (project, extensionBundleId, settings) => {
+  const target = createWidgetTarget(project, extensionBundleId);
+  applySettingsToTarget(project, target.uuid, settings);
+  addWidgetSourcesBuildPhase(project, target.uuid);
+  addWidgetExtensionGroup(project);
+  addWidgetFrameworks(project, target.uuid);
+  embedWidgetExtension(project, target.uuid);
 };
 
 const addWidgetExtensionTarget = (project, config) => {
   const extensionBundleId = getExtensionBundleId(config);
   const settings = buildSettings(config);
-
-  // 0. Check if the target already exists
-  const existingTargets = project.pbxNativeTargetSection();
-  const targetExists = Object.values(existingTargets).some(
-    (t) => typeof t === "object" && t !== null && t.name === EXTENSION_NAME
-  );
-
-  // 1. Create structural elements only if the target doesn't exist
-  if (!targetExists) {
-    const target = project.addTarget(
-      EXTENSION_NAME,
-      "app_extension",
-      EXTENSION_NAME,
-      extensionBundleId
-    );
-
-    // Apply build settings immediately after target creation — the xcode
-    // package creates Debug/Release configs but leaves them sparse.
-    const nativeTarget = project.pbxNativeTargetSection()[target.uuid];
-    const configListId = nativeTarget?.buildConfigurationList;
-    if (configListId) {
-      const configList = project.hash.project.objects.XCConfigurationList?.[configListId];
-      if (configList?.buildConfigurations) {
-        const buildConfigs = project.hash.project.objects.XCBuildConfiguration;
-        for (const ref of configList.buildConfigurations) {
-          const config = buildConfigs?.[ref.value];
-          if (typeof config === "object" && config.buildSettings) {
-            config.buildSettings = { ...config.buildSettings, ...settings };
-          }
-        }
-      }
-    }
-
-    const sourcesBuildPhaseUuid = generateUuid(project);
-    project.addBuildPhase(
-      SWIFT_FILES.map((f) => `${EXTENSION_NAME}/${f}`),
-      "PBXSourcesBuildPhase",
-      "Sources",
-      target.uuid,
-      undefined,
-      sourcesBuildPhaseUuid
-    );
-
-    const groupUuid = generateUuid(project);
-    const extensionGroup = project.addPbxGroup(
-      [...STATIC_EXTENSION_FILES, "WidgetConfig.swift"],
-      EXTENSION_NAME,
-      EXTENSION_NAME,
-      '"<group>"',
-      { uuid: groupUuid }
-    );
-    const mainGroupId = project.getFirstProject().firstProject.mainGroup;
-    project.addToPbxGroup(extensionGroup.uuid, mainGroupId);
-
-    const frameworksBuildPhaseUuid = generateUuid(project);
-    project.addBuildPhase(
-      [],
-      "PBXFrameworksBuildPhase",
-      "Frameworks",
-      target.uuid,
-      undefined,
-      frameworksBuildPhaseUuid
-    );
-
-    project.addFramework("WidgetKit.framework", {
-      target: target.uuid,
-      link: true,
-    });
-    project.addFramework("SwiftUI.framework", {
-      target: target.uuid,
-      link: true,
-    });
-
-    // Embed the extension in the main app — create the phase with an empty
-    // file list, then manually wire the target's product reference into the
-    // phase so CocoaPods doesn't encounter an orphaned PBXFileReference.
-    const mainTarget = project.getFirstTarget();
-    const embedPhaseUuid = generateUuid(project);
-    project.addBuildPhase(
-      [],
-      "PBXCopyFilesBuildPhase",
-      "Embed App Extensions",
-      mainTarget.firstTarget.uuid,
-      "app_extension",
-      embedPhaseUuid
-    );
-
-    // Find the target's product reference (the .appex created by addTarget)
-    const nativeTargetEntry = project.pbxNativeTargetSection()[target.uuid];
-    const productRefUuid = nativeTargetEntry?.productReference;
-
-    if (productRefUuid) {
-      // Add product to the Products group so CocoaPods can resolve its parent
-      const productsGroupKey = Object.keys(project.hash.project.objects.PBXGroup || {}).find(
-        (key) => {
-          const group = project.hash.project.objects.PBXGroup[key];
-          return typeof group === "object" && group.name === "Products";
-        }
-      );
-      if (productsGroupKey) {
-        const productsGroup = project.hash.project.objects.PBXGroup[productsGroupKey];
-        const alreadyInGroup = productsGroup.children?.some((c) => c.value === productRefUuid);
-        if (!alreadyInGroup) {
-          productsGroup.children.push({
-            value: productRefUuid,
-            comment: `${EXTENSION_NAME}.appex`,
-          });
-        }
-      }
-
-      // Add a PBXBuildFile referencing the product in the embed phase
-      const buildFileUuid = generateUuid(project);
-      project.hash.project.objects.PBXBuildFile[buildFileUuid] = {
-        isa: "PBXBuildFile",
-        fileRef: productRefUuid,
-        settings: { ATTRIBUTES: ["RemoveHeadersOnCopy"] },
-      };
-      project.hash.project.objects.PBXBuildFile[`${buildFileUuid}_comment`] =
-        `${EXTENSION_NAME}.appex in Embed App Extensions`;
-
-      // Add the build file to the embed phase's files array
-      const copyFilesPhases = project.hash.project.objects.PBXCopyFilesBuildPhase || {};
-      const embedPhase = copyFilesPhases[embedPhaseUuid];
-      if (embedPhase) {
-        embedPhase.files.push({
-          value: buildFileUuid,
-          comment: `${EXTENSION_NAME}.appex in Embed App Extensions`,
-        });
-      }
-    }
+  if (!targetExists(project)) {
+    createWidgetExtensionStructure(project, extensionBundleId, settings);
   }
-
-  // 2. Always reconcile build settings
   reconcileBuildSettings(project, settings);
 };
 


### PR DESCRIPTION
- deepen goals derivations
- split auth and qa flows
- stage widget and calendar helpers


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored auth and QA flows, goal derivations, calendar helpers, and iOS widget setup to reduce complexity and improve reliability. Includes a small API change to `deriveBudgetNudges`.

- **Refactors**
  - Auth: extracted helpers for restore/sign-in/sign-out, streamlined onboarding resets, and improved error capture and push token cleanup.
  - QA: normalized flag parsing with safe defaults, modular `fetch` inspector with offline simulation, and bounded log/history.
  - Goals: clearer median/projection helpers and nudge calculation with top categories and stable sorting.
  - Calendar: added date/occurrence contexts and frequency handlers for cleaner, reusable logic.
  - Widget: modular Xcode project updates for target creation, frameworks, and embed phase with consistent build settings reconciliation.

- **Migration**
  - Update calls to `deriveBudgetNudges` to use an input object: `{ currentAmount, targetAmount, netMonthlySavings, spendingByCategory }`.

<sup>Written for commit 1d0814e97e1f347ba4ee31a0b060b66a681c4e5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

