### PR TITLE
refactor(mobile): burn down wave 3 lizard

### DIFF
--- a/apps/mobile/__tests__/activity/query-service.test.ts
+++ b/apps/mobile/__tests__/activity/query-service.test.ts
@@ -215,7 +215,12 @@ describe("activity query service", () => {
       limit: 5,
       offset: 0,
     });
-    expect(getTransfersPaginated).toHaveBeenCalledWith(expect.anything(), USER_ID, 5, 0);
+    expect(getTransfersPaginated).toHaveBeenCalledWith({
+      db: expect.anything(),
+      userId: USER_ID,
+      limit: 5,
+      offset: 0,
+    });
   });
 
   it("orders same-day transaction activity with the transaction source sort key", () => {

--- a/apps/mobile/__tests__/ai-chat/callers.test.ts
+++ b/apps/mobile/__tests__/ai-chat/callers.test.ts
@@ -21,14 +21,14 @@ describe("ai chat callers", () => {
   });
 
   test("ChatScreen catches action-status persistence failures", () => {
-    expect(chatScreenSource).toContain("updateChatActionStatus(db, userId, messageId, status)");
+    expect(chatScreenSource).toContain("updateChatActionStatus({ db, userId, messageId, status })");
     expect(chatScreenSource).toContain(".catch(captureError)");
     expect(chatScreenSource).toContain("persistActionStatus");
     expect(chatScreenSource).not.toContain(
-      'void updateChatActionStatus(db, userId, messageId, "confirmed")'
+      'void updateChatActionStatus({ db, userId, messageId, status: "confirmed" })'
     );
     expect(chatScreenSource).not.toContain(
-      'void updateChatActionStatus(db, userId, messageId, "dismissed")'
+      'void updateChatActionStatus({ db, userId, messageId, status: "dismissed" })'
     );
   });
 });

--- a/apps/mobile/__tests__/ai-chat/chat-row-mappers.test.ts
+++ b/apps/mobile/__tests__/ai-chat/chat-row-mappers.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { mapChatMessageRow } from "@/features/ai-chat/lib/chat-row-mappers";
+import { generateChatMessageId, generateChatSessionId, toIsoDateTime } from "@/shared/lib";
+
+type ChatMessageRow = Parameters<typeof mapChatMessageRow>[0];
+
+const makeRow = (overrides: Partial<ChatMessageRow> = {}): ChatMessageRow => ({
+  id: generateChatMessageId(),
+  sessionId: generateChatSessionId(),
+  role: "assistant",
+  content: "I can help with that",
+  action: null,
+  actionStatus: null,
+  createdAt: toIsoDateTime(new Date("2026-04-18T10:15:00.000Z")),
+  ...overrides,
+});
+
+describe("chat row mappers", () => {
+  it("maps valid persisted actions", () => {
+    const message = mapChatMessageRow(
+      makeRow({
+        action:
+          '{"type":"delete","transactionId":"tx-123","description":"Uber","amount":15000,"date":"2026-03-01"}',
+      })
+    );
+
+    expect(message.action).toEqual({
+      type: "delete",
+      transactionId: "tx-123",
+      description: "Uber",
+      amount: 15000,
+      date: "2026-03-01",
+    });
+  });
+
+  it("returns a null action for malformed persisted JSON", () => {
+    expect(() => mapChatMessageRow(makeRow({ action: "{not valid json}" }))).not.toThrow();
+    expect(mapChatMessageRow(makeRow({ action: "{not valid json}" })).action).toBeNull();
+  });
+});

