### PR TITLE
refactor(mobile): reduce wave 2 complexity

### DIFF
--- a/apps/mobile/__tests__/activity/query-service.test.ts
+++ b/apps/mobile/__tests__/activity/query-service.test.ts
@@ -67,38 +67,119 @@ function makeTransferRow(
   };
 }
 
-describe("activity query service", () => {
-  it("merges transactions and transfers into one newest-first activity page", () => {
-    const getTransactionsPaginated = vi.fn().mockReturnValue([
-      makeTransactionRow({
-        id: "tx-newer" as TransactionId,
-        date: "2026-04-19" as IsoDate,
-        updatedAt: "2026-04-19T08:00:00.000Z" as IsoDateTime,
-      }),
-      makeTransactionRow({
-        id: "tx-older" as TransactionId,
-        date: "2026-04-17" as IsoDate,
-        updatedAt: "2026-04-17T08:00:00.000Z" as IsoDateTime,
-      }),
-    ]);
-    const getTransfersPaginated = vi.fn().mockReturnValue([
-      makeTransferRow({
-        id: "tr-newest" as TransferId,
-        date: "2026-04-19" as IsoDate,
-        updatedAt: "2026-04-19T09:00:00.000Z" as IsoDateTime,
-      }),
-    ]);
-    const service = createActivityQueryService({
+type ActivityServiceHarnessInput = {
+  readonly transactionRows: readonly ReturnType<typeof makeTransactionRow>[];
+  readonly transferRows: readonly ReturnType<typeof makeTransferRow>[];
+};
+
+const PAGINATION_TRANSACTION_ROWS = [
+  makeTransactionRow({
+    id: "tx-1" as TransactionId,
+    date: "2026-04-19" as IsoDate,
+    updatedAt: "2026-04-19T08:00:00.000Z" as IsoDateTime,
+  }),
+  makeTransactionRow({
+    id: "tx-2" as TransactionId,
+    date: "2026-04-18" as IsoDate,
+    updatedAt: "2026-04-18T08:00:00.000Z" as IsoDateTime,
+  }),
+  makeTransactionRow({
+    id: "tx-3" as TransactionId,
+    date: "2026-04-17" as IsoDate,
+    updatedAt: "2026-04-17T08:00:00.000Z" as IsoDateTime,
+  }),
+];
+
+const PAGINATION_TRANSFER_ROWS = [
+  makeTransferRow({
+    id: "tr-1" as TransferId,
+    date: "2026-04-19" as IsoDate,
+    updatedAt: "2026-04-19T09:00:00.000Z" as IsoDateTime,
+  }),
+  makeTransferRow({
+    id: "tr-2" as TransferId,
+    date: "2026-04-18" as IsoDate,
+    updatedAt: "2026-04-18T09:00:00.000Z" as IsoDateTime,
+  }),
+  makeTransferRow({
+    id: "tr-3" as TransferId,
+    date: "2026-04-16" as IsoDate,
+    updatedAt: "2026-04-16T09:00:00.000Z" as IsoDateTime,
+  }),
+];
+
+const SAME_DAY_TRANSACTION_ROWS = [
+  makeTransactionRow({
+    id: "tx-edited" as TransactionId,
+    date: "2026-04-19" as IsoDate,
+    createdAt: "2026-04-19T09:00:00.000Z" as IsoDateTime,
+    updatedAt: "2026-04-19T13:00:00.000Z" as IsoDateTime,
+  }),
+];
+
+const SAME_DAY_TRANSFER_ROWS = [
+  makeTransferRow({
+    id: "tr-midday" as TransferId,
+    date: "2026-04-19" as IsoDate,
+    updatedAt: "2026-04-19T10:00:00.000Z" as IsoDateTime,
+  }),
+];
+
+const MERGED_TRANSACTION_ROWS = [
+  makeTransactionRow({
+    id: "tx-newer" as TransactionId,
+    date: "2026-04-19" as IsoDate,
+    updatedAt: "2026-04-19T08:00:00.000Z" as IsoDateTime,
+  }),
+  makeTransactionRow({
+    id: "tx-older" as TransactionId,
+    date: "2026-04-17" as IsoDate,
+    updatedAt: "2026-04-17T08:00:00.000Z" as IsoDateTime,
+  }),
+];
+
+const MERGED_TRANSFER_ROWS = [
+  makeTransferRow({
+    id: "tr-newest" as TransferId,
+    date: "2026-04-19" as IsoDate,
+    updatedAt: "2026-04-19T09:00:00.000Z" as IsoDateTime,
+  }),
+];
+
+function createActivityServiceHarness(input: ActivityServiceHarnessInput) {
+  const getTransactionsPaginated = vi.fn().mockReturnValue(input.transactionRows);
+  const getTransfersPaginated = vi.fn().mockReturnValue(input.transferRows);
+
+  return {
+    getTransactionsPaginated,
+    getTransfersPaginated,
+    service: createActivityQueryService({
       getTransactionsPaginated,
       getTransfersPaginated,
-    });
+    }),
+  };
+}
 
-    const snapshot = service.loadPage({
-      db: {} as never,
-      userId: USER_ID,
-      pageSize: 30,
-      offset: 0,
+function loadActivitySnapshot(
+  service: ReturnType<typeof createActivityServiceHarness>["service"],
+  pageSize: number,
+  offset: number
+) {
+  return service.loadPage({
+    db: {} as never,
+    userId: USER_ID,
+    pageSize,
+    offset,
+  });
+}
+
+describe("activity query service", () => {
+  it("merges transactions and transfers into one newest-first activity page", () => {
+    const { service } = createActivityServiceHarness({
+      transactionRows: MERGED_TRANSACTION_ROWS,
+      transferRows: MERGED_TRANSFER_ROWS,
     });
+    const snapshot = loadActivitySnapshot(service, 30, 0);
 
     expect(snapshot.hasMore).toBe(false);
     expect(snapshot.offset).toBe(3);
@@ -110,89 +191,39 @@ describe("activity query service", () => {
   });
 
   it("paginates after merging instead of paging the sources independently", () => {
-    const getTransactionsPaginated = vi.fn().mockReturnValue([
-      makeTransactionRow({
-        id: "tx-1" as TransactionId,
-        date: "2026-04-19" as IsoDate,
-        updatedAt: "2026-04-19T08:00:00.000Z" as IsoDateTime,
-      }),
-      makeTransactionRow({
-        id: "tx-2" as TransactionId,
-        date: "2026-04-18" as IsoDate,
-        updatedAt: "2026-04-18T08:00:00.000Z" as IsoDateTime,
-      }),
-      makeTransactionRow({
-        id: "tx-3" as TransactionId,
-        date: "2026-04-17" as IsoDate,
-        updatedAt: "2026-04-17T08:00:00.000Z" as IsoDateTime,
-      }),
-    ]);
-    const getTransfersPaginated = vi.fn().mockReturnValue([
-      makeTransferRow({
-        id: "tr-1" as TransferId,
-        date: "2026-04-19" as IsoDate,
-        updatedAt: "2026-04-19T09:00:00.000Z" as IsoDateTime,
-      }),
-      makeTransferRow({
-        id: "tr-2" as TransferId,
-        date: "2026-04-18" as IsoDate,
-        updatedAt: "2026-04-18T09:00:00.000Z" as IsoDateTime,
-      }),
-      makeTransferRow({
-        id: "tr-3" as TransferId,
-        date: "2026-04-16" as IsoDate,
-        updatedAt: "2026-04-16T09:00:00.000Z" as IsoDateTime,
-      }),
-    ]);
-    const service = createActivityQueryService({
-      getTransactionsPaginated,
-      getTransfersPaginated,
-    });
+    const { service, getTransactionsPaginated, getTransfersPaginated } =
+      createActivityServiceHarness({
+        transactionRows: PAGINATION_TRANSACTION_ROWS,
+        transferRows: PAGINATION_TRANSFER_ROWS,
+      });
 
-    const snapshot = service.loadPage({
-      db: {} as never,
-      userId: USER_ID,
-      pageSize: 2,
-      offset: 2,
-    });
+    const snapshot = loadActivitySnapshot(service, 2, 2);
 
-    expect(snapshot.hasMore).toBe(true);
-    expect(snapshot.offset).toBe(4);
+    expect(snapshot).toEqual(
+      expect.objectContaining({
+        hasMore: true,
+        offset: 4,
+      })
+    );
     expect(snapshot.pages.map((item) => `${item.kind}:${item.id}`)).toEqual([
       "transaction:tx-2",
       "transfer:tr-2",
     ]);
-    expect(getTransactionsPaginated).toHaveBeenCalledWith(expect.anything(), USER_ID, 5, 0);
+    expect(getTransactionsPaginated).toHaveBeenCalledWith({
+      db: expect.anything(),
+      userId: USER_ID,
+      limit: 5,
+      offset: 0,
+    });
     expect(getTransfersPaginated).toHaveBeenCalledWith(expect.anything(), USER_ID, 5, 0);
   });
 
   it("orders same-day transaction activity with the transaction source sort key", () => {
-    const getTransactionsPaginated = vi.fn().mockReturnValue([
-      makeTransactionRow({
-        id: "tx-edited" as TransactionId,
-        date: "2026-04-19" as IsoDate,
-        createdAt: "2026-04-19T09:00:00.000Z" as IsoDateTime,
-        updatedAt: "2026-04-19T13:00:00.000Z" as IsoDateTime,
-      }),
-    ]);
-    const getTransfersPaginated = vi.fn().mockReturnValue([
-      makeTransferRow({
-        id: "tr-midday" as TransferId,
-        date: "2026-04-19" as IsoDate,
-        updatedAt: "2026-04-19T10:00:00.000Z" as IsoDateTime,
-      }),
-    ]);
-    const service = createActivityQueryService({
-      getTransactionsPaginated,
-      getTransfersPaginated,
+    const { service } = createActivityServiceHarness({
+      transactionRows: SAME_DAY_TRANSACTION_ROWS,
+      transferRows: SAME_DAY_TRANSFER_ROWS,
     });
-
-    const snapshot = service.loadPage({
-      db: {} as never,
-      userId: USER_ID,
-      pageSize: 30,
-      offset: 0,
-    });
+    const snapshot = loadActivitySnapshot(service, 30, 0);
 
     expect(snapshot.pages.map((item) => `${item.kind}:${item.id}`)).toEqual([
       "transfer:tr-midday",

--- a/apps/mobile/__tests__/capture-sources/dedup.test.ts
+++ b/apps/mobile/__tests__/capture-sources/dedup.test.ts
@@ -19,12 +19,21 @@ const mockDb = {
   where: mockWhere,
 } as any;
 
+const DISTINCT_FINGERPRINT_INPUTS = [
+  { source: "email", amount: 5000, date: "2026-03-07", merchant: "Uber Eats" },
+  { source: "email", amount: 9999, date: "2026-03-07", merchant: "Uber Eats" },
+  { source: "notification", amount: 5000, date: "2026-03-07", merchant: "Uber Eats" },
+  { source: "email", amount: 5000, date: "2026-03-08", merchant: "Uber Eats" },
+  { source: "email", amount: 5000, date: "2026-03-07", merchant: "Starbucks" },
+] as const;
+
 describe("captureFingerprint", () => {
   it("returns a deterministic string for the same inputs", async () => {
     const { captureFingerprint } = await import("@/features/capture-sources/lib/dedup");
 
-    const a = captureFingerprint("email", 5000, "2026-03-07", "Uber Eats");
-    const b = captureFingerprint("email", 5000, "2026-03-07", "Uber Eats");
+    const input = DISTINCT_FINGERPRINT_INPUTS[0];
+    const a = captureFingerprint(input);
+    const b = captureFingerprint(input);
 
     expect(a).toBe(b);
   });
@@ -32,20 +41,26 @@ describe("captureFingerprint", () => {
   it("produces different output for different inputs", async () => {
     const { captureFingerprint } = await import("@/features/capture-sources/lib/dedup");
 
-    const a = captureFingerprint("email", 5000, "2026-03-07", "Uber Eats");
-    const b = captureFingerprint("email", 9999, "2026-03-07", "Uber Eats");
-    const c = captureFingerprint("notification", 5000, "2026-03-07", "Uber Eats");
-    const d = captureFingerprint("email", 5000, "2026-03-08", "Uber Eats");
-    const e = captureFingerprint("email", 5000, "2026-03-07", "Starbucks");
+    const fingerprints = DISTINCT_FINGERPRINT_INPUTS.map((input) => captureFingerprint(input));
 
-    expect(new Set([a, b, c, d, e]).size).toBe(5);
+    expect(new Set(fingerprints).size).toBe(DISTINCT_FINGERPRINT_INPUTS.length);
   });
 
   it("normalizes merchant name (lowercase, trimmed, collapsed spaces)", async () => {
     const { captureFingerprint } = await import("@/features/capture-sources/lib/dedup");
 
-    const a = captureFingerprint("email", 1000, "2026-03-07", "  Uber  Eats  ");
-    const b = captureFingerprint("email", 1000, "2026-03-07", "uber eats");
+    const a = captureFingerprint({
+      source: "email",
+      amount: 1000,
+      date: "2026-03-07",
+      merchant: "  Uber  Eats  ",
+    });
+    const b = captureFingerprint({
+      source: "email",
+      amount: 1000,
+      date: "2026-03-07",
+      merchant: "uber eats",
+    });
 
     expect(a).toBe(b);
   });
@@ -93,13 +108,13 @@ describe("findDuplicateTransaction", () => {
     mockWhere.mockResolvedValueOnce([{ id: "tx-1", description: "Uber Eats" }]);
 
     const { findDuplicateTransaction } = await import("@/features/capture-sources/lib/dedup");
-    const result = await findDuplicateTransaction(
-      mockDb,
-      "user-1",
-      5000,
-      "2026-03-07",
-      "Uber Eats"
-    );
+    const result = await findDuplicateTransaction({
+      db: mockDb,
+      userId: "user-1",
+      amount: 5000,
+      date: "2026-03-07",
+      merchant: "Uber Eats",
+    });
 
     expect(result).toBe("tx-1");
   });
@@ -108,13 +123,13 @@ describe("findDuplicateTransaction", () => {
     mockWhere.mockResolvedValueOnce([]);
 
     const { findDuplicateTransaction } = await import("@/features/capture-sources/lib/dedup");
-    const result = await findDuplicateTransaction(
-      mockDb,
-      "user-1",
-      5000,
-      "2026-03-07",
-      "Uber Eats"
-    );
+    const result = await findDuplicateTransaction({
+      db: mockDb,
+      userId: "user-1",
+      amount: 5000,
+      date: "2026-03-07",
+      merchant: "Uber Eats",
+    });
 
     expect(result).toBeNull();
   });
@@ -123,13 +138,13 @@ describe("findDuplicateTransaction", () => {
     mockWhere.mockResolvedValueOnce([{ id: "tx-2", description: "  UBER   EATS  " }]);
 
     const { findDuplicateTransaction } = await import("@/features/capture-sources/lib/dedup");
-    const result = await findDuplicateTransaction(
-      mockDb,
-      "user-1",
-      5000,
-      "2026-03-07",
-      "uber eats"
-    );
+    const result = await findDuplicateTransaction({
+      db: mockDb,
+      userId: "user-1",
+      amount: 5000,
+      date: "2026-03-07",
+      merchant: "uber eats",
+    });
 
     expect(result).toBe("tx-2");
   });
@@ -138,13 +153,13 @@ describe("findDuplicateTransaction", () => {
     mockWhere.mockResolvedValueOnce([{ id: "tx-3", description: "Starbucks" }]);
 
     const { findDuplicateTransaction } = await import("@/features/capture-sources/lib/dedup");
-    const result = await findDuplicateTransaction(
-      mockDb,
-      "user-1",
-      5000,
-      "2026-03-07",
-      "Uber Eats"
-    );
+    const result = await findDuplicateTransaction({
+      db: mockDb,
+      userId: "user-1",
+      amount: 5000,
+      date: "2026-03-07",
+      merchant: "Uber Eats",
+    });
 
     expect(result).toBeNull();
   });
@@ -153,13 +168,13 @@ describe("findDuplicateTransaction", () => {
     mockWhere.mockResolvedValueOnce([{ id: "tx-sub-1", description: "BOLD Natural Medical" }]);
 
     const { findDuplicateTransaction } = await import("@/features/capture-sources/lib/dedup");
-    const result = await findDuplicateTransaction(
-      mockDb,
-      "user-1",
-      100000,
-      "2026-03-21",
-      "Natural Medical"
-    );
+    const result = await findDuplicateTransaction({
+      db: mockDb,
+      userId: "user-1",
+      amount: 100000,
+      date: "2026-03-21",
+      merchant: "Natural Medical",
+    });
 
     expect(result).toBe("tx-sub-1");
   });
@@ -168,13 +183,13 @@ describe("findDuplicateTransaction", () => {
     mockWhere.mockResolvedValueOnce([{ id: "tx-sub-2", description: "HARISSA" }]);
 
     const { findDuplicateTransaction } = await import("@/features/capture-sources/lib/dedup");
-    const result = await findDuplicateTransaction(
-      mockDb,
-      "user-1",
-      160100,
-      "2026-03-20",
-      "HARISSA HF2"
-    );
+    const result = await findDuplicateTransaction({
+      db: mockDb,
+      userId: "user-1",
+      amount: 160100,
+      date: "2026-03-20",
+      merchant: "HARISSA HF2",
+    });
 
     expect(result).toBe("tx-sub-2");
   });
@@ -183,13 +198,13 @@ describe("findDuplicateTransaction", () => {
     mockWhere.mockResolvedValueOnce([{ id: "tx-short", description: "AB" }]);
 
     const { findDuplicateTransaction } = await import("@/features/capture-sources/lib/dedup");
-    const result = await findDuplicateTransaction(
-      mockDb,
-      "user-1",
-      5000,
-      "2026-03-07",
-      "ABC Store"
-    );
+    const result = await findDuplicateTransaction({
+      db: mockDb,
+      userId: "user-1",
+      amount: 5000,
+      date: "2026-03-07",
+      merchant: "ABC Store",
+    });
 
     expect(result).toBeNull();
   });
@@ -198,13 +213,13 @@ describe("findDuplicateTransaction", () => {
     mockWhere.mockResolvedValueOnce([{ id: "tx-null", description: null }]);
 
     const { findDuplicateTransaction } = await import("@/features/capture-sources/lib/dedup");
-    const result = await findDuplicateTransaction(
-      mockDb,
-      "user-1",
-      5000,
-      "2026-03-07",
-      "Uber Eats"
-    );
+    const result = await findDuplicateTransaction({
+      db: mockDb,
+      userId: "user-1",
+      amount: 5000,
+      date: "2026-03-07",
+      merchant: "Uber Eats",
+    });
 
     expect(result).toBeNull();
   });

--- a/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
@@ -664,11 +664,13 @@ describe("processRetries", () => {
     await processRetries(mockDb, USER_ID);
 
     expect(mockMarkRetrySuccess).toHaveBeenCalledWith(
-      mockDb,
-      "pe-retry-1",
-      "success",
-      expect.stringMatching(/^tx-/),
-      0.9
+      expect.objectContaining({
+        db: mockDb,
+        id: "pe-retry-1",
+        status: "success",
+        transactionId: expect.stringMatching(/^tx-/),
+        confidence: 0.9,
+      })
     );
   });
 
@@ -687,11 +689,13 @@ describe("processRetries", () => {
     await processRetries(mockDb, USER_ID);
 
     expect(mockMarkRetrySuccess).toHaveBeenCalledWith(
-      mockDb,
-      "pe-retry-1",
-      "needs_review",
-      expect.stringMatching(/^tx-/),
-      0.5
+      expect.objectContaining({
+        db: mockDb,
+        id: "pe-retry-1",
+        status: "needs_review",
+        transactionId: expect.stringMatching(/^tx-/),
+        confidence: 0.5,
+      })
     );
   });
 
@@ -702,7 +706,14 @@ describe("processRetries", () => {
 
     const result = await processRetries(mockDb, USER_ID);
 
-    expect(mockMarkForRetry).toHaveBeenCalledWith(mockDb, "pe-retry-1", 3, expect.any(String));
+    expect(mockMarkForRetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        db: mockDb,
+        id: "pe-retry-1",
+        retryCount: 3,
+        nextRetryAt: expect.any(String),
+      })
+    );
     expect(result.retried).toBe(1);
     expect(result.succeeded).toBe(0);
   });
@@ -721,7 +732,14 @@ describe("processRetries", () => {
 
     const result = await processRetries(mockDb, USER_ID);
 
-    expect(mockMarkForRetry).toHaveBeenCalledWith(mockDb, "pe-retry-1", 2, expect.any(String));
+    expect(mockMarkForRetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        db: mockDb,
+        id: "pe-retry-1",
+        retryCount: 2,
+        nextRetryAt: expect.any(String),
+      })
+    );
     expect(result.retried).toBe(1);
     expect(result.succeeded).toBe(0);
   });
@@ -745,10 +763,12 @@ describe("processRetries", () => {
     await processRetries(mockDb, USER_ID);
 
     expect(mockUpdateProcessedEmailStatus).toHaveBeenCalledWith(
-      mockDb,
-      "pe-retry-1",
-      "skipped",
-      null
+      expect.objectContaining({
+        db: mockDb,
+        id: "pe-retry-1",
+        status: "skipped",
+        transactionId: null,
+      })
     );
   });
 
@@ -769,11 +789,13 @@ describe("processRetries", () => {
 
     expect(mockInsertTransaction).not.toHaveBeenCalled();
     expect(mockMarkRetrySuccess).toHaveBeenCalledWith(
-      mockDb,
-      "pe-retry-1",
-      "success",
-      "tx-existing",
-      0.9
+      expect.objectContaining({
+        db: mockDb,
+        id: "pe-retry-1",
+        status: "success",
+        transactionId: "tx-existing",
+        confidence: 0.9,
+      })
     );
     expect(result.succeeded).toBe(1);
   });
@@ -806,7 +828,14 @@ describe("processRetries", () => {
 
     const result = await processRetries(mockDb, USER_ID);
 
-    expect(mockMarkForRetry).toHaveBeenCalledWith(mockDb, "pe-retry-1", 2, expect.any(String));
+    expect(mockMarkForRetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        db: mockDb,
+        id: "pe-retry-1",
+        retryCount: 2,
+        nextRetryAt: expect.any(String),
+      })
+    );
     expect(result.retried).toBe(1);
     expect(result.succeeded).toBe(0);
   });

--- a/apps/mobile/__tests__/email-capture/repository.test.ts
+++ b/apps/mobile/__tests__/email-capture/repository.test.ts
@@ -254,12 +254,12 @@ describe("email capture repository", () => {
   it("updateProcessedEmailStatus updates status and transactionId", async () => {
     const { updateProcessedEmailStatus } = await import("@/features/email-capture/lib/repository");
 
-    await updateProcessedEmailStatus(
-      mockDb,
-      "pe-1" as ProcessedEmailId,
-      "success",
-      "tx-1" as TransactionId
-    );
+    await updateProcessedEmailStatus({
+      db: mockDb,
+      id: "pe-1" as ProcessedEmailId,
+      status: "success",
+      transactionId: "tx-1" as TransactionId,
+    });
 
     expect(mockUpdate).toHaveBeenCalled();
     expect(mockSet).toHaveBeenCalledWith({ status: "success", transactionId: "tx-1" });
@@ -284,12 +284,12 @@ describe("email capture repository", () => {
   it("markForRetry updates status, retryCount, nextRetryAt, rawBody", async () => {
     const { markForRetry } = await import("@/features/email-capture/lib/repository");
 
-    await markForRetry(
-      mockDb,
-      "pe-1" as ProcessedEmailId,
-      2,
-      "2026-03-15T13:00:00Z" as IsoDateTime
-    );
+    await markForRetry({
+      db: mockDb,
+      id: "pe-1" as ProcessedEmailId,
+      retryCount: 2,
+      nextRetryAt: "2026-03-15T13:00:00Z" as IsoDateTime,
+    });
 
     expect(mockUpdate).toHaveBeenCalled();
     expect(mockSet).toHaveBeenCalledWith({
@@ -316,13 +316,13 @@ describe("email capture repository", () => {
   it("markRetrySuccess sets status, transactionId, confidence, clears rawBody", async () => {
     const { markRetrySuccess } = await import("@/features/email-capture/lib/repository");
 
-    await markRetrySuccess(
-      mockDb,
-      "pe-1" as ProcessedEmailId,
-      "success",
-      "tx-5" as TransactionId,
-      0.95
-    );
+    await markRetrySuccess({
+      db: mockDb,
+      id: "pe-1" as ProcessedEmailId,
+      status: "success",
+      transactionId: "tx-5" as TransactionId,
+      confidence: 0.95,
+    });
 
     expect(mockUpdate).toHaveBeenCalled();
     expect(mockSet).toHaveBeenCalledWith({

--- a/apps/mobile/__tests__/email-capture/retry-integration.test.ts
+++ b/apps/mobile/__tests__/email-capture/retry-integration.test.ts
@@ -81,6 +81,75 @@ function insertRetryEmail(overrides: Partial<typeof processedEmails.$inferInsert
   return row;
 }
 
+function queueDueRetryEmail(overrides: Partial<typeof processedEmails.$inferInsert> = {}) {
+  const dueAt = new Date(Date.now() - 60_000).toISOString() as IsoDateTime;
+  return insertRetryEmail({ nextRetryAt: dueAt, ...overrides });
+}
+
+function mockSuccessfulRetryParse() {
+  mockParseEmailApi.mockResolvedValueOnce({
+    type: "expense",
+    amount: 50000,
+    categoryId: "other",
+    description: "Compra en Exito",
+    date: "2026-03-05",
+    confidence: 0.9,
+  });
+}
+
+async function getRetryEmail() {
+  const [row] = await db
+    .select()
+    .from(processedEmails)
+    .where(eq(processedEmails.id, "pe-retry-1" as ProcessedEmailId));
+  return row ?? null;
+}
+
+async function getInsertedTransactions() {
+  return db.select().from(transactions);
+}
+
+async function getSyncQueueEntries() {
+  return db.select().from(syncQueue);
+}
+
+function expectRetryResult(
+  result: Awaited<ReturnType<typeof processRetries>>,
+  expected: Pick<
+    Awaited<ReturnType<typeof processRetries>>,
+    "retried" | "succeeded" | "permanentlyFailed"
+  >
+) {
+  expect(result).toEqual(expect.objectContaining(expected));
+}
+
+async function expectSuccessfulRetryArtifacts() {
+  const [txRow] = await getInsertedTransactions();
+  expect(txRow).toEqual(
+    expect.objectContaining({
+      amount: 50000,
+      source: "email_gmail",
+      accountId: `fa-default-${USER_ID}`,
+      accountAttributionState: "unresolved",
+    })
+  );
+
+  expect(await getSyncQueueEntries()).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ tableName: "financialAccounts" }),
+      expect.objectContaining({ tableName: "transactions" }),
+    ])
+  );
+
+  expect(await getRetryEmail()).toEqual(
+    expect.objectContaining({
+      status: "success",
+      rawBody: null,
+      transactionId: txRow?.id,
+    })
+  );
+}
+
 describe("retry queue integration (real SQLite)", () => {
   it("migration adds rawBody, retryCount, nextRetryAt columns", () => {
     const columns = sqlite.pragma("table_info(processed_emails)") as {
@@ -132,7 +201,12 @@ describe("retry queue integration (real SQLite)", () => {
     insertRetryEmail({ nextRetryAt: pastTime, retryCount: 1 });
 
     const futureTime = new Date(Date.now() + 300_000).toISOString() as IsoDateTime;
-    await markForRetry(db as any, "pe-retry-1" as ProcessedEmailId, 2, futureTime);
+    await markForRetry({
+      db: db as any,
+      id: "pe-retry-1" as ProcessedEmailId,
+      retryCount: 2,
+      nextRetryAt: futureTime,
+    });
 
     const [row] = await db
       .select()
@@ -160,13 +234,13 @@ describe("retry queue integration (real SQLite)", () => {
   it("markRetrySuccess sets status/transactionId/confidence and clears rawBody", async () => {
     insertRetryEmail({ nextRetryAt: new Date().toISOString() as IsoDateTime });
 
-    await markRetrySuccess(
-      db as any,
-      "pe-retry-1" as ProcessedEmailId,
-      "success",
-      "tx-42" as TransactionId,
-      0.95
-    );
+    await markRetrySuccess({
+      db: db as any,
+      id: "pe-retry-1" as ProcessedEmailId,
+      status: "success",
+      transactionId: "tx-42" as TransactionId,
+      confidence: 0.95,
+    });
 
     const [row] = await db
       .select()
@@ -179,52 +253,14 @@ describe("retry queue integration (real SQLite)", () => {
   });
 
   it("full flow: pending_retry email → successful retry → transaction created", async () => {
-    const pastTime = new Date(Date.now() - 60_000).toISOString() as IsoDateTime;
-    insertRetryEmail({ nextRetryAt: pastTime });
-
-    mockParseEmailApi.mockResolvedValueOnce({
-      type: "expense",
-      amount: 50000,
-      categoryId: "other",
-      description: "Compra en Exito",
-      date: "2026-03-05",
-      confidence: 0.9,
-    });
+    queueDueRetryEmail();
+    mockSuccessfulRetryParse();
 
     const result = await processRetries(db as any, USER_ID);
 
-    expect(result.succeeded).toBe(1);
-    expect(result.retried).toBe(0);
-    expect(result.permanentlyFailed).toBe(0);
-
-    // Verify parseEmailApi was called with the cached rawBody
+    expectRetryResult(result, { succeeded: 1, retried: 0, permanentlyFailed: 0 });
     expect(mockParseEmailApi).toHaveBeenCalledWith("Su compra por $50.000 fue aprobada en EXITO");
-
-    // Verify transaction was created in DB
-    const txRows = await db.select().from(transactions);
-    expect(txRows).toHaveLength(1);
-    expect(txRows[0]?.amount).toBe(50000);
-    expect(txRows[0]?.source).toBe("email_gmail");
-    expect(txRows[0]?.accountId).toBe(`fa-default-${USER_ID}`);
-    expect(txRows[0]?.accountAttributionState).toBe("unresolved");
-
-    // Verify sync queue entry
-    const syncRows = await db.select().from(syncQueue);
-    expect(syncRows).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ tableName: "financialAccounts" }),
-        expect.objectContaining({ tableName: "transactions" }),
-      ])
-    );
-
-    // Verify processed email was updated
-    const [pe] = await db
-      .select()
-      .from(processedEmails)
-      .where(eq(processedEmails.id, "pe-retry-1" as ProcessedEmailId));
-    expect(pe?.status).toBe("success");
-    expect(pe?.rawBody).toBeNull();
-    expect(pe?.transactionId).toBe(txRows[0]?.id);
+    await expectSuccessfulRetryArtifacts();
   });
 
   it("full flow: pending_retry email → parse fails again → rescheduled with backoff", async () => {

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -862,7 +862,12 @@ describe("email capture boundary", () => {
 
       await confirmReviewedEmail(mockDb, mockUserId as UserId, "pe-1", "food", mockRefresh);
 
-      expect(updateProcessedEmailStatus).toHaveBeenCalledWith(mockDb, "pe-1", "success", "tx-1");
+      expect(updateProcessedEmailStatus).toHaveBeenCalledWith({
+        db: mockDb,
+        id: "pe-1",
+        status: "success",
+        transactionId: "tx-1",
+      });
       expect(useEmailCaptureStore.getState().needsReviewEmails).toHaveLength(0);
       // Verify merchant rule was saved
       expect(insertMerchantRule).toHaveBeenCalledWith(

--- a/apps/mobile/__tests__/transactions/group-by-date.test.ts
+++ b/apps/mobile/__tests__/transactions/group-by-date.test.ts
@@ -28,7 +28,7 @@ function makeTx(overrides: Partial<StoredTransaction> & { date: Date }): StoredT
 describe("buildListData", () => {
   it("returns empty items and stickyIndices for empty input", async () => {
     const { buildListData } = await import("@/features/transactions/lib/group-by-date");
-    const result = buildListData([]);
+    const result = buildListData({ transactions: [] });
 
     expect(result.items).toEqual([]);
     expect(result.stickyIndices).toEqual([]);
@@ -37,7 +37,7 @@ describe("buildListData", () => {
   it("returns one date header and one transaction for a single item", async () => {
     const { buildListData } = await import("@/features/transactions/lib/group-by-date");
     const tx = makeTx({ date: new Date(2026, 2, 10) }); // March 10, 2026
-    const result = buildListData([tx]);
+    const result = buildListData({ transactions: [tx] });
 
     expect(result.items).toHaveLength(2);
     expect(result.items[0]).toMatchObject({ kind: "date-header" });
@@ -49,7 +49,7 @@ describe("buildListData", () => {
     const { buildListData } = await import("@/features/transactions/lib/group-by-date");
     const tx1 = makeTx({ id: "tx-1" as TransactionId, date: new Date(2026, 2, 10) });
     const tx2 = makeTx({ id: "tx-2" as TransactionId, date: new Date(2026, 2, 10) });
-    const result = buildListData([tx1, tx2]);
+    const result = buildListData({ transactions: [tx1, tx2] });
 
     expect(result.items).toHaveLength(3); // 1 header + 2 transactions
     expect(result.items[0]).toMatchObject({ kind: "date-header" });
@@ -62,7 +62,7 @@ describe("buildListData", () => {
     const { buildListData } = await import("@/features/transactions/lib/group-by-date");
     const tx1 = makeTx({ id: "tx-1" as TransactionId, date: new Date(2026, 2, 14) });
     const tx2 = makeTx({ id: "tx-2" as TransactionId, date: new Date(2026, 2, 13) });
-    const result = buildListData([tx1, tx2]);
+    const result = buildListData({ transactions: [tx1, tx2] });
 
     // header1, tx1, header2, tx2
     expect(result.items).toHaveLength(4);
@@ -76,7 +76,7 @@ describe("buildListData", () => {
   it("labels today's date as 'Today'", async () => {
     const { buildListData } = await import("@/features/transactions/lib/group-by-date");
     const tx = makeTx({ date: new Date() });
-    const result = buildListData([tx]);
+    const result = buildListData({ transactions: [tx] });
 
     expect(result.items[0]).toMatchObject({
       kind: "date-header",
@@ -89,7 +89,7 @@ describe("buildListData", () => {
     const yesterday = new Date();
     yesterday.setDate(yesterday.getDate() - 1);
     const tx = makeTx({ date: yesterday });
-    const result = buildListData([tx]);
+    const result = buildListData({ transactions: [tx] });
 
     expect(result.items[0]).toMatchObject({
       kind: "date-header",
@@ -100,7 +100,7 @@ describe("buildListData", () => {
   it("formats older dates as 'Month day'", async () => {
     const { buildListData } = await import("@/features/transactions/lib/group-by-date");
     const tx = makeTx({ date: new Date(2026, 0, 15) }); // Jan 15, 2026
-    const result = buildListData([tx]);
+    const result = buildListData({ transactions: [tx] });
 
     expect(result.items[0]).toMatchObject({
       kind: "date-header",
@@ -114,7 +114,7 @@ describe("buildListData", () => {
     const tx2 = makeTx({ id: "tx-2" as TransactionId, date: new Date(2026, 2, 14) });
     const tx3 = makeTx({ id: "tx-3" as TransactionId, date: new Date(2026, 2, 13) });
     const tx4 = makeTx({ id: "tx-4" as TransactionId, date: new Date(2026, 2, 12) });
-    const result = buildListData([tx1, tx2, tx3, tx4]);
+    const result = buildListData({ transactions: [tx1, tx2, tx3, tx4] });
 
     // [header@0, tx1, tx2, header@3, tx3, header@5, tx4]
     expect(result.stickyIndices).toEqual([0, 3, 5]);
@@ -127,7 +127,7 @@ describe("buildListData", () => {
     const input = [tx1, tx2];
     const inputCopy = [...input];
 
-    buildListData(input);
+    buildListData({ transactions: input });
 
     expect(input).toEqual(inputCopy);
   });

--- a/apps/mobile/__tests__/transactions/query-service.test.ts
+++ b/apps/mobile/__tests__/transactions/query-service.test.ts
@@ -121,7 +121,12 @@ describe("transaction query service", () => {
     expect(snapshot.sameData).toBe(true);
     expect(snapshot.offset).toBe(1);
     expect(snapshot.hasMore).toBe(false);
-    expect(getTransactionsPaginated).toHaveBeenCalledWith(expect.anything(), mockUserId, 30, 0);
+    expect(getTransactionsPaginated).toHaveBeenCalledWith({
+      db: expect.anything(),
+      userId: mockUserId,
+      limit: 30,
+      offset: 0,
+    });
   });
 
   it("uses an inclusive 30-day daily-spending window", () => {
@@ -138,12 +143,12 @@ describe("transaction query service", () => {
       userId: mockUserId,
     });
 
-    expect(getDailySpendingAggregate).toHaveBeenCalledWith(
-      expect.anything(),
-      mockUserId,
-      "2026-03-14",
-      "2026-04-12"
-    );
+    expect(getDailySpendingAggregate).toHaveBeenCalledWith({
+      db: expect.anything(),
+      userId: mockUserId,
+      startDate: "2026-03-14",
+      endDate: "2026-04-12",
+    });
   });
 
   it("returns null for deleted or cross-user transaction lookups", () => {

--- a/apps/mobile/__tests__/transactions/repository-pagination.test.ts
+++ b/apps/mobile/__tests__/transactions/repository-pagination.test.ts
@@ -50,28 +50,48 @@ describe("getTransactionsPaginated", () => {
     mockAll.mockReturnValueOnce(mockRows);
 
     const { getTransactionsPaginated } = await import("@/features/transactions/lib/repository");
-    const result = getTransactionsPaginated(mockDb, "user-1" as UserId, 30, 0);
+    const result = getTransactionsPaginated({
+      db: mockDb,
+      userId: "user-1" as UserId,
+      limit: 30,
+      offset: 0,
+    });
 
     expect(result).toEqual(mockRows);
   });
 
   it("calls limit with limit+1 for hasMore detection", async () => {
     const { getTransactionsPaginated } = await import("@/features/transactions/lib/repository");
-    getTransactionsPaginated(mockDb, "user-1" as UserId, 30, 0);
+    getTransactionsPaginated({
+      db: mockDb,
+      userId: "user-1" as UserId,
+      limit: 30,
+      offset: 0,
+    });
 
     expect(mockLimit).toHaveBeenCalledWith(31);
   });
 
   it("calls offset with the given offset value", async () => {
     const { getTransactionsPaginated } = await import("@/features/transactions/lib/repository");
-    getTransactionsPaginated(mockDb, "user-1" as UserId, 30, 60);
+    getTransactionsPaginated({
+      db: mockDb,
+      userId: "user-1" as UserId,
+      limit: 30,
+      offset: 60,
+    });
 
     expect(mockOffset).toHaveBeenCalledWith(60);
   });
 
   it("queries the correct table with select and from", async () => {
     const { getTransactionsPaginated } = await import("@/features/transactions/lib/repository");
-    getTransactionsPaginated(mockDb, "user-1" as UserId, 30, 0);
+    getTransactionsPaginated({
+      db: mockDb,
+      userId: "user-1" as UserId,
+      limit: 30,
+      offset: 0,
+    });
 
     expect(mockSelect).toHaveBeenCalled();
     expect(mockFrom).toHaveBeenCalled();
@@ -83,7 +103,12 @@ describe("getTransactionsPaginated", () => {
     mockAll.mockReturnValueOnce([]);
 
     const { getTransactionsPaginated } = await import("@/features/transactions/lib/repository");
-    const result = getTransactionsPaginated(mockDb, "user-1" as UserId, 30, 0);
+    const result = getTransactionsPaginated({
+      db: mockDb,
+      userId: "user-1" as UserId,
+      limit: 30,
+      offset: 0,
+    });
 
     expect(result).toEqual([]);
   });
@@ -193,12 +218,12 @@ describe("getDailySpendingAggregate", () => {
     mockAll.mockReturnValueOnce(mockResult);
 
     const { getDailySpendingAggregate } = await import("@/features/transactions/lib/repository");
-    const result = getDailySpendingAggregate(
-      mockDb,
-      "user-1" as UserId,
-      "2026-02-12" as IsoDate,
-      "2026-03-14" as IsoDate
-    );
+    const result = getDailySpendingAggregate({
+      db: mockDb,
+      userId: "user-1" as UserId,
+      startDate: "2026-02-12" as IsoDate,
+      endDate: "2026-03-14" as IsoDate,
+    });
 
     expect(result).toEqual(mockResult);
   });
@@ -207,12 +232,12 @@ describe("getDailySpendingAggregate", () => {
     mockAll.mockReturnValueOnce([]);
 
     const { getDailySpendingAggregate } = await import("@/features/transactions/lib/repository");
-    const result = getDailySpendingAggregate(
-      mockDb,
-      "user-1" as UserId,
-      "2026-02-12" as IsoDate,
-      "2026-03-14" as IsoDate
-    );
+    const result = getDailySpendingAggregate({
+      db: mockDb,
+      userId: "user-1" as UserId,
+      startDate: "2026-02-12" as IsoDate,
+      endDate: "2026-03-14" as IsoDate,
+    });
 
     expect(result).toEqual([]);
   });
@@ -247,12 +272,12 @@ describe("getRecentTransactions", () => {
     mockAll.mockReturnValueOnce(mockRows);
 
     const { getRecentTransactions } = await import("@/features/transactions/lib/repository");
-    const result = getRecentTransactions(
-      mockDb,
-      "user-1" as UserId,
-      "2026-03" as Month,
-      "2026-02" as Month
-    );
+    const result = getRecentTransactions({
+      db: mockDb,
+      userId: "user-1" as UserId,
+      currentMonth: "2026-03" as Month,
+      previousMonth: "2026-02" as Month,
+    });
 
     expect(result).toEqual(mockRows);
   });
@@ -261,19 +286,24 @@ describe("getRecentTransactions", () => {
     mockAll.mockReturnValueOnce([]);
 
     const { getRecentTransactions } = await import("@/features/transactions/lib/repository");
-    const result = getRecentTransactions(
-      mockDb,
-      "user-1" as UserId,
-      "2026-03" as Month,
-      "2026-02" as Month
-    );
+    const result = getRecentTransactions({
+      db: mockDb,
+      userId: "user-1" as UserId,
+      currentMonth: "2026-03" as Month,
+      previousMonth: "2026-02" as Month,
+    });
 
     expect(result).toEqual([]);
   });
 
   it("calls where and orderBy for filtering and sorting", async () => {
     const { getRecentTransactions } = await import("@/features/transactions/lib/repository");
-    getRecentTransactions(mockDb, "user-1" as UserId, "2026-03" as Month, "2026-02" as Month);
+    getRecentTransactions({
+      db: mockDb,
+      userId: "user-1" as UserId,
+      currentMonth: "2026-03" as Month,
+      previousMonth: "2026-02" as Month,
+    });
 
     expect(mockSelect).toHaveBeenCalled();
     expect(mockFrom).toHaveBeenCalled();

--- a/apps/mobile/app/edit-transaction.tsx
+++ b/apps/mobile/app/edit-transaction.tsx
@@ -93,13 +93,18 @@ export default function EditTransactionScreen() {
       router.back();
       await afterDismiss();
       try {
-        const result = await updateTransactionDirect(db, userId, transactionId, {
-          type,
-          digits,
-          categoryId,
-          accountId,
-          description,
-          date,
+        const result = await updateTransactionDirect({
+          db,
+          userId,
+          id: transactionId,
+          fields: {
+            type,
+            digits,
+            categoryId,
+            accountId,
+            description,
+            date,
+          },
         });
         if (!result.success) {
           showErrorToast(t("transactions.updateFailed"));

--- a/apps/mobile/features/account-suggestions/lib/dismissals-repository.ts
+++ b/apps/mobile/features/account-suggestions/lib/dismissals-repository.ts
@@ -3,6 +3,12 @@ import { type AnyDb, accountSuggestionDismissals, enqueueSync, syncQueue } from 
 import { generateSyncQueueId } from "@/shared/lib";
 
 export type AccountSuggestionDismissalRow = typeof accountSuggestionDismissals.$inferInsert;
+type ActiveDismissalLookupInput = {
+  readonly db: AnyDb;
+  readonly userId: AccountSuggestionDismissalRow["userId"];
+  readonly scope: AccountSuggestionDismissalRow["scope"];
+  readonly value: AccountSuggestionDismissalRow["value"];
+};
 
 export function getAccountSuggestionDismissalById(
   db: AnyDb,
@@ -32,20 +38,15 @@ export function getAccountSuggestionDismissalsForUser(
     .all();
 }
 
-export function getActiveAccountSuggestionDismissal(
-  db: AnyDb,
-  userId: AccountSuggestionDismissalRow["userId"],
-  scope: AccountSuggestionDismissalRow["scope"],
-  value: AccountSuggestionDismissalRow["value"]
-) {
-  const rows = db
+export function getActiveAccountSuggestionDismissal(input: ActiveDismissalLookupInput) {
+  const rows = input.db
     .select()
     .from(accountSuggestionDismissals)
     .where(
       and(
-        eq(accountSuggestionDismissals.userId, userId),
-        eq(accountSuggestionDismissals.scope, scope),
-        eq(accountSuggestionDismissals.value, value),
+        eq(accountSuggestionDismissals.userId, input.userId),
+        eq(accountSuggestionDismissals.scope, input.scope),
+        eq(accountSuggestionDismissals.value, input.value),
         isNull(accountSuggestionDismissals.deletedAt)
       )
     )
@@ -82,61 +83,75 @@ function persistAccountSuggestionDismissal(db: AnyDb, row: AccountSuggestionDism
     .run();
 }
 
-export function upsertAccountSuggestionDismissal(db: AnyDb, row: AccountSuggestionDismissalRow) {
-  db.transaction((tx) => {
-    const existingById = getAccountSuggestionDismissalById(tx, row.id);
-    const activeDuplicate =
-      row.deletedAt == null
-        ? getActiveAccountSuggestionDismissal(tx, row.userId, row.scope, row.value)
-        : null;
-    const duplicate = activeDuplicate?.id !== row.id ? activeDuplicate : null;
+function getActiveDuplicateDismissal(db: AnyDb, row: AccountSuggestionDismissalRow) {
+  const activeDuplicate =
+    row.deletedAt == null
+      ? getActiveAccountSuggestionDismissal({
+          db,
+          userId: row.userId,
+          scope: row.scope,
+          value: row.value,
+        })
+      : null;
 
-    if (existingById && existingById.updatedAt >= row.updatedAt) {
-      return;
-    }
+  return activeDuplicate?.id !== row.id ? activeDuplicate : null;
+}
 
-    if (duplicate && duplicate.updatedAt >= row.updatedAt) {
-      return;
-    }
+function shouldSkipDismissalPersist(
+  existingById: AccountSuggestionDismissalRow | null,
+  duplicate: AccountSuggestionDismissalRow | null,
+  row: AccountSuggestionDismissalRow
+) {
+  return (
+    (existingById != null && existingById.updatedAt >= row.updatedAt) ||
+    (duplicate != null && duplicate.updatedAt >= row.updatedAt)
+  );
+}
 
-    if (duplicate) {
-      deleteDismissalDuplicate(tx, duplicate.id);
-    }
+function upsertDismissalInTransaction(db: AnyDb, row: AccountSuggestionDismissalRow) {
+  const existingById = getAccountSuggestionDismissalById(db, row.id);
+  const duplicate = getActiveDuplicateDismissal(db, row);
+  if (shouldSkipDismissalPersist(existingById, duplicate, row)) {
+    return;
+  }
 
-    persistAccountSuggestionDismissal(tx, row);
+  if (duplicate) {
+    deleteDismissalDuplicate(db, duplicate.id);
+  }
+
+  persistAccountSuggestionDismissal(db, row);
+}
+
+function saveDismissalInTransaction(db: AnyDb, row: AccountSuggestionDismissalRow) {
+  const existingById = getAccountSuggestionDismissalById(db, row.id);
+  const duplicate = getActiveDuplicateDismissal(db, row);
+  if (existingById && duplicate) {
+    deleteDismissalDuplicate(db, duplicate.id);
+  }
+
+  const persistedRow =
+    existingById == null && duplicate
+      ? {
+          ...row,
+          id: duplicate.id,
+          createdAt: duplicate.createdAt,
+        }
+      : row;
+  persistAccountSuggestionDismissal(db, persistedRow);
+
+  enqueueSync(db, {
+    id: generateSyncQueueId(),
+    tableName: "accountSuggestionDismissals",
+    rowId: persistedRow.id,
+    operation: existingById || duplicate ? "update" : "insert",
+    createdAt: row.updatedAt,
   });
 }
 
+export function upsertAccountSuggestionDismissal(db: AnyDb, row: AccountSuggestionDismissalRow) {
+  db.transaction((tx) => upsertDismissalInTransaction(tx, row));
+}
+
 export function saveAccountSuggestionDismissal(db: AnyDb, row: AccountSuggestionDismissalRow) {
-  db.transaction((tx) => {
-    const existingById = getAccountSuggestionDismissalById(tx, row.id);
-    const activeDuplicate =
-      row.deletedAt == null
-        ? getActiveAccountSuggestionDismissal(tx, row.userId, row.scope, row.value)
-        : null;
-    const duplicate = activeDuplicate?.id !== row.id ? activeDuplicate : null;
-
-    if (existingById && duplicate) {
-      deleteDismissalDuplicate(tx, duplicate.id);
-    }
-
-    const persistedRow =
-      existingById == null && duplicate
-        ? {
-            ...row,
-            id: duplicate.id,
-            createdAt: duplicate.createdAt,
-          }
-        : row;
-
-    persistAccountSuggestionDismissal(tx, persistedRow);
-
-    enqueueSync(tx, {
-      id: generateSyncQueueId(),
-      tableName: "accountSuggestionDismissals",
-      rowId: persistedRow.id,
-      operation: existingById || duplicate ? "update" : "insert",
-      createdAt: row.updatedAt,
-    });
-  });
+  db.transaction((tx) => saveDismissalInTransaction(tx, row));
 }

--- a/apps/mobile/features/account-suggestions/lib/presentation.ts
+++ b/apps/mobile/features/account-suggestions/lib/presentation.ts
@@ -16,6 +16,14 @@ type RankedSuggestedFinancialAccount = {
 };
 
 const WALLET_SOURCE_FAMILIES = new Set(["nequi", "daviplata", "wallet"]);
+const DIRECT_KIND_BY_EVIDENCE_TYPE = new Map<
+  AccountCreationSuggestion["evidenceType"],
+  FinancialAccountKind
+>([["card_hint", "credit_card"]]);
+const CONFIDENCE_LABEL_BY_EVIDENCE_TYPE = new Map<
+  AccountCreationSuggestion["evidenceType"],
+  SuggestedFinancialAccountDraft["confidenceLabel"]
+>([["last4", "HIGH"]]);
 
 function toTitleCaseSegment(segment: string) {
   return segment.length === 0 ? segment : `${segment[0]?.toUpperCase()}${segment.slice(1)}`;
@@ -37,16 +45,21 @@ function buildEvidenceLabel(suggestion: AccountCreationSuggestion) {
   return suggestion.evidenceType === "last4" ? `••${suggestion.value}` : suggestion.value;
 }
 
-function inferKind(suggestion: AccountCreationSuggestion): FinancialAccountKind {
-  if (suggestion.evidenceType === "card_hint") {
-    return "credit_card";
-  }
-
-  if (
+function isWalletAliasSuggestion(suggestion: AccountCreationSuggestion) {
+  return (
     suggestion.evidenceType === "alias_token" &&
     (WALLET_SOURCE_FAMILIES.has(suggestion.sourceFamily) ||
       normalizeSearchText(suggestion.value).includes("wallet"))
-  ) {
+  );
+}
+
+function inferKind(suggestion: AccountCreationSuggestion): FinancialAccountKind {
+  const directKind = DIRECT_KIND_BY_EVIDENCE_TYPE.get(suggestion.evidenceType);
+  if (directKind) {
+    return directKind;
+  }
+
+  if (isWalletAliasSuggestion(suggestion)) {
     return "wallet";
   }
 
@@ -69,8 +82,20 @@ function buildSuggestedName(
   return `${sourceLabel} ${evidenceLabel}`;
 }
 
-function toConfidenceLabel(suggestion: AccountCreationSuggestion): "HIGH" | "MED" {
-  return suggestion.evidenceType === "last4" ? "HIGH" : "MED";
+function getKindScore(account: FinancialAccountRow, draft: SuggestedFinancialAccountDraft) {
+  return account.kind === draft.kind ? 4 : 0;
+}
+
+function getSourceScore(normalizedName: string, normalizedSource: string) {
+  return normalizedName.includes(normalizedSource) ? 2 : 0;
+}
+
+function getEvidenceScore(normalizedName: string, normalizedEvidence: string) {
+  return normalizedEvidence.length > 0 && normalizedName.includes(normalizedEvidence) ? 1 : 0;
+}
+
+function getDefaultPenalty(account: FinancialAccountRow) {
+  return account.isDefault ? -1 : 0;
 }
 
 function scoreSuggestedFinancialAccount(
@@ -80,13 +105,13 @@ function scoreSuggestedFinancialAccount(
   const normalizedName = normalizeSearchText(account.name);
   const normalizedSource = normalizeSearchText(draft.sourceLabel);
   const normalizedEvidence = normalizeSearchText(draft.evidenceLabel.replaceAll("•", ""));
-  const kindScore = account.kind === draft.kind ? 4 : 0;
-  const sourceScore = normalizedName.includes(normalizedSource) ? 2 : 0;
-  const evidenceScore =
-    normalizedEvidence.length > 0 && normalizedName.includes(normalizedEvidence) ? 1 : 0;
-  const defaultPenalty = account.isDefault ? -1 : 0;
 
-  return kindScore + sourceScore + evidenceScore + defaultPenalty;
+  return [
+    getKindScore(account, draft),
+    getSourceScore(normalizedName, normalizedSource),
+    getEvidenceScore(normalizedName, normalizedEvidence),
+    getDefaultPenalty(account),
+  ].reduce((total, score) => total + score, 0);
 }
 
 export function buildSuggestedFinancialAccountDraft(
@@ -101,7 +126,7 @@ export function buildSuggestedFinancialAccountDraft(
     name: buildSuggestedName(sourceLabel, evidenceLabel, kind),
     sourceLabel,
     evidenceLabel,
-    confidenceLabel: toConfidenceLabel(suggestion),
+    confidenceLabel: CONFIDENCE_LABEL_BY_EVIDENCE_TYPE.get(suggestion.evidenceType) ?? "MED",
     occurrences: suggestion.occurrences,
   };
 }

--- a/apps/mobile/features/account-suggestions/services/create-account-suggestion-service.ts
+++ b/apps/mobile/features/account-suggestions/services/create-account-suggestion-service.ts
@@ -210,23 +210,19 @@ export function createAccountSuggestionService({
   }
 
   return {
-    listSuggestions({
-      db,
-      userId,
-      limit,
-      minimumOccurrences = 2,
-    }: ListSuggestionsInput): readonly AccountCreationSuggestion[] {
+    listSuggestions(input: ListSuggestionsInput): readonly AccountCreationSuggestion[] {
+      const minimumOccurrences = input.minimumOccurrences ?? 2;
       return applyLimit(
         filterDismissedSuggestions(
           filterAlreadyLinkedSuggestions(
             deriveAccountSuggestions(
-              loadRepeatedCaptureEvidenceForUser(db, userId, minimumOccurrences)
+              loadRepeatedCaptureEvidenceForUser(input.db, input.userId, minimumOccurrences)
             ),
-            loadFinancialAccountIdentifiersForUser(db, userId)
+            loadFinancialAccountIdentifiersForUser(input.db, input.userId)
           ),
-          loadAccountSuggestionDismissalsForUser(db, userId)
+          loadAccountSuggestionDismissalsForUser(input.db, input.userId)
         ),
-        limit
+        input.limit
       );
     },
 
@@ -265,22 +261,16 @@ export function createAccountSuggestionService({
       );
     },
 
-    createSuggestedAccount({
-      db,
-      userId,
-      suggestion,
-      name,
-      kind,
-    }: CreateSuggestedAccountInput): AcceptSuggestionResult {
+    createSuggestedAccount(input: CreateSuggestedAccountInput): AcceptSuggestionResult {
       const updatedAt = now();
       const accountId = createAccountId();
 
-      return db.transaction((tx) => {
+      return input.db.transaction((tx) => {
         persistFinancialAccount(tx, {
           id: accountId,
-          userId,
-          name,
-          kind,
+          userId: input.userId,
+          name: input.name,
+          kind: input.kind,
           isDefault: false,
           createdAt: updatedAt,
           updatedAt,
@@ -289,9 +279,9 @@ export function createAccountSuggestionService({
 
         return acceptSuggestionWithTimestamp({
           db: tx,
-          userId,
+          userId: input.userId,
           accountId,
-          suggestion,
+          suggestion: input.suggestion,
           updatedAt,
         });
       });

--- a/apps/mobile/features/activity/services/create-activity-query-service.ts
+++ b/apps/mobile/features/activity/services/create-activity-query-service.ts
@@ -127,10 +127,16 @@ export function createActivityQueryService({
   getTransfersPaginated: loadTransfersPaginated = getTransfersPaginated,
 }: CreateActivityQueryServiceDeps = {}) {
   return {
-    loadPage({ db, userId, pageSize, offset }: LoadActivityPageInput): ActivityPageSnapshot {
+    loadPage(input: LoadActivityPageInput): ActivityPageSnapshot {
+      const { db, userId, pageSize, offset } = input;
       const fetchSize = offset + pageSize + 1;
       const mergedItems = toStoredActivityItems(
-        loadTransactionsPaginated(db, userId, fetchSize, 0),
+        loadTransactionsPaginated({
+          db,
+          userId,
+          limit: fetchSize,
+          offset: 0,
+        }),
         loadTransfersPaginated(db, userId, fetchSize, 0),
         fetchSize
       );

--- a/apps/mobile/features/capture-sources/dedup.public.ts
+++ b/apps/mobile/features/capture-sources/dedup.public.ts
@@ -3,15 +3,15 @@ import { assertCopAmount, assertIsoDate, assertUserId } from "@/shared/types/ass
 import type { TransactionId } from "@/shared/types/branded";
 import { findDuplicateTransaction as findDuplicateTransactionInternal } from "./lib/dedup";
 
-export function findDuplicateTransaction(
-  db: AnyDb,
-  userId: string,
-  amount: number,
-  date: string,
-  merchant: string
-): Promise<TransactionId | null> {
-  assertUserId(userId);
-  assertCopAmount(amount);
-  assertIsoDate(date);
-  return findDuplicateTransactionInternal(db, userId, amount, date, merchant);
+export function findDuplicateTransaction(input: {
+  readonly db: AnyDb;
+  readonly userId: string;
+  readonly amount: number;
+  readonly date: string;
+  readonly merchant: string;
+}): Promise<TransactionId | null> {
+  assertUserId(input.userId);
+  assertCopAmount(input.amount);
+  assertIsoDate(input.date);
+  return findDuplicateTransactionInternal(input);
 }

--- a/apps/mobile/features/capture-sources/lib/dedup.ts
+++ b/apps/mobile/features/capture-sources/lib/dedup.ts
@@ -6,17 +6,26 @@ import { merchantsMatch, normalizeMerchant } from "@/shared/lib/normalize-mercha
 import { assertCopAmount, assertIsoDate, assertUserId } from "@/shared/types/assertions";
 import type { TransactionId } from "@/shared/types/branded";
 
+type CaptureFingerprintInput = {
+  readonly source: string;
+  readonly amount: number;
+  readonly date: string;
+  readonly merchant: string;
+};
+type DuplicateTransactionLookupInput = {
+  readonly db: AnyDb;
+  readonly userId: string;
+  readonly amount: number;
+  readonly date: string;
+  readonly merchant: string;
+};
+
 /**
  * Creates a fingerprint hash for deduplication across capture sources.
  * Same amount + date + normalized merchant → same fingerprint.
  */
-export function captureFingerprint(
-  source: string,
-  amount: number,
-  date: string,
-  merchant: string
-): string {
-  return `${source}:${amount}:${date}:${normalizeMerchant(merchant)}`;
+export function captureFingerprint(input: CaptureFingerprintInput): string {
+  return `${input.source}:${input.amount}:${input.date}:${normalizeMerchant(input.merchant)}`;
 }
 
 /**
@@ -36,17 +45,13 @@ export async function isCaptureProcessed(db: AnyDb, fingerprintHash: string): Pr
  * Returns the existing transaction ID if found, null otherwise.
  */
 export async function findDuplicateTransaction(
-  db: AnyDb,
-  userId: string,
-  amount: number,
-  date: string,
-  merchant: string
+  input: DuplicateTransactionLookupInput
 ): Promise<TransactionId | null> {
-  assertUserId(userId);
-  assertCopAmount(amount);
-  assertIsoDate(date);
-  const normalized = normalizeMerchant(merchant);
-  const rows = await db
+  assertUserId(input.userId);
+  assertCopAmount(input.amount);
+  assertIsoDate(input.date);
+  const normalized = normalizeMerchant(input.merchant);
+  const rows = await input.db
     .select({
       id: transactions.id,
       description: transactions.description,
@@ -54,9 +59,9 @@ export async function findDuplicateTransaction(
     .from(transactions)
     .where(
       and(
-        ...getActiveTransactionConditions(userId),
-        eq(transactions.amount, amount),
-        eq(transactions.date, date)
+        ...getActiveTransactionConditions(input.userId),
+        eq(transactions.amount, input.amount),
+        eq(transactions.date, input.date)
       )
     );
 

--- a/apps/mobile/features/capture-sources/services/apple-pay-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/apple-pay-pipeline.ts
@@ -50,7 +50,12 @@ export async function processApplePayIntent(
   const source: "apple_pay" = "apple_pay";
 
   // Check fingerprint dedup
-  const fingerprint = captureFingerprint(source, amount, today, intent.merchant);
+  const fingerprint = captureFingerprint({
+    source,
+    amount,
+    date: today,
+    merchant: intent.merchant,
+  });
 
   if (inFlightFingerprints.has(fingerprint)) {
     capturePipelineEvent({ source: "apple_pay", saved: 0, skippedDuplicate: 1 });
@@ -66,7 +71,13 @@ export async function processApplePayIntent(
       return { saved: false, skippedDuplicate: true, transactionId: null };
     }
     // Cross-source dedup
-    const existingTxId = await findDuplicateTransaction(db, userId, amount, today, intent.merchant);
+    const existingTxId = await findDuplicateTransaction({
+      db,
+      userId,
+      amount,
+      date: today,
+      merchant: intent.merchant,
+    });
 
     if (existingTxId) {
       const now = toIsoDateTime(new Date());

--- a/apps/mobile/features/capture-sources/services/capture-ingestion.ts
+++ b/apps/mobile/features/capture-sources/services/capture-ingestion.ts
@@ -1,4 +1,3 @@
-import { Effect } from "effect";
 import type {
   PipelineResult,
   ProcessEmails,
@@ -74,27 +73,104 @@ type SameFeatureDeps = Pick<
 >;
 
 type EmailDeps = Pick<CaptureIngestionDeps, "processEmails" | "processRetries">;
+type IngestSameFeatureCommandInput = {
+  readonly db: AnyDb;
+  readonly deps: Partial<SameFeatureDeps>;
+  readonly command: CaptureIngestionCommand;
+};
+type IngestEmailCommandInput = {
+  readonly db: AnyDb;
+  readonly deps: EmailDeps;
+  readonly command: EmailCaptureIngestionCommand;
+};
 
 let defaultDepsPromise: Promise<SameFeatureDeps> | null = null;
+
+async function importDefaultDeps(): Promise<SameFeatureDeps> {
+  const [notification, applePay, widget] = await Promise.all([
+    import("./notification-pipeline"),
+    import("./apple-pay-pipeline"),
+    import("./widget-pipeline"),
+  ]);
+
+  return {
+    processNotification: notification.processNotification,
+    processApplePayIntent: applePay.processApplePayIntent,
+    processWidgetTransactions: widget.processWidgetTransactions,
+  };
+}
 
 async function loadDefaultDeps(): Promise<SameFeatureDeps> {
   if (defaultDepsPromise) return defaultDepsPromise;
 
-  defaultDepsPromise = (async () => {
-    const [notification, applePay, widget] = await Promise.all([
-      import("./notification-pipeline"),
-      import("./apple-pay-pipeline"),
-      import("./widget-pipeline"),
-    ]);
-
-    return {
-      processNotification: notification.processNotification,
-      processApplePayIntent: applePay.processApplePayIntent,
-      processWidgetTransactions: widget.processWidgetTransactions,
-    };
-  })();
+  defaultDepsPromise = importDefaultDeps();
 
   return defaultDepsPromise;
+}
+
+async function getNotificationHandler(
+  deps: Partial<SameFeatureDeps>
+): Promise<NotificationHandler> {
+  return deps.processNotification ?? (await loadDefaultDeps()).processNotification;
+}
+
+async function getApplePayHandler(deps: Partial<SameFeatureDeps>): Promise<ApplePayHandler> {
+  return deps.processApplePayIntent ?? (await loadDefaultDeps()).processApplePayIntent;
+}
+
+async function getWidgetHandler(deps: Partial<SameFeatureDeps>): Promise<WidgetHandler> {
+  return deps.processWidgetTransactions ?? (await loadDefaultDeps()).processWidgetTransactions;
+}
+
+async function ingestSameFeatureCommand(
+  input: IngestSameFeatureCommandInput
+): Promise<CaptureIngestionOutcome> {
+  switch (input.command.kind) {
+    case "notification":
+      return (await getNotificationHandler(input.deps))(
+        input.db,
+        input.command.userId,
+        input.command.notification
+      );
+    case "apple_pay":
+      return (await getApplePayHandler(input.deps))(
+        input.db,
+        input.command.userId,
+        input.command.intent
+      );
+    case "widget":
+      return (await getWidgetHandler(input.deps))(input.db, input.command.userId);
+  }
+}
+
+function isSameFeatureCommand(
+  command: AnyCaptureIngestionCommand
+): command is CaptureIngestionCommand {
+  return (
+    command.kind === "notification" || command.kind === "apple_pay" || command.kind === "widget"
+  );
+}
+
+async function ingestEmailCommand(
+  input: IngestEmailCommandInput
+): Promise<EmailCaptureIngestionOutcome> {
+  switch (input.command.kind) {
+    case "email_batch":
+      return input.deps.processEmails(
+        input.db,
+        input.command.userId,
+        input.command.emails,
+        input.command.onProgress
+      );
+    case "email_retry":
+      return input.deps.processRetries(input.db, input.command.userId);
+  }
+}
+
+function hasEmailDeps(
+  deps: Partial<CaptureIngestionDeps>
+): deps is Partial<SameFeatureDeps> & EmailDeps {
+  return Boolean(deps.processEmails && deps.processRetries);
 }
 
 export function createCaptureIngestionPort(
@@ -110,40 +186,13 @@ export function createCaptureIngestionPort(
   deps: Partial<CaptureIngestionDeps> = {}
 ): CaptureIngestionPort | CaptureIngestionPortWithEmail {
   const ingestDefault: CaptureIngestionPort["ingest"] = (command) =>
-    runAppEffect(
-      Effect.gen(function* () {
-        switch (command.kind) {
-          case "notification": {
-            const processNotification =
-              deps.processNotification ?? (yield* fromThunk(loadDefaultDeps)).processNotification;
-            return yield* fromThunk(() =>
-              processNotification(db, command.userId, command.notification)
-            );
-          }
-          case "apple_pay": {
-            const processApplePayIntent =
-              deps.processApplePayIntent ??
-              (yield* fromThunk(loadDefaultDeps)).processApplePayIntent;
-            return yield* fromThunk(() =>
-              processApplePayIntent(db, command.userId, command.intent)
-            );
-          }
-          case "widget": {
-            const processWidgetTransactions =
-              deps.processWidgetTransactions ??
-              (yield* fromThunk(loadDefaultDeps)).processWidgetTransactions;
-            return yield* fromThunk(() => processWidgetTransactions(db, command.userId));
-          }
-        }
-      })
-    );
+    runAppEffect(fromThunk(() => ingestSameFeatureCommand({ db, deps, command })));
 
-  if (!deps.processEmails || !deps.processRetries) {
+  if (!hasEmailDeps(deps)) {
     return { ingest: ingestDefault };
   }
 
-  const processEmails = deps.processEmails;
-  const processRetries = deps.processRetries;
+  const emailDeps = deps;
 
   function ingestWithEmail(command: CaptureIngestionCommand): Promise<CaptureIngestionOutcome>;
   function ingestWithEmail(
@@ -152,22 +201,9 @@ export function createCaptureIngestionPort(
   function ingestWithEmail(
     command: AnyCaptureIngestionCommand
   ): Promise<AnyCaptureIngestionOutcome> {
-    return runAppEffect(
-      Effect.gen(function* () {
-        switch (command.kind) {
-          case "notification":
-          case "apple_pay":
-          case "widget":
-            return yield* fromThunk(() => ingestDefault(command));
-          case "email_batch":
-            return yield* fromThunk(() =>
-              processEmails(db, command.userId, command.emails, command.onProgress)
-            );
-          case "email_retry":
-            return yield* fromThunk(() => processRetries(db, command.userId));
-        }
-      })
-    );
+    return isSameFeatureCommand(command)
+      ? ingestDefault(command)
+      : runAppEffect(fromThunk(() => ingestEmailCommand({ db, deps: emailDeps, command })));
   }
 
   return { ingest: ingestWithEmail };

--- a/apps/mobile/features/capture-sources/services/notification-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/notification-pipeline.ts
@@ -155,7 +155,12 @@ async function parseNotificationStage(context: NotificationContext): Promise<Par
 }
 
 function buildNotificationFingerprint(context: NotificationContext, parsed: ParsedNotification) {
-  return captureFingerprint(context.source, parsed.amount, parsed.date, parsed.merchant);
+  return captureFingerprint({
+    source: context.source,
+    amount: parsed.amount,
+    date: parsed.date,
+    merchant: parsed.merchant,
+  });
 }
 
 function normalizeParsedNotification(parsed: RawParsedNotification): ParsedNotification {
@@ -223,13 +228,13 @@ async function findDuplicateCapture(
     return { kind: "already_processed" };
   }
 
-  const transactionId = await findDuplicateTransaction(
-    context.db,
-    context.userId,
-    context.parsed.amount,
-    context.parsed.date,
-    context.parsed.merchant
-  );
+  const transactionId = await findDuplicateTransaction({
+    db: context.db,
+    userId: context.userId,
+    amount: context.parsed.amount,
+    date: context.parsed.date,
+    merchant: context.parsed.merchant,
+  });
 
   return transactionId ? { kind: "cross_source", transactionId } : null;
 }

--- a/apps/mobile/features/capture-sources/services/widget-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/widget-pipeline.ts
@@ -25,7 +25,7 @@ function toTransactionId(widgetEntryId: string): TransactionId {
 }
 
 function widgetFingerprint(entryId: string, amount: number, date: string): string {
-  return captureFingerprint("widget", amount, date, entryId);
+  return captureFingerprint({ source: "widget", amount, date, merchant: entryId });
 }
 
 export type WidgetPipelineResult = {
@@ -91,7 +91,13 @@ export async function processWidgetTransactions(
         continue;
       }
 
-      const existingTxId = await findDuplicateTransaction(db, userId, amount, date, description);
+      const existingTxId = await findDuplicateTransaction({
+        db,
+        userId,
+        amount,
+        date,
+        merchant: description,
+      });
 
       if (existingTxId) {
         await insertProcessedCapture(db, {

--- a/apps/mobile/features/dashboard/components/HomeScreen.tsx
+++ b/apps/mobile/features/dashboard/components/HomeScreen.tsx
@@ -66,12 +66,12 @@ const TransactionItem = memo(function TransactionItem({
     <View>
       {showDateHeader && (
         <DateHeader
-          label={makeDateLabel(
-            tx.date,
-            t("dates.today"),
-            t("dates.yesterday"),
-            getDateFnsLocale(locale)
-          )}
+          label={makeDateLabel({
+            date: tx.date,
+            todayLabel: t("dates.today"),
+            yesterdayLabel: t("dates.yesterday"),
+            dateFnsLocale: getDateFnsLocale(locale),
+          })}
         />
       )}
       <View className="px-4">
@@ -107,12 +107,12 @@ const TransferItem = memo(function TransferItem({
     <View>
       {showDateHeader && (
         <DateHeader
-          label={makeDateLabel(
-            item.date,
-            t("dates.today"),
-            t("dates.yesterday"),
-            getDateFnsLocale(locale)
-          )}
+          label={makeDateLabel({
+            date: item.date,
+            todayLabel: t("dates.today"),
+            yesterdayLabel: t("dates.yesterday"),
+            dateFnsLocale: getDateFnsLocale(locale),
+          })}
         />
       )}
       <View className="px-4">

--- a/apps/mobile/features/email-capture/lib/financial-meaning-review.ts
+++ b/apps/mobile/features/email-capture/lib/financial-meaning-review.ts
@@ -51,12 +51,12 @@ export async function resolveFinancialMeaningReview(db: AnyDb, processedEmailId:
     return;
   }
 
-  await updateProcessedEmailStatus(
+  await updateProcessedEmailStatus({
     db,
-    processedEmailId,
-    "success",
-    processedEmail.transactionId ?? null
-  );
+    id: processedEmailId,
+    status: "success",
+    transactionId: processedEmail.transactionId ?? null,
+  });
 }
 
 export async function dismissFinancialMeaningReview(
@@ -99,6 +99,11 @@ export async function dismissFinancialMeaningReview(
       }
     }
 
-    saveProcessedEmailStatus(tx, processedEmailId, "skipped", null);
+    saveProcessedEmailStatus({
+      db: tx,
+      id: processedEmailId,
+      status: "skipped",
+      transactionId: null,
+    });
   });
 }

--- a/apps/mobile/features/email-capture/lib/progress-phases.ts
+++ b/apps/mobile/features/email-capture/lib/progress-phases.ts
@@ -20,6 +20,19 @@ type ProgressData = {
   readonly failed: number;
   readonly needsReview: number;
 };
+type ProgressDisplayBuilderInput = {
+  readonly phase: ProgressPhase;
+  readonly progress: ProgressData;
+  readonly t?: TranslateFn;
+};
+
+const EMPTY_PROGRESS_DATA: ProgressData = {
+  total: 0,
+  completed: 0,
+  saved: 0,
+  failed: 0,
+  needsReview: 0,
+};
 
 export const shouldShowProgress = (
   emailCount: number,
@@ -27,56 +40,88 @@ export const shouldShowProgress = (
   threshold: number = 5
 ): boolean => isFirstFetch || emailCount >= threshold;
 
+function buildFetchingDisplay({ phase, t }: ProgressDisplayBuilderInput): ProgressDisplay {
+  return {
+    phase,
+    title: t ? t("progress.fetchingTitle") : "Fetching your emails...",
+    subtitle: t ? t("progress.fetchingSubtitle") : "Reading the last 30 days",
+    fractionComplete: 0,
+    transactionsFound: 0,
+    needsReview: 0,
+  };
+}
+
+function buildProcessingSubtitle(progress: ProgressData, t?: TranslateFn): string {
+  return t
+    ? t("progress.processingSubtitle", {
+        completed: progress.completed,
+        total: progress.total,
+      })
+    : `${progress.completed} of ${progress.total}`;
+}
+
+function buildProcessingDisplay({
+  phase,
+  progress,
+  t,
+}: ProgressDisplayBuilderInput): ProgressDisplay {
+  return {
+    phase,
+    title: t ? t("progress.scanningTitle") : "Scanning emails...",
+    subtitle: buildProcessingSubtitle(progress, t),
+    fractionComplete: progress.total === 0 ? 0 : progress.completed / progress.total,
+    transactionsFound: progress.saved,
+    needsReview: progress.needsReview,
+  };
+}
+
+function buildFailedSuffix(progress: ProgressData, t?: TranslateFn): string {
+  if (progress.failed === 0) {
+    return "";
+  }
+
+  return t
+    ? t("progress.failedSuffix", { failed: progress.failed })
+    : ` (${progress.failed} couldn't be read)`;
+}
+
+function buildCompleteSubtitle(progress: ProgressData, t?: TranslateFn): string {
+  const base = t
+    ? t("progress.completeSubtitle", { saved: progress.saved, total: progress.total })
+    : `Found ${progress.saved} transactions from ${progress.total} emails`;
+  return `${base}${buildFailedSuffix(progress, t)}`;
+}
+
+function buildCompleteDisplay({
+  phase,
+  progress,
+  t,
+}: ProgressDisplayBuilderInput): ProgressDisplay {
+  return {
+    phase,
+    title: t ? t("progress.completeTitle") : "Import complete!",
+    subtitle: buildCompleteSubtitle(progress, t),
+    fractionComplete: 1,
+    transactionsFound: progress.saved,
+    needsReview: progress.needsReview,
+  };
+}
+
 export const buildProgressDisplay = (
   phase: ProgressPhase,
   progress: ProgressData | null,
   _providerNames: readonly string[],
   t?: TranslateFn
-): ProgressDisplay => {
-  const base = { phase } as const;
-
-  if (phase === "fetching") {
-    return {
-      ...base,
-      title: t ? t("progress.fetchingTitle") : "Fetching your emails...",
-      subtitle: t ? t("progress.fetchingSubtitle") : "Reading the last 30 days",
-      fractionComplete: 0,
-      transactionsFound: 0,
-      needsReview: 0,
-    };
-  }
-
-  const p = progress ?? { total: 0, completed: 0, saved: 0, failed: 0, needsReview: 0 };
-
-  if (phase === "processing") {
-    return {
-      ...base,
-      title: t ? t("progress.scanningTitle") : "Scanning emails...",
-      subtitle: t
-        ? t("progress.processingSubtitle", { completed: p.completed, total: p.total })
-        : `${p.completed} of ${p.total}`,
-      fractionComplete: p.total === 0 ? 0 : p.completed / p.total,
-      transactionsFound: p.saved,
-      needsReview: p.needsReview,
-    };
-  }
-
-  // phase === "complete"
-  const failedSuffix =
-    p.failed > 0
-      ? t
-        ? t("progress.failedSuffix", { failed: p.failed })
-        : ` (${p.failed} couldn't be read)`
-      : "";
-  return {
-    ...base,
-    title: t ? t("progress.completeTitle") : "Import complete!",
-    subtitle: `${t ? t("progress.completeSubtitle", { saved: p.saved, total: p.total }) : `Found ${p.saved} transactions from ${p.total} emails`}${failedSuffix}`,
-    fractionComplete: 1,
-    transactionsFound: p.saved,
-    needsReview: p.needsReview,
-  };
-};
+): ProgressDisplay =>
+  ({
+    fetching: buildFetchingDisplay,
+    processing: buildProcessingDisplay,
+    complete: buildCompleteDisplay,
+  })[phase]({
+    phase,
+    progress: progress ?? EMPTY_PROGRESS_DATA,
+    t,
+  });
 
 export const shouldMorphToBanner = (needsReviewCount: number): boolean => needsReviewCount > 0;
 

--- a/apps/mobile/features/email-capture/lib/repository.ts
+++ b/apps/mobile/features/email-capture/lib/repository.ts
@@ -11,6 +11,25 @@ import type {
 
 export type EmailAccountRow = typeof emailAccounts.$inferInsert;
 export type ProcessedEmailRow = typeof processedEmails.$inferInsert;
+type ProcessedEmailStatusUpdateInput = {
+  readonly db: AnyDb;
+  readonly id: ProcessedEmailId;
+  readonly status: string;
+  readonly transactionId: TransactionId | null;
+};
+type RetryScheduleInput = {
+  readonly db: AnyDb;
+  readonly id: ProcessedEmailId;
+  readonly retryCount: number;
+  readonly nextRetryAt: IsoDateTime;
+};
+type RetrySuccessInput = {
+  readonly db: AnyDb;
+  readonly id: ProcessedEmailId;
+  readonly status: "success" | "needs_review";
+  readonly transactionId: TransactionId;
+  readonly confidence: number;
+};
 
 export async function insertEmailAccount(db: AnyDb, row: EmailAccountRow) {
   await db.insert(emailAccounts).values(row);
@@ -91,22 +110,26 @@ export async function getNeedsReviewEmailByTransactionId(db: AnyDb, transactionI
   return rows[0] ?? null;
 }
 
-export async function updateProcessedEmailStatus(
+function getProcessedEmailUpdateQuery(
   db: AnyDb,
   id: ProcessedEmailId,
-  status: string,
-  transactionId: TransactionId | null
+  fields: Partial<ProcessedEmailRow>
 ) {
-  await db.update(processedEmails).set({ status, transactionId }).where(eq(processedEmails.id, id));
+  return db.update(processedEmails).set(fields).where(eq(processedEmails.id, id));
 }
 
-export function updateProcessedEmailStatusInTransaction(
-  db: AnyDb,
-  id: ProcessedEmailId,
-  status: string,
-  transactionId: TransactionId | null
-) {
-  db.update(processedEmails).set({ status, transactionId }).where(eq(processedEmails.id, id)).run();
+export async function updateProcessedEmailStatus(input: ProcessedEmailStatusUpdateInput) {
+  await getProcessedEmailUpdateQuery(input.db, input.id, {
+    status: input.status,
+    transactionId: input.transactionId,
+  });
+}
+
+export function updateProcessedEmailStatusInTransaction(input: ProcessedEmailStatusUpdateInput) {
+  getProcessedEmailUpdateQuery(input.db, input.id, {
+    status: input.status,
+    transactionId: input.transactionId,
+  }).run();
 }
 
 export async function dismissProcessedEmail(db: AnyDb, id: ProcessedEmailId) {
@@ -127,16 +150,12 @@ export async function getPendingRetryEmails(db: AnyDb) {
     .limit(50);
 }
 
-export async function markForRetry(
-  db: AnyDb,
-  id: ProcessedEmailId,
-  retryCount: number,
-  nextRetryAt: IsoDateTime
-) {
-  await db
-    .update(processedEmails)
-    .set({ status: "pending_retry", retryCount, nextRetryAt })
-    .where(eq(processedEmails.id, id));
+export async function markForRetry(input: RetryScheduleInput) {
+  await getProcessedEmailUpdateQuery(input.db, input.id, {
+    status: "pending_retry",
+    retryCount: input.retryCount,
+    nextRetryAt: input.nextRetryAt,
+  });
 }
 
 export async function markPermanentlyFailed(db: AnyDb, id: ProcessedEmailId) {
@@ -146,15 +165,11 @@ export async function markPermanentlyFailed(db: AnyDb, id: ProcessedEmailId) {
     .where(eq(processedEmails.id, id));
 }
 
-export async function markRetrySuccess(
-  db: AnyDb,
-  id: ProcessedEmailId,
-  status: "success" | "needs_review",
-  transactionId: TransactionId,
-  confidence: number
-) {
-  await db
-    .update(processedEmails)
-    .set({ status, transactionId, confidence, rawBody: null })
-    .where(eq(processedEmails.id, id));
+export async function markRetrySuccess(input: RetrySuccessInput) {
+  await getProcessedEmailUpdateQuery(input.db, input.id, {
+    status: input.status,
+    transactionId: input.transactionId,
+    confidence: input.confidence,
+    rawBody: null,
+  });
 }

--- a/apps/mobile/features/email-capture/services/create-email-pipeline-service.ts
+++ b/apps/mobile/features/email-capture/services/create-email-pipeline-service.ts
@@ -75,36 +75,36 @@ type CreateEmailPipelineServiceDeps = {
     userId: UserId,
     merchantKey: string
   ) => Promise<CategoryId | null>;
-  readonly findDuplicateTransaction: (
-    db: AnyDb,
-    userId: UserId,
-    amount: LlmParsedTransaction["amount"],
-    date: LlmParsedTransaction["date"],
-    description: string
-  ) => Promise<TransactionId | null>;
+  readonly findDuplicateTransaction: (input: {
+    readonly db: AnyDb;
+    readonly userId: UserId;
+    readonly amount: LlmParsedTransaction["amount"];
+    readonly date: LlmParsedTransaction["date"];
+    readonly merchant: string;
+  }) => Promise<TransactionId | null>;
   readonly getProcessedExternalIds: (db: AnyDb, externalIds: string[]) => Promise<Set<string>>;
   readonly getPendingRetryEmails: (db: AnyDb) => Promise<readonly ProcessedEmailRow[]>;
   readonly insertProcessedEmail: (db: AnyDb, row: ProcessedEmailRow) => Promise<void>;
-  readonly markForRetry: (
-    db: AnyDb,
-    id: ProcessedEmailId,
-    retryCount: number,
-    nextRetryAt: IsoDateTime
-  ) => Promise<void>;
+  readonly markForRetry: (input: {
+    readonly db: AnyDb;
+    readonly id: ProcessedEmailId;
+    readonly retryCount: number;
+    readonly nextRetryAt: IsoDateTime;
+  }) => Promise<void>;
   readonly markPermanentlyFailed: (db: AnyDb, id: ProcessedEmailId) => Promise<void>;
-  readonly markRetrySuccess: (
-    db: AnyDb,
-    id: ProcessedEmailId,
-    status: "success" | "needs_review",
-    transactionId: TransactionId,
-    confidence: number
-  ) => Promise<void>;
-  readonly updateProcessedEmailStatus: (
-    db: AnyDb,
-    id: ProcessedEmailId,
-    status: string,
-    transactionId: TransactionId | null
-  ) => Promise<void>;
+  readonly markRetrySuccess: (input: {
+    readonly db: AnyDb;
+    readonly id: ProcessedEmailId;
+    readonly status: "success" | "needs_review";
+    readonly transactionId: TransactionId;
+    readonly confidence: number;
+  }) => Promise<void>;
+  readonly updateProcessedEmailStatus: (input: {
+    readonly db: AnyDb;
+    readonly id: ProcessedEmailId;
+    readonly status: string;
+    readonly transactionId: TransactionId | null;
+  }) => Promise<void>;
   readonly buildEmailCaptureEvidence: (input: { from: string }) => readonly CaptureEvidenceSeed[];
   readonly saveCaptureEvidenceRows: (
     db: AnyDb,
@@ -407,7 +407,13 @@ function getPendingRetryEmailsEffect(db: AnyDb) {
 function findDuplicateTransactionEffect(db: AnyDb, userId: UserId, parsed: LlmParsedTransaction) {
   return Effect.flatMap(EmailPipelineDeps.tag, ({ findDuplicateTransaction }) =>
     fromPromise(() =>
-      findDuplicateTransaction(db, userId, parsed.amount, parsed.date, parsed.description)
+      findDuplicateTransaction({
+        db,
+        userId,
+        amount: parsed.amount,
+        date: parsed.date,
+        merchant: parsed.description,
+      })
     )
   );
 }
@@ -675,7 +681,14 @@ function insertMerchantRuleEffect(input: MerchantRuleEffectInput) {
 
 function markForRetryEffect(input: RetryScheduleEffectInput) {
   return Effect.flatMap(EmailPipelineDeps.tag, ({ markForRetry }) =>
-    fromPromise(() => markForRetry(input.db, input.id, input.retryCount, input.nextRetryAt))
+    fromPromise(() =>
+      markForRetry({
+        db: input.db,
+        id: input.id,
+        retryCount: input.retryCount,
+        nextRetryAt: input.nextRetryAt,
+      })
+    )
   );
 }
 
@@ -688,7 +701,13 @@ function markPermanentlyFailedEffect(db: AnyDb, id: ProcessedEmailId) {
 function markRetrySuccessEffect(input: RetrySuccessEffectInput) {
   return Effect.flatMap(EmailPipelineDeps.tag, ({ markRetrySuccess }) =>
     fromPromise(() =>
-      markRetrySuccess(input.db, input.id, input.status, input.transactionId, input.confidence)
+      markRetrySuccess({
+        db: input.db,
+        id: input.id,
+        status: input.status,
+        transactionId: input.transactionId,
+        confidence: input.confidence,
+      })
     )
   );
 }
@@ -696,7 +715,12 @@ function markRetrySuccessEffect(input: RetrySuccessEffectInput) {
 function updateProcessedEmailStatusEffect(input: ProcessedEmailStatusEffectInput) {
   return Effect.flatMap(EmailPipelineDeps.tag, ({ updateProcessedEmailStatus }) =>
     fromPromise(() =>
-      updateProcessedEmailStatus(input.db, input.id, input.status, input.transactionId)
+      updateProcessedEmailStatus({
+        db: input.db,
+        id: input.id,
+        status: input.status,
+        transactionId: input.transactionId,
+      })
     )
   );
 }

--- a/apps/mobile/features/email-capture/services/create-parse-email-service.ts
+++ b/apps/mobile/features/email-capture/services/create-parse-email-service.ts
@@ -14,6 +14,12 @@ import type { LlmParsedTransaction } from "./llm-parser";
 import { llmOutputSchema } from "./llm-parser";
 
 type ParseMode = "classify" | "full_parse" | "parse_notification";
+type ParseFunctionResult<Response> = {
+  readonly data?: Response | null;
+  readonly error?: {
+    readonly message?: string;
+  } | null;
+};
 
 type ParseEmailResponse = {
   readonly success: boolean;
@@ -49,64 +55,102 @@ function invokeParseEmailFunctionEffect<Response>(body: string, mode: ParseMode)
   );
 }
 
+function logParseApiFailureEffect(
+  warningPrefix: "parse_email" | "parse_notification",
+  response: ParseFunctionResult<ParseEmailResponse>
+) {
+  return Effect.zipRight(
+    captureWarningEffect(`${warningPrefix}_api_failed`, {
+      errorMessage: response.error?.message ?? "unknown",
+      hasData: response.data != null,
+    }),
+    Effect.succeed(null)
+  );
+}
+
+function validateParsedTransactionEffect(
+  warningPrefix: "parse_email" | "parse_notification",
+  data: unknown
+) {
+  const result = llmOutputSchema.safeParse(data);
+  if (!result.success) {
+    return Effect.zipRight(
+      captureWarningEffect(`${warningPrefix}_validation_failed`, {
+        issueCount: result.error.issues.length,
+      }),
+      Effect.succeed(null)
+    );
+  }
+
+  return Effect.succeed(result.data);
+}
+
+function handleParseTransactionResponseEffect(
+  warningPrefix: "parse_email" | "parse_notification",
+  response: ParseFunctionResult<ParseEmailResponse>
+) {
+  if (response.error != null || !response.data?.success) {
+    return logParseApiFailureEffect(warningPrefix, response);
+  }
+
+  return validateParsedTransactionEffect(warningPrefix, response.data.data);
+}
+
+function logParseExceptionEffect(
+  warningPrefix: "parse_email" | "parse_notification",
+  error: unknown
+) {
+  return Effect.zipRight(
+    captureWarningEffect(`${warningPrefix}_api_exception`, {
+      errorType: error instanceof Error ? error.message : "unknown",
+    }),
+    Effect.succeed(null)
+  );
+}
+
 function parseTransactionEffect(
   body: string,
   mode: Extract<ParseMode, "full_parse" | "parse_notification">,
   warningPrefix: "parse_email" | "parse_notification"
 ) {
   return Effect.catchAll(
-    Effect.gen(function* () {
-      const response = yield* invokeParseEmailFunctionEffect<ParseEmailResponse>(body, mode);
-      const { data, error } = response;
+    Effect.flatMap(invokeParseEmailFunctionEffect<ParseEmailResponse>(body, mode), (response) =>
+      handleParseTransactionResponseEffect(warningPrefix, response)
+    ),
+    (error) => logParseExceptionEffect(warningPrefix, error)
+  );
+}
 
-      if (error != null || !data?.success) {
-        yield* captureWarningEffect(`${warningPrefix}_api_failed`, {
-          errorMessage: error?.message ?? "unknown",
-          hasData: data != null,
-        });
-        return null;
-      }
-
-      const result = llmOutputSchema.safeParse(data.data);
-      if (!result.success) {
-        yield* captureWarningEffect(`${warningPrefix}_validation_failed`, {
-          issueCount: result.error.issues.length,
-        });
-        return null;
-      }
-
-      return result.data;
+function logClassifyApiFailureEffect(response: ParseFunctionResult<ClassifyResponse>) {
+  return Effect.zipRight(
+    captureWarningEffect("classify_merchant_failed", {
+      hasError: response.error != null,
+      errorMessage: response.error?.message ?? "unknown",
     }),
-    (error) =>
-      Effect.zipRight(
-        captureWarningEffect(`${warningPrefix}_api_exception`, {
-          errorType: error instanceof Error ? error.message : "unknown",
-        }),
-        Effect.succeed(null)
-      )
+    Effect.succeed("other")
+  );
+}
+
+function handleClassifyMerchantResponseEffect(
+  response: ParseFunctionResult<ClassifyResponse>,
+  validCategoryIds: readonly string[]
+) {
+  if (response.error != null || !response.data?.success) {
+    return logClassifyApiFailureEffect(response);
+  }
+
+  const categoryId = response.data.data?.categoryId;
+  return Effect.succeed(
+    categoryId != null && validCategoryIds.includes(categoryId) ? categoryId : "other"
   );
 }
 
 function classifyMerchantEffect(merchant: string, validCategoryIds: readonly string[]) {
   return Effect.catchAll(
-    Effect.gen(function* () {
-      const response = yield* invokeParseEmailFunctionEffect<ClassifyResponse>(
-        merchant,
-        "classify"
-      );
-      const { data, error } = response;
-
-      if (error != null || !data?.success) {
-        yield* captureWarningEffect("classify_merchant_failed", {
-          hasError: error != null,
-          errorMessage: error?.message ?? "unknown",
-        });
-        return "other";
-      }
-
-      const categoryId = data.data?.categoryId;
-      return categoryId != null && validCategoryIds.includes(categoryId) ? categoryId : "other";
-    }),
+    Effect.flatMap(
+      invokeParseEmailFunctionEffect<ClassifyResponse>(merchant, "classify"),
+      (response) => handleClassifyMerchantResponseEffect(response, validCategoryIds)
+    ),
     () => Effect.succeed("other")
   );
 }

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -406,7 +406,12 @@ export async function confirmReviewedEmail(
     await insertMerchantRule(db, userId, merchantKey, categoryId, now);
   }
 
-  await updateProcessedEmailStatus(db, processedEmail.id, "success", processedEmail.transactionId);
+  await updateProcessedEmailStatus({
+    db,
+    id: processedEmail.id,
+    status: "success",
+    transactionId: processedEmail.transactionId,
+  });
   if (!isActiveEmailCaptureSession(session)) return;
 
   useEmailCaptureStore.getState().removeNeedsReviewEmail(processedEmailId);

--- a/apps/mobile/features/financial-accounts/lib/balance-maps.ts
+++ b/apps/mobile/features/financial-accounts/lib/balance-maps.ts
@@ -1,0 +1,94 @@
+import type { CopAmount, FinancialAccountId } from "@/shared/types/branded";
+import type { FinancialAccountKind } from "../schema";
+
+type AccountBalanceMap = Record<string, CopAmount>;
+type AccountRow = {
+  readonly id: FinancialAccountId;
+  readonly kind: FinancialAccountKind;
+};
+type BalanceAggregateRow = {
+  readonly accountId: FinancialAccountId;
+  readonly total: CopAmount;
+};
+type OpeningBalanceAggregateRow = {
+  readonly accountId: FinancialAccountId;
+  readonly amount: CopAmount;
+};
+type BuildAccountBalanceMapInput = {
+  readonly accounts: readonly AccountRow[];
+  readonly openingBalanceTotals: AccountBalanceMap;
+  readonly transactionTotals: AccountBalanceMap;
+  readonly transferTotals: AccountBalanceMap;
+};
+
+export function getAccountKindMap(
+  accounts: readonly AccountRow[]
+): Record<string, FinancialAccountKind> {
+  return Object.fromEntries(accounts.map((account) => [account.id, account.kind])) as Record<
+    string,
+    FinancialAccountKind
+  >;
+}
+
+export function getOpeningBalanceTotals(
+  rows: readonly OpeningBalanceAggregateRow[],
+  accountKinds: Record<string, FinancialAccountKind>
+): AccountBalanceMap {
+  const totals: AccountBalanceMap = {};
+
+  rows.forEach((row) => {
+    totals[row.accountId] = getOpeningBalanceEffect(
+      accountKinds[row.accountId] ?? "checking",
+      row.amount
+    );
+  });
+
+  return totals;
+}
+
+export function combineTransferBalanceEffects(
+  outgoingRows: readonly BalanceAggregateRow[],
+  incomingRows: readonly BalanceAggregateRow[]
+): AccountBalanceMap {
+  const totals: AccountBalanceMap = {};
+
+  [...outgoingRows, ...incomingRows].forEach((row) => {
+    totals[row.accountId] = (getAccountBalanceTotal(totals, row.accountId) +
+      row.total) as CopAmount;
+  });
+
+  return totals;
+}
+
+export function buildAccountBalanceMap(
+  input: BuildAccountBalanceMapInput
+): Record<string, CopAmount> {
+  const totals: AccountBalanceMap = {};
+
+  input.accounts.forEach((account) => {
+    totals[account.id] = sumAccountBalanceTotals([
+      input.openingBalanceTotals[account.id],
+      input.transactionTotals[account.id],
+      input.transferTotals[account.id],
+    ]);
+  });
+
+  return totals;
+}
+
+function getOpeningBalanceEffect(kind: FinancialAccountKind, amount: CopAmount): CopAmount {
+  return (kind === "credit_card" ? -amount : amount) as CopAmount;
+}
+
+function getAccountBalanceTotal(
+  totals: AccountBalanceMap,
+  accountId: FinancialAccountId
+): CopAmount {
+  return (totals[accountId] ?? 0) as CopAmount;
+}
+
+function sumAccountBalanceTotals(totals: readonly (CopAmount | undefined)[]): CopAmount {
+  return totals
+    .filter((total): total is CopAmount => total !== undefined)
+    .reduce((sum, total) => (sum + total) as CopAmount, 0 as CopAmount);
+}

--- a/apps/mobile/features/financial-accounts/lib/balance-repository.ts
+++ b/apps/mobile/features/financial-accounts/lib/balance-repository.ts
@@ -4,6 +4,12 @@ import type { AnyDb } from "@/shared/db/client";
 import { financialAccounts, openingBalances, transactions, transfers } from "@/shared/db/schema";
 import type { CopAmount, FinancialAccountId, IsoDate, UserId } from "@/shared/types/branded";
 import type { FinancialAccountKind } from "../schema";
+import {
+  buildAccountBalanceMap,
+  combineTransferBalanceEffects,
+  getAccountKindMap,
+  getOpeningBalanceTotals,
+} from "./balance-maps";
 
 type AccountBalanceMap = Record<string, CopAmount>;
 
@@ -24,10 +30,6 @@ type OpeningBalanceAggregateRow = {
 
 function toAggregateMap(rows: readonly BalanceAggregateRow[]): AccountBalanceMap {
   return Object.fromEntries(rows.map((row) => [row.accountId, row.total])) as AccountBalanceMap;
-}
-
-function getOpeningBalanceEffect(kind: FinancialAccountKind, amount: CopAmount): CopAmount {
-  return (kind === "credit_card" ? -amount : amount) as CopAmount;
 }
 
 function getFinancialAccountsForBalance(db: AnyDb, userId: UserId): readonly AccountRow[] {
@@ -141,51 +143,26 @@ function getIncomingTransferBalanceEffects(
     }));
 }
 
-function combineTransferBalanceEffects(
-  outgoingRows: readonly BalanceAggregateRow[],
-  incomingRows: readonly BalanceAggregateRow[]
-): AccountBalanceMap {
-  const rows = [...outgoingRows, ...incomingRows];
-  const accountIds = Array.from(new Set(rows.map((row) => row.accountId)));
-
-  return Object.fromEntries(
-    accountIds.map((accountId) => [
-      accountId,
-      rows
-        .filter((row) => row.accountId === accountId)
-        .reduce((total, row) => (total + row.total) as CopAmount, 0 as CopAmount),
-    ])
-  ) as AccountBalanceMap;
-}
-
 export function getFinancialAccountBalancesForUser(
   db: AnyDb,
   userId: UserId,
   asOfDate: IsoDate
 ): Record<string, CopAmount> {
   const accounts = getFinancialAccountsForBalance(db, userId);
-  const accountKinds = Object.fromEntries(
-    accounts.map((account) => [account.id, account.kind])
-  ) as Record<string, FinancialAccountKind>;
-  const openingBalanceRows = getOpeningBalanceAmounts(db, userId, asOfDate);
-  const openingBalanceTotals = Object.fromEntries(
-    openingBalanceRows.map((row) => [
-      row.accountId,
-      getOpeningBalanceEffect(accountKinds[row.accountId] ?? "checking", row.amount),
-    ])
-  ) as AccountBalanceMap;
+  const openingBalanceTotals = getOpeningBalanceTotals(
+    getOpeningBalanceAmounts(db, userId, asOfDate),
+    getAccountKindMap(accounts)
+  );
   const transactionTotals = toAggregateMap(getTransactionBalanceEffects(db, userId, asOfDate));
   const transferTotals = combineTransferBalanceEffects(
     getOutgoingTransferBalanceEffects(db, userId, asOfDate),
     getIncomingTransferBalanceEffects(db, userId, asOfDate)
   );
 
-  return Object.fromEntries(
-    accounts.map((account) => [
-      account.id,
-      ((openingBalanceTotals[account.id] ?? 0) +
-        (transactionTotals[account.id] ?? 0) +
-        (transferTotals[account.id] ?? 0)) as CopAmount,
-    ])
-  ) as Record<string, CopAmount>;
+  return buildAccountBalanceMap({
+    accounts,
+    openingBalanceTotals,
+    transactionTotals,
+    transferTotals,
+  });
 }

--- a/apps/mobile/features/financial-accounts/lib/default-account-bootstrap.ts
+++ b/apps/mobile/features/financial-accounts/lib/default-account-bootstrap.ts
@@ -1,0 +1,87 @@
+import type { IsoDateTime } from "@/shared/types/branded";
+import type { FinancialAccountKind } from "../schema";
+import { buildDefaultFinancialAccountId as toDefaultFinancialAccountId } from "./default-account";
+import type { FinancialAccountRow } from "./repository";
+
+const DEFAULT_FINANCIAL_ACCOUNT_KIND: FinancialAccountKind = "cash";
+type DefaultFinancialAccountFields = {
+  readonly name: FinancialAccountRow["name"];
+  readonly kind: FinancialAccountRow["kind"];
+  readonly statementClosingDay: FinancialAccountRow["statementClosingDay"];
+  readonly paymentDueDay: FinancialAccountRow["paymentDueDay"];
+  readonly createdAt: FinancialAccountRow["createdAt"];
+};
+
+export function findCanonicalFinancialAccount(
+  rows: readonly FinancialAccountRow[],
+  userId: FinancialAccountRow["userId"]
+) {
+  const canonicalId = toDefaultFinancialAccountId(userId);
+  return rows.find((row) => row.id === canonicalId) ?? null;
+}
+
+export function findExistingDefaultFinancialAccount(rows: readonly FinancialAccountRow[]) {
+  return rows.find((row) => row.isDefault) ?? null;
+}
+
+export function promoteFinancialAccountToDefault(
+  row: FinancialAccountRow,
+  now: IsoDateTime
+): FinancialAccountRow {
+  return {
+    ...row,
+    isDefault: true,
+    updatedAt: now,
+    deletedAt: null,
+  };
+}
+
+export function buildDefaultFinancialAccountRow(
+  userId: FinancialAccountRow["userId"],
+  now: IsoDateTime,
+  name: string,
+  existingCanonical: FinancialAccountRow | null
+): FinancialAccountRow {
+  const defaultFields = getDefaultFinancialAccountFields({
+    existingCanonical,
+    name,
+    now,
+  });
+
+  return {
+    id: toDefaultFinancialAccountId(userId),
+    userId,
+    ...defaultFields,
+    isDefault: true,
+    updatedAt: now,
+    deletedAt: null,
+  };
+}
+
+type DefaultFinancialAccountFieldInput = {
+  readonly existingCanonical: FinancialAccountRow | null;
+  readonly name: string;
+  readonly now: IsoDateTime;
+};
+
+function getDefaultFinancialAccountFields(
+  input: DefaultFinancialAccountFieldInput
+): DefaultFinancialAccountFields {
+  if (!input.existingCanonical) {
+    return {
+      name: input.name,
+      kind: DEFAULT_FINANCIAL_ACCOUNT_KIND,
+      statementClosingDay: null,
+      paymentDueDay: null,
+      createdAt: input.now,
+    };
+  }
+
+  return {
+    name: input.existingCanonical.name,
+    kind: input.existingCanonical.kind,
+    statementClosingDay: input.existingCanonical.statementClosingDay,
+    paymentDueDay: input.existingCanonical.paymentDueDay,
+    createdAt: input.existingCanonical.createdAt,
+  };
+}

--- a/apps/mobile/features/financial-accounts/lib/opening-balances-repository.ts
+++ b/apps/mobile/features/financial-accounts/lib/opening-balances-repository.ts
@@ -52,57 +52,68 @@ function persistOpeningBalance(db: AnyDb, row: OpeningBalanceRow) {
     .run();
 }
 
-export function upsertOpeningBalance(db: AnyDb, row: OpeningBalanceRow) {
-  db.transaction((tx) => {
-    const existingById = getOpeningBalanceById(tx, row.id);
-    const activeDuplicate =
-      row.deletedAt == null ? findActiveOpeningBalanceByAccountId(tx, row.accountId) : null;
-    const duplicate = activeDuplicate?.id !== row.id ? activeDuplicate : null;
+function getActiveOpeningBalanceDuplicate(db: AnyDb, row: OpeningBalanceRow) {
+  const activeDuplicate =
+    row.deletedAt == null ? findActiveOpeningBalanceByAccountId(db, row.accountId) : null;
+  return activeDuplicate?.id !== row.id ? activeDuplicate : null;
+}
 
-    if (existingById && existingById.updatedAt >= row.updatedAt) {
-      return;
-    }
+function shouldSkipOpeningBalancePersist(
+  existingById: OpeningBalanceRow | null,
+  duplicate: OpeningBalanceRow | null,
+  row: OpeningBalanceRow
+) {
+  return (
+    (existingById != null && existingById.updatedAt >= row.updatedAt) ||
+    (duplicate != null && duplicate.updatedAt >= row.updatedAt)
+  );
+}
 
-    if (duplicate && duplicate.updatedAt >= row.updatedAt) {
-      return;
-    }
+function upsertOpeningBalanceInTransaction(db: AnyDb, row: OpeningBalanceRow) {
+  const existingById = getOpeningBalanceById(db, row.id);
+  const duplicate = getActiveOpeningBalanceDuplicate(db, row);
+  if (shouldSkipOpeningBalancePersist(existingById, duplicate, row)) {
+    return;
+  }
 
-    if (duplicate) {
-      deleteOpeningBalanceDuplicate(tx, duplicate.id);
-    }
+  if (duplicate) {
+    deleteOpeningBalanceDuplicate(db, duplicate.id);
+  }
 
-    persistOpeningBalance(tx, row);
+  persistOpeningBalance(db, row);
+}
+
+function saveOpeningBalanceInTransaction(db: AnyDb, row: OpeningBalanceRow) {
+  const existingById = getOpeningBalanceById(db, row.id);
+  const duplicate = getActiveOpeningBalanceDuplicate(db, row);
+  if (existingById && duplicate) {
+    deleteOpeningBalanceDuplicate(db, duplicate.id);
+  }
+
+  const persistedRow =
+    existingById == null && duplicate
+      ? {
+          ...row,
+          id: duplicate.id,
+          createdAt: duplicate.createdAt,
+        }
+      : row;
+
+  persistOpeningBalance(db, persistedRow);
+
+  enqueueSync(db, {
+    id: generateSyncQueueId(),
+    tableName: "openingBalances",
+    rowId: persistedRow.id,
+    operation: existingById || duplicate ? "update" : "insert",
+    createdAt: row.updatedAt,
   });
 }
 
+export function upsertOpeningBalance(db: AnyDb, row: OpeningBalanceRow) {
+  db.transaction((tx) => upsertOpeningBalanceInTransaction(tx, row));
+}
+
 export function saveOpeningBalance(db: AnyDb, row: OpeningBalanceRow) {
-  db.transaction((tx) => {
-    const existingById = getOpeningBalanceById(tx, row.id);
-    const activeDuplicate =
-      row.deletedAt == null ? findActiveOpeningBalanceByAccountId(tx, row.accountId) : null;
-    const duplicate = activeDuplicate?.id !== row.id ? activeDuplicate : null;
-
-    if (existingById && duplicate) {
-      deleteOpeningBalanceDuplicate(tx, duplicate.id);
-    }
-
-    const persistedRow =
-      existingById == null && duplicate
-        ? {
-            ...row,
-            id: duplicate.id,
-            createdAt: duplicate.createdAt,
-          }
-        : row;
-
-    persistOpeningBalance(tx, persistedRow);
-
-    enqueueSync(tx, {
-      id: generateSyncQueueId(),
-      tableName: "openingBalances",
-      rowId: persistedRow.id,
-      operation: existingById || duplicate ? "update" : "insert",
-      createdAt: row.updatedAt,
-    });
-  });
+  db.transaction((tx) => saveOpeningBalanceInTransaction(tx, row));
 }

--- a/apps/mobile/features/financial-accounts/lib/repository.ts
+++ b/apps/mobile/features/financial-accounts/lib/repository.ts
@@ -4,8 +4,13 @@ import { enqueueSync, financialAccounts } from "@/shared/db";
 import { useLocaleStore } from "@/shared/i18n";
 import { generateSyncQueueId, toIsoDateTime } from "@/shared/lib";
 import type { IsoDateTime } from "@/shared/types/branded";
-import type { FinancialAccountKind } from "../schema";
 import { buildDefaultFinancialAccountId } from "./default-account";
+import {
+  buildDefaultFinancialAccountRow,
+  findCanonicalFinancialAccount,
+  findExistingDefaultFinancialAccount,
+  promoteFinancialAccountToDefault,
+} from "./default-account-bootstrap";
 
 export type FinancialAccountRow = typeof financialAccounts.$inferInsert;
 
@@ -13,8 +18,12 @@ type EnsureDefaultFinancialAccountOptions = {
   readonly now?: IsoDateTime;
   readonly name?: string;
 };
-
-const DEFAULT_FINANCIAL_ACCOUNT_KIND: FinancialAccountKind = "cash";
+type EnsureDefaultFinancialAccountContext = {
+  readonly db: AnyDb;
+  readonly userId: FinancialAccountRow["userId"];
+  readonly now: IsoDateTime;
+  readonly name: string;
+};
 
 function getDefaultFinancialAccountName() {
   return useLocaleStore.getState().t("financialAccounts.defaultName");
@@ -33,28 +42,23 @@ function getActiveFinancialAccountRowsForUser(db: AnyDb, userId: FinancialAccoun
     .all();
 }
 
-function findCanonicalFinancialAccount(
-  rows: readonly FinancialAccountRow[],
-  userId: FinancialAccountRow["userId"]
-) {
-  const canonicalId = buildDefaultFinancialAccountId(userId);
-  return rows.find((row) => row.id === canonicalId) ?? null;
-}
+function resolveExistingDefaultFinancialAccount(
+  context: EnsureDefaultFinancialAccountContext
+): FinancialAccountRow | null {
+  const activeRows = getActiveFinancialAccountRowsForUser(context.db, context.userId);
+  const existingDefault = findExistingDefaultFinancialAccount(activeRows);
+  if (existingDefault) {
+    return existingDefault;
+  }
 
-function findExistingDefaultFinancialAccount(rows: readonly FinancialAccountRow[]) {
-  return rows.find((row) => row.isDefault) ?? null;
-}
+  const canonicalActive = findCanonicalFinancialAccount(activeRows, context.userId);
+  if (!canonicalActive) {
+    return null;
+  }
 
-function promoteFinancialAccountToDefault(
-  row: FinancialAccountRow,
-  now: IsoDateTime
-): FinancialAccountRow {
-  return {
-    ...row,
-    isDefault: true,
-    updatedAt: now,
-    deletedAt: null,
-  };
+  const promotedRow = promoteFinancialAccountToDefault(canonicalActive, context.now);
+  saveFinancialAccount(context.db, promotedRow);
+  return promotedRow;
 }
 
 export function getFinancialAccountById(db: AnyDb, id: FinancialAccountRow["id"]) {
@@ -112,39 +116,31 @@ export function ensureDefaultFinancialAccount(
   userId: FinancialAccountRow["userId"],
   options: EnsureDefaultFinancialAccountOptions = {}
 ) {
-  const now = getDefaultFinancialAccountCreateTime(options.now);
-  const name = options.name ?? getDefaultFinancialAccountName();
+  const context = {
+    db,
+    userId,
+    now: getDefaultFinancialAccountCreateTime(options.now),
+    name: options.name ?? getDefaultFinancialAccountName(),
+  } satisfies EnsureDefaultFinancialAccountContext;
 
   return db.transaction((tx) => {
-    const activeRows = getActiveFinancialAccountRowsForUser(tx, userId);
-    const existingDefault = findExistingDefaultFinancialAccount(activeRows);
-
+    const transactionContext = {
+      ...context,
+      db: tx,
+    } satisfies EnsureDefaultFinancialAccountContext;
+    const existingDefault = resolveExistingDefaultFinancialAccount(transactionContext);
     if (existingDefault) {
       return existingDefault;
     }
 
-    const canonicalActive = findCanonicalFinancialAccount(activeRows, userId);
-    if (canonicalActive) {
-      const promotedRow = promoteFinancialAccountToDefault(canonicalActive, now);
-      saveFinancialAccount(tx, promotedRow);
-      return promotedRow;
-    }
-
-    const canonicalId = buildDefaultFinancialAccountId(userId);
+    const canonicalId = buildDefaultFinancialAccountId(transactionContext.userId);
     const existingCanonical = getFinancialAccountById(tx, canonicalId);
-    const row = {
-      id: canonicalId,
-      userId,
-      name: existingCanonical?.name || name,
-      kind: existingCanonical?.kind || DEFAULT_FINANCIAL_ACCOUNT_KIND,
-      isDefault: true,
-      statementClosingDay: existingCanonical?.statementClosingDay ?? null,
-      paymentDueDay: existingCanonical?.paymentDueDay ?? null,
-      createdAt: existingCanonical?.createdAt ?? now,
-      updatedAt: now,
-      deletedAt: null,
-    } satisfies FinancialAccountRow;
-
+    const row = buildDefaultFinancialAccountRow(
+      transactionContext.userId,
+      transactionContext.now,
+      transactionContext.name,
+      existingCanonical
+    );
     saveFinancialAccount(tx, row);
     return row;
   });

--- a/apps/mobile/features/search/components/SearchScreen.tsx
+++ b/apps/mobile/features/search/components/SearchScreen.tsx
@@ -45,12 +45,12 @@ const SearchTransactionItem = memo(function SearchTransactionItem({
       {showDateHeader && (
         <View className="px-4 pt-4 pb-1">
           <Text className="font-poppins-semibold text-caption text-secondary dark:text-secondary-dark">
-            {makeDateLabel(
-              tx.date,
-              t("dates.today"),
-              t("dates.yesterday"),
-              getDateFnsLocale(locale)
-            )}
+            {makeDateLabel({
+              date: tx.date,
+              todayLabel: t("dates.today"),
+              yesterdayLabel: t("dates.yesterday"),
+              dateFnsLocale: getDateFnsLocale(locale),
+            })}
           </Text>
         </View>
       )}

--- a/apps/mobile/features/transactions/lib/build-transaction.ts
+++ b/apps/mobile/features/transactions/lib/build-transaction.ts
@@ -57,7 +57,7 @@ const toTransactionSource = (source: string | undefined | null): string => sourc
 const isAccountAttributionState = (state: string | undefined): state is AccountAttributionState =>
   state === "confirmed" || state === "inferred" || state === "unresolved";
 
-const getDefaultAccountAttributionState = (
+export const getDefaultAccountAttributionState = (
   source: string | undefined | null
 ): AccountAttributionState =>
   TRANSACTION_SOURCES_WITH_CONFIRMED_DEFAULT.has(source ?? "manual") ? "confirmed" : "unresolved";

--- a/apps/mobile/features/transactions/lib/group-by-date.ts
+++ b/apps/mobile/features/transactions/lib/group-by-date.ts
@@ -10,44 +10,59 @@ export type DateHeader = {
 };
 
 export type ListItem = DateHeader | StoredTransaction;
+type DateLabelInput = {
+  readonly date: Date;
+  readonly todayLabel?: string;
+  readonly yesterdayLabel?: string;
+  readonly dateFnsLocale?: Locale;
+};
+type DateLabelOptions = Omit<DateLabelInput, "date">;
+type BuildListDataInput = {
+  readonly transactions: readonly StoredTransaction[];
+  readonly todayLabel?: string;
+  readonly yesterdayLabel?: string;
+  readonly dateFnsLocale?: Locale;
+};
 
 export function isDateHeader(item: ListItem): item is DateHeader {
   return "kind" in item;
 }
 
-export function makeDateLabel(
-  date: Date,
+export function makeDateLabel({
+  date,
   todayLabel = "Today",
   yesterdayLabel = "Yesterday",
-  dateFnsLocale?: Locale
-): string {
+  dateFnsLocale,
+}: DateLabelInput): string {
   if (isToday(date)) return todayLabel;
   if (isYesterday(date)) return yesterdayLabel;
   return format(date, "MMMM d", dateFnsLocale ? { locale: dateFnsLocale } : undefined);
 }
 
-export function buildListData(
-  transactions: readonly StoredTransaction[],
-  todayLabel = "Today",
-  yesterdayLabel = "Yesterday",
-  dateFnsLocale?: Locale
-): {
+function buildDateHeader(transaction: StoredTransaction, options: DateLabelOptions): DateHeader {
+  return {
+    kind: "date-header",
+    label: makeDateLabel({ date: transaction.date, ...options }),
+    dateKey: toIsoDate(transaction.date),
+  };
+}
+
+export function buildListData(input: BuildListDataInput): {
   readonly items: ListItem[];
   readonly stickyIndices: number[];
 } {
+  const { transactions, todayLabel = "Today", yesterdayLabel = "Yesterday", dateFnsLocale } = input;
   // Local mutation for O(n) performance on the render path (CLAUDE.md performance exemption).
   const items: ListItem[] = [];
   const stickyIndices: number[] = [];
+  const labelOptions = { todayLabel, yesterdayLabel, dateFnsLocale };
 
   transactions.reduce<string | null>((prev, tx) => {
-    const dateKey = toIsoDate(tx.date);
+    const header = buildDateHeader(tx, labelOptions);
+    const dateKey = header.dateKey;
     if (dateKey !== prev) {
       stickyIndices.push(items.length);
-      items.push({
-        kind: "date-header" as const,
-        label: makeDateLabel(tx.date, todayLabel, yesterdayLabel, dateFnsLocale),
-        dateKey,
-      });
+      items.push(header);
     }
     items.push(tx);
     return dateKey;

--- a/apps/mobile/features/transactions/lib/group-by-date.ts
+++ b/apps/mobile/features/transactions/lib/group-by-date.ts
@@ -58,11 +58,10 @@ export function buildListData(input: BuildListDataInput): {
   const labelOptions = { todayLabel, yesterdayLabel, dateFnsLocale };
 
   transactions.reduce<string | null>((prev, tx) => {
-    const header = buildDateHeader(tx, labelOptions);
-    const dateKey = header.dateKey;
+    const dateKey = toIsoDate(tx.date);
     if (dateKey !== prev) {
       stickyIndices.push(items.length);
-      items.push(header);
+      items.push(buildDateHeader(tx, labelOptions));
     }
     items.push(tx);
     return dateKey;

--- a/apps/mobile/features/transactions/lib/repository.ts
+++ b/apps/mobile/features/transactions/lib/repository.ts
@@ -15,10 +15,29 @@ import type {
 } from "@/shared/types/branded";
 import type { AccountAttributionState } from "../schema";
 import { getActiveTransactionConditions } from "./active-transaction-conditions";
+import { getDefaultAccountAttributionState } from "./build-transaction";
 
 export type { SyncOperation, SyncQueueEntry, SyncTableName } from "@/shared/db";
 
 type PersistedTransactionRow = typeof transactions.$inferInsert;
+type TransactionsPageInput = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly limit: number;
+  readonly offset: number;
+};
+type DailySpendingAggregateInput = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly startDate: IsoDate;
+  readonly endDate: IsoDate;
+};
+type RecentTransactionsInput = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly currentMonth: Month;
+  readonly previousMonth: Month;
+};
 
 export type TransactionRow = Omit<
   PersistedTransactionRow,
@@ -29,16 +48,28 @@ export type TransactionRow = Omit<
   supersededAt?: IsoDateTime | null;
 };
 
-function getDefaultAttributionState(row: TransactionRow): AccountAttributionState {
-  return row.source === "manual" || row.source == null ? "confirmed" : "unresolved";
+function resolveTransactionSource(row: TransactionRow): string {
+  return row.source ?? "manual";
+}
+
+function resolveTransactionAccountId(row: TransactionRow): FinancialAccountId {
+  return row.accountId ?? buildDefaultFinancialAccountId(row.userId);
+}
+
+function resolveTransactionAttributionState(
+  row: TransactionRow,
+  source: string
+): AccountAttributionState | string {
+  return row.accountAttributionState ?? getDefaultAccountAttributionState(source);
 }
 
 function normalizeTransactionRow(row: TransactionRow): PersistedTransactionRow {
+  const source = resolveTransactionSource(row);
   return {
     ...row,
-    source: row.source ?? "manual",
-    accountId: row.accountId ?? buildDefaultFinancialAccountId(row.userId),
-    accountAttributionState: row.accountAttributionState ?? getDefaultAttributionState(row),
+    source,
+    accountId: resolveTransactionAccountId(row),
+    accountAttributionState: resolveTransactionAttributionState(row, source),
     supersededAt: row.supersededAt ?? null,
   };
 }
@@ -56,19 +87,14 @@ export function getAllTransactions(db: AnyDb, userId: UserId): TransactionRow[] 
     .all() as TransactionRow[];
 }
 
-export function getTransactionsPaginated(
-  db: AnyDb,
-  userId: UserId,
-  limit: number,
-  offset: number
-): TransactionRow[] {
-  return db
+export function getTransactionsPaginated(input: TransactionsPageInput): TransactionRow[] {
+  return input.db
     .select()
     .from(transactions)
-    .where(and(...getActiveTransactionConditions(userId)))
+    .where(and(...getActiveTransactionConditions(input.userId)))
     .orderBy(desc(transactions.date), desc(transactions.createdAt))
-    .limit(limit + 1)
-    .offset(offset)
+    .limit(input.limit + 1)
+    .offset(input.offset)
     .all() as TransactionRow[];
 }
 
@@ -107,12 +133,9 @@ export function getSpendingByCategoryAggregate(
 }
 
 export function getDailySpendingAggregate(
-  db: AnyDb,
-  userId: UserId,
-  startDate: IsoDate,
-  endDate: IsoDate
+  input: DailySpendingAggregateInput
 ): { date: IsoDate; total: CopAmount }[] {
-  return db
+  return input.db
     .select({
       date: transactions.date,
       total: sum(transactions.amount).mapWith((val) => Number(val) as CopAmount),
@@ -120,9 +143,9 @@ export function getDailySpendingAggregate(
     .from(transactions)
     .where(
       and(
-        ...getActiveTransactionConditions(userId),
+        ...getActiveTransactionConditions(input.userId),
         eq(transactions.type, "expense"),
-        between(transactions.date, startDate, endDate)
+        between(transactions.date, input.startDate, input.endDate)
       )
     )
     .groupBy(transactions.date)
@@ -159,21 +182,16 @@ export function getMonthlyTotalsByType(
     .all();
 }
 
-export function getRecentTransactions(
-  db: AnyDb,
-  userId: UserId,
-  currentMonth: Month,
-  previousMonth: Month
-): TransactionRow[] {
-  return db
+export function getRecentTransactions(input: RecentTransactionsInput): TransactionRow[] {
+  return input.db
     .select()
     .from(transactions)
     .where(
       and(
-        ...getActiveTransactionConditions(userId),
+        ...getActiveTransactionConditions(input.userId),
         or(
-          like(transactions.date, `${currentMonth}%`),
-          like(transactions.date, `${previousMonth}%`)
+          like(transactions.date, `${input.currentMonth}%`),
+          like(transactions.date, `${input.previousMonth}%`)
         )
       )
     )

--- a/apps/mobile/features/transactions/services/create-transaction-query-service.ts
+++ b/apps/mobile/features/transactions/services/create-transaction-query-service.ts
@@ -104,7 +104,7 @@ function loadAggregateSnapshot(
   const endDate = toIsoDate(now);
   const categorySpending = loadSpendingByCategory(db, userId, currentMonth);
   const balance = categorySpending.reduce((sum, category) => sum + category.total, 0);
-  const dailySpending = loadDailySpending(db, userId, startDate, endDate);
+  const dailySpending = loadDailySpending({ db, userId, startDate, endDate });
 
   return {
     balance,
@@ -130,7 +130,7 @@ export function createTransactionQueryService({
       pageSize,
     }: LoadInitialSnapshotInput): TransactionPageSnapshot & TransactionAggregateSnapshot {
       const pageSnapshot = toPageSnapshot(
-        loadTransactionsPaginated(db, userId, pageSize, 0),
+        loadTransactionsPaginated({ db, userId, limit: pageSize, offset: 0 }),
         pageSize
       );
       return {
@@ -139,8 +139,16 @@ export function createTransactionQueryService({
       };
     },
 
-    loadNextPage({ db, userId, pageSize, offset }: LoadPageInput): TransactionPageSnapshot {
-      return toPageSnapshot(loadTransactionsPaginated(db, userId, pageSize, offset), pageSize);
+    loadNextPage(input: LoadPageInput): TransactionPageSnapshot {
+      return toPageSnapshot(
+        loadTransactionsPaginated({
+          db: input.db,
+          userId: input.userId,
+          limit: input.pageSize,
+          offset: input.offset,
+        }),
+        input.pageSize
+      );
     },
 
     loadRefreshSnapshot({
@@ -152,7 +160,7 @@ export function createTransactionQueryService({
     }: LoadRefreshSnapshotInput): TransactionRefreshSnapshot {
       const reloadSize = Math.max(currentOffset, pageSize);
       const pageSnapshot = toPageSnapshot(
-        loadTransactionsPaginated(db, userId, reloadSize, 0),
+        loadTransactionsPaginated({ db, userId, limit: reloadSize, offset: 0 }),
         reloadSize
       );
       return {
@@ -169,13 +177,9 @@ export function createTransactionQueryService({
       return loadAggregateOnlySnapshot(db, userId);
     },
 
-    getStoredTransaction({
-      db,
-      userId,
-      transactionId,
-    }: GetStoredTransactionInput): StoredTransaction | null {
-      const row = loadTransactionById(db, transactionId);
-      if (!row || row.userId !== userId || !isActiveTransactionRow(row)) {
+    getStoredTransaction(input: GetStoredTransactionInput): StoredTransaction | null {
+      const row = loadTransactionById(input.db, input.transactionId);
+      if (!row || row.userId !== input.userId || !isActiveTransactionRow(row)) {
         return null;
       }
       return toStoredTransaction(row);

--- a/apps/mobile/features/transactions/store.ts
+++ b/apps/mobile/features/transactions/store.ts
@@ -79,6 +79,33 @@ const INITIAL_FORM: Pick<
   accountId: null,
   description: "",
 };
+const INITIAL_PAGINATION_STATE: Pick<TransactionState, "pages" | "offset" | "hasMore"> = {
+  pages: [],
+  offset: 0,
+  hasMore: true,
+};
+const INITIAL_AGGREGATE_STATE: Pick<
+  TransactionState,
+  "balance" | "categorySpending" | "dailySpending" | "dataRevision"
+> = {
+  balance: 0,
+  categorySpending: [],
+  dailySpending: [],
+  dataRevision: 0,
+};
+type UpdateTransactionDirectInput = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly id: TransactionId;
+  readonly fields: {
+    readonly type: TransactionType;
+    readonly digits: string;
+    readonly categoryId: CategoryId | null;
+    readonly accountId: FinancialAccountId | null;
+    readonly description: string;
+    readonly date: Date;
+  };
+};
 
 function createInitialState(activeUserId: UserId | null): TransactionState {
   return {
@@ -86,13 +113,8 @@ function createInitialState(activeUserId: UserId | null): TransactionState {
     ...INITIAL_FORM,
     defaultAccountId: null,
     date: new Date(),
-    pages: [],
-    offset: 0,
-    hasMore: true,
-    balance: 0,
-    categorySpending: [],
-    dailySpending: [],
-    dataRevision: 0,
+    ...INITIAL_PAGINATION_STATE,
+    ...INITIAL_AGGREGATE_STATE,
     editingId: null,
   };
 }
@@ -388,18 +410,9 @@ export async function updateCurrentTransaction(
 }
 
 export async function updateTransactionDirect(
-  db: AnyDb,
-  userId: UserId,
-  id: TransactionId,
-  fields: {
-    readonly type: TransactionType;
-    readonly digits: string;
-    readonly categoryId: CategoryId | null;
-    readonly accountId: FinancialAccountId | null;
-    readonly description: string;
-    readonly date: Date;
-  }
+  input: UpdateTransactionDirectInput
 ): Promise<TransactionMutationResult> {
+  const { db, userId, id, fields } = input;
   const sessionId = transactionsSessionId;
   if (!isActiveTransactionSession(userId, sessionId)) {
     return { success: false, error: "Store not initialized" };

--- a/apps/mobile/features/transfers/lib/reclassify-transaction-as-transfer.ts
+++ b/apps/mobile/features/transfers/lib/reclassify-transaction-as-transfer.ts
@@ -112,7 +112,12 @@ export function reclassifyTransactionAsTransfer(
     relinkEvidenceToTransfer(tx, existingTransaction.id, built.transfer.id, updatedAt);
 
     if (input.processedEmailId) {
-      saveProcessedEmailStatus(tx, input.processedEmailId, "success", existingTransaction.id);
+      saveProcessedEmailStatus({
+        db: tx,
+        id: input.processedEmailId,
+        status: "success",
+        transactionId: existingTransaction.id,
+      });
     }
   });
 


### PR DESCRIPTION
- refactor wave 2 hotspots
- normalize object-input helpers
- add regression coverage

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized object-based inputs across capture, email, transactions, and accounts to reduce parameter bugs and simplify wave 2 pipelines. Fixed extra date headers in lists by computing date labels only when needed while keeping grouping behavior.

- **Refactors**
  - Switched to object inputs for core APIs: `captureFingerprint`, `findDuplicateTransaction`, email capture repository methods, transaction/activity queries, and store actions.
  - Simplified capture ingestion and notification/apple/widget pipelines; unified fingerprinting and duplicate lookups.
  - Extracted financial account helpers (`balance-maps`, `default-account-bootstrap`); refactored balance and opening balance repositories.
  - Updated date label and transaction grouping helpers to object inputs; adjusted `HomeScreen`, `SearchScreen`.

- **Migration**
  - Update callers to pass objects for: `updateProcessedEmailStatus`, `markForRetry`, `markRetrySuccess`, `getTransactionsPaginated`, `loadDailySpending`, `buildListData`, `makeDateLabel`, `updateTransactionDirect`.

<sup>Written for commit 5f7fd822614fd58d5ceafa6121b75922413cfedb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