--- a/apps/mobile/__tests__/search/repository.test.ts
+++ b/apps/mobile/__tests__/search/repository.test.ts
@@ -44,7 +44,13 @@ describe("search repository", () => {
   it("searchTransactionsPaginated calls db with limit+1 for hasMore detection", async () => {
     const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
 
-    searchTransactionsPaginated(mockDb, USER_ID, EMPTY_FILTERS, 30, 0);
+    searchTransactionsPaginated({
+      db: mockDb,
+      userId: USER_ID,
+      filters: EMPTY_FILTERS,
+      limit: 30,
+      offset: 0,
+    });
 
     expect(mockSelect).toHaveBeenCalled();
     expect(mockFrom).toHaveBeenCalled();
@@ -58,7 +64,13 @@ describe("search repository", () => {
   it("searchTransactionsPaginated passes correct offset", async () => {
     const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
 
-    searchTransactionsPaginated(mockDb, USER_ID, EMPTY_FILTERS, 30, 60);
+    searchTransactionsPaginated({
+      db: mockDb,
+      userId: USER_ID,
+      filters: EMPTY_FILTERS,
+      limit: 30,
+      offset: 60,
+    });
 
     expect(mockOffset).toHaveBeenCalledWith(60);
   });
@@ -86,7 +98,13 @@ describe("search repository", () => {
   it("applies query filter via LIKE when query is non-empty", async () => {
     const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
 
-    searchTransactionsPaginated(mockDb, USER_ID, withFilters({ query: "coffee" }), 30, 0);
+    searchTransactionsPaginated({
+      db: mockDb,
+      userId: USER_ID,
+      filters: withFilters({ query: "coffee" }),
+      limit: 30,
+      offset: 0,
+    });
 
     expect(mockWhere).toHaveBeenCalled();
   });
@@ -94,7 +112,13 @@ describe("search repository", () => {
   it("does not apply LIKE filter when query is empty", async () => {
     const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
 
-    searchTransactionsPaginated(mockDb, USER_ID, EMPTY_FILTERS, 30, 0);
+    searchTransactionsPaginated({
+      db: mockDb,
+      userId: USER_ID,
+      filters: EMPTY_FILTERS,
+      limit: 30,
+      offset: 0,
+    });
 
     expect(mockWhere).toHaveBeenCalled();
   });
@@ -102,13 +126,13 @@ describe("search repository", () => {
   it("applies categoryIds filter via inArray", async () => {
     const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
 
-    searchTransactionsPaginated(
-      mockDb,
-      USER_ID,
-      withFilters({ categoryIds: ["food", "transport"] }),
-      30,
-      0
-    );
+    searchTransactionsPaginated({
+      db: mockDb,
+      userId: USER_ID,
+      filters: withFilters({ categoryIds: ["food", "transport"] }),
+      limit: 30,
+      offset: 0,
+    });
 
     expect(mockWhere).toHaveBeenCalled();
   });
@@ -116,13 +140,13 @@ describe("search repository", () => {
   it("applies date range filters", async () => {
     const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
 
-    searchTransactionsPaginated(
-      mockDb,
-      USER_ID,
-      withFilters({ dateFrom: "2026-03-01", dateTo: "2026-03-31" }),
-      30,
-      0
-    );
+    searchTransactionsPaginated({
+      db: mockDb,
+      userId: USER_ID,
+      filters: withFilters({ dateFrom: "2026-03-01", dateTo: "2026-03-31" }),
+      limit: 30,
+      offset: 0,
+    });
 
     expect(mockWhere).toHaveBeenCalled();
   });
@@ -130,13 +154,13 @@ describe("search repository", () => {
   it("applies amount range filters", async () => {
     const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
 
-    searchTransactionsPaginated(
-      mockDb,
-      USER_ID,
-      withFilters({ amountMin: 100, amountMax: 5000 }),
-      30,
-      0
-    );
+    searchTransactionsPaginated({
+      db: mockDb,
+      userId: USER_ID,
+      filters: withFilters({ amountMin: 100, amountMax: 5000 }),
+      limit: 30,
+      offset: 0,
+    });
 
     expect(mockWhere).toHaveBeenCalled();
   });
@@ -144,7 +168,13 @@ describe("search repository", () => {
   it("applies type filter when not all", async () => {
     const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
 
-    searchTransactionsPaginated(mockDb, USER_ID, withFilters({ type: "expense" }), 30, 0);
+    searchTransactionsPaginated({
+      db: mockDb,
+      userId: USER_ID,
+      filters: withFilters({ type: "expense" }),
+      limit: 30,
+      offset: 0,
+    });
 
     expect(mockWhere).toHaveBeenCalled();
   });
@@ -152,7 +182,13 @@ describe("search repository", () => {
   it("does not apply type filter when type is all", async () => {
     const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
 
-    searchTransactionsPaginated(mockDb, USER_ID, withFilters({ type: "all" }), 30, 0);
+    searchTransactionsPaginated({
+      db: mockDb,
+      userId: USER_ID,
+      filters: withFilters({ type: "all" }),
+      limit: 30,
+      offset: 0,
+    });
 
     expect(mockWhere).toHaveBeenCalled();
   });
@@ -166,7 +202,13 @@ describe("search repository", () => {
 
     const { searchTransactionsPaginated } = await import("../../features/search/lib/repository");
 
-    const result = searchTransactionsPaginated(mockDb, USER_ID, withFilters({ query: "o" }), 30, 0);
+    const result = searchTransactionsPaginated({
+      db: mockDb,
+      userId: USER_ID,
+      filters: withFilters({ query: "o" }),
+      limit: 30,
+      offset: 0,
+    });
 
     expect(result).toEqual(mockRows);
   });

--- a/apps/mobile/__tests__/search/store.test.ts
+++ b/apps/mobile/__tests__/search/store.test.ts
@@ -54,13 +54,13 @@ describe("search store boundary", () => {
 
     executeSearch(mockDb, USER_ID);
 
-    expect(mockSearchTransactionsPaginated).toHaveBeenCalledWith(
-      mockDb,
-      USER_ID,
-      expect.objectContaining({ query: "coffee" }),
-      30,
-      0
-    );
+    expect(mockSearchTransactionsPaginated).toHaveBeenCalledWith({
+      db: mockDb,
+      userId: USER_ID,
+      filters: expect.objectContaining({ query: "coffee" }),
+      limit: 30,
+      offset: 0,
+    });
     expect(mockSearchTransactionsAggregate).toHaveBeenCalledWith(
       mockDb,
       USER_ID,
@@ -85,13 +85,13 @@ describe("search store boundary", () => {
 
     loadNextSearchPage(mockDb, USER_ID);
 
-    expect(mockSearchTransactionsPaginated).toHaveBeenCalledWith(
-      mockDb,
-      USER_ID,
-      EMPTY_FILTERS,
-      30,
-      1
-    );
+    expect(mockSearchTransactionsPaginated).toHaveBeenCalledWith({
+      db: mockDb,
+      userId: USER_ID,
+      filters: EMPTY_FILTERS,
+      limit: 30,
+      offset: 1,
+    });
     expect(useSearchStore.getState().results).toEqual([
       makeRow("tx-1"),
       expect.objectContaining({ id: "tx-2" }),
@@ -108,13 +108,13 @@ describe("search store boundary", () => {
     updateSearchQuery(mockDb, USER_ID, "rent");
 
     expect(useSearchStore.getState().filters.query).toBe("rent");
-    expect(mockSearchTransactionsPaginated).toHaveBeenCalledWith(
-      mockDb,
-      USER_ID,
-      expect.objectContaining({ query: "rent" }),
-      30,
-      0
-    );
+    expect(mockSearchTransactionsPaginated).toHaveBeenCalledWith({
+      db: mockDb,
+      userId: USER_ID,
+      filters: expect.objectContaining({ query: "rent" }),
+      limit: 30,
+      offset: 0,
+    });
     expect(useSearchStore.getState().results).toEqual([
       expect.objectContaining({ id: "tx-9", converted: true }),
     ]);

--- a/apps/mobile/__tests__/transfers/build-transfer.test.ts
+++ b/apps/mobile/__tests__/transfers/build-transfer.test.ts
@@ -26,7 +26,12 @@ const validInput = {
 
 describe("buildTransfer", () => {
   test("builds a tracked-account transfer with one amount and two explicit sides", () => {
-    const result = buildTransfer(validInput, "user-1" as UserId, "tr-1" as TransferId, NOW);
+    const result = buildTransfer({
+      input: validInput,
+      userId: "user-1" as UserId,
+      id: "tr-1" as TransferId,
+      now: NOW,
+    });
 
     expect(result).toMatchObject({
       success: true,
@@ -42,43 +47,43 @@ describe("buildTransfer", () => {
   });
 
   test("rejects transfers that do not have two explicit sides", () => {
-    const missingFrom = buildTransfer(
-      { ...validInput, fromSide: null },
-      "user-1" as UserId,
-      "tr-2" as TransferId,
-      NOW
-    );
-    const missingTo = buildTransfer(
-      { ...validInput, toSide: null },
-      "user-1" as UserId,
-      "tr-3" as TransferId,
-      NOW
-    );
+    const missingFrom = buildTransfer({
+      input: { ...validInput, fromSide: null },
+      userId: "user-1" as UserId,
+      id: "tr-2" as TransferId,
+      now: NOW,
+    });
+    const missingTo = buildTransfer({
+      input: { ...validInput, toSide: null },
+      userId: "user-1" as UserId,
+      id: "tr-3" as TransferId,
+      now: NOW,
+    });
 
     expect(missingFrom).toEqual({ success: false, error: "fromSideRequired" });
     expect(missingTo).toEqual({ success: false, error: "toSideRequired" });
   });
 
   test("allows the generic outside side only when the other side is a tracked account", () => {
-    const trackedToOutside = buildTransfer(
-      {
+    const trackedToOutside = buildTransfer({
+      input: {
         ...validInput,
         toSide: { kind: "external" as const, label: OUTSIDE_FIDY_LABEL },
       },
-      "user-1" as UserId,
-      "tr-4" as TransferId,
-      NOW
-    );
-    const outsideToOutside = buildTransfer(
-      {
+      userId: "user-1" as UserId,
+      id: "tr-4" as TransferId,
+      now: NOW,
+    });
+    const outsideToOutside = buildTransfer({
+      input: {
         ...validInput,
         fromSide: { kind: "external" as const, label: OUTSIDE_FIDY_LABEL },
         toSide: { kind: "external" as const, label: OUTSIDE_FIDY_LABEL },
       },
-      "user-1" as UserId,
-      "tr-5" as TransferId,
-      NOW
-    );
+      userId: "user-1" as UserId,
+      id: "tr-5" as TransferId,
+      now: NOW,
+    });
 
     expect(trackedToOutside).toMatchObject({
       success: true,
@@ -90,15 +95,15 @@ describe("buildTransfer", () => {
   });
 
   test("rejects transfers where both tracked sides point to the same account", () => {
-    const result = buildTransfer(
-      {
+    const result = buildTransfer({
+      input: {
         ...validInput,
         toSide: { kind: "account" as const, accountId: "fa-checking" as FinancialAccountId },
       },
-      "user-1" as UserId,
-      "tr-6" as TransferId,
-      NOW
-    );
+      userId: "user-1" as UserId,
+      id: "tr-6" as TransferId,
+      now: NOW,
+    });
 
     expect(result).toEqual({ success: false, error: "distinctSidesRequired" });
   });

--- a/apps/mobile/__tests__/transfers/repository-pagination.test.ts
+++ b/apps/mobile/__tests__/transfers/repository-pagination.test.ts
@@ -31,14 +31,14 @@ describe("getTransfersPaginated", () => {
 
   it("calls limit with limit+1 for hasMore detection", async () => {
     const { getTransfersPaginated } = await import("@/features/transfers/lib/repository");
-    getTransfersPaginated(mockDb, "user-1" as UserId, 30, 0);
+    getTransfersPaginated({ db: mockDb, userId: "user-1" as UserId, limit: 30, offset: 0 });
 
     expect(mockLimit).toHaveBeenCalledWith(31);
   });
 
   it("uses a unique tiebreaker in the sort order", async () => {
     const { getTransfersPaginated } = await import("@/features/transfers/lib/repository");
-    getTransfersPaginated(mockDb, "user-1" as UserId, 30, 0);
+    getTransfersPaginated({ db: mockDb, userId: "user-1" as UserId, limit: 30, offset: 0 });
 
     expect(mockOrderBy).toHaveBeenCalledOnce();
     expect(mockOrderBy.mock.calls[0]).toHaveLength(3);

--- a/apps/mobile/app/create-budget.tsx
+++ b/apps/mobile/app/create-budget.tsx
@@ -219,7 +219,7 @@ export default function CreateBudgetScreen() {
       }}
       onUpdateBudget={(id, amount) => {
         if (!userId || !db) return Promise.resolve(false);
-        return updateBudget(db, userId, id, amount);
+        return updateBudget({ db, userId, id, amount });
       }}
       onDeleteBudget={(id) => {
         if (!userId || !db) return Promise.resolve(false);

--- a/apps/mobile/features/activity/services/activity-items.ts
+++ b/apps/mobile/features/activity/services/activity-items.ts
@@ -1,0 +1,80 @@
+import { toStoredTransaction } from "@/features/transactions/lib/build-transaction";
+import type { TransactionRow } from "@/features/transactions/lib/repository";
+import type { StoredTransaction } from "@/features/transactions/schema";
+import { type StoredTransfer, toStoredTransfer } from "@/features/transfers/lib/build-transfer";
+import type { TransferRow } from "@/features/transfers/lib/repository";
+
+export type StoredActivityItem =
+  | {
+      readonly kind: "transaction";
+      readonly id: StoredTransaction["id"];
+      readonly date: Date;
+      readonly updatedAt: Date;
+      readonly transaction: StoredTransaction;
+    }
+  | {
+      readonly kind: "transfer";
+      readonly id: StoredTransfer["id"];
+      readonly date: Date;
+      readonly updatedAt: Date;
+      readonly transfer: StoredTransfer;
+    };
+
+type ActivityItemsInput = {
+  readonly transactionRows: readonly TransactionRow[];
+  readonly transferRows: readonly TransferRow[];
+  readonly fetchSize: number;
+};
+
+function toTransactionActivityItem(row: TransactionRow): StoredActivityItem {
+  const transaction = toStoredTransaction(row);
+  return {
+    kind: "transaction",
+    id: transaction.id,
+    date: transaction.date,
+    updatedAt: transaction.updatedAt,
+    transaction,
+  };
+}
+
+function toTransferActivityItem(row: TransferRow): StoredActivityItem {
+  const transfer = toStoredTransfer(row);
+  return {
+    kind: "transfer",
+    id: transfer.id,
+    date: transfer.date,
+    updatedAt: transfer.updatedAt,
+    transfer,
+  };
+}
+
+export function toStoredActivityItems(input: ActivityItemsInput): readonly StoredActivityItem[] {
+  const { transactionRows, transferRows, fetchSize } = input;
+  return mergeActivityItems(
+    transactionRows.slice(0, fetchSize).map(toTransactionActivityItem),
+    transferRows.slice(0, fetchSize).map(toTransferActivityItem)
+  );
+}
+
+function getActivitySecondarySortTime(item: StoredActivityItem): number {
+  return item.kind === "transaction"
+    ? item.transaction.createdAt.getTime()
+    : item.transfer.updatedAt.getTime();
+}
+
+function compareActivityItems(left: StoredActivityItem, right: StoredActivityItem) {
+  const dateDiff = right.date.getTime() - left.date.getTime();
+  if (dateDiff !== 0) {
+    return dateDiff;
+  }
+
+  const secondaryDiff = getActivitySecondarySortTime(right) - getActivitySecondarySortTime(left);
+  return secondaryDiff !== 0 ? secondaryDiff : right.id.localeCompare(left.id);
+}
+
+function mergeActivityItems(
+  left: readonly StoredActivityItem[],
+  right: readonly StoredActivityItem[]
+): readonly StoredActivityItem[] {
+  return [...left, ...right].sort(compareActivityItems);
+}

--- a/apps/mobile/features/activity/services/create-activity-query-service.ts
+++ b/apps/mobile/features/activity/services/create-activity-query-service.ts
@@ -1,26 +1,10 @@
-import { toStoredTransaction } from "@/features/transactions/lib/build-transaction";
 import { getTransactionsPaginated } from "@/features/transactions/lib/repository";
-import type { StoredTransaction } from "@/features/transactions/schema";
-import { type StoredTransfer, toStoredTransfer } from "@/features/transfers/lib/build-transfer";
 import { getTransfersPaginated } from "@/features/transfers/lib/repository";
 import type { AnyDb } from "@/shared/db/client";
 import type { UserId } from "@/shared/types/branded";
+import { type StoredActivityItem, toStoredActivityItems } from "./activity-items";
 
-export type StoredActivityItem =
-  | {
-      readonly kind: "transaction";
-      readonly id: StoredTransaction["id"];
-      readonly date: Date;
-      readonly updatedAt: Date;
-      readonly transaction: StoredTransaction;
-    }
-  | {
-      readonly kind: "transfer";
-      readonly id: StoredTransfer["id"];
-      readonly date: Date;
-      readonly updatedAt: Date;
-      readonly transfer: StoredTransfer;
-    };
+export type { StoredActivityItem } from "./activity-items";
 
 export type ActivityPageSnapshot = {
   readonly pages: readonly StoredActivityItem[];
@@ -39,116 +23,51 @@ type CreateActivityQueryServiceDeps = {
   readonly getTransactionsPaginated?: typeof getTransactionsPaginated;
   readonly getTransfersPaginated?: typeof getTransfersPaginated;
 };
+type LoadActivityPageRequest = LoadActivityPageInput & {
+  readonly transactionsLoader: typeof getTransactionsPaginated;
+  readonly transfersLoader: typeof getTransfersPaginated;
+};
 
-function toStoredActivityItems(
-  transactionRows: ReturnType<typeof getTransactionsPaginated>,
-  transferRows: ReturnType<typeof getTransfersPaginated>,
-  fetchSize: number
-): readonly StoredActivityItem[] {
-  const transactionItems = transactionRows.slice(0, fetchSize).map((row) => {
-    const transaction = toStoredTransaction(row);
-    return {
-      kind: "transaction" as const,
-      id: transaction.id,
-      date: transaction.date,
-      updatedAt: transaction.updatedAt,
-      transaction,
-    };
+function loadActivityPage(input: LoadActivityPageRequest): ActivityPageSnapshot {
+  const fetchSize = input.offset + input.pageSize + 1;
+  const mergedItems = toStoredActivityItems({
+    transactionRows: input.transactionsLoader({
+      db: input.db,
+      userId: input.userId,
+      limit: fetchSize,
+      offset: 0,
+    }),
+    transferRows: input.transfersLoader({
+      db: input.db,
+      userId: input.userId,
+      limit: fetchSize,
+      offset: 0,
+    }),
+    fetchSize,
   });
-  const transferItems = transferRows.slice(0, fetchSize).map((row) => {
-    const transfer = toStoredTransfer(row);
-    return {
-      kind: "transfer" as const,
-      id: transfer.id,
-      date: transfer.date,
-      updatedAt: transfer.updatedAt,
-      transfer,
-    };
-  });
+  const window = mergedItems.slice(input.offset, input.offset + input.pageSize + 1);
+  const hasMore = window.length > input.pageSize;
+  const pages = hasMore ? window.slice(0, input.pageSize) : window;
 
-  return mergeActivityItems(transactionItems, transferItems);
-}
-
-function compareActivityItems(left: StoredActivityItem, right: StoredActivityItem) {
-  const dateDiff = right.date.getTime() - left.date.getTime();
-
-  if (dateDiff !== 0) {
-    return dateDiff;
-  }
-
-  const leftSecondarySortTime =
-    left.kind === "transaction"
-      ? left.transaction.createdAt.getTime()
-      : left.transfer.updatedAt.getTime();
-  const rightSecondarySortTime =
-    right.kind === "transaction"
-      ? right.transaction.createdAt.getTime()
-      : right.transfer.updatedAt.getTime();
-  const secondaryDiff = rightSecondarySortTime - leftSecondarySortTime;
-
-  if (secondaryDiff !== 0) {
-    return secondaryDiff;
-  }
-
-  return right.id.localeCompare(left.id);
-}
-
-function mergeActivityItems(
-  left: readonly StoredActivityItem[],
-  right: readonly StoredActivityItem[]
-): readonly StoredActivityItem[] {
-  const merged: StoredActivityItem[] = [];
-  let leftIndex = 0;
-  let rightIndex = 0;
-
-  // Keep pagination windows stack-safe even when the merged offset grows large.
-  while (leftIndex < left.length && rightIndex < right.length) {
-    const leftHead = left[leftIndex];
-    const rightHead = right[rightIndex];
-
-    if (leftHead == null || rightHead == null) {
-      break;
-    }
-
-    if (compareActivityItems(leftHead, rightHead) <= 0) {
-      merged.push(leftHead);
-      leftIndex += 1;
-    } else {
-      merged.push(rightHead);
-      rightIndex += 1;
-    }
-  }
-
-  return [...merged, ...left.slice(leftIndex), ...right.slice(rightIndex)];
-}
-
-export function createActivityQueryService({
-  getTransactionsPaginated: loadTransactionsPaginated = getTransactionsPaginated,
-  getTransfersPaginated: loadTransfersPaginated = getTransfersPaginated,
-}: CreateActivityQueryServiceDeps = {}) {
   return {
-    loadPage(input: LoadActivityPageInput): ActivityPageSnapshot {
-      const { db, userId, pageSize, offset } = input;
-      const fetchSize = offset + pageSize + 1;
-      const mergedItems = toStoredActivityItems(
-        loadTransactionsPaginated({
-          db,
-          userId,
-          limit: fetchSize,
-          offset: 0,
-        }),
-        loadTransfersPaginated(db, userId, fetchSize, 0),
-        fetchSize
-      );
-      const window = mergedItems.slice(offset, offset + pageSize + 1);
-      const hasMore = window.length > pageSize;
-      const pages = hasMore ? window.slice(0, pageSize) : window;
+    pages,
+    offset: input.offset + pages.length,
+    hasMore,
+  };
+}
 
-      return {
-        pages,
-        offset: offset + pages.length,
-        hasMore,
-      };
-    },
+export function createActivityQueryService(deps: CreateActivityQueryServiceDeps = {}) {
+  const {
+    getTransactionsPaginated: transactionsLoader = getTransactionsPaginated,
+    getTransfersPaginated: transfersLoader = getTransfersPaginated,
+  } = deps;
+
+  return {
+    loadPage: (input: LoadActivityPageInput) =>
+      loadActivityPage({
+        ...input,
+        transactionsLoader,
+        transfersLoader,
+      }),
   };
 }

--- a/apps/mobile/features/ai-chat/components/ChatScreen.tsx
+++ b/apps/mobile/features/ai-chat/components/ChatScreen.tsx
@@ -58,7 +58,7 @@ export function ChatScreen({ onBack }: ChatScreenProps) {
   const persistActionStatus = useCallback(
     (messageId: ChatMessageId, status: ActionStatus) => {
       if (!db || !userId) return;
-      void updateChatActionStatus(db, userId, messageId, status).catch(captureError);
+      void updateChatActionStatus({ db, userId, messageId, status }).catch(captureError);
     },
     [db, userId]
   );

--- a/apps/mobile/features/ai-chat/lib/chat-row-mappers.ts
+++ b/apps/mobile/features/ai-chat/lib/chat-row-mappers.ts
@@ -2,6 +2,18 @@ import type { chatMessages, chatSessions } from "@/shared/db";
 import { requireIsoDateTime } from "@/shared/types/assertions";
 import type { ActionStatus, ChatAction, ChatMessage, ChatSession } from "../schema";
 
+const parseChatAction = (action: string | null): ChatAction | null => {
+  if (action === null) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(action) as ChatAction;
+  } catch {
+    return null;
+  }
+};
+
 export function mapChatSessionRow(row: typeof chatSessions.$inferSelect): ChatSession {
   return {
     id: row.id,
@@ -19,7 +31,7 @@ export function mapChatMessageRow(row: typeof chatMessages.$inferSelect): ChatMe
     sessionId: row.sessionId,
     role: row.role as "user" | "assistant",
     content: row.content,
-    action: row.action ? (JSON.parse(row.action) as ChatAction) : null,
+    action: parseChatAction(row.action),
     actionStatus: row.actionStatus as ActionStatus | null,
     createdAt: requireIsoDateTime(row.createdAt),
   };

--- a/apps/mobile/features/ai-chat/lib/chat-row-mappers.ts
+++ b/apps/mobile/features/ai-chat/lib/chat-row-mappers.ts
@@ -1,0 +1,26 @@
+import type { chatMessages, chatSessions } from "@/shared/db";
+import { requireIsoDateTime } from "@/shared/types/assertions";
+import type { ActionStatus, ChatAction, ChatMessage, ChatSession } from "../schema";
+
+export function mapChatSessionRow(row: typeof chatSessions.$inferSelect): ChatSession {
+  return {
+    id: row.id,
+    userId: row.userId,
+    title: row.title,
+    createdAt: requireIsoDateTime(row.createdAt),
+    expiresAt: requireIsoDateTime(row.expiresAt),
+    deletedAt: row.deletedAt ? requireIsoDateTime(row.deletedAt) : null,
+  };
+}
+
+export function mapChatMessageRow(row: typeof chatMessages.$inferSelect): ChatMessage {
+  return {
+    id: row.id,
+    sessionId: row.sessionId,
+    role: row.role as "user" | "assistant",
+    content: row.content,
+    action: row.action ? (JSON.parse(row.action) as ChatAction) : null,
+    actionStatus: row.actionStatus as ActionStatus | null,
+    createdAt: requireIsoDateTime(row.createdAt),
+  };
+}

--- a/apps/mobile/features/ai-chat/store.ts
+++ b/apps/mobile/features/ai-chat/store.ts
@@ -1,9 +1,9 @@
 import { and, asc, desc, eq, isNull } from "drizzle-orm";
-import { create } from "zustand";
+import { create, type StateCreator } from "zustand";
 import { type AnyDb, chatMessages, chatSessions } from "@/shared/db";
 import { generateChatMessageId, generateChatSessionId, toIsoDateTime } from "@/shared/lib";
-import { requireIsoDateTime } from "@/shared/types/assertions";
 import type { ChatMessageId, ChatSessionId, UserId } from "@/shared/types/branded";
+import { mapChatMessageRow, mapChatSessionRow } from "./lib/chat-row-mappers";
 import { deriveConversationTitle, findExpiredSessions } from "./lib/sessions";
 import type { ActionStatus, ChatAction, ChatMessage, ChatSession } from "./schema";
 
@@ -39,136 +39,94 @@ type ChatActions = {
   dismissExpiredBanner: () => void;
 };
 
-export const useChatStore = create<ChatState & ChatActions>((set) => ({
-  activeUserId: null,
-  sessions: [],
-  currentSessionId: null,
-  messages: [],
-  isStreaming: false,
-  streamingContent: "",
-  expiredSessionCount: 0,
+type ChatStore = ChatState & ChatActions;
+type ChatSetState = Parameters<StateCreator<ChatStore>>[0];
+type UpdateChatActionStatusInput = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly messageId: ChatMessageId;
+  readonly status: ActionStatus;
+};
 
-  beginSession: (userId) =>
-    set({
-      activeUserId: userId,
-      sessions: [],
-      currentSessionId: null,
-      messages: [],
-      isStreaming: false,
-      streamingContent: "",
-      expiredSessionCount: 0,
-    }),
+function createChatState(activeUserId: UserId | null): ChatState {
+  return {
+    activeUserId,
+    sessions: [],
+    currentSessionId: null,
+    messages: [],
+    isStreaming: false,
+    streamingContent: "",
+    expiredSessionCount: 0,
+  };
+}
 
-  setSessions: (sessions) => set({ sessions: [...sessions] }),
+function beginChatSession(set: ChatSetState): ChatActions["beginSession"] {
+  return (userId) => set(createChatState(userId));
+}
 
-  prependSession: (session) =>
+function prependChatSession(set: ChatSetState): ChatActions["prependSession"] {
+  return (session) =>
     set((state) => ({
       sessions: [session, ...state.sessions],
       currentSessionId: session.id,
       messages: [],
-    })),
+    }));
+}
 
-  removeSession: (sessionId) =>
+function removeChatSession(set: ChatSetState): ChatActions["removeSession"] {
+  return (sessionId) =>
     set((state) => ({
       sessions: state.sessions.filter((session) => session.id !== sessionId),
       currentSessionId: state.currentSessionId === sessionId ? null : state.currentSessionId,
       messages: state.currentSessionId === sessionId ? [] : state.messages,
-    })),
+    }));
+}
 
-  setCurrentSessionId: (currentSessionId) => set({ currentSessionId, messages: [] }),
-
-  setMessages: (messages) => set({ messages: [...messages] }),
-
-  appendMessage: (message) =>
-    set((state) => ({
-      messages: [...state.messages, message],
-    })),
-
-  setMessageActionStatus: (messageId, status) =>
+function setChatMessageActionStatus(set: ChatSetState): ChatActions["setMessageActionStatus"] {
+  return (messageId, status) =>
     set((state) => ({
       messages: state.messages.map((message) =>
         message.id === messageId ? { ...message, actionStatus: status } : message
       ),
-    })),
+    }));
+}
 
-  setStreaming: (isStreaming) => set({ isStreaming }),
+function createChatActions(set: ChatSetState): ChatActions {
+  return {
+    beginSession: beginChatSession(set),
+    setSessions: (sessions) => set({ sessions: [...sessions] }),
+    prependSession: prependChatSession(set),
+    removeSession: removeChatSession(set),
+    setCurrentSessionId: (currentSessionId) => set({ currentSessionId, messages: [] }),
+    setMessages: (messages) => set({ messages: [...messages] }),
+    appendMessage: (message) =>
+      set((state) => ({
+        messages: [...state.messages, message],
+      })),
+    setMessageActionStatus: setChatMessageActionStatus(set),
+    setStreaming: (isStreaming) => set({ isStreaming }),
+    setStreamingContent: (streamingContent) => set({ streamingContent }),
+    setExpiredSessionCount: (expiredSessionCount) => set({ expiredSessionCount }),
+    clearCurrentConversation: () =>
+      set({
+        currentSessionId: null,
+        messages: [],
+        isStreaming: false,
+        streamingContent: "",
+      }),
+    dismissExpiredBanner: () => set({ expiredSessionCount: 0 }),
+  };
+}
 
-  setStreamingContent: (streamingContent) => set({ streamingContent }),
+const createChatStoreState: StateCreator<ChatStore> = (set) => ({
+  ...createChatState(null),
+  ...createChatActions(set),
+});
 
-  setExpiredSessionCount: (expiredSessionCount) => set({ expiredSessionCount }),
-
-  clearCurrentConversation: () =>
-    set({
-      currentSessionId: null,
-      messages: [],
-      isStreaming: false,
-      streamingContent: "",
-    }),
-
-  dismissExpiredBanner: () => set({ expiredSessionCount: 0 }),
-}));
+export const useChatStore = create<ChatStore>(createChatStoreState);
 
 function isActiveChatSession(userId: UserId, sessionId: number): boolean {
   return chatStoreSessionId === sessionId && useChatStore.getState().activeUserId === userId;
-}
-
-function isCurrentLoadSessionsRequest(
-  requestId: number,
-  userId: UserId,
-  sessionId: number
-): boolean {
-  return loadChatSessionsRequestId === requestId && isActiveChatSession(userId, sessionId);
-}
-
-function isCurrentSelectSessionRequest(
-  requestId: number,
-  userId: UserId,
-  sessionId: number,
-  chatSessionId: ChatSessionId
-): boolean {
-  return (
-    selectChatSessionRequestId === requestId &&
-    isActiveChatSession(userId, sessionId) &&
-    useChatStore.getState().currentSessionId === chatSessionId
-  );
-}
-
-function mapChatSessionRow(row: {
-  id: ChatSessionId;
-  userId: UserId;
-  title: string;
-  createdAt: string;
-  expiresAt: string;
-  deletedAt: string | null;
-}): ChatSession {
-  return {
-    id: row.id,
-    userId: row.userId,
-    title: row.title,
-    createdAt: requireIsoDateTime(row.createdAt),
-    expiresAt: requireIsoDateTime(row.expiresAt),
-    deletedAt: row.deletedAt ? requireIsoDateTime(row.deletedAt) : null,
-  };
-}
-
-function mapChatMessageRow(row: {
-  id: ChatMessageId;
-  sessionId: ChatSessionId;
-  role: string;
-  content: string;
-  action: string | null;
-  actionStatus: string | null;
-  createdAt: string;
-}): ChatMessage {
-  return {
-    id: row.id,
-    sessionId: row.sessionId,
-    role: row.role as "user" | "assistant",
-    content: row.content,
-    action: row.action ? (JSON.parse(row.action) as ChatAction) : null,
-    actionStatus: row.actionStatus as ActionStatus | null,
-    createdAt: requireIsoDateTime(row.createdAt),
-  };
 }
 
 export function initializeChatSession(userId: UserId): void {
@@ -185,13 +143,15 @@ export function startNewChat(): void {
 export async function loadChatSessions(db: AnyDb, userId: UserId): Promise<void> {
   const requestId = ++loadChatSessionsRequestId;
   const sessionId = chatStoreSessionId;
+  const isCurrentRequest = () =>
+    loadChatSessionsRequestId === requestId && isActiveChatSession(userId, sessionId);
   const rows = await db
     .select()
     .from(chatSessions)
     .where(and(eq(chatSessions.userId, userId), isNull(chatSessions.deletedAt)))
     .orderBy(desc(chatSessions.createdAt));
 
-  if (!isCurrentLoadSessionsRequest(requestId, userId, sessionId)) return;
+  if (!isCurrentRequest()) return;
   useChatStore.getState().setSessions(rows.map(mapChatSessionRow));
 }
 
@@ -257,6 +217,10 @@ export async function selectChatSession(
 ): Promise<void> {
   const requestId = ++selectChatSessionRequestId;
   const sessionId = chatStoreSessionId;
+  const isCurrentRequest = () =>
+    selectChatSessionRequestId === requestId &&
+    isActiveChatSession(userId, sessionId) &&
+    useChatStore.getState().currentSessionId === id;
   useChatStore.getState().setCurrentSessionId(id);
 
   const rows = await db
@@ -265,7 +229,7 @@ export async function selectChatSession(
     .where(eq(chatMessages.sessionId, id))
     .orderBy(asc(chatMessages.createdAt));
 
-  if (!isCurrentSelectSessionRequest(requestId, userId, sessionId, id)) return;
+  if (!isCurrentRequest()) return;
   useChatStore.getState().setMessages(rows.map(mapChatMessageRow));
 }
 
@@ -358,12 +322,8 @@ export async function addAssistantChatMessage(
   return message;
 }
 
-export async function updateChatActionStatus(
-  db: AnyDb,
-  userId: UserId,
-  messageId: ChatMessageId,
-  status: ActionStatus
-): Promise<void> {
+export async function updateChatActionStatus(input: UpdateChatActionStatusInput): Promise<void> {
+  const { db, userId, messageId, status } = input;
   const sessionId = chatStoreSessionId;
   if (!isActiveChatSession(userId, sessionId)) return;
 

--- a/apps/mobile/features/budget/services/subscribe-budget-to-transactions.ts
+++ b/apps/mobile/features/budget/services/subscribe-budget-to-transactions.ts
@@ -5,6 +5,23 @@ type SubscribeBudgetToTransactionsInput = {
   readonly reload: () => void;
 };
 
+type BudgetReloadAction = "queue" | "reload" | "skip";
+type BudgetReloadState = {
+  readonly currentRevision: number;
+  readonly previousRevision: number;
+  readonly hasLoadedBudgetState: boolean;
+  readonly hasPendingReload: boolean;
+};
+
+function getBudgetReloadAction(input: BudgetReloadState): BudgetReloadAction {
+  if (!input.hasLoadedBudgetState) {
+    return input.currentRevision !== input.previousRevision ? "queue" : "skip";
+  }
+  return input.currentRevision === input.previousRevision && !input.hasPendingReload
+    ? "skip"
+    : "reload";
+}
+
 export function subscribeBudgetToTransactions({
   subscribeTransactions,
   getTransactionDataRevision,
@@ -16,12 +33,18 @@ export function subscribeBudgetToTransactions({
 
   return subscribeTransactions(() => {
     const currentRevision = getTransactionDataRevision();
-    if (currentRevision !== previousRevision && !hasLoadedBudgetState()) {
+    const action = getBudgetReloadAction({
+      currentRevision,
+      previousRevision,
+      hasLoadedBudgetState: hasLoadedBudgetState(),
+      hasPendingReload,
+    });
+
+    if (action === "queue") {
       hasPendingReload = true;
       return;
     }
-    if (currentRevision === previousRevision && !hasPendingReload) return;
-    if (!hasLoadedBudgetState()) return;
+    if (action === "skip") return;
 
     previousRevision = currentRevision;
     hasPendingReload = false;

--- a/apps/mobile/features/budget/store.ts
+++ b/apps/mobile/features/budget/store.ts
@@ -1,5 +1,5 @@
 import { addMonths, subMonths } from "date-fns";
-import { create } from "zustand";
+import { create, type StateCreator } from "zustand";
 import { insertNotificationRecord } from "@/features/notifications";
 import { useSettingsStore } from "@/features/settings";
 import { CATEGORY_MAP } from "@/features/transactions";
@@ -86,37 +86,43 @@ type BudgetActions = {
   clearPendingPermissionRequest: () => void;
 };
 
-export const useBudgetStore = create<BudgetState & BudgetActions>((set) => ({
-  activeUserId: null,
-  currentMonth: formatMonth(new Date()),
-  budgets: [],
-  budgetProgress: [],
-  summary: { totalBudget: 0, totalSpent: 0, percentUsed: 0 },
-  autoSuggestions: [],
-  acknowledgedAlerts: new Set(),
-  pendingAlerts: [],
-  pendingPermissionRequest: false,
-  hasLoadedOnce: false,
-  isLoading: false,
+type BudgetStore = BudgetState & BudgetActions;
+type BudgetSetState = Parameters<StateCreator<BudgetStore>>[0];
+type BudgetRequest = {
+  readonly requestId: number;
+  readonly userId: UserId;
+  readonly month: Month;
+  readonly sessionId: number;
+};
+type UpdateBudgetInput = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly id: BudgetId;
+  readonly amount: CopAmount;
+};
 
-  beginSession: (userId) =>
-    set((state) => ({
-      activeUserId: userId,
-      currentMonth: state.currentMonth,
-      budgets: [],
-      budgetProgress: [],
-      summary: { totalBudget: 0, totalSpent: 0, percentUsed: 0 },
-      autoSuggestions: [],
-      acknowledgedAlerts: new Set(),
-      pendingAlerts: [],
-      pendingPermissionRequest: false,
-      hasLoadedOnce: false,
-      isLoading: false,
-    })),
+function createBudgetState(currentMonth: Month, activeUserId: UserId | null): BudgetState {
+  return {
+    activeUserId,
+    currentMonth,
+    budgets: [],
+    budgetProgress: [],
+    summary: { totalBudget: 0, totalSpent: 0, percentUsed: 0 },
+    autoSuggestions: [],
+    acknowledgedAlerts: new Set(),
+    pendingAlerts: [],
+    pendingPermissionRequest: false,
+    hasLoadedOnce: false,
+    isLoading: false,
+  };
+}
 
-  setMonth: (currentMonth) => set({ currentMonth }),
+function beginBudgetSession(set: BudgetSetState): BudgetActions["beginSession"] {
+  return (userId) => set((state) => createBudgetState(state.currentMonth, userId));
+}
 
-  setSnapshot: (snapshot) =>
+function setBudgetSnapshot(set: BudgetSetState): BudgetActions["setSnapshot"] {
+  return (snapshot) =>
     set((state) => ({
       budgets: snapshot.budgets as Budget[],
       budgetProgress: snapshot.budgetProgress as BudgetProgress[],
@@ -126,14 +132,11 @@ export const useBudgetStore = create<BudgetState & BudgetActions>((set) => ({
       pendingPermissionRequest: state.pendingPermissionRequest || snapshot.pendingPermissionRequest,
       hasLoadedOnce: true,
       isLoading: false,
-    })),
+    }));
+}
 
-  setAutoSuggestions: (autoSuggestions) =>
-    set({ autoSuggestions: [...autoSuggestions] as BudgetSuggestion[] }),
-
-  setIsLoading: (isLoading) => set({ isLoading }),
-
-  acknowledgeAlert: (budgetId, threshold) =>
+function acknowledgeBudgetAlert(set: BudgetSetState): BudgetActions["acknowledgeAlert"] {
+  return (budgetId, threshold) =>
     set((state) => {
       const nextState = budgetAlertStateManager.acknowledgeAlert({
         budgetId,
@@ -148,39 +151,43 @@ export const useBudgetStore = create<BudgetState & BudgetActions>((set) => ({
         acknowledgedAlerts: new Set(nextState.acknowledgedAlerts),
         pendingAlerts: nextState.pendingAlerts,
       };
-    }),
-
-  clearPendingPermissionRequest: () => {
-    set({ pendingPermissionRequest: false });
-  },
-}));
-
-function isCurrentBudgetRequest(
-  requestId: number,
-  userId: UserId,
-  month: Month,
-  sessionId: number
-): boolean {
-  return (
-    loadBudgetsRequestId === requestId &&
-    useBudgetStore.getState().activeUserId === userId &&
-    useBudgetStore.getState().currentMonth === month &&
-    budgetSessionId === sessionId
-  );
+    });
 }
+
+function createBudgetActions(set: BudgetSetState): BudgetActions {
+  return {
+    beginSession: beginBudgetSession(set),
+    setMonth: (currentMonth) => set({ currentMonth }),
+    setSnapshot: setBudgetSnapshot(set),
+    setAutoSuggestions: (autoSuggestions) =>
+      set({ autoSuggestions: [...autoSuggestions] as BudgetSuggestion[] }),
+    setIsLoading: (isLoading) => set({ isLoading }),
+    acknowledgeAlert: acknowledgeBudgetAlert(set),
+    clearPendingPermissionRequest: () => {
+      set({ pendingPermissionRequest: false });
+    },
+  };
+}
+
+const createBudgetStoreState: StateCreator<BudgetStore> = (set) => ({
+  ...createBudgetState(formatMonth(new Date()), null),
+  ...createBudgetActions(set),
+});
+
+export const useBudgetStore = create<BudgetStore>(createBudgetStoreState);
 
 function isActiveBudgetSession(userId: UserId, sessionId: number): boolean {
   return budgetSessionId === sessionId && useBudgetStore.getState().activeUserId === userId;
 }
 
-async function refreshBudgetsForActiveSession(
-  db: AnyDb,
-  userId: UserId,
-  sessionId: number
-): Promise<boolean> {
-  if (!isActiveBudgetSession(userId, sessionId)) return false;
-  await loadBudgetsForUser(db, userId);
-  return isActiveBudgetSession(userId, sessionId);
+async function refreshBudgetsForActiveSession(input: {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly sessionId: number;
+}): Promise<boolean> {
+  if (!isActiveBudgetSession(input.userId, input.sessionId)) return false;
+  await loadBudgetsForUser(input.db, input.userId);
+  return isActiveBudgetSession(input.userId, input.sessionId);
 }
 
 export function initializeBudgetSession(userId: UserId): void {
@@ -190,9 +197,16 @@ export function initializeBudgetSession(userId: UserId): void {
 }
 
 export async function loadBudgetsForUser(db: AnyDb, userId: UserId): Promise<void> {
-  const requestId = ++loadBudgetsRequestId;
-  const sessionId = budgetSessionId;
-  const requestedMonth = useBudgetStore.getState().currentMonth;
+  const request: BudgetRequest = {
+    requestId: ++loadBudgetsRequestId,
+    userId,
+    month: useBudgetStore.getState().currentMonth,
+    sessionId: budgetSessionId,
+  };
+  const isCurrentRequest = () =>
+    loadBudgetsRequestId === request.requestId &&
+    isActiveBudgetSession(request.userId, request.sessionId) &&
+    useBudgetStore.getState().currentMonth === request.month;
   const previous = {
     pendingAlerts: useBudgetStore.getState().pendingAlerts,
     acknowledgedAlerts: useBudgetStore.getState().acknowledgedAlerts,
@@ -201,17 +215,15 @@ export async function loadBudgetsForUser(db: AnyDb, userId: UserId): Promise<voi
   useBudgetStore.getState().setIsLoading(true);
 
   try {
-    const snapshot = await createLiveBudgetMonitoring(db, userId, () =>
-      isCurrentBudgetRequest(requestId, userId, requestedMonth, sessionId)
-    ).refreshMonth({
+    const snapshot = await createLiveBudgetMonitoring(db, userId, isCurrentRequest).refreshMonth({
       db,
       userId,
-      month: requestedMonth,
+      month: request.month,
       previous,
     });
 
-    if (!isCurrentBudgetRequest(requestId, userId, requestedMonth, sessionId)) {
-      if (loadBudgetsRequestId === requestId) {
+    if (!isCurrentRequest()) {
+      if (loadBudgetsRequestId === request.requestId) {
         useBudgetStore.getState().setIsLoading(false);
       }
       return;
@@ -219,7 +231,7 @@ export async function loadBudgetsForUser(db: AnyDb, userId: UserId): Promise<voi
 
     useBudgetStore.getState().setSnapshot(snapshot);
   } catch {
-    if (loadBudgetsRequestId === requestId) {
+    if (loadBudgetsRequestId === request.requestId) {
       useBudgetStore.getState().setIsLoading(false);
     }
   }
@@ -292,15 +304,11 @@ export async function createBudget(
   }
 
   trackBudgetCreated({ category: String(categoryId) });
-  return refreshBudgetsForActiveSession(db, userId, sessionId);
+  return refreshBudgetsForActiveSession({ db, userId, sessionId });
 }
 
-export async function updateBudget(
-  db: AnyDb,
-  userId: UserId,
-  id: BudgetId,
-  amount: CopAmount
-): Promise<boolean> {
+export async function updateBudget(input: UpdateBudgetInput): Promise<boolean> {
+  const { db, userId, id, amount } = input;
   const sessionId = budgetSessionId;
   const now = toIsoDateTime(new Date());
 
@@ -316,7 +324,7 @@ export async function updateBudget(
     return false;
   }
 
-  return refreshBudgetsForActiveSession(db, userId, sessionId);
+  return refreshBudgetsForActiveSession({ db, userId, sessionId });
 }
 
 export async function deleteBudget(db: AnyDb, userId: UserId, id: BudgetId): Promise<boolean> {
@@ -334,7 +342,7 @@ export async function deleteBudget(db: AnyDb, userId: UserId, id: BudgetId): Pro
     return false;
   }
 
-  return refreshBudgetsForActiveSession(db, userId, sessionId);
+  return refreshBudgetsForActiveSession({ db, userId, sessionId });
 }
 
 export async function copyBudgetsForward(
@@ -361,7 +369,7 @@ export async function copyBudgetsForward(
 
   if (!isActiveBudgetSession(userId, sessionId)) return false;
   useBudgetStore.getState().setMonth(targetMonth);
-  return refreshBudgetsForActiveSession(db, userId, sessionId);
+  return refreshBudgetsForActiveSession({ db, userId, sessionId });
 }
 
 export async function acceptBudgetSuggestions(
@@ -397,5 +405,5 @@ export async function acceptBudgetSuggestions(
     return false;
   }
 
-  return refreshBudgetsForActiveSession(db, userId, sessionId);
+  return refreshBudgetsForActiveSession({ db, userId, sessionId });
 }

--- a/apps/mobile/features/review-queues/lib/attribution-review-service.ts
+++ b/apps/mobile/features/review-queues/lib/attribution-review-service.ts
@@ -1,8 +1,8 @@
-import type { AccountCreationSuggestion } from "@/features/account-suggestions";
 import {
-  buildSuggestedFinancialAccountDraft,
+  type AccountCreationSuggestion,
   createAccountSuggestionFingerprint,
-} from "@/features/account-suggestions";
+} from "@/features/account-suggestions/lib/derive-account-suggestions";
+import { buildSuggestedFinancialAccountDraft } from "@/features/account-suggestions/lib/presentation";
 import { createAccountSuggestionService } from "@/features/account-suggestions/services/create-account-suggestion-service";
 import { getCaptureEvidenceRowsForTransaction } from "@/features/capture-evidence/lib/repository";
 import {
@@ -65,6 +65,37 @@ function normalizeSearchText(value: string) {
   return value.toLowerCase().replace(/\s+/g, " ").trim();
 }
 
+function scoreCardHintKind(kind: FinancialAccountRow["kind"]) {
+  return kind === "credit_card" ? 5 : 0;
+}
+
+function scoreLast4Kind(kind: FinancialAccountRow["kind"]) {
+  if (kind === "credit_card") {
+    return 4;
+  }
+  return kind === "checking" ? 1 : 0;
+}
+
+function scoreAccountHintKind(kind: FinancialAccountRow["kind"]) {
+  if (kind === "wallet") {
+    return 4;
+  }
+  return kind === "checking" ? 2 : 0;
+}
+
+function getSuggestedKindScore(
+  account: FinancialAccountRow,
+  suggestion: AccountCreationSuggestion
+) {
+  if (suggestion.evidenceType === "card_hint") {
+    return scoreCardHintKind(account.kind);
+  }
+  if (suggestion.evidenceType === "last4") {
+    return scoreLast4Kind(account.kind);
+  }
+  return scoreAccountHintKind(account.kind);
+}
+
 function scoreSuggestedAccount(
   account: FinancialAccountRow,
   suggestion: AccountCreationSuggestion
@@ -72,27 +103,25 @@ function scoreSuggestedAccount(
   const normalizedName = normalizeSearchText(account.name);
   const normalizedSource = normalizeSearchText(suggestion.sourceFamily);
   const normalizedEvidence = normalizeSearchText(suggestion.value);
-  const kindScore =
-    suggestion.evidenceType === "card_hint"
-      ? account.kind === "credit_card"
-        ? 5
-        : 0
-      : suggestion.evidenceType === "last4"
-        ? account.kind === "credit_card"
-          ? 4
-          : account.kind === "checking"
-            ? 1
-            : 0
-        : account.kind === "wallet"
-          ? 4
-          : account.kind === "checking"
-            ? 2
-            : 0;
+  const kindScore = getSuggestedKindScore(account, suggestion);
   const sourceScore = normalizedName.includes(normalizedSource) ? 2 : 0;
   const evidenceScore = normalizedName.includes(normalizedEvidence) ? 1 : 0;
   const defaultPenalty = account.isDefault ? -1 : 0;
 
   return kindScore + sourceScore + evidenceScore + defaultPenalty;
+}
+
+type ScoredSuggestedAccount = {
+  readonly account: FinancialAccountRow;
+  readonly score: number;
+};
+
+function compareSuggestedAccounts(left: ScoredSuggestedAccount, right: ScoredSuggestedAccount) {
+  return (
+    right.score - left.score ||
+    Number(left.account.isDefault) - Number(right.account.isDefault) ||
+    left.account.name.localeCompare(right.account.name)
+  );
 }
 
 function getSuggestedAccount(
@@ -105,29 +134,26 @@ function getSuggestedAccount(
         account,
         score: scoreSuggestedAccount(account, suggestion),
       }))
-      .sort(
-        (left, right) =>
-          right.score - left.score ||
-          Number(left.account.isDefault) - Number(right.account.isDefault) ||
-          left.account.name.localeCompare(right.account.name)
-      )
+      .sort(compareSuggestedAccounts)
       .find((item) => item.score > 0)?.account ?? null
   );
 }
 
-function getBestMatchingSuggestion(
-  suggestions: readonly AccountCreationSuggestion[],
-  transactionId: TransactionId,
-  db: AnyDb,
-  userId: UserId
-) {
+function getBestMatchingSuggestion(input: {
+  readonly suggestions: readonly AccountCreationSuggestion[];
+  readonly transactionId: TransactionId;
+  readonly db: AnyDb;
+  readonly userId: UserId;
+}) {
   const evidenceFingerprints = new Set(
-    getCaptureEvidenceRowsForTransaction(db, userId, transactionId).map((row) =>
+    getCaptureEvidenceRowsForTransaction(input.db, input.userId, input.transactionId).map((row) =>
       createAccountSuggestionFingerprint(row.scope, row.value)
     )
   );
 
-  return suggestions.find((suggestion) => evidenceFingerprints.has(suggestion.fingerprint)) ?? null;
+  return (
+    input.suggestions.find((suggestion) => evidenceFingerprints.has(suggestion.fingerprint)) ?? null
+  );
 }
 
 function toReviewItem(
@@ -145,6 +171,50 @@ function toReviewItem(
     evidenceLabel: suggestion
       ? buildSuggestedFinancialAccountDraft(suggestion).evidenceLabel
       : null,
+  };
+}
+
+function confirmSuggestedOwnerInTransaction(input: {
+  readonly tx: AnyDb;
+  readonly transactionId: TransactionId;
+  readonly userId: UserId;
+  readonly suggestedAccount: FinancialAccountRow;
+  readonly suggestion: AccountCreationSuggestion;
+  readonly updatedAt: IsoDateTime;
+  readonly getTransactionById: typeof loadTransactionById;
+  readonly accountSuggestionService: ReturnType<typeof createAccountSuggestionService>;
+}): ConfirmSuggestedOwnerResult {
+  const currentTransaction = input.getTransactionById(input.tx, input.transactionId);
+  if (!currentTransaction) {
+    return { success: false, error: "reviewItemNotFound" };
+  }
+
+  input.accountSuggestionService.acceptSuggestion({
+    db: input.tx,
+    userId: input.userId,
+    accountId: input.suggestedAccount.id,
+    suggestion: input.suggestion,
+  });
+
+  upsertTransaction(input.tx, {
+    ...currentTransaction,
+    accountId: input.suggestedAccount.id,
+    accountAttributionState: "confirmed",
+    updatedAt: input.updatedAt,
+  });
+
+  enqueueSync(input.tx, {
+    id: generateSyncQueueId(),
+    tableName: "transactions",
+    rowId: input.transactionId,
+    operation: "update",
+    createdAt: input.updatedAt,
+  });
+
+  return {
+    success: true,
+    accountId: input.suggestedAccount.id,
+    suggestionFingerprint: input.suggestion.fingerprint,
   };
 }
 
@@ -167,7 +237,12 @@ export function createAttributionReviewService({
         toReviewItem(
           transaction,
           accounts,
-          getBestMatchingSuggestion(suggestions, transaction.id, db, userId)
+          getBestMatchingSuggestion({
+            suggestions,
+            transactionId: transaction.id,
+            db,
+            userId,
+          })
         )
       );
   };
@@ -179,64 +254,40 @@ export function createAttributionReviewService({
   }: ListQueueItemsInput & { transactionId: TransactionId }) =>
     listQueueItems({ db, userId }).find((item) => item.transaction.id === transactionId) ?? null;
 
+  function confirmSuggestedOwner(input: ConfirmSuggestedOwnerInput): ConfirmSuggestedOwnerResult {
+    const { db, userId, transactionId } = input;
+    const item = getReviewItem({ db, userId, transactionId });
+
+    if (!item) {
+      return { success: false, error: "reviewItemNotFound" };
+    }
+
+    if (!item.suggestion || !item.suggestedAccount) {
+      return { success: false, error: "suggestedOwnerUnavailable" };
+    }
+
+    const { suggestedAccount, suggestion } = item;
+    const updatedAt = now();
+
+    return db.transaction(
+      (tx): ConfirmSuggestedOwnerResult =>
+        confirmSuggestedOwnerInTransaction({
+          tx,
+          transactionId,
+          userId,
+          suggestion,
+          updatedAt,
+          suggestedAccount,
+          getTransactionById,
+          accountSuggestionService,
+        })
+    );
+  }
+
   return {
     listQueueItems,
 
     getReviewItem,
-
-    confirmSuggestedOwner({
-      db,
-      userId,
-      transactionId,
-    }: ConfirmSuggestedOwnerInput): ConfirmSuggestedOwnerResult {
-      const item = getReviewItem({ db, userId, transactionId });
-
-      if (!item) {
-        return { success: false, error: "reviewItemNotFound" };
-      }
-
-      if (!item.suggestion || !item.suggestedAccount) {
-        return { success: false, error: "suggestedOwnerUnavailable" };
-      }
-
-      const { suggestedAccount, suggestion } = item;
-      const updatedAt = now();
-
-      return db.transaction((tx): ConfirmSuggestedOwnerResult => {
-        const currentTransaction = getTransactionById(tx, transactionId);
-
-        if (!currentTransaction) {
-          return { success: false, error: "reviewItemNotFound" };
-        }
-
-        accountSuggestionService.acceptSuggestion({
-          db: tx,
-          userId,
-          accountId: suggestedAccount.id,
-          suggestion,
-        });
-
-        upsertTransaction(tx, {
-          ...currentTransaction,
-          accountId: suggestedAccount.id,
-          accountAttributionState: "confirmed",
-          updatedAt,
-        });
-
-        enqueueSync(tx, {
-          id: generateSyncQueueId(),
-          tableName: "transactions",
-          rowId: transactionId,
-          operation: "update",
-          createdAt: updatedAt,
-        });
-
-        return {
-          success: true,
-          accountId: suggestedAccount.id,
-          suggestionFingerprint: suggestion.fingerprint,
-        };
-      });
-    },
+    confirmSuggestedOwner,
   };
 }

--- a/apps/mobile/features/search/lib/repository.ts
+++ b/apps/mobile/features/search/lib/repository.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, gte, inArray, like, lte, sql } from "drizzle-orm";
+import { and, count, desc, eq, gte, inArray, like, lte, type SQL, sql } from "drizzle-orm";
 import { getActiveTransactionConditions } from "@/features/transactions/lib/active-transaction-conditions";
 import type { AnyDb } from "@/shared/db/client";
 import { transactions } from "@/shared/db/schema";
@@ -6,36 +6,59 @@ import { requireCategoryId, requireCopAmount, requireIsoDate } from "@/shared/ty
 import type { UserId } from "@/shared/types/branded";
 import type { SearchFilters, SearchSummary } from "./types";
 
-function buildSearchConditions(userId: UserId, filters: SearchFilters) {
-  const trimmedQuery = filters.query.trim();
-  const categoryIds = filters.categoryIds
-    .filter((id) => id.trim().length > 0)
-    .map((id) => requireCategoryId(id));
-  return [
-    ...getActiveTransactionConditions(userId),
-    ...(trimmedQuery.length > 0 ? [like(transactions.description, `%${trimmedQuery}%`)] : []),
-    ...(categoryIds.length > 0 ? [inArray(transactions.categoryId, categoryIds)] : []),
-    ...(filters.dateFrom !== null
-      ? [gte(transactions.date, requireIsoDate(filters.dateFrom))]
-      : []),
-    ...(filters.dateTo !== null ? [lte(transactions.date, requireIsoDate(filters.dateTo))] : []),
-    ...(filters.amountMin !== null
-      ? [gte(transactions.amount, requireCopAmount(filters.amountMin))]
-      : []),
-    ...(filters.amountMax !== null
-      ? [lte(transactions.amount, requireCopAmount(filters.amountMax))]
-      : []),
-    ...(filters.type !== "all" ? [eq(transactions.type, filters.type)] : []),
-  ];
+type SearchCondition = SQL<unknown>;
+type SearchTransactionsPageInput = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly filters: SearchFilters;
+  readonly limit: number;
+  readonly offset: number;
+};
+type SearchConditionBuilder = (filters: SearchFilters) => SearchCondition | null;
+
+function compactSearchConditions(
+  conditions: readonly (SearchCondition | null)[]
+): readonly SearchCondition[] {
+  return conditions.filter((condition): condition is SearchCondition => condition !== null);
 }
 
-export function searchTransactionsPaginated(
-  db: AnyDb,
-  userId: UserId,
-  filters: SearchFilters,
-  limit: number,
-  offset: number
-) {
+function toCategoryIds(categoryIds: SearchFilters["categoryIds"]) {
+  return categoryIds.filter((id) => id.trim().length > 0).map((id) => requireCategoryId(id));
+}
+
+const SEARCH_CONDITION_BUILDERS: readonly SearchConditionBuilder[] = [
+  (filters) => {
+    const trimmedQuery = filters.query.trim();
+    return trimmedQuery.length > 0 ? like(transactions.description, `%${trimmedQuery}%`) : null;
+  },
+  (filters) => {
+    const ids = toCategoryIds(filters.categoryIds);
+    return ids.length > 0 ? inArray(transactions.categoryId, ids) : null;
+  },
+  (filters) =>
+    filters.dateFrom !== null ? gte(transactions.date, requireIsoDate(filters.dateFrom)) : null,
+  (filters) =>
+    filters.dateTo !== null ? lte(transactions.date, requireIsoDate(filters.dateTo)) : null,
+  (filters) =>
+    filters.amountMin !== null
+      ? gte(transactions.amount, requireCopAmount(filters.amountMin))
+      : null,
+  (filters) =>
+    filters.amountMax !== null
+      ? lte(transactions.amount, requireCopAmount(filters.amountMax))
+      : null,
+  (filters) => (filters.type !== "all" ? eq(transactions.type, filters.type) : null),
+];
+
+function buildSearchConditions(userId: UserId, filters: SearchFilters) {
+  return compactSearchConditions([
+    ...getActiveTransactionConditions(userId),
+    ...SEARCH_CONDITION_BUILDERS.map((buildCondition) => buildCondition(filters)),
+  ]);
+}
+
+export function searchTransactionsPaginated(input: SearchTransactionsPageInput) {
+  const { db, userId, filters, limit, offset } = input;
   const conditions = buildSearchConditions(userId, filters);
   return db
     .select()

--- a/apps/mobile/features/search/store.ts
+++ b/apps/mobile/features/search/store.ts
@@ -84,7 +84,13 @@ export function executeSearch(db: AnyDb, userId: UserId): void {
   setIsSearching(true);
 
   try {
-    const rows = searchTransactionsPaginated(db, userId, filters, PAGE_SIZE, 0);
+    const rows = searchTransactionsPaginated({
+      db,
+      userId,
+      filters,
+      limit: PAGE_SIZE,
+      offset: 0,
+    });
     const hasMore = rows.length > PAGE_SIZE;
     const pageData = (hasMore ? rows.slice(0, PAGE_SIZE) : rows).map(toStoredTransaction);
     const summary = searchTransactionsAggregate(db, userId, filters);
@@ -99,7 +105,13 @@ export function loadNextSearchPage(db: AnyDb, userId: UserId): void {
   if (!hasMore) return;
 
   try {
-    const rows = searchTransactionsPaginated(db, userId, filters, PAGE_SIZE, offset);
+    const rows = searchTransactionsPaginated({
+      db,
+      userId,
+      filters,
+      limit: PAGE_SIZE,
+      offset,
+    });
     const hasMoreResults = rows.length > PAGE_SIZE;
     const pageData = (hasMoreResults ? rows.slice(0, PAGE_SIZE) : rows).map(toStoredTransaction);
     appendSearchResults(pageData, hasMoreResults);

--- a/apps/mobile/features/sync/lib/conflict-detection.ts
+++ b/apps/mobile/features/sync/lib/conflict-detection.ts
@@ -7,13 +7,12 @@ type TransactionRow = {
   readonly deletedAt: string | null;
 };
 
+function toComparableTransactionValues(row: TransactionRow) {
+  return [row.amount, row.categoryId, row.description, row.date, row.type, row.deletedAt] as const;
+}
+
 export function hasDataConflict(local: TransactionRow, server: TransactionRow): boolean {
-  return (
-    local.amount !== server.amount ||
-    local.categoryId !== server.categoryId ||
-    local.description !== server.description ||
-    local.date !== server.date ||
-    local.type !== server.type ||
-    local.deletedAt !== server.deletedAt
-  );
+  const localValues = toComparableTransactionValues(local);
+  const serverValues = toComparableTransactionValues(server);
+  return localValues.some((value, index) => value !== serverValues[index]);
 }

--- a/apps/mobile/features/sync/services/syncEngine.ts
+++ b/apps/mobile/features/sync/services/syncEngine.ts
@@ -1210,11 +1210,9 @@ function toComparableTransactionRow(row: ComparableTransactionRow) {
 function toComparableLocalTransactionRow(row: LocalTransactionRow) {
   return {
     ...row,
-    accountId: row.accountId ?? buildDefaultFinancialAccountId(row.userId),
-    accountAttributionState: row.accountAttributionState ?? "confirmed",
-    supersededAt: row.supersededAt ?? null,
-    description: row.description ?? null,
-    deletedAt: row.deletedAt ?? null,
+    ...toSupabaseTransactionAccountDefaults(row),
+    ...toSupabaseTransactionDeleteFields(row),
+    description: toSupabaseTransactionDescription(row),
   };
 }
 function hasTransactionPullConflict(

--- a/apps/mobile/features/transfers/lib/build-transfer-helpers.ts
+++ b/apps/mobile/features/transfers/lib/build-transfer-helpers.ts
@@ -1,0 +1,108 @@
+import { parseDigitsToAmount } from "@/shared/lib/format-money";
+import type { CopAmount, FinancialAccountId } from "@/shared/types/branded";
+import type {
+  BuildTransferCommand,
+  StoredTransfer,
+  TransferBuildError,
+  TransferSide,
+} from "./build-transfer";
+
+export type TransferSideValidationResult =
+  | { success: true; fromSide: TransferSide; toSide: TransferSide }
+  | { success: false; error: TransferBuildError };
+
+function normalizeExternalLabel(label: string): string {
+  const trimmed = label.trim();
+  return trimmed.length > 0 ? trimmed : "Outside Fidy";
+}
+
+function trimLabel(side: TransferSide): TransferSide {
+  if (side.kind === "account") {
+    return side;
+  }
+  return { kind: "external", label: normalizeExternalLabel(side.label) };
+}
+
+function isAccountSide(side: TransferSide): side is Extract<TransferSide, { kind: "account" }> {
+  return side.kind === "account";
+}
+
+function hasTrackedTransferSide(fromSide: TransferSide, toSide: TransferSide): boolean {
+  return isAccountSide(fromSide) || isAccountSide(toSide);
+}
+
+function hasDuplicateTrackedTransferSide(fromSide: TransferSide, toSide: TransferSide): boolean {
+  return (
+    isAccountSide(fromSide) && isAccountSide(toSide) && fromSide.accountId === toSide.accountId
+  );
+}
+
+export function buildTransferAmount(digits: string): CopAmount | null {
+  const amount = parseDigitsToAmount(digits);
+  return amount > 0 ? (amount as CopAmount) : null;
+}
+
+export function validateTransferSides(
+  fromSide: TransferSide | null,
+  toSide: TransferSide | null
+): TransferSideValidationResult {
+  if (fromSide == null) {
+    return { success: false, error: "fromSideRequired" };
+  }
+  if (toSide == null) {
+    return { success: false, error: "toSideRequired" };
+  }
+
+  const normalizedFromSide = trimLabel(fromSide);
+  const normalizedToSide = trimLabel(toSide);
+  if (!hasTrackedTransferSide(normalizedFromSide, normalizedToSide)) {
+    return { success: false, error: "trackedAccountRequired" };
+  }
+  if (hasDuplicateTrackedTransferSide(normalizedFromSide, normalizedToSide)) {
+    return { success: false, error: "distinctSidesRequired" };
+  }
+
+  return {
+    success: true,
+    fromSide: normalizedFromSide,
+    toSide: normalizedToSide,
+  };
+}
+
+export function toStoredTransferSide(
+  accountId: FinancialAccountId | null,
+  externalLabel: string | null
+): TransferSide {
+  if (accountId != null) {
+    return { kind: "account", accountId };
+  }
+  return { kind: "external", label: externalLabel ?? "Outside Fidy" };
+}
+
+export function toTransferAccountId(side: TransferSide): FinancialAccountId | null {
+  return side.kind === "account" ? side.accountId : null;
+}
+
+export function toTransferExternalLabel(side: TransferSide): string | null {
+  return side.kind === "external" ? side.label : null;
+}
+
+export function buildStoredTransfer(
+  command: BuildTransferCommand,
+  amount: CopAmount,
+  sides: { readonly fromSide: TransferSide; readonly toSide: TransferSide }
+): StoredTransfer {
+  const { input: formInput, userId, id, now, existing = null } = command;
+  return {
+    id,
+    userId,
+    amount,
+    fromSide: sides.fromSide,
+    toSide: sides.toSide,
+    description: formInput.description.trim(),
+    date: formInput.date,
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now,
+    deletedAt: existing?.deletedAt ?? null,
+  };
+}

--- a/apps/mobile/features/transfers/lib/build-transfer.ts
+++ b/apps/mobile/features/transfers/lib/build-transfer.ts
@@ -1,7 +1,11 @@
-import { parseIsoDate, toIsoDate, toIsoDateTime } from "@/shared/lib/format-date";
-import { parseDigitsToAmount } from "@/shared/lib/format-money";
 import type { CopAmount, FinancialAccountId, TransferId, UserId } from "@/shared/types/branded";
-import type { TransferRow } from "./repository";
+import {
+  buildStoredTransfer,
+  buildTransferAmount,
+  validateTransferSides,
+} from "./build-transfer-helpers";
+
+export { toStoredTransfer, toTransferRow } from "./transfer-row-mappers";
 
 export const OUTSIDE_FIDY_LABEL = "Outside Fidy";
 
@@ -28,12 +32,20 @@ export type StoredTransfer = {
   readonly deletedAt: Date | null;
 };
 
-type BuildTransferInput = {
+export type BuildTransferInput = {
   readonly digits: string;
   readonly fromSide: TransferSide | null;
   readonly toSide: TransferSide | null;
   readonly description: string;
   readonly date: Date;
+};
+
+export type BuildTransferCommand = {
+  readonly input: BuildTransferInput;
+  readonly userId: UserId;
+  readonly id: TransferId;
+  readonly now: Date;
+  readonly existing?: StoredTransfer | null;
 };
 
 export type TransferBuildError =
@@ -43,103 +55,24 @@ export type TransferBuildError =
   | "trackedAccountRequired"
   | "distinctSidesRequired";
 
-const trimLabel = (side: TransferSide): TransferSide =>
-  side.kind === "external"
-    ? { kind: "external", label: side.label.trim() || OUTSIDE_FIDY_LABEL }
-    : side;
+type TransferBuildResult =
+  | { success: true; transfer: StoredTransfer }
+  | { success: false; error: TransferBuildError };
 
-const isAccountSide = (side: TransferSide): side is Extract<TransferSide, { kind: "account" }> =>
-  side.kind === "account";
-
-const hasTrackedAccount = (fromSide: TransferSide, toSide: TransferSide): boolean =>
-  isAccountSide(fromSide) || isAccountSide(toSide);
-
-const hasDistinctSides = (fromSide: TransferSide, toSide: TransferSide): boolean =>
-  !(isAccountSide(fromSide) && isAccountSide(toSide) && fromSide.accountId === toSide.accountId);
-
-export function buildTransfer(
-  input: BuildTransferInput,
-  userId: UserId,
-  id: TransferId,
-  now: Date,
-  existing: StoredTransfer | null = null
-): { success: true; transfer: StoredTransfer } | { success: false; error: TransferBuildError } {
-  const amount = parseDigitsToAmount(input.digits);
-
-  if (amount <= 0) {
+export function buildTransfer(command: BuildTransferCommand): TransferBuildResult {
+  const { input } = command;
+  const amount = buildTransferAmount(input.digits);
+  if (amount == null) {
     return { success: false, error: "amountRequired" };
   }
 
-  if (input.fromSide == null) {
-    return { success: false, error: "fromSideRequired" };
-  }
-
-  if (input.toSide == null) {
-    return { success: false, error: "toSideRequired" };
-  }
-
-  const fromSide = trimLabel(input.fromSide);
-  const toSide = trimLabel(input.toSide);
-
-  if (!hasTrackedAccount(fromSide, toSide)) {
-    return { success: false, error: "trackedAccountRequired" };
-  }
-
-  if (!hasDistinctSides(fromSide, toSide)) {
-    return { success: false, error: "distinctSidesRequired" };
+  const sides = validateTransferSides(input.fromSide, input.toSide);
+  if (!sides.success) {
+    return sides;
   }
 
   return {
     success: true,
-    transfer: {
-      id,
-      userId,
-      amount: amount as CopAmount,
-      fromSide,
-      toSide,
-      description: input.description.trim(),
-      date: input.date,
-      createdAt: existing?.createdAt ?? now,
-      updatedAt: now,
-      deletedAt: existing?.deletedAt ?? null,
-    },
-  };
-}
-
-export function toStoredTransfer(row: TransferRow): StoredTransfer {
-  return {
-    id: row.id,
-    userId: row.userId,
-    amount: row.amount,
-    fromSide:
-      row.fromAccountId != null
-        ? { kind: "account", accountId: row.fromAccountId }
-        : { kind: "external", label: row.fromExternalLabel ?? OUTSIDE_FIDY_LABEL },
-    toSide:
-      row.toAccountId != null
-        ? { kind: "account", accountId: row.toAccountId }
-        : { kind: "external", label: row.toExternalLabel ?? OUTSIDE_FIDY_LABEL },
-    description: row.description ?? "",
-    date: parseIsoDate(row.date),
-    createdAt: new Date(row.createdAt),
-    updatedAt: new Date(row.updatedAt),
-    deletedAt: row.deletedAt ? new Date(row.deletedAt) : null,
-  };
-}
-
-export function toTransferRow(transfer: StoredTransfer): TransferRow {
-  return {
-    id: transfer.id,
-    userId: transfer.userId,
-    amount: transfer.amount,
-    fromAccountId: transfer.fromSide.kind === "account" ? transfer.fromSide.accountId : null,
-    toAccountId: transfer.toSide.kind === "account" ? transfer.toSide.accountId : null,
-    fromExternalLabel: transfer.fromSide.kind === "external" ? transfer.fromSide.label : null,
-    toExternalLabel: transfer.toSide.kind === "external" ? transfer.toSide.label : null,
-    description: transfer.description || null,
-    date: toIsoDate(transfer.date),
-    createdAt: toIsoDateTime(transfer.createdAt),
-    updatedAt: toIsoDateTime(transfer.updatedAt),
-    deletedAt: transfer.deletedAt ? toIsoDateTime(transfer.deletedAt) : null,
+    transfer: buildStoredTransfer(command, amount, sides),
   };
 }

--- a/apps/mobile/features/transfers/lib/mutation-service.ts
+++ b/apps/mobile/features/transfers/lib/mutation-service.ts
@@ -2,6 +2,7 @@ import type { AnyDb } from "@/shared/db";
 import { generateTransferId } from "@/shared/lib/generate-id";
 import type { TransferId, UserId } from "@/shared/types/branded";
 import {
+  type BuildTransferInput,
   buildTransfer,
   type StoredTransfer,
   type TransferBuildError,
@@ -10,11 +11,11 @@ import {
 import type { TransferRow } from "./repository";
 
 export type TransferFormInput = {
-  readonly digits: string;
-  readonly fromSide: Parameters<typeof buildTransfer>[0]["fromSide"];
-  readonly toSide: Parameters<typeof buildTransfer>[0]["toSide"];
-  readonly description: string;
-  readonly date: Date;
+  readonly digits: BuildTransferInput["digits"];
+  readonly fromSide: BuildTransferInput["fromSide"];
+  readonly toSide: BuildTransferInput["toSide"];
+  readonly description: BuildTransferInput["description"];
+  readonly date: BuildTransferInput["date"];
 };
 
 export type TransferMutationError = TransferBuildError | "storeNotInitialized" | "saveFailed";
@@ -49,7 +50,12 @@ export function createTransferMutationService({
         return { success: false, error: "storeNotInitialized" };
       }
 
-      const built = buildTransfer(input, userId, createId(), now());
+      const built = buildTransfer({
+        input,
+        userId,
+        id: createId(),
+        now: now(),
+      });
       if (!built.success) {
         return built;
       }

--- a/apps/mobile/features/transfers/lib/reclassify-transaction-as-transfer.ts
+++ b/apps/mobile/features/transfers/lib/reclassify-transaction-as-transfer.ts
@@ -73,18 +73,18 @@ export function reclassifyTransactionAsTransfer(
   }
 
   const nowDate = now();
-  const built = buildTransfer(
-    {
+  const built = buildTransfer({
+    input: {
       digits: input.digits,
       fromSide: input.fromSide,
       toSide: input.toSide,
       description: input.description,
       date: input.date,
     },
-    input.userId,
-    createId(),
-    nowDate
-  );
+    userId: input.userId,
+    id: createId(),
+    now: nowDate,
+  });
 
   if (!built.success) {
     return built;

--- a/apps/mobile/features/transfers/lib/repository.ts
+++ b/apps/mobile/features/transfers/lib/repository.ts
@@ -5,6 +5,20 @@ import { transfers } from "@/shared/db/schema";
 import { generateSyncQueueId } from "@/shared/lib/generate-id";
 
 export type TransferRow = typeof transfers.$inferInsert;
+type GetTransfersPageInput = {
+  readonly db: AnyDb;
+  readonly userId: TransferRow["userId"];
+  readonly limit: number;
+  readonly offset: number;
+};
+
+function queryActiveTransfers(db: AnyDb, userId: TransferRow["userId"]) {
+  return db
+    .select()
+    .from(transfers)
+    .where(and(eq(transfers.userId, userId), isNull(transfers.deletedAt)))
+    .orderBy(desc(transfers.date), desc(transfers.updatedAt), desc(transfers.id));
+}
 
 export function getTransferById(db: AnyDb, id: TransferRow["id"]) {
   const rows = db.select().from(transfers).where(eq(transfers.id, id)).all();
@@ -48,25 +62,12 @@ export function saveTransfer(db: AnyDb, row: TransferRow) {
 }
 
 export function getTransfersForUser(db: AnyDb, userId: TransferRow["userId"]) {
-  return db
-    .select()
-    .from(transfers)
-    .where(and(eq(transfers.userId, userId), isNull(transfers.deletedAt)))
-    .orderBy(desc(transfers.date), desc(transfers.updatedAt), desc(transfers.id))
-    .all();
+  return queryActiveTransfers(db, userId).all();
 }
 
-export function getTransfersPaginated(
-  db: AnyDb,
-  userId: TransferRow["userId"],
-  limit: number,
-  offset: number
-) {
-  return db
-    .select()
-    .from(transfers)
-    .where(and(eq(transfers.userId, userId), isNull(transfers.deletedAt)))
-    .orderBy(desc(transfers.date), desc(transfers.updatedAt), desc(transfers.id))
+export function getTransfersPaginated(input: GetTransfersPageInput) {
+  const { db, userId, limit, offset } = input;
+  return queryActiveTransfers(db, userId)
     .limit(limit + 1)
     .offset(offset)
     .all();

--- a/apps/mobile/features/transfers/lib/transfer-row-mappers.ts
+++ b/apps/mobile/features/transfers/lib/transfer-row-mappers.ts
@@ -1,0 +1,55 @@
+import { parseIsoDate, toIsoDate, toIsoDateTime } from "@/shared/lib/format-date";
+import type { StoredTransfer } from "./build-transfer";
+import {
+  toStoredTransferSide,
+  toTransferAccountId,
+  toTransferExternalLabel,
+} from "./build-transfer-helpers";
+import type { TransferRow } from "./repository";
+
+function toStoredTransferSideFromRow(
+  accountId: TransferRow["fromAccountId"] | TransferRow["toAccountId"],
+  externalLabel: TransferRow["fromExternalLabel"] | TransferRow["toExternalLabel"]
+) {
+  return toStoredTransferSide(accountId ?? null, externalLabel ?? null);
+}
+
+function toStoredTransferDescription(description: TransferRow["description"]): string {
+  return description ?? "";
+}
+
+function toStoredTransferDeletedAt(deletedAt: TransferRow["deletedAt"]): Date | null {
+  return deletedAt ? new Date(deletedAt) : null;
+}
+
+export function toStoredTransfer(row: TransferRow): StoredTransfer {
+  return {
+    id: row.id,
+    userId: row.userId,
+    amount: row.amount,
+    fromSide: toStoredTransferSideFromRow(row.fromAccountId, row.fromExternalLabel),
+    toSide: toStoredTransferSideFromRow(row.toAccountId, row.toExternalLabel),
+    description: toStoredTransferDescription(row.description),
+    date: parseIsoDate(row.date),
+    createdAt: new Date(row.createdAt),
+    updatedAt: new Date(row.updatedAt),
+    deletedAt: toStoredTransferDeletedAt(row.deletedAt),
+  };
+}
+
+export function toTransferRow(transfer: StoredTransfer): TransferRow {
+  return {
+    id: transfer.id,
+    userId: transfer.userId,
+    amount: transfer.amount,
+    fromAccountId: toTransferAccountId(transfer.fromSide),
+    toAccountId: toTransferAccountId(transfer.toSide),
+    fromExternalLabel: toTransferExternalLabel(transfer.fromSide),
+    toExternalLabel: toTransferExternalLabel(transfer.toSide),
+    description: transfer.description || null,
+    date: toIsoDate(transfer.date),
+    createdAt: toIsoDateTime(transfer.createdAt),
+    updatedAt: toIsoDateTime(transfer.updatedAt),
+    deletedAt: transfer.deletedAt ? toIsoDateTime(transfer.deletedAt) : null,
+  };
+}

--- a/apps/mobile/shared/db/supabase.ts
+++ b/apps/mobile/shared/db/supabase.ts
@@ -6,28 +6,51 @@ const secureStoreAdapter = {
   setItem: (key: string, value: string) => SecureStore.setItemAsync(key, value),
   removeItem: (key: string) => SecureStore.deleteItemAsync(key),
 };
+const supabaseAuthOptions = {
+  storage: secureStoreAdapter,
+  autoRefreshToken: true,
+  persistSession: true,
+  detectSessionInUrl: false,
+};
 
 let client: SupabaseClient | null = null;
 
-export function getSupabase(): SupabaseClient {
-  if (!client) {
-    const url = process.env.EXPO_PUBLIC_SUPABASE_URL ?? "";
-    const anonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? "";
-    if (!url || !anonKey) {
-      throw new Error("Missing EXPO_PUBLIC_SUPABASE_URL or EXPO_PUBLIC_SUPABASE_ANON_KEY");
-    }
-    client = createClient(url, anonKey, {
-      auth: {
-        storage: secureStoreAdapter,
-        autoRefreshToken: true,
-        persistSession: true,
-        detectSessionInUrl: false,
-      },
-    });
+type SupabaseConfig = {
+  readonly url: string;
+  readonly anonKey: string;
+};
+
+function readOptionalEnv(
+  name: "EXPO_PUBLIC_SUPABASE_URL" | "EXPO_PUBLIC_SUPABASE_ANON_KEY"
+): string {
+  const value = process.env[name];
+  return typeof value === "string" ? value : "";
+}
+
+function readSupabaseConfig(): SupabaseConfig {
+  const url = readOptionalEnv("EXPO_PUBLIC_SUPABASE_URL");
+  if (url.length === 0) {
+    throw new Error("Missing EXPO_PUBLIC_SUPABASE_URL or EXPO_PUBLIC_SUPABASE_ANON_KEY");
   }
-  return client;
+
+  const anonKey = readOptionalEnv("EXPO_PUBLIC_SUPABASE_ANON_KEY");
+  if (anonKey.length === 0) {
+    throw new Error("Missing EXPO_PUBLIC_SUPABASE_URL or EXPO_PUBLIC_SUPABASE_ANON_KEY");
+  }
+
+  return { url, anonKey };
 }
 
 export function resetSupabase() {
   client = null;
+}
+
+export function getSupabase(): SupabaseClient {
+  if (client) {
+    return client;
+  }
+
+  const { url, anonKey } = readSupabaseConfig();
+  client = createClient(url, anonKey, { auth: supabaseAuthOptions });
+  return client;
 }

--- a/apps/mobile/shared/effect/runtime.ts
+++ b/apps/mobile/shared/effect/runtime.ts
@@ -22,19 +22,12 @@ export function makeAppTag<Service>(key: string): Context.Tag<Service, Service> 
   return Context.GenericTag<Service>(key);
 }
 
-export function runWithService<A, E, I, S>(
-  effect: AppEffect<A, E, I>,
-  tag: Context.Tag<I, S>,
-  service: S
-): Promise<A> {
-  return runAppEffect(Effect.provideService(effect, tag, service));
-}
-
 export function bindAppService<I, S>(tag: Context.Tag<I, S>, service: S): BoundAppService<I, S> {
   return {
     provide: <A, E, R>(effect: AppEffect<A, E, I | R>) =>
       Effect.provideService(effect, tag, service),
-    run: <A, E>(effect: AppEffect<A, E, I>) => runWithService(effect, tag, service),
+    run: <A, E>(effect: AppEffect<A, E, I>) =>
+      runAppEffect(Effect.provideService(effect, tag, service)),
   };
 }
 

--- a/apps/mobile/shared/lib/format-date.ts
+++ b/apps/mobile/shared/lib/format-date.ts
@@ -23,12 +23,13 @@ export function toIsoDate(date: Date): IsoDate {
  * Parses an ISO date string (YYYY-MM-DD) into a local Date (midnight local time).
  * Avoids `new Date("YYYY-MM-DD")` which parses as UTC and shifts dates in negative UTC offsets.
  */
+function toDatePart(value: string | undefined, fallback: number): number {
+  return Number(value ?? String(fallback));
+}
+
 export function parseIsoDate(isoDate: IsoDate): Date {
-  const parts = isoDate.split("-").map(Number);
-  const year = parts[0] ?? 0;
-  const month = parts[1] ?? 1;
-  const day = parts[2] ?? 1;
-  return new Date(year, month - 1, day);
+  const [year, month, day] = isoDate.split("-");
+  return new Date(toDatePart(year, 0), toDatePart(month, 1) - 1, toDatePart(day, 1));
 }
 
 export function parseOptionalIsoDate(value: string | null | undefined): Date | null {

--- a/plans/lizard-complexity-debt.json
+++ b/plans/lizard-complexity-debt.json
@@ -6,14 +6,6 @@
   },
   "violations": [
     {
-      "key": "(anonymous)@104-116@apps/mobile/features/review-queues/lib/attribution-review-service.ts",
-      "file": "apps/mobile/features/review-queues/lib/attribution-review-service.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 6,
-      "nloc": 12,
-      "parameterCount": 0
-    },
-    {
       "key": "(anonymous)@106-140@apps/mobile/__tests__/transfers/repository.test.ts",
       "file": "apps/mobile/__tests__/transfers/repository.test.ts",
       "function": "(anonymous)",
@@ -27,14 +19,6 @@
       "function": "(anonymous)",
       "cyclomaticComplexity": 1,
       "nloc": 40,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@111-142@apps/mobile/features/account-suggestions/lib/dismissals-repository.ts",
-      "file": "apps/mobile/features/account-suggestions/lib/dismissals-repository.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 7,
-      "nloc": 22,
       "parameterCount": 0
     },
     {
@@ -54,35 +38,11 @@
       "parameterCount": 0
     },
     {
-      "key": "(anonymous)@112-167@apps/mobile/__tests__/activity/query-service.test.ts",
-      "file": "apps/mobile/__tests__/activity/query-service.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 54,
-      "parameterCount": 0
-    },
-    {
       "key": "(anonymous)@1131-1167@apps/mobile/__tests__/sync/syncEngine.test.ts",
       "file": "apps/mobile/__tests__/sync/syncEngine.test.ts",
       "function": "(anonymous)",
       "cyclomaticComplexity": 1,
       "nloc": 35,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@114-138@apps/mobile/features/capture-sources/services/capture-ingestion.ts",
-      "file": "apps/mobile/features/capture-sources/services/capture-ingestion.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 10,
-      "nloc": 25,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@118-150@apps/mobile/features/financial-accounts/lib/repository.ts",
-      "file": "apps/mobile/features/financial-accounts/lib/repository.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 11,
-      "nloc": 29,
       "parameterCount": 0
     },
     {
@@ -166,14 +126,6 @@
       "parameterCount": 0
     },
     {
-      "key": "(anonymous)@156-169@apps/mobile/features/capture-sources/services/capture-ingestion.ts",
-      "file": "apps/mobile/features/capture-sources/services/capture-ingestion.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 6,
-      "nloc": 14,
-      "parameterCount": 0
-    },
-    {
       "key": "(anonymous)@161-195@apps/mobile/features/transactions/mutations-boundary.test.ts",
       "file": "apps/mobile/features/transactions/mutations-boundary.test.ts",
       "function": "(anonymous)",
@@ -182,43 +134,11 @@
       "parameterCount": 0
     },
     {
-      "key": "(anonymous)@169-201@apps/mobile/__tests__/activity/query-service.test.ts",
-      "file": "apps/mobile/__tests__/activity/query-service.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 31,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@17-29@apps/mobile/features/budget/services/subscribe-budget-to-transactions.ts",
-      "file": "apps/mobile/features/budget/services/subscribe-budget-to-transactions.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 6,
-      "nloc": 12,
-      "parameterCount": 0
-    },
-    {
       "key": "(anonymous)@173-208@apps/mobile/__tests__/financial-accounts/opening-balances.test.ts",
       "file": "apps/mobile/__tests__/financial-accounts/opening-balances.test.ts",
       "function": "(anonymous)",
       "cyclomaticComplexity": 1,
       "nloc": 34,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@174-215@apps/mobile/features/auth/store.ts",
-      "file": "apps/mobile/features/auth/store.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 5,
-      "nloc": 32,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@181-228@apps/mobile/__tests__/email-capture/retry-integration.test.ts",
-      "file": "apps/mobile/__tests__/email-capture/retry-integration.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 6,
-      "nloc": 37,
       "parameterCount": 0
     },
     {
@@ -430,14 +350,6 @@
       "parameterCount": 0
     },
     {
-      "key": "(anonymous)@48-93@apps/mobile/features/qa/network-inspector.ts",
-      "file": "apps/mobile/features/qa/network-inspector.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 4,
-      "nloc": 40,
-      "parameterCount": 0
-    },
-    {
       "key": "(anonymous)@486-531@apps/mobile/__tests__/email-capture/email-pipeline.test.ts",
       "file": "apps/mobile/__tests__/email-capture/email-pipeline.test.ts",
       "function": "(anonymous)",
@@ -478,14 +390,6 @@
       "parameterCount": 0
     },
     {
-      "key": "(anonymous)@56-75@apps/mobile/features/financial-accounts/lib/opening-balances-repository.ts",
-      "file": "apps/mobile/features/financial-accounts/lib/opening-balances-repository.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 8,
-      "nloc": 16,
-      "parameterCount": 0
-    },
-    {
       "key": "(anonymous)@57-190@apps/mobile/__tests__/transfers/reclassify-transaction-as-transfer.test.ts",
       "file": "apps/mobile/__tests__/transfers/reclassify-transaction-as-transfer.test.ts",
       "function": "(anonymous)",
@@ -502,27 +406,11 @@
       "parameterCount": 0
     },
     {
-      "key": "(anonymous)@58-79@apps/mobile/features/email-capture/services/create-parse-email-service.ts",
-      "file": "apps/mobile/features/email-capture/services/create-parse-email-service.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 6,
-      "nloc": 19,
-      "parameterCount": 0
-    },
-    {
       "key": "(anonymous)@594-631@apps/mobile/__tests__/email-capture/store.test.ts",
       "file": "apps/mobile/__tests__/email-capture/store.test.ts",
       "function": "(anonymous)",
       "cyclomaticComplexity": 1,
       "nloc": 35,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@61-81@apps/mobile/features/calendar/lib/calendar-utils.ts",
-      "file": "apps/mobile/features/calendar/lib/calendar-utils.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 10,
-      "nloc": 20,
       "parameterCount": 0
     },
     {
@@ -598,14 +486,6 @@
       "parameterCount": 0
     },
     {
-      "key": "(anonymous)@71-110@apps/mobile/__tests__/activity/query-service.test.ts",
-      "file": "apps/mobile/__tests__/activity/query-service.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 38,
-      "parameterCount": 0
-    },
-    {
       "key": "(anonymous)@71-170@apps/mobile/__tests__/review-queues/attribution-review-service.test.ts",
       "file": "apps/mobile/__tests__/review-queues/attribution-review-service.test.ts",
       "function": "(anonymous)",
@@ -646,14 +526,6 @@
       "parameterCount": 0
     },
     {
-      "key": "(anonymous)@79-108@apps/mobile/features/financial-accounts/lib/opening-balances-repository.ts",
-      "file": "apps/mobile/features/financial-accounts/lib/opening-balances-repository.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 7,
-      "nloc": 20,
-      "parameterCount": 0
-    },
-    {
       "key": "(anonymous)@802-847@apps/mobile/__tests__/email-capture/store.test.ts",
       "file": "apps/mobile/__tests__/email-capture/store.test.ts",
       "function": "(anonymous)",
@@ -670,27 +542,11 @@
       "parameterCount": 0
     },
     {
-      "key": "(anonymous)@86-107@apps/mobile/features/account-suggestions/lib/dismissals-repository.ts",
-      "file": "apps/mobile/features/account-suggestions/lib/dismissals-repository.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 8,
-      "nloc": 18,
-      "parameterCount": 0
-    },
-    {
       "key": "(anonymous)@86-139@apps/mobile/__tests__/goals/repository.test.ts",
       "file": "apps/mobile/__tests__/goals/repository.test.ts",
       "function": "(anonymous)",
       "cyclomaticComplexity": 1,
       "nloc": 50,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@88-108@apps/mobile/features/notifications/lib/derive.ts",
-      "file": "apps/mobile/features/notifications/lib/derive.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 8,
-      "nloc": 16,
       "parameterCount": 0
     },
     {
@@ -718,14 +574,6 @@
       "parameterCount": 0
     },
     {
-      "key": "(anonymous)@92-109@apps/mobile/features/email-capture/services/create-parse-email-service.ts",
-      "file": "apps/mobile/features/email-capture/services/create-parse-email-service.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 7,
-      "nloc": 16,
-      "parameterCount": 0
-    },
-    {
       "key": "(anonymous)@950-984@apps/mobile/__tests__/sync/syncEngine.test.ts",
       "file": "apps/mobile/__tests__/sync/syncEngine.test.ts",
       "function": "(anonymous)",
@@ -750,22 +598,6 @@
       "parameterCount": 0
     },
     {
-      "key": ">@25-31@apps/mobile/shared/effect/runtime.ts",
-      "file": "apps/mobile/shared/effect/runtime.ts",
-      "function": ">",
-      "cyclomaticComplexity": 1,
-      "nloc": 7,
-      "parameterCount": 4
-    },
-    {
-      "key": "addWidgetExtensionTarget@164-301@apps/mobile/plugins/withFidyWidget.js",
-      "file": "apps/mobile/plugins/withFidyWidget.js",
-      "function": "addWidgetExtensionTarget",
-      "cyclomaticComplexity": 13,
-      "nloc": 109,
-      "parameterCount": 0
-    },
-    {
       "key": "base64UrlEncode@10-247@apps/mobile/features/email-capture/services/email-adapter.ts",
       "file": "apps/mobile/features/email-capture/services/email-adapter.ts",
       "function": "base64UrlEncode",
@@ -780,46 +612,6 @@
       "cyclomaticComplexity": 3,
       "nloc": 13,
       "parameterCount": 5
-    },
-    {
-      "key": "buildProgressDisplay@35-79@apps/mobile/features/email-capture/lib/progress-phases.ts",
-      "file": "apps/mobile/features/email-capture/lib/progress-phases.ts",
-      "function": "buildProgressDisplay",
-      "cyclomaticComplexity": 13,
-      "nloc": 34,
-      "parameterCount": 0
-    },
-    {
-      "key": "buildSearchConditions@9-30@apps/mobile/features/search/lib/repository.ts",
-      "file": "apps/mobile/features/search/lib/repository.ts",
-      "function": "buildSearchConditions",
-      "cyclomaticComplexity": 8,
-      "nloc": 22,
-      "parameterCount": 2
-    },
-    {
-      "key": "buildSettings@94-132@apps/mobile/plugins/withFidyWidget.js",
-      "file": "apps/mobile/plugins/withFidyWidget.js",
-      "function": "buildSettings",
-      "cyclomaticComplexity": 2,
-      "nloc": 36,
-      "parameterCount": 0
-    },
-    {
-      "key": "captureFingerprint@13-25@apps/mobile/features/capture-sources/lib/dedup.ts",
-      "file": "apps/mobile/features/capture-sources/lib/dedup.ts",
-      "function": "captureFingerprint",
-      "cyclomaticComplexity": 1,
-      "nloc": 9,
-      "parameterCount": 4
-    },
-    {
-      "key": "computeMedian@74-86@apps/mobile/features/goals/lib/derive.ts",
-      "file": "apps/mobile/features/goals/lib/derive.ts",
-      "function": "computeMedian",
-      "cyclomaticComplexity": 12,
-      "nloc": 10,
-      "parameterCount": 1
     },
     {
       "key": "conflictRow@59-94@apps/mobile/__tests__/sync/sync-conflict-resolution.test.ts",
@@ -870,30 +662,6 @@
       "parameterCount": 0
     },
     {
-      "key": "createInitialState@83-114@apps/mobile/features/transactions/store.ts",
-      "file": "apps/mobile/features/transactions/store.ts",
-      "function": "createInitialState",
-      "cyclomaticComplexity": 1,
-      "nloc": 31,
-      "parameterCount": 1
-    },
-    {
-      "key": "createSuggestedAccount@268-298@apps/mobile/features/account-suggestions/services/create-account-suggestion-service.ts",
-      "file": "apps/mobile/features/account-suggestions/services/create-account-suggestion-service.ts",
-      "function": "createSuggestedAccount",
-      "cyclomaticComplexity": 1,
-      "nloc": 11,
-      "parameterCount": 6
-    },
-    {
-      "key": "deriveBudgetNudges@266-306@apps/mobile/features/goals/lib/derive.ts",
-      "file": "apps/mobile/features/goals/lib/derive.ts",
-      "function": "deriveBudgetNudges",
-      "cyclomaticComplexity": 3,
-      "nloc": 18,
-      "parameterCount": 4
-    },
-    {
       "key": "deriveEffectiveOnboardingComplete@55-62@apps/mobile/features/auth/lib/effective-auth.ts",
       "file": "apps/mobile/features/auth/lib/effective-auth.ts",
       "function": "deriveEffectiveOnboardingComplete",
@@ -902,28 +670,12 @@
       "parameterCount": 4
     },
     {
-      "key": "deriveGoalCardStatus@386-405@apps/mobile/features/goals/lib/derive.ts",
-      "file": "apps/mobile/features/goals/lib/derive.ts",
-      "function": "deriveGoalCardStatus",
-      "cyclomaticComplexity": 6,
-      "nloc": 17,
-      "parameterCount": 2
-    },
-    {
       "key": "deriveGoalPaceGuidance@89-93@apps/mobile/features/goals/services/create-goal-query-service.ts",
       "file": "apps/mobile/features/goals/services/create-goal-query-service.ts",
       "function": "deriveGoalPaceGuidance",
       "cyclomaticComplexity": 1,
       "nloc": 4,
       "parameterCount": 4
-    },
-    {
-      "key": "deriveGoalProjection@118-167@apps/mobile/features/goals/lib/derive.ts",
-      "file": "apps/mobile/features/goals/lib/derive.ts",
-      "function": "deriveGoalProjection",
-      "cyclomaticComplexity": 3,
-      "nloc": 33,
-      "parameterCount": 3
     },
     {
       "key": "derivePeriodDelta@59-70@apps/mobile/features/analytics/services/create-analytics-service.ts",
@@ -966,59 +718,11 @@
       "parameterCount": 1
     },
     {
-      "key": "findDuplicateTransaction@38-69@apps/mobile/features/capture-sources/lib/dedup.ts",
-      "file": "apps/mobile/features/capture-sources/lib/dedup.ts",
-      "function": "findDuplicateTransaction",
-      "cyclomaticComplexity": 3,
-      "nloc": 27,
-      "parameterCount": 5
-    },
-    {
-      "key": "findDuplicateTransaction@6-17@apps/mobile/features/capture-sources/dedup.public.ts",
-      "file": "apps/mobile/features/capture-sources/dedup.public.ts",
-      "function": "findDuplicateTransaction",
-      "cyclomaticComplexity": 1,
-      "nloc": 12,
-      "parameterCount": 5
-    },
-    {
-      "key": "getActiveAccountSuggestionDismissal@35-54@apps/mobile/features/account-suggestions/lib/dismissals-repository.ts",
-      "file": "apps/mobile/features/account-suggestions/lib/dismissals-repository.ts",
-      "function": "getActiveAccountSuggestionDismissal",
-      "cyclomaticComplexity": 3,
-      "nloc": 20,
-      "parameterCount": 4
-    },
-    {
-      "key": "getBestMatchingSuggestion@118-131@apps/mobile/features/review-queues/lib/attribution-review-service.ts",
-      "file": "apps/mobile/features/review-queues/lib/attribution-review-service.ts",
-      "function": "getBestMatchingSuggestion",
-      "cyclomaticComplexity": 3,
-      "nloc": 13,
-      "parameterCount": 4
-    },
-    {
       "key": "getCaptureEvidenceRowsForScopeValue@204-223@apps/mobile/features/capture-evidence/lib/repository.ts",
       "file": "apps/mobile/features/capture-evidence/lib/repository.ts",
       "function": "getCaptureEvidenceRowsForScopeValue",
       "cyclomaticComplexity": 1,
       "nloc": 20,
-      "parameterCount": 4
-    },
-    {
-      "key": "getCategoryVisuals@63-70@apps/mobile/features/notifications/lib/display.ts",
-      "file": "apps/mobile/features/notifications/lib/display.ts",
-      "function": "getCategoryVisuals",
-      "cyclomaticComplexity": 15,
-      "nloc": 8,
-      "parameterCount": 0
-    },
-    {
-      "key": "getDailySpendingAggregate@109-119@apps/mobile/features/transactions/lib/repository.ts",
-      "file": "apps/mobile/features/transactions/lib/repository.ts",
-      "function": "getDailySpendingAggregate",
-      "cyclomaticComplexity": 1,
-      "nloc": 11,
       "parameterCount": 4
     },
     {
@@ -1028,22 +732,6 @@
       "cyclomaticComplexity": 3,
       "nloc": 9,
       "parameterCount": 4
-    },
-    {
-      "key": "getDefaultAttributionState@32-46@apps/mobile/features/transactions/lib/repository.ts",
-      "file": "apps/mobile/features/transactions/lib/repository.ts",
-      "function": "getDefaultAttributionState",
-      "cyclomaticComplexity": 11,
-      "nloc": 13,
-      "parameterCount": 1
-    },
-    {
-      "key": "getFinancialAccountBalancesForUser@161-191@apps/mobile/features/financial-accounts/lib/balance-repository.ts",
-      "file": "apps/mobile/features/financial-accounts/lib/balance-repository.ts",
-      "function": "getFinancialAccountBalancesForUser",
-      "cyclomaticComplexity": 9,
-      "nloc": 28,
-      "parameterCount": 3
     },
     {
       "key": "getFirstNonEmptyRouteParam@6-15@apps/mobile/features/goals/lib/route-params.ts",
@@ -1086,14 +774,6 @@
       "parameterCount": 0
     },
     {
-      "key": "getNextOccurrence@91-123@apps/mobile/features/calendar/lib/calendar-utils.ts",
-      "file": "apps/mobile/features/calendar/lib/calendar-utils.ts",
-      "function": "getNextOccurrence",
-      "cyclomaticComplexity": 10,
-      "nloc": 32,
-      "parameterCount": 2
-    },
-    {
       "key": "getNextOnboardingStep@26-40@apps/mobile/features/onboarding/lib/flow.ts",
       "file": "apps/mobile/features/onboarding/lib/flow.ts",
       "function": "getNextOnboardingStep",
@@ -1110,59 +790,11 @@
       "parameterCount": 0
     },
     {
-      "key": "getRecentTransactions@162-184@apps/mobile/features/transactions/lib/repository.ts",
-      "file": "apps/mobile/features/transactions/lib/repository.ts",
-      "function": "getRecentTransactions",
-      "cyclomaticComplexity": 1,
-      "nloc": 22,
-      "parameterCount": 4
-    },
-    {
-      "key": "getRequestUrl@12-17@apps/mobile/features/qa/network-inspector.ts",
-      "file": "apps/mobile/features/qa/network-inspector.ts",
-      "function": "getRequestUrl",
-      "cyclomaticComplexity": 6,
-      "nloc": 6,
-      "parameterCount": 1
-    },
-    {
-      "key": "getStoredTransaction@172-182@apps/mobile/features/transactions/services/create-transaction-query-service.ts",
-      "file": "apps/mobile/features/transactions/services/create-transaction-query-service.ts",
-      "function": "getStoredTransaction",
-      "cyclomaticComplexity": 4,
-      "nloc": 11,
-      "parameterCount": 4
-    },
-    {
-      "key": "getSupabase@12-31@apps/mobile/shared/db/supabase.ts",
-      "file": "apps/mobile/shared/db/supabase.ts",
-      "function": "getSupabase",
-      "cyclomaticComplexity": 8,
-      "nloc": 19,
-      "parameterCount": 0
-    },
-    {
       "key": "getSupabase@51-59@apps/mobile/__tests__/auth/store.test.ts",
       "file": "apps/mobile/__tests__/auth/store.test.ts",
       "function": "getSupabase",
       "cyclomaticComplexity": 1,
       "nloc": 9,
-      "parameterCount": 4
-    },
-    {
-      "key": "getTransactionsPaginated@59-75@apps/mobile/features/transactions/lib/repository.ts",
-      "file": "apps/mobile/features/transactions/lib/repository.ts",
-      "function": "getTransactionsPaginated",
-      "cyclomaticComplexity": 1,
-      "nloc": 16,
-      "parameterCount": 4
-    },
-    {
-      "key": "getTransfersPaginated@59-73@apps/mobile/features/transfers/lib/repository.ts",
-      "file": "apps/mobile/features/transfers/lib/repository.ts",
-      "function": "getTransfersPaginated",
-      "cyclomaticComplexity": 1,
-      "nloc": 15,
       "parameterCount": 4
     },
     {
@@ -1172,14 +804,6 @@
       "cyclomaticComplexity": 7,
       "nloc": 12,
       "parameterCount": 1
-    },
-    {
-      "key": "hasDataConflict@10-19@apps/mobile/features/sync/lib/conflict-detection.ts",
-      "file": "apps/mobile/features/sync/lib/conflict-detection.ts",
-      "function": "hasDataConflict",
-      "cyclomaticComplexity": 6,
-      "nloc": 10,
-      "parameterCount": 2
     },
     {
       "key": "hasInvalidBillingDayInput@11-32@apps/mobile/features/financial-accounts/lib/form-screen.ts",
@@ -1206,59 +830,11 @@
       "parameterCount": 0
     },
     {
-      "key": "inferKind@40-70@apps/mobile/features/account-suggestions/lib/presentation.ts",
-      "file": "apps/mobile/features/account-suggestions/lib/presentation.ts",
-      "function": "inferKind",
-      "cyclomaticComplexity": 7,
-      "nloc": 26,
-      "parameterCount": 3
-    },
-    {
-      "key": "isActiveChatSession@111-171@apps/mobile/features/ai-chat/store.ts",
-      "file": "apps/mobile/features/ai-chat/store.ts",
-      "function": "isActiveChatSession",
-      "cyclomaticComplexity": 7,
-      "nloc": 57,
-      "parameterCount": 7
-    },
-    {
-      "key": "isCurrentBudgetRequest@158-184@apps/mobile/features/budget/store.ts",
-      "file": "apps/mobile/features/budget/store.ts",
-      "function": "isCurrentBudgetRequest",
-      "cyclomaticComplexity": 6,
-      "nloc": 25,
-      "parameterCount": 7
-    },
-    {
       "key": "linkCaptureEvidenceToTransaction@116-148@apps/mobile/features/capture-evidence/lib/repository.ts",
       "file": "apps/mobile/features/capture-evidence/lib/repository.ts",
       "function": "linkCaptureEvidenceToTransaction",
       "cyclomaticComplexity": 2,
       "nloc": 18,
-      "parameterCount": 4
-    },
-    {
-      "key": "listSuggestions@213-231@apps/mobile/features/account-suggestions/services/create-account-suggestion-service.ts",
-      "file": "apps/mobile/features/account-suggestions/services/create-account-suggestion-service.ts",
-      "function": "listSuggestions",
-      "cyclomaticComplexity": 1,
-      "nloc": 19,
-      "parameterCount": 5
-    },
-    {
-      "key": "loadNextPage@142-144@apps/mobile/features/transactions/services/create-transaction-query-service.ts",
-      "file": "apps/mobile/features/transactions/services/create-transaction-query-service.ts",
-      "function": "loadNextPage",
-      "cyclomaticComplexity": 1,
-      "nloc": 3,
-      "parameterCount": 4
-    },
-    {
-      "key": "loadPage@130-146@apps/mobile/features/activity/services/create-activity-query-service.ts",
-      "file": "apps/mobile/features/activity/services/create-activity-query-service.ts",
-      "function": "loadPage",
-      "cyclomaticComplexity": 2,
-      "nloc": 16,
       "parameterCount": 4
     },
     {
@@ -1270,59 +846,11 @@
       "parameterCount": 4
     },
     {
-      "key": "makeDateLabel@18-29@apps/mobile/features/transactions/lib/group-by-date.ts",
-      "file": "apps/mobile/features/transactions/lib/group-by-date.ts",
-      "function": "makeDateLabel",
-      "cyclomaticComplexity": 4,
-      "nloc": 11,
-      "parameterCount": 4
-    },
-    {
-      "key": "makeDateLabel@48-54@apps/mobile/features/transactions/lib/group-by-date.ts",
-      "file": "apps/mobile/features/transactions/lib/group-by-date.ts",
-      "function": "makeDateLabel",
-      "cyclomaticComplexity": 1,
-      "nloc": 7,
-      "parameterCount": 4
-    },
-    {
-      "key": "markForRetry@130-140@apps/mobile/features/email-capture/lib/repository.ts",
-      "file": "apps/mobile/features/email-capture/lib/repository.ts",
-      "function": "markForRetry",
-      "cyclomaticComplexity": 1,
-      "nloc": 11,
-      "parameterCount": 4
-    },
-    {
-      "key": "markRetrySuccess@149-160@apps/mobile/features/email-capture/lib/repository.ts",
-      "file": "apps/mobile/features/email-capture/lib/repository.ts",
-      "function": "markRetrySuccess",
-      "cyclomaticComplexity": 1,
-      "nloc": 12,
-      "parameterCount": 5
-    },
-    {
-      "key": "mergeActivityItems@96-125@apps/mobile/features/activity/services/create-activity-query-service.ts",
-      "file": "apps/mobile/features/activity/services/create-activity-query-service.ts",
-      "function": "mergeActivityItems",
-      "cyclomaticComplexity": 6,
-      "nloc": 24,
-      "parameterCount": 2
-    },
-    {
       "key": "parseActionFromResponse@7-18@apps/mobile/features/ai-chat/lib/parse-action.ts",
       "file": "apps/mobile/features/ai-chat/lib/parse-action.ts",
       "function": "parseActionFromResponse",
       "cyclomaticComplexity": 6,
       "nloc": 11,
-      "parameterCount": 1
-    },
-    {
-      "key": "parseIsoDate@26-34@apps/mobile/shared/lib/format-date.ts",
-      "file": "apps/mobile/shared/lib/format-date.ts",
-      "function": "parseIsoDate",
-      "cyclomaticComplexity": 7,
-      "nloc": 8,
       "parameterCount": 1
     },
     {
@@ -1332,22 +860,6 @@
       "cyclomaticComplexity": 6,
       "nloc": 16,
       "parameterCount": 1
-    },
-    {
-      "key": "parseStoredFlags@65-112@apps/mobile/features/qa/devtools-store.ts",
-      "file": "apps/mobile/features/qa/devtools-store.ts",
-      "function": "parseStoredFlags",
-      "cyclomaticComplexity": 11,
-      "nloc": 41,
-      "parameterCount": 1
-    },
-    {
-      "key": "reconcileBuildSettings@135-162@apps/mobile/plugins/withFidyWidget.js",
-      "file": "apps/mobile/plugins/withFidyWidget.js",
-      "function": "reconcileBuildSettings",
-      "cyclomaticComplexity": 10,
-      "nloc": 22,
-      "parameterCount": 0
     },
     {
       "key": "relinkCaptureEvidenceToTransfer@150-180@apps/mobile/features/capture-evidence/lib/repository.ts",
@@ -1366,27 +878,11 @@
       "parameterCount": 4
     },
     {
-      "key": "restoreSession@50-96@apps/mobile/features/auth/store.ts",
-      "file": "apps/mobile/features/auth/store.ts",
-      "function": "restoreSession",
-      "cyclomaticComplexity": 11,
-      "nloc": 44,
-      "parameterCount": 0
-    },
-    {
       "key": "sanitize@10-47@apps/mobile/features/email-capture/services/outlook-adapter.ts",
       "file": "apps/mobile/features/email-capture/services/outlook-adapter.ts",
       "function": "sanitize",
       "cyclomaticComplexity": 1,
       "nloc": 38,
-      "parameterCount": 0
-    },
-    {
-      "key": "save@44-70@apps/mobile/features/transfers/lib/mutation-service.ts",
-      "file": "apps/mobile/features/transfers/lib/mutation-service.ts",
-      "function": "save",
-      "cyclomaticComplexity": 6,
-      "nloc": 21,
       "parameterCount": 0
     },
     {
@@ -1430,22 +926,6 @@
       "parameterCount": 3
     },
     {
-      "key": "scoreSuggestedAccount@68-96@apps/mobile/features/review-queues/lib/attribution-review-service.ts",
-      "file": "apps/mobile/features/review-queues/lib/attribution-review-service.ts",
-      "function": "scoreSuggestedAccount",
-      "cyclomaticComplexity": 11,
-      "nloc": 28,
-      "parameterCount": 2
-    },
-    {
-      "key": "searchTransactionsPaginated@32-48@apps/mobile/features/search/lib/repository.ts",
-      "file": "apps/mobile/features/search/lib/repository.ts",
-      "function": "searchTransactionsPaginated",
-      "cyclomaticComplexity": 1,
-      "nloc": 17,
-      "parameterCount": 5
-    },
-    {
       "key": "sessionId@66-72@apps/mobile/__tests__/ai-chat/store.test.ts",
       "file": "apps/mobile/__tests__/ai-chat/store.test.ts",
       "function": "sessionId",
@@ -1454,68 +934,12 @@
       "parameterCount": 0
     },
     {
-      "key": "signIn@128-171@apps/mobile/features/auth/store.ts",
-      "file": "apps/mobile/features/auth/store.ts",
-      "function": "signIn",
-      "cyclomaticComplexity": 11,
-      "nloc": 42,
-      "parameterCount": 0
-    },
-    {
-      "key": "toComparableLocalTransactionRow@1210-1219@apps/mobile/features/sync/services/syncEngine.ts",
-      "file": "apps/mobile/features/sync/services/syncEngine.ts",
-      "function": "toComparableLocalTransactionRow",
-      "cyclomaticComplexity": 11,
-      "nloc": 10,
-      "parameterCount": 1
-    },
-    {
-      "key": "toConfidenceLabel@72-90@apps/mobile/features/account-suggestions/lib/presentation.ts",
-      "file": "apps/mobile/features/account-suggestions/lib/presentation.ts",
-      "function": "toConfidenceLabel",
-      "cyclomaticComplexity": 7,
-      "nloc": 17,
-      "parameterCount": 2
-    },
-    {
       "key": "toggleCaptureSourcePackage@88-112@apps/mobile/features/capture-sources/store.ts",
       "file": "apps/mobile/features/capture-sources/store.ts",
       "function": "toggleCaptureSourcePackage",
       "cyclomaticComplexity": 3,
       "nloc": 23,
       "parameterCount": 4
-    },
-    {
-      "key": "toStoredActivityItems@43-94@apps/mobile/features/activity/services/create-activity-query-service.ts",
-      "file": "apps/mobile/features/activity/services/create-activity-query-service.ts",
-      "function": "toStoredActivityItems",
-      "cyclomaticComplexity": 5,
-      "nloc": 28,
-      "parameterCount": 4
-    },
-    {
-      "key": "toStoredTransfer@109-130@apps/mobile/features/transfers/lib/build-transfer.ts",
-      "file": "apps/mobile/features/transfers/lib/build-transfer.ts",
-      "function": "toStoredTransfer",
-      "cyclomaticComplexity": 10,
-      "nloc": 21,
-      "parameterCount": 1
-    },
-    {
-      "key": "toTransferRow@130-145@apps/mobile/features/transfers/lib/build-transfer.ts",
-      "file": "apps/mobile/features/transfers/lib/build-transfer.ts",
-      "function": "toTransferRow",
-      "cyclomaticComplexity": 7,
-      "nloc": 16,
-      "parameterCount": 1
-    },
-    {
-      "key": "trimLabel@82-107@apps/mobile/features/transfers/lib/build-transfer.ts",
-      "file": "apps/mobile/features/transfers/lib/build-transfer.ts",
-      "function": "trimLabel",
-      "cyclomaticComplexity": 7,
-      "nloc": 23,
-      "parameterCount": 1
     },
     {
       "key": "unresolvedConflictCountEffect@106-132@apps/mobile/features/sync/services/create-sync-service.ts",
@@ -1534,14 +958,6 @@
       "parameterCount": 4
     },
     {
-      "key": "updateBudget@298-320@apps/mobile/features/budget/store.ts",
-      "file": "apps/mobile/features/budget/store.ts",
-      "function": "updateBudget",
-      "cyclomaticComplexity": 3,
-      "nloc": 21,
-      "parameterCount": 4
-    },
-    {
       "key": "updateBudgetAmount@37-39@apps/mobile/features/budget/lib/repository.ts",
       "file": "apps/mobile/features/budget/lib/repository.ts",
       "function": "updateBudgetAmount",
@@ -1550,43 +966,11 @@
       "parameterCount": 4
     },
     {
-      "key": "updateChatActionStatus@361-374@apps/mobile/features/ai-chat/store.ts",
-      "file": "apps/mobile/features/ai-chat/store.ts",
-      "function": "updateChatActionStatus",
-      "cyclomaticComplexity": 3,
-      "nloc": 12,
-      "parameterCount": 4
-    },
-    {
       "key": "updateGoal@27-44@apps/mobile/features/goals/lib/repository.ts",
       "file": "apps/mobile/features/goals/lib/repository.ts",
       "function": "updateGoal",
       "cyclomaticComplexity": 1,
       "nloc": 18,
-      "parameterCount": 4
-    },
-    {
-      "key": "updateProcessedEmailStatus@94-101@apps/mobile/features/email-capture/lib/repository.ts",
-      "file": "apps/mobile/features/email-capture/lib/repository.ts",
-      "function": "updateProcessedEmailStatus",
-      "cyclomaticComplexity": 1,
-      "nloc": 8,
-      "parameterCount": 4
-    },
-    {
-      "key": "updateProcessedEmailStatusInTransaction@103-110@apps/mobile/features/email-capture/lib/repository.ts",
-      "file": "apps/mobile/features/email-capture/lib/repository.ts",
-      "function": "updateProcessedEmailStatusInTransaction",
-      "cyclomaticComplexity": 1,
-      "nloc": 8,
-      "parameterCount": 4
-    },
-    {
-      "key": "updateTransactionDirect@390-409@apps/mobile/features/transactions/store.ts",
-      "file": "apps/mobile/features/transactions/store.ts",
-      "function": "updateTransactionDirect",
-      "cyclomaticComplexity": 2,
-      "nloc": 19,
       "parameterCount": 4
     },
     {


### PR DESCRIPTION
- deepen activity and transfer helpers
- reshape budget, search, and ai chat boundaries
- refresh strict complexity ledger

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored mobile data boundaries to use helper modules and object-based params across activity, transfers, search, budget, and chat. Stabilized pagination and added chat row mappers with safe action parsing to prevent crashes.

- **Refactors**
  - Standardized object params for pagination/updates (`getTransfersPaginated`, `searchTransactionsPaginated`, `updateChatActionStatus`, `updateBudget`); `buildTransfer` now takes an object.
  - Added helpers/mappers: activity items, transfer builders + row mappers, and chat row mappers; simplified related stores.
  - Pagination uses limit+1 for hasMore and deterministic ordering with unique tiebreakers.
  - Budget: clearer reload rules and leaner store wiring.
  - Infra: Supabase client config cleanup, safer ISO date parsing, simpler effect runtime and conflict checks; attribution review service reorg; complexity ledger refreshed.

- **Migration**
  - Update callers to use object args:
    - `getTransfersPaginated({ db, userId, limit, offset })`
    - `searchTransactionsPaginated({ db, userId, filters, limit, offset })`
    - `updateChatActionStatus({ db, userId, messageId, status })`
    - `updateBudget({ db, userId, id, amount })`
    - `buildTransfer({ input, userId, id, now })`

<sup>Written for commit 7446ef1d3b8368a211f462c84ab871a5533a7014. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

