### PR TITLE
test(mobile): finish wave 4 burn-down

### DIFF
--- a/apps/mobile/__tests__/account-suggestions/service.test.ts
+++ b/apps/mobile/__tests__/account-suggestions/service.test.ts
@@ -30,6 +30,14 @@ let db: ReturnType<typeof drizzle>;
 
 const USER_ID = "user-1" as UserId;
 const NOW = "2026-04-19T10:00:00.000Z" as IsoDateTime;
+const DEFAULT_ACCOUNT_ID = "fa-default-user-1" as FinancialAccountId;
+const DEFAULT_SUGGESTION_TRANSACTION = {
+  amount: 120000 as CopAmount,
+  description: "Compra 1234",
+  accountId: DEFAULT_ACCOUNT_ID,
+};
+
+type SuggestionEvidenceInput = Parameters<typeof saveCaptureEvidence>[1];
 
 beforeEach(() => {
   sqlite = new Database(":memory:");
@@ -41,74 +49,242 @@ afterEach(() => {
   sqlite.close();
 });
 
-function saveEvidenceRow(
-  id: string,
-  row: {
-    readonly sourceFamily: string;
-    readonly evidenceType: string;
-    readonly scope: string;
-    readonly value: string;
-    readonly processedEmailId?: string;
-    readonly processedCaptureId?: string;
-    readonly transactionId?: string | null;
-    readonly updatedAt?: IsoDateTime;
-  }
-) {
+function saveEvidenceRow(id: string, row: Partial<SuggestionEvidenceInput>) {
   saveCaptureEvidence(db as any, {
     id: id as CaptureEvidenceId,
     userId: USER_ID,
-    sourceFamily: row.sourceFamily,
-    evidenceType: row.evidenceType,
-    scope: row.scope,
-    value: row.value,
-    transactionId: (row.transactionId ?? null) as TransactionId | null,
-    processedEmailId: (row.processedEmailId ?? null) as ProcessedEmailId | null,
-    processedCaptureId: (row.processedCaptureId ?? null) as ProcessedCaptureId | null,
-    createdAt: row.updatedAt ?? NOW,
-    updatedAt: row.updatedAt ?? NOW,
+    sourceFamily: "bancolombia",
+    evidenceType: "last4",
+    scope: "notification:bancolombia:last4",
+    value: "1234",
+    transactionId: null,
+    processedEmailId: null,
+    processedCaptureId: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+    deletedAt: null,
+    ...row,
+  });
+}
+
+function insertSuggestionTransactionRecord(
+  id: string,
+  state: "unresolved" | "confirmed",
+  overrides: Partial<{
+    amount: CopAmount;
+    description: string;
+    accountId: FinancialAccountId;
+  }> = {}
+) {
+  insertTransaction(db as any, {
+    id: id as TransactionId,
+    userId: USER_ID,
+    type: "expense",
+    ...DEFAULT_SUGGESTION_TRANSACTION,
+    ...overrides,
+    categoryId: "shopping" as CategoryId,
+    date: "2026-04-19" as IsoDate,
+    accountAttributionState: state,
+    source: "notification_android",
+    createdAt: NOW,
+    updatedAt: NOW,
     deletedAt: null,
   });
 }
 
+function createSuggestionService(
+  overrides: Partial<Parameters<typeof createAccountSuggestionService>[0]> = {}
+) {
+  return createAccountSuggestionService(overrides);
+}
+
+function getFirstSuggestion(service = createSuggestionService()) {
+  const suggestion = service.listSuggestions({ db: db as any, userId: USER_ID })[0];
+  expect(suggestion).toBeDefined();
+  return suggestion!;
+}
+
+function seedRepeatedScopedSuggestionEvidence() {
+  saveEvidenceRow("ce-last4-1", {
+    processedCaptureId: "pc-1" as ProcessedCaptureId,
+    transactionId: "tx-1" as TransactionId,
+  });
+  saveEvidenceRow("ce-last4-2", {
+    processedCaptureId: "pc-2" as ProcessedCaptureId,
+    transactionId: "tx-2" as TransactionId,
+    updatedAt: "2026-04-19T11:00:00.000Z" as IsoDateTime,
+  });
+  saveEvidenceRow("ce-sender-1", {
+    evidenceType: "sender_email",
+    scope: "email:bancolombia:sender",
+    value: "notificaciones@bancolombia.com.co",
+    processedEmailId: "pe-1" as ProcessedEmailId,
+  });
+  saveEvidenceRow("ce-sender-2", {
+    evidenceType: "sender_email",
+    scope: "email:bancolombia:sender",
+    value: "notificaciones@bancolombia.com.co",
+    processedEmailId: "pe-2" as ProcessedEmailId,
+    updatedAt: "2026-04-19T11:30:00.000Z" as IsoDateTime,
+  });
+}
+
+function seedSuggestionAcceptanceScenario(linkedAccountId: FinancialAccountId) {
+  upsertFinancialAccount(db as any, {
+    id: linkedAccountId,
+    userId: USER_ID,
+    name: "Bancolombia Visa",
+    kind: "credit_card",
+    isDefault: false,
+    createdAt: NOW,
+    updatedAt: NOW,
+    deletedAt: null,
+  });
+  insertSuggestionTransactionRecord("tx-unresolved", "unresolved");
+  insertSuggestionTransactionRecord("tx-confirmed", "confirmed", {
+    amount: 98000 as CopAmount,
+    description: "Compra confirmada 1234",
+  });
+  saveEvidenceRow("ce-match-1", {
+    processedCaptureId: "pc-1" as ProcessedCaptureId,
+    transactionId: "tx-unresolved" as TransactionId,
+  });
+  saveEvidenceRow("ce-match-2", {
+    processedCaptureId: "pc-2" as ProcessedCaptureId,
+    transactionId: "tx-confirmed" as TransactionId,
+    updatedAt: "2026-04-19T11:00:00.000Z" as IsoDateTime,
+  });
+}
+
+function seedLast4RankingEvidence() {
+  saveEvidenceRow("ce-last4-a-1", { processedCaptureId: "pc-1" as ProcessedCaptureId });
+  saveEvidenceRow("ce-last4-a-2", {
+    processedCaptureId: "pc-2" as ProcessedCaptureId,
+    updatedAt: "2026-04-19T11:00:00.000Z" as IsoDateTime,
+  });
+  saveEvidenceRow("ce-last4-b-1", {
+    sourceFamily: "davivienda",
+    scope: "notification:davivienda:last4",
+    value: "9999",
+    processedCaptureId: "pc-3" as ProcessedCaptureId,
+  });
+  saveEvidenceRow("ce-last4-b-2", {
+    sourceFamily: "davivienda",
+    scope: "notification:davivienda:last4",
+    value: "9999",
+    processedCaptureId: "pc-4" as ProcessedCaptureId,
+    updatedAt: "2026-04-19T11:10:00.000Z" as IsoDateTime,
+  });
+}
+
+function seedCardHintRankingEvidence() {
+  saveEvidenceRow("ce-card-1", {
+    sourceFamily: "apple_pay",
+    evidenceType: "card_hint",
+    scope: "apple_pay:card_hint",
+    value: "visa platinum 1234",
+    processedCaptureId: "pc-5" as ProcessedCaptureId,
+  });
+  saveEvidenceRow("ce-card-2", {
+    sourceFamily: "apple_pay",
+    evidenceType: "card_hint",
+    scope: "apple_pay:card_hint",
+    value: "visa platinum 1234",
+    processedCaptureId: "pc-6" as ProcessedCaptureId,
+    updatedAt: "2026-04-19T11:20:00.000Z" as IsoDateTime,
+  });
+}
+
+function seedAliasRankingEvidence() {
+  saveEvidenceRow("ce-alias-1", {
+    sourceFamily: "nequi",
+    evidenceType: "alias_token",
+    scope: "notification:nequi:alias",
+    value: "debito",
+    processedCaptureId: "pc-7" as ProcessedCaptureId,
+  });
+  saveEvidenceRow("ce-alias-2", {
+    sourceFamily: "nequi",
+    evidenceType: "alias_token",
+    scope: "notification:nequi:alias",
+    value: "debito",
+    processedCaptureId: "pc-8" as ProcessedCaptureId,
+    updatedAt: "2026-04-19T11:30:00.000Z" as IsoDateTime,
+  });
+}
+
+function seedSuggestionRankingEvidence() {
+  seedLast4RankingEvidence();
+  seedCardHintRankingEvidence();
+  seedAliasRankingEvidence();
+}
+
+function seedSuggestedAccountCreationScenario() {
+  insertSuggestionTransactionRecord("tx-create-account", "unresolved", {
+    amount: 145000 as CopAmount,
+  });
+  saveEvidenceRow("ce-create-1", {
+    processedCaptureId: "pc-1" as ProcessedCaptureId,
+    transactionId: "tx-create-account" as TransactionId,
+  });
+  saveEvidenceRow("ce-create-2", {
+    processedCaptureId: "pc-2" as ProcessedCaptureId,
+    updatedAt: "2026-04-19T11:00:00.000Z" as IsoDateTime,
+  });
+}
+
+function expectLinkedIdentifier(accountId: FinancialAccountId) {
+  expect(getFinancialAccountIdentifiersForAccount(db as any, accountId)).toEqual([
+    expect.objectContaining({
+      accountId,
+      scope: "notification:bancolombia:last4",
+      value: "1234",
+    }),
+  ]);
+}
+
+function expectCreatedSuggestedAccountState() {
+  expect(getFinancialAccountById(db as any, "fa-created" as FinancialAccountId)).toEqual(
+    expect.objectContaining({
+      id: "fa-created",
+      userId: USER_ID,
+      name: "Bancolombia account",
+      kind: "checking",
+      isDefault: false,
+    })
+  );
+  expectLinkedIdentifier("fa-created" as FinancialAccountId);
+  expect(getTransactionById(db as any, "tx-create-account" as TransactionId)).toEqual(
+    expect.objectContaining({
+      accountId: "fa-created",
+      accountAttributionState: "inferred",
+      updatedAt: "2026-04-19T12:00:00.000Z",
+    })
+  );
+}
+
+function expectAcceptedSuggestionSideEffects(linkedAccountId: FinancialAccountId) {
+  expectLinkedIdentifier(linkedAccountId);
+  expect(getTransactionById(db as any, "tx-unresolved" as TransactionId)).toEqual(
+    expect.objectContaining({
+      accountId: linkedAccountId,
+      accountAttributionState: "inferred",
+      updatedAt: "2026-04-19T12:00:00.000Z",
+    })
+  );
+  expect(getTransactionById(db as any, "tx-confirmed" as TransactionId)).toEqual(
+    expect.objectContaining({
+      accountId: DEFAULT_ACCOUNT_ID,
+      accountAttributionState: "confirmed",
+      updatedAt: NOW,
+    })
+  );
+}
+
 describe("account suggestion service", () => {
   it("lists repeated scoped suggestions and ignores repeated sender-only evidence", () => {
-    saveEvidenceRow("ce-last4-1", {
-      sourceFamily: "bancolombia",
-      evidenceType: "last4",
-      scope: "notification:bancolombia:last4",
-      value: "1234",
-      processedCaptureId: "pc-1",
-      transactionId: "tx-1",
-    });
-
-    saveEvidenceRow("ce-last4-2", {
-      sourceFamily: "bancolombia",
-      evidenceType: "last4",
-      scope: "notification:bancolombia:last4",
-      value: "1234",
-      processedCaptureId: "pc-2",
-      transactionId: "tx-2",
-      updatedAt: "2026-04-19T11:00:00.000Z" as IsoDateTime,
-    });
-
-    saveEvidenceRow("ce-sender-1", {
-      sourceFamily: "bancolombia",
-      evidenceType: "sender_email",
-      scope: "email:bancolombia:sender",
-      value: "notificaciones@bancolombia.com.co",
-      processedEmailId: "pe-1",
-    });
-
-    saveEvidenceRow("ce-sender-2", {
-      sourceFamily: "bancolombia",
-      evidenceType: "sender_email",
-      scope: "email:bancolombia:sender",
-      value: "notificaciones@bancolombia.com.co",
-      processedEmailId: "pe-2",
-      updatedAt: "2026-04-19T11:30:00.000Z" as IsoDateTime,
-    });
-
-    const service = createAccountSuggestionService();
+    seedRepeatedScopedSuggestionEvidence();
+    const service = createSuggestionService();
     const suggestions = service.listSuggestions({ db: db as any, userId: USER_ID });
 
     expect(suggestions).toEqual([
@@ -123,37 +299,17 @@ describe("account suggestion service", () => {
   });
 
   it("suppresses a dismissed suggestion until stronger evidence appears", () => {
-    saveEvidenceRow("ce-last4-1", {
-      sourceFamily: "bancolombia",
-      evidenceType: "last4",
-      scope: "notification:bancolombia:last4",
-      value: "1234",
-      processedCaptureId: "pc-1",
-      transactionId: "tx-1",
-    });
-
-    saveEvidenceRow("ce-last4-2", {
-      sourceFamily: "bancolombia",
-      evidenceType: "last4",
-      scope: "notification:bancolombia:last4",
-      value: "1234",
-      processedCaptureId: "pc-2",
-      transactionId: "tx-2",
-      updatedAt: "2026-04-19T11:00:00.000Z" as IsoDateTime,
-    });
-
-    const service = createAccountSuggestionService({
+    seedRepeatedScopedSuggestionEvidence();
+    const service = createSuggestionService({
       now: () => NOW,
       createDismissalId: () => "asd-1" as never,
     });
-    const suggestion = service.listSuggestions({ db: db as any, userId: USER_ID })[0];
-
-    expect(suggestion).toBeDefined();
+    const suggestion = getFirstSuggestion(service);
 
     service.dismissSuggestion({
       db: db as any,
       userId: USER_ID,
-      suggestion: suggestion!,
+      suggestion,
     });
 
     expect(service.listSuggestions({ db: db as any, userId: USER_ID })).toEqual([]);
@@ -163,8 +319,8 @@ describe("account suggestion service", () => {
       evidenceType: "last4",
       scope: "notification:bancolombia:last4",
       value: "1234",
-      processedCaptureId: "pc-3",
-      transactionId: "tx-3",
+      processedCaptureId: "pc-3" as ProcessedCaptureId,
+      transactionId: "tx-3" as TransactionId,
       updatedAt: "2026-04-19T12:00:00.000Z" as IsoDateTime,
     });
 
@@ -179,82 +335,18 @@ describe("account suggestion service", () => {
 
   it("accepts a suggestion by saving an identifier and reprocessing matching unresolved transactions only", () => {
     const linkedAccountId = "fa-2" as FinancialAccountId;
-
-    upsertFinancialAccount(db as any, {
-      id: linkedAccountId,
-      userId: USER_ID,
-      name: "Bancolombia Visa",
-      kind: "credit_card",
-      isDefault: false,
-      createdAt: NOW,
-      updatedAt: NOW,
-      deletedAt: null,
-    });
-
-    insertTransaction(db as any, {
-      id: "tx-unresolved" as TransactionId,
-      userId: USER_ID,
-      type: "expense",
-      amount: 120000 as CopAmount,
-      categoryId: "shopping" as CategoryId,
-      description: "Compra 1234",
-      date: "2026-04-19" as IsoDate,
-      accountId: "fa-default-user-1" as FinancialAccountId,
-      accountAttributionState: "unresolved",
-      source: "notification_android",
-      createdAt: NOW,
-      updatedAt: NOW,
-      deletedAt: null,
-    });
-
-    insertTransaction(db as any, {
-      id: "tx-confirmed" as TransactionId,
-      userId: USER_ID,
-      type: "expense",
-      amount: 98000 as CopAmount,
-      categoryId: "shopping" as CategoryId,
-      description: "Compra confirmada 1234",
-      date: "2026-04-19" as IsoDate,
-      accountId: "fa-default-user-1" as FinancialAccountId,
-      accountAttributionState: "confirmed",
-      source: "notification_android",
-      createdAt: NOW,
-      updatedAt: NOW,
-      deletedAt: null,
-    });
-
-    saveEvidenceRow("ce-match-1", {
-      sourceFamily: "bancolombia",
-      evidenceType: "last4",
-      scope: "notification:bancolombia:last4",
-      value: "1234",
-      processedCaptureId: "pc-1",
-      transactionId: "tx-unresolved",
-    });
-
-    saveEvidenceRow("ce-match-2", {
-      sourceFamily: "bancolombia",
-      evidenceType: "last4",
-      scope: "notification:bancolombia:last4",
-      value: "1234",
-      processedCaptureId: "pc-2",
-      transactionId: "tx-confirmed",
-      updatedAt: "2026-04-19T11:00:00.000Z" as IsoDateTime,
-    });
-
-    const service = createAccountSuggestionService({
+    seedSuggestionAcceptanceScenario(linkedAccountId);
+    const service = createSuggestionService({
       now: () => "2026-04-19T12:00:00.000Z" as IsoDateTime,
       createIdentifierId: () => "fai-1" as never,
     });
-    const suggestion = service.listSuggestions({ db: db as any, userId: USER_ID })[0];
-
-    expect(suggestion).toBeDefined();
+    const suggestion = getFirstSuggestion(service);
 
     const result = service.acceptSuggestion({
       db: db as any,
       userId: USER_ID,
       accountId: linkedAccountId,
-      suggestion: suggestion!,
+      suggestion,
     });
 
     expect(result).toEqual({
@@ -263,97 +355,13 @@ describe("account suggestion service", () => {
       identifierValue: "1234",
       reprocessedTransactionIds: ["tx-unresolved"],
     });
-
-    expect(getFinancialAccountIdentifiersForAccount(db as any, linkedAccountId)).toEqual([
-      expect.objectContaining({
-        accountId: linkedAccountId,
-        scope: "notification:bancolombia:last4",
-        value: "1234",
-      }),
-    ]);
-
-    expect(getTransactionById(db as any, "tx-unresolved" as TransactionId)).toEqual(
-      expect.objectContaining({
-        accountId: linkedAccountId,
-        accountAttributionState: "inferred",
-        updatedAt: "2026-04-19T12:00:00.000Z",
-      })
-    );
-
-    expect(getTransactionById(db as any, "tx-confirmed" as TransactionId)).toEqual(
-      expect.objectContaining({
-        accountId: "fa-default-user-1",
-        accountAttributionState: "confirmed",
-        updatedAt: NOW,
-      })
-    );
-
+    expectAcceptedSuggestionSideEffects(linkedAccountId);
     expect(service.listSuggestions({ db: db as any, userId: USER_ID })).toEqual([]);
   });
 
   it("returns the top three strongest suggestions in stable score order", () => {
-    saveEvidenceRow("ce-last4-a-1", {
-      sourceFamily: "bancolombia",
-      evidenceType: "last4",
-      scope: "notification:bancolombia:last4",
-      value: "1234",
-      processedCaptureId: "pc-1",
-    });
-    saveEvidenceRow("ce-last4-a-2", {
-      sourceFamily: "bancolombia",
-      evidenceType: "last4",
-      scope: "notification:bancolombia:last4",
-      value: "1234",
-      processedCaptureId: "pc-2",
-      updatedAt: "2026-04-19T11:00:00.000Z" as IsoDateTime,
-    });
-    saveEvidenceRow("ce-last4-b-1", {
-      sourceFamily: "davivienda",
-      evidenceType: "last4",
-      scope: "notification:davivienda:last4",
-      value: "9999",
-      processedCaptureId: "pc-3",
-    });
-    saveEvidenceRow("ce-last4-b-2", {
-      sourceFamily: "davivienda",
-      evidenceType: "last4",
-      scope: "notification:davivienda:last4",
-      value: "9999",
-      processedCaptureId: "pc-4",
-      updatedAt: "2026-04-19T11:10:00.000Z" as IsoDateTime,
-    });
-    saveEvidenceRow("ce-card-1", {
-      sourceFamily: "apple_pay",
-      evidenceType: "card_hint",
-      scope: "apple_pay:card_hint",
-      value: "visa platinum 1234",
-      processedCaptureId: "pc-5",
-    });
-    saveEvidenceRow("ce-card-2", {
-      sourceFamily: "apple_pay",
-      evidenceType: "card_hint",
-      scope: "apple_pay:card_hint",
-      value: "visa platinum 1234",
-      processedCaptureId: "pc-6",
-      updatedAt: "2026-04-19T11:20:00.000Z" as IsoDateTime,
-    });
-    saveEvidenceRow("ce-alias-1", {
-      sourceFamily: "nequi",
-      evidenceType: "alias_token",
-      scope: "notification:nequi:alias",
-      value: "debito",
-      processedCaptureId: "pc-7",
-    });
-    saveEvidenceRow("ce-alias-2", {
-      sourceFamily: "nequi",
-      evidenceType: "alias_token",
-      scope: "notification:nequi:alias",
-      value: "debito",
-      processedCaptureId: "pc-8",
-      updatedAt: "2026-04-19T11:30:00.000Z" as IsoDateTime,
-    });
-
-    const service = createAccountSuggestionService();
+    seedSuggestionRankingEvidence();
+    const service = createSuggestionService();
     const suggestions = service.listSuggestions({
       db: db as any,
       userId: USER_ID,
@@ -369,53 +377,18 @@ describe("account suggestion service", () => {
   });
 
   it("creates a financial account from a suggestion and reprocesses matching unresolved transactions", () => {
-    insertTransaction(db as any, {
-      id: "tx-create-account" as TransactionId,
-      userId: USER_ID,
-      type: "expense",
-      amount: 145000 as CopAmount,
-      categoryId: "shopping" as CategoryId,
-      description: "Compra 1234",
-      date: "2026-04-19" as IsoDate,
-      accountId: "fa-default-user-1" as FinancialAccountId,
-      accountAttributionState: "unresolved",
-      source: "notification_android",
-      createdAt: NOW,
-      updatedAt: NOW,
-      deletedAt: null,
-    });
-
-    saveEvidenceRow("ce-create-1", {
-      sourceFamily: "bancolombia",
-      evidenceType: "last4",
-      scope: "notification:bancolombia:last4",
-      value: "1234",
-      processedCaptureId: "pc-1",
-      transactionId: "tx-create-account",
-    });
-
-    saveEvidenceRow("ce-create-2", {
-      sourceFamily: "bancolombia",
-      evidenceType: "last4",
-      scope: "notification:bancolombia:last4",
-      value: "1234",
-      processedCaptureId: "pc-2",
-      updatedAt: "2026-04-19T11:00:00.000Z" as IsoDateTime,
-    });
-
-    const service = createAccountSuggestionService({
+    seedSuggestedAccountCreationScenario();
+    const service = createSuggestionService({
       now: () => "2026-04-19T12:00:00.000Z" as IsoDateTime,
       createAccountId: () => "fa-created" as FinancialAccountId,
       createIdentifierId: () => "fai-created" as never,
     });
-    const suggestion = service.listSuggestions({ db: db as any, userId: USER_ID })[0];
-
-    expect(suggestion).toBeDefined();
+    const suggestion = getFirstSuggestion(service);
 
     const result = service.createSuggestedAccount({
       db: db as any,
       userId: USER_ID,
-      suggestion: suggestion!,
+      suggestion,
       name: "Bancolombia account",
       kind: "checking",
     });
@@ -426,34 +399,7 @@ describe("account suggestion service", () => {
       identifierValue: "1234",
       reprocessedTransactionIds: ["tx-create-account"],
     });
-
-    expect(getFinancialAccountById(db as any, "fa-created" as FinancialAccountId)).toEqual(
-      expect.objectContaining({
-        id: "fa-created",
-        userId: USER_ID,
-        name: "Bancolombia account",
-        kind: "checking",
-        isDefault: false,
-      })
-    );
-
-    expect(
-      getFinancialAccountIdentifiersForAccount(db as any, "fa-created" as FinancialAccountId)
-    ).toEqual([
-      expect.objectContaining({
-        accountId: "fa-created",
-        scope: "notification:bancolombia:last4",
-        value: "1234",
-      }),
-    ]);
-
-    expect(getTransactionById(db as any, "tx-create-account" as TransactionId)).toEqual(
-      expect.objectContaining({
-        accountId: "fa-created",
-        accountAttributionState: "inferred",
-        updatedAt: "2026-04-19T12:00:00.000Z",
-      })
-    );
+    expectCreatedSuggestedAccountState();
   });
 
   it("rolls back account creation when a later suggestion step fails", () => {
@@ -478,8 +424,8 @@ describe("account suggestion service", () => {
       evidenceType: "last4",
       scope: "notification:bancolombia:last4",
       value: "1234",
-      processedCaptureId: "pc-1",
-      transactionId: "tx-create-account",
+      processedCaptureId: "pc-1" as ProcessedCaptureId,
+      transactionId: "tx-create-account" as TransactionId,
     });
 
     saveEvidenceRow("ce-create-2", {
@@ -487,7 +433,7 @@ describe("account suggestion service", () => {
       evidenceType: "last4",
       scope: "notification:bancolombia:last4",
       value: "1234",
-      processedCaptureId: "pc-2",
+      processedCaptureId: "pc-2" as ProcessedCaptureId,
       updatedAt: "2026-04-19T11:00:00.000Z" as IsoDateTime,
     });
 

--- a/apps/mobile/__tests__/budget/monitoring.test.ts
+++ b/apps/mobile/__tests__/budget/monitoring.test.ts
@@ -4,6 +4,7 @@ import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BudgetAlertState } from "@/features/budget/lib/monitoring";
 import { createBudgetMonitoringModule } from "@/features/budget/lib/monitoring";
 import { insertBudget } from "@/features/budget/lib/repository";
 import { insertTransaction } from "@/features/transactions/lib/repository";
@@ -84,70 +85,168 @@ const insertExpense = (
     source: "manual",
   });
 
+function createMonitoringModule() {
+  return createBudgetMonitoringModule({
+    getBudgetAlertsEnabled: () => true,
+    getLocale: () => "es",
+    resolveCategoryLabel: mockResolveCategoryLabel,
+    scheduleBudgetAlert: mockScheduleBudgetAlert,
+    insertNotification: mockInsertNotification,
+  });
+}
+
+async function refreshCurrentMonth(
+  module = createMonitoringModule(),
+  previous: BudgetAlertState | undefined = {
+    pendingAlerts: [],
+    acknowledgedAlerts: new Set(),
+  }
+) {
+  return module.refreshMonth({
+    db: db as any,
+    userId: USER_ID,
+    month: CURRENT_MONTH,
+    ...(previous ? { previous } : {}),
+  });
+}
+
+function createPendingAlertState(): BudgetAlertState {
+  return {
+    pendingAlerts: [
+      {
+        budgetId: "budget-1" as BudgetId,
+        categoryId: "food" as CategoryId,
+        threshold: 80 as const,
+        percentUsed: 85,
+        suggestionKey: undefined,
+        daysLeft: 10,
+        remainingAmount: 15000 as CopAmount,
+      },
+      {
+        budgetId: "budget-2" as BudgetId,
+        categoryId: "transport" as CategoryId,
+        threshold: 80 as const,
+        percentUsed: 90,
+        suggestionKey: undefined,
+        daysLeft: 10,
+        remainingAmount: 10000 as CopAmount,
+      },
+    ],
+    acknowledgedAlerts: new Set(["budget-2:80"]),
+  };
+}
+
+function seedBudgetAlertScenario() {
+  insertBudgetRow();
+  insertBudgetRow({
+    id: "budget-2" as BudgetId,
+    categoryId: "transport" as CategoryId,
+    amount: 50000 as CopAmount,
+  });
+  insertExpense({ id: "tx-1", categoryId: "food" as CategoryId, amount: 85000 as CopAmount });
+  insertExpense({
+    id: "tx-2",
+    categoryId: "transport" as CategoryId,
+    amount: 10000 as CopAmount,
+  });
+  insertExpense({
+    id: "tx-3",
+    categoryId: "entertainment" as CategoryId,
+    amount: 43234 as CopAmount,
+    date: "2026-02-12",
+    month: "2026-02" as Month,
+  });
+}
+
+function expectDeliveredBudgetAlert(result: Awaited<ReturnType<typeof refreshCurrentMonth>>) {
+  expect(result.budgets).toHaveLength(2);
+  expect(result.budgetProgress).toHaveLength(2);
+  expect(result.summary).toEqual({
+    totalBudget: 150000,
+    totalSpent: 95000,
+    percentUsed: 63,
+  });
+  expect(result.autoSuggestions).toEqual([
+    { categoryId: "entertainment" as CategoryId, suggestedAmount: 44000 as CopAmount },
+  ]);
+  expect(result.pendingAlerts).toHaveLength(1);
+  expect(result.pendingAlerts[0]?.budgetId).toBe("budget-1");
+  expect(result.pendingPermissionRequest).toBe(false);
+  expect(mockResolveCategoryLabel).toHaveBeenCalledWith("food", "es");
+  expect(mockScheduleBudgetAlert).toHaveBeenCalledOnce();
+  expect(mockInsertNotification).toHaveBeenCalledOnce();
+  const inserted = mockInsertNotification.mock.calls[0]?.[0] as { params: string };
+  expect(JSON.parse(inserted.params)).toMatchObject({
+    category: "es:food",
+    threshold: 80,
+    daysLeft: expect.any(Number),
+  });
+}
+
+function seedInitialOverBudgetScenario() {
+  insertBudgetRow({
+    id: "budget-1" as BudgetId,
+    categoryId: "food" as CategoryId,
+    amount: 100000 as CopAmount,
+  });
+  insertBudgetRow({
+    id: "budget-2" as BudgetId,
+    categoryId: "transport" as CategoryId,
+    amount: 50000 as CopAmount,
+  });
+  insertExpense({
+    id: "tx-1",
+    categoryId: "food" as CategoryId,
+    amount: 110000 as CopAmount,
+  });
+}
+
+function expectInitialOverBudgetProgress(result: Awaited<ReturnType<typeof refreshCurrentMonth>>) {
+  expect(result.budgetProgress).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        budgetId: "budget-1",
+        spent: 110000,
+        remaining: -10000,
+        percentUsed: 110,
+      }),
+      expect.objectContaining({
+        budgetId: "budget-2",
+        spent: 0,
+        remaining: 50000,
+        percentUsed: 0,
+      }),
+    ])
+  );
+}
+
+function expectInitialOverBudgetDelivery(result: Awaited<ReturnType<typeof refreshCurrentMonth>>) {
+  expect(result.pendingPermissionRequest).toBe(false);
+  expect(result.pendingAlerts).toEqual([
+    expect.objectContaining({
+      budgetId: "budget-1",
+      threshold: 100,
+    }),
+  ]);
+  expect(mockScheduleBudgetAlert).toHaveBeenCalledWith(
+    expect.objectContaining({ budgetId: "budget-1", threshold: 100 }),
+    "es:food",
+    true
+  );
+  expect(mockInsertNotification).toHaveBeenCalledWith(
+    expect.objectContaining({
+      titleKey: "notifications.budgetExceeded",
+      messageKey: "notifications.budgetExceededMsg",
+      dedupKey: "budget_alert:food:100:2026-03",
+    })
+  );
+}
+
 describe("createBudgetMonitoringModule", () => {
   it("refreshMonth loads budgets, derives alerts, and delivers fresh ones", async () => {
-    insertBudgetRow();
-    insertBudgetRow({
-      id: "budget-2" as BudgetId,
-      categoryId: "transport" as CategoryId,
-      amount: 50000 as CopAmount,
-    });
-
-    insertExpense({ id: "tx-1", categoryId: "food" as CategoryId, amount: 85000 as CopAmount });
-    insertExpense({
-      id: "tx-2",
-      categoryId: "transport" as CategoryId,
-      amount: 10000 as CopAmount,
-    });
-    insertExpense({
-      id: "tx-3",
-      categoryId: "entertainment" as CategoryId,
-      amount: 43234 as CopAmount,
-      date: "2026-02-12",
-      month: "2026-02" as Month,
-    });
-
-    const module = createBudgetMonitoringModule({
-      getBudgetAlertsEnabled: () => true,
-      getLocale: () => "es",
-      resolveCategoryLabel: mockResolveCategoryLabel,
-      scheduleBudgetAlert: mockScheduleBudgetAlert,
-      insertNotification: mockInsertNotification,
-    });
-
-    const result = await module.refreshMonth({
-      db: db as any,
-      userId: USER_ID,
-      month: CURRENT_MONTH,
-      previous: {
-        pendingAlerts: [],
-        acknowledgedAlerts: new Set(),
-      },
-    });
-
-    expect(result.budgets).toHaveLength(2);
-    expect(result.budgetProgress).toHaveLength(2);
-    expect(result.summary).toEqual({
-      totalBudget: 150000,
-      totalSpent: 95000,
-      percentUsed: 63,
-    });
-    expect(result.autoSuggestions).toEqual([
-      { categoryId: "entertainment" as CategoryId, suggestedAmount: 44000 as CopAmount },
-    ]);
-    expect(result.pendingAlerts).toHaveLength(1);
-    expect(result.pendingAlerts[0]?.budgetId).toBe("budget-1");
-    expect(result.pendingPermissionRequest).toBe(false);
-    expect(mockResolveCategoryLabel).toHaveBeenCalledWith("food", "es");
-    expect(mockScheduleBudgetAlert).toHaveBeenCalledOnce();
-    expect(mockInsertNotification).toHaveBeenCalledOnce();
-
-    const inserted = mockInsertNotification.mock.calls[0]?.[0] as { params: string };
-    expect(JSON.parse(inserted.params)).toMatchObject({
-      category: "es:food",
-      threshold: 80,
-      daysLeft: expect.any(Number),
-    });
+    seedBudgetAlertScenario();
+    const result = await refreshCurrentMonth();
+    expectDeliveredBudgetAlert(result);
   });
 
   it("refreshMonth skips duplicate delivery when the same alert is still pending", async () => {
@@ -158,23 +257,8 @@ describe("createBudgetMonitoringModule", () => {
       amount: 85000 as CopAmount,
     });
 
-    const module = createBudgetMonitoringModule({
-      getBudgetAlertsEnabled: () => true,
-      getLocale: () => "es",
-      resolveCategoryLabel: mockResolveCategoryLabel,
-      scheduleBudgetAlert: mockScheduleBudgetAlert,
-      insertNotification: mockInsertNotification,
-    });
-
-    const first = await module.refreshMonth({
-      db: db as any,
-      userId: USER_ID,
-      month: CURRENT_MONTH,
-      previous: {
-        pendingAlerts: [],
-        acknowledgedAlerts: new Set(),
-      },
-    });
+    const module = createMonitoringModule();
+    const first = await refreshCurrentMonth(module);
 
     expect(first.pendingAlerts).toHaveLength(1);
     expect(mockScheduleBudgetAlert).toHaveBeenCalledOnce();
@@ -184,14 +268,9 @@ describe("createBudgetMonitoringModule", () => {
     mockInsertNotification.mockClear();
     mockResolveCategoryLabel.mockClear();
 
-    const second = await module.refreshMonth({
-      db: db as any,
-      userId: USER_ID,
-      month: CURRENT_MONTH,
-      previous: {
-        pendingAlerts: first.pendingAlerts,
-        acknowledgedAlerts: new Set(),
-      },
+    const second = await refreshCurrentMonth(module, {
+      pendingAlerts: first.pendingAlerts,
+      acknowledgedAlerts: new Set(),
     });
 
     expect(second.pendingAlerts).toHaveLength(1);
@@ -210,23 +289,7 @@ describe("createBudgetMonitoringModule", () => {
 
     mockScheduleBudgetAlert.mockResolvedValueOnce({ type: "needs_permission" });
 
-    const module = createBudgetMonitoringModule({
-      getBudgetAlertsEnabled: () => true,
-      getLocale: () => "es",
-      resolveCategoryLabel: mockResolveCategoryLabel,
-      scheduleBudgetAlert: mockScheduleBudgetAlert,
-      insertNotification: mockInsertNotification,
-    });
-
-    const result = await module.refreshMonth({
-      db: db as any,
-      userId: USER_ID,
-      month: CURRENT_MONTH,
-      previous: {
-        pendingAlerts: [],
-        acknowledgedAlerts: new Set(),
-      },
-    });
+    const result = await refreshCurrentMonth();
 
     expect(result.pendingPermissionRequest).toBe(true);
     expect(mockScheduleBudgetAlert).toHaveBeenCalledOnce();
@@ -260,23 +323,7 @@ describe("createBudgetMonitoringModule", () => {
       .mockResolvedValueOnce({ type: "scheduled", id: "notif-1" })
       .mockRejectedValueOnce(new Error("push service down"));
 
-    const module = createBudgetMonitoringModule({
-      getBudgetAlertsEnabled: () => true,
-      getLocale: () => "es",
-      resolveCategoryLabel: mockResolveCategoryLabel,
-      scheduleBudgetAlert: mockScheduleBudgetAlert,
-      insertNotification: mockInsertNotification,
-    });
-
-    const result = await module.refreshMonth({
-      db: db as any,
-      userId: USER_ID,
-      month: CURRENT_MONTH,
-      previous: {
-        pendingAlerts: [],
-        acknowledgedAlerts: new Set(),
-      },
-    });
+    const result = await refreshCurrentMonth();
 
     expect(result.pendingPermissionRequest).toBe(false);
     expect(result.pendingAlerts).toHaveLength(2);
@@ -285,73 +332,10 @@ describe("createBudgetMonitoringModule", () => {
   });
 
   it("refreshMonth derives initial over-budget alerts without previous state", async () => {
-    insertBudgetRow({
-      id: "budget-1" as BudgetId,
-      categoryId: "food" as CategoryId,
-      amount: 100000 as CopAmount,
-    });
-    insertBudgetRow({
-      id: "budget-2" as BudgetId,
-      categoryId: "transport" as CategoryId,
-      amount: 50000 as CopAmount,
-    });
-
-    insertExpense({
-      id: "tx-1",
-      categoryId: "food" as CategoryId,
-      amount: 110000 as CopAmount,
-    });
-
-    const module = createBudgetMonitoringModule({
-      getBudgetAlertsEnabled: () => true,
-      getLocale: () => "es",
-      resolveCategoryLabel: mockResolveCategoryLabel,
-      scheduleBudgetAlert: mockScheduleBudgetAlert,
-      insertNotification: mockInsertNotification,
-    });
-
-    const result = await module.refreshMonth({
-      db: db as any,
-      userId: USER_ID,
-      month: CURRENT_MONTH,
-    });
-
-    expect(result.pendingPermissionRequest).toBe(false);
-    expect(result.budgetProgress).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          budgetId: "budget-1",
-          spent: 110000,
-          remaining: -10000,
-          percentUsed: 110,
-        }),
-        expect.objectContaining({
-          budgetId: "budget-2",
-          spent: 0,
-          remaining: 50000,
-          percentUsed: 0,
-        }),
-      ])
-    );
-    expect(result.pendingAlerts).toEqual([
-      expect.objectContaining({
-        budgetId: "budget-1",
-        threshold: 100,
-      }),
-    ]);
-    expect(mockScheduleBudgetAlert).toHaveBeenCalledOnce();
-    expect(mockScheduleBudgetAlert).toHaveBeenCalledWith(
-      expect.objectContaining({ budgetId: "budget-1", threshold: 100 }),
-      "es:food",
-      true
-    );
-    expect(mockInsertNotification).toHaveBeenCalledWith(
-      expect.objectContaining({
-        titleKey: "notifications.budgetExceeded",
-        messageKey: "notifications.budgetExceededMsg",
-        dedupKey: "budget_alert:food:100:2026-03",
-      })
-    );
+    seedInitialOverBudgetScenario();
+    const result = await refreshCurrentMonth(undefined, undefined);
+    expectInitialOverBudgetProgress(result);
+    expectInitialOverBudgetDelivery(result);
   });
 
   it("loads transaction aggregates from the transactions public surface", async () => {
@@ -419,15 +403,7 @@ describe("createBudgetMonitoringModule", () => {
       month: "2026-02" as Month,
     });
 
-    const module = createBudgetMonitoringModule({
-      getBudgetAlertsEnabled: () => true,
-      getLocale: () => "es",
-      resolveCategoryLabel: mockResolveCategoryLabel,
-      scheduleBudgetAlert: mockScheduleBudgetAlert,
-      insertNotification: mockInsertNotification,
-    });
-
-    const suggestions = module.loadAutoSuggestions({
+    const suggestions = createMonitoringModule().loadAutoSuggestions({
       db: db as any,
       userId: USER_ID,
       month: CURRENT_MONTH,
@@ -442,40 +418,10 @@ describe("createBudgetMonitoringModule", () => {
   });
 
   it("acknowledgeAlert removes the targeted alert from pending state", () => {
-    const module = createBudgetMonitoringModule({
-      getBudgetAlertsEnabled: () => true,
-      getLocale: () => "es",
-      resolveCategoryLabel: mockResolveCategoryLabel,
-      scheduleBudgetAlert: mockScheduleBudgetAlert,
-      insertNotification: mockInsertNotification,
-    });
-
-    const nextState = module.acknowledgeAlert({
+    const nextState = createMonitoringModule().acknowledgeAlert({
       budgetId: "budget-1" as BudgetId,
       threshold: 80,
-      alertState: {
-        pendingAlerts: [
-          {
-            budgetId: "budget-1" as BudgetId,
-            categoryId: "food" as CategoryId,
-            threshold: 80,
-            percentUsed: 85,
-            suggestionKey: undefined,
-            daysLeft: 10,
-            remainingAmount: 15000 as CopAmount,
-          },
-          {
-            budgetId: "budget-2" as BudgetId,
-            categoryId: "transport" as CategoryId,
-            threshold: 80,
-            percentUsed: 90,
-            suggestionKey: undefined,
-            daysLeft: 10,
-            remainingAmount: 10000 as CopAmount,
-          },
-        ],
-        acknowledgedAlerts: new Set(["budget-2:80"]),
-      },
+      alertState: createPendingAlertState(),
     });
 
     expect(nextState.pendingAlerts).toHaveLength(1);

--- a/apps/mobile/__tests__/budget/repository.test.ts
+++ b/apps/mobile/__tests__/budget/repository.test.ts
@@ -9,6 +9,17 @@ import type {
   UserId,
 } from "@/shared/types/branded";
 
+type BudgetRow = {
+  id: BudgetId;
+  userId: UserId;
+  categoryId: CategoryId;
+  amount: CopAmount;
+  month: Month;
+  createdAt: IsoDateTime;
+  updatedAt: IsoDateTime;
+  deletedAt: IsoDateTime | null;
+};
+
 const mockRun = vi.fn();
 const mockAll = vi.fn().mockReturnValue([]);
 const mockOnConflictDoUpdate = vi.fn().mockReturnThis();
@@ -29,6 +40,38 @@ const mockDb = {
   update: mockUpdate,
 } as any;
 
+const USER_ID = "user-1" as UserId;
+const SOURCE_MONTH = "2026-02" as Month;
+const TARGET_MONTH = "2026-03" as Month;
+const COPY_NOW = "2026-03-01T00:00:00.000Z" as IsoDateTime;
+
+function makeBudgetRow(overrides: Partial<BudgetRow> = {}): BudgetRow {
+  return {
+    id: "budget-1" as BudgetId,
+    userId: USER_ID,
+    categoryId: "food" as CategoryId,
+    amount: 50000 as CopAmount,
+    month: TARGET_MONTH,
+    createdAt: "2026-03-01T00:00:00.000Z" as IsoDateTime,
+    updatedAt: "2026-03-01T00:00:00.000Z" as IsoDateTime,
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+async function loadBudgetRepository() {
+  return import("@/features/budget/lib/repository");
+}
+
+function mockCopySourceAndTarget(sourceRows: BudgetRow[], targetRows: BudgetRow[] = []) {
+  mockAll.mockReturnValueOnce(sourceRows).mockReturnValueOnce(targetRows);
+}
+
+async function runCopyBudgets(generateId: () => BudgetId) {
+  const { copyBudgetsToMonth } = await loadBudgetRepository();
+  return copyBudgetsToMonth(mockDb, USER_ID, SOURCE_MONTH, TARGET_MONTH, COPY_NOW, generateId);
+}
+
 describe("budget repository", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -47,18 +90,8 @@ describe("budget repository", () => {
 
   describe("insertBudget", () => {
     it("calls db.insert with the correct row", async () => {
-      const { insertBudget } = await import("@/features/budget/lib/repository");
-
-      const row = {
-        id: "budget-1" as BudgetId,
-        userId: "user-1" as UserId,
-        categoryId: "food" as CategoryId,
-        amount: 50000 as CopAmount,
-        month: "2026-03" as Month,
-        createdAt: "2026-03-01T00:00:00.000Z" as IsoDateTime,
-        updatedAt: "2026-03-01T00:00:00.000Z" as IsoDateTime,
-        deletedAt: null,
-      };
+      const { insertBudget } = await loadBudgetRepository();
+      const row = makeBudgetRow();
 
       insertBudget(mockDb, row);
 
@@ -69,18 +102,13 @@ describe("budget repository", () => {
     });
 
     it("uses onConflictDoUpdate to un-delete a soft-deleted budget", async () => {
-      const { insertBudget } = await import("@/features/budget/lib/repository");
-
-      const row = {
+      const { insertBudget } = await loadBudgetRepository();
+      const row = makeBudgetRow({
         id: "budget-new" as BudgetId,
-        userId: "user-1" as UserId,
-        categoryId: "food" as CategoryId,
         amount: 60000 as CopAmount,
-        month: "2026-03" as Month,
         createdAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
         updatedAt: "2026-03-10T00:00:00.000Z" as IsoDateTime,
-        deletedAt: null,
-      };
+      });
 
       insertBudget(mockDb, row);
 
@@ -99,22 +127,11 @@ describe("budget repository", () => {
 
   describe("getBudgetsForMonth", () => {
     it("filters by userId and month and excludes soft-deleted", async () => {
-      const mockRows = [
-        {
-          id: "budget-1",
-          userId: "user-1",
-          categoryId: "food",
-          amount: 50000,
-          month: "2026-03",
-          createdAt: "2026-03-01T00:00:00.000Z",
-          updatedAt: "2026-03-01T00:00:00.000Z",
-          deletedAt: null,
-        },
-      ];
+      const mockRows = [makeBudgetRow()];
       mockAll.mockReturnValueOnce(mockRows);
 
-      const { getBudgetsForMonth } = await import("@/features/budget/lib/repository");
-      const result = getBudgetsForMonth(mockDb, "user-1" as UserId, "2026-03" as Month);
+      const { getBudgetsForMonth } = await loadBudgetRepository();
+      const result = getBudgetsForMonth(mockDb, USER_ID, TARGET_MONTH);
 
       expect(mockSelect).toHaveBeenCalled();
       expect(mockFrom).toHaveBeenCalled();
@@ -126,8 +143,8 @@ describe("budget repository", () => {
     it("returns empty array when no budgets found", async () => {
       mockAll.mockReturnValueOnce([]);
 
-      const { getBudgetsForMonth } = await import("@/features/budget/lib/repository");
-      const result = getBudgetsForMonth(mockDb, "user-1" as UserId, "2026-03" as Month);
+      const { getBudgetsForMonth } = await loadBudgetRepository();
+      const result = getBudgetsForMonth(mockDb, USER_ID, TARGET_MONTH);
 
       expect(result).toEqual([]);
     });
@@ -135,19 +152,10 @@ describe("budget repository", () => {
 
   describe("getBudgetById", () => {
     it("returns the row when found", async () => {
-      const mockRow = {
-        id: "budget-1",
-        userId: "user-1",
-        categoryId: "food",
-        amount: 50000,
-        month: "2026-03",
-        createdAt: "2026-03-01T00:00:00.000Z",
-        updatedAt: "2026-03-01T00:00:00.000Z",
-        deletedAt: null,
-      };
+      const mockRow = makeBudgetRow();
       mockAll.mockReturnValueOnce([mockRow]);
 
-      const { getBudgetById } = await import("@/features/budget/lib/repository");
+      const { getBudgetById } = await loadBudgetRepository();
       const result = getBudgetById(mockDb, "budget-1" as BudgetId);
 
       expect(mockSelect).toHaveBeenCalled();
@@ -157,7 +165,7 @@ describe("budget repository", () => {
     it("returns null when not found", async () => {
       mockAll.mockReturnValueOnce([]);
 
-      const { getBudgetById } = await import("@/features/budget/lib/repository");
+      const { getBudgetById } = await loadBudgetRepository();
       const result = getBudgetById(mockDb, "nonexistent" as BudgetId);
 
       expect(result).toBeNull();
@@ -166,7 +174,7 @@ describe("budget repository", () => {
 
   describe("updateBudgetAmount", () => {
     it("sets amount and updatedAt", async () => {
-      const { updateBudgetAmount } = await import("@/features/budget/lib/repository");
+      const { updateBudgetAmount } = await loadBudgetRepository();
 
       updateBudgetAmount(
         mockDb,
@@ -186,7 +194,7 @@ describe("budget repository", () => {
 
   describe("softDeleteBudget", () => {
     it("sets deletedAt and updatedAt", async () => {
-      const { softDeleteBudget } = await import("@/features/budget/lib/repository");
+      const { softDeleteBudget } = await loadBudgetRepository();
 
       softDeleteBudget(mockDb, "budget-1" as BudgetId, "2026-03-15T00:00:00.000Z" as IsoDateTime);
 
@@ -201,69 +209,30 @@ describe("budget repository", () => {
 
   describe("copyBudgetsToMonth", () => {
     it("copies source month budgets to target month with new IDs", async () => {
-      const sourceRows = [
-        {
-          id: "budget-1",
-          userId: "user-1",
-          categoryId: "food",
-          amount: 50000,
-          month: "2026-02",
-          createdAt: "2026-02-01T00:00:00.000Z",
-          updatedAt: "2026-02-01T00:00:00.000Z",
-          deletedAt: null,
-        },
-        {
-          id: "budget-2",
-          userId: "user-1",
-          categoryId: "transport",
-          amount: 20000,
-          month: "2026-02",
-          createdAt: "2026-02-01T00:00:00.000Z",
-          updatedAt: "2026-02-01T00:00:00.000Z",
-          deletedAt: null,
-        },
-      ];
-
-      // First call: getBudgetsForMonth(source), second call: getBudgetsForMonth(target) → empty
-      mockAll.mockReturnValueOnce(sourceRows).mockReturnValueOnce([]);
-
-      const { copyBudgetsToMonth } = await import("@/features/budget/lib/repository");
+      mockCopySourceAndTarget([
+        makeBudgetRow({ month: SOURCE_MONTH }),
+        makeBudgetRow({
+          id: "budget-2" as BudgetId,
+          categoryId: "transport" as CategoryId,
+          amount: 20000 as CopAmount,
+          month: SOURCE_MONTH,
+        }),
+      ]);
 
       let idCounter = 0;
       const generateId = vi.fn(() => `new-budget-${++idCounter}` as BudgetId);
-      const now = "2026-03-01T00:00:00.000Z";
+      const newIds = await runCopyBudgets(generateId);
 
-      const newIds = copyBudgetsToMonth(
-        mockDb,
-        "user-1" as UserId,
-        "2026-02" as Month,
-        "2026-03" as Month,
-        now as IsoDateTime,
-        generateId
-      );
-
-      expect(newIds).toHaveLength(2);
       expect(newIds).toEqual(["new-budget-1", "new-budget-2"]);
       expect(generateId).toHaveBeenCalledTimes(2);
-      // insert called once per copied budget (plus the select)
       expect(mockInsert).toHaveBeenCalledTimes(2);
     });
 
     it("returns empty array when source month has no budgets", async () => {
-      // First call: source → empty; second call: target → empty
-      mockAll.mockReturnValueOnce([]).mockReturnValueOnce([]);
+      mockCopySourceAndTarget([]);
 
-      const { copyBudgetsToMonth } = await import("@/features/budget/lib/repository");
       const generateId = vi.fn(() => "new-id" as BudgetId);
-
-      const newIds = copyBudgetsToMonth(
-        mockDb,
-        "user-1" as UserId,
-        "2026-02" as Month,
-        "2026-03" as Month,
-        "2026-03-01T00:00:00.000Z" as IsoDateTime,
-        generateId
-      );
+      const newIds = await runCopyBudgets(generateId);
 
       expect(newIds).toEqual([]);
       expect(generateId).not.toHaveBeenCalled();
@@ -271,40 +240,17 @@ describe("budget repository", () => {
     });
 
     it("excludes soft-deleted budgets from source", async () => {
-      // getBudgetsForMonth already filters deleted (via isNull), so only active ones returned
-      const activeRows = [
-        {
-          id: "budget-1",
-          userId: "user-1",
-          categoryId: "food",
-          amount: 50000,
-          month: "2026-02",
-          createdAt: "2026-02-01T00:00:00.000Z",
-          updatedAt: "2026-02-01T00:00:00.000Z",
-          deletedAt: null,
-        },
-      ];
-      // First call: source → activeRows; second call: target → empty
-      mockAll.mockReturnValueOnce(activeRows).mockReturnValueOnce([]);
+      mockCopySourceAndTarget([makeBudgetRow({ month: SOURCE_MONTH })]);
 
-      const { copyBudgetsToMonth } = await import("@/features/budget/lib/repository");
       let counter = 0;
       const generateId = vi.fn(() => `new-${++counter}` as BudgetId);
-
-      const newIds = copyBudgetsToMonth(
-        mockDb,
-        "user-1" as UserId,
-        "2026-02" as Month,
-        "2026-03" as Month,
-        "2026-03-01T00:00:00.000Z" as IsoDateTime,
-        generateId
-      );
+      const newIds = await runCopyBudgets(generateId);
 
       expect(newIds).toHaveLength(1);
       expect(mockInsert).toHaveBeenCalledTimes(1);
       expect(mockValues).toHaveBeenCalledWith(
         expect.objectContaining({
-          month: "2026-03",
+          month: TARGET_MONTH,
           categoryId: "food",
           amount: 50000,
           deletedAt: null,
@@ -313,65 +259,30 @@ describe("budget repository", () => {
     });
 
     it("skips categories that already exist in the target month", async () => {
-      const sourceRows = [
-        {
-          id: "budget-1",
-          userId: "user-1",
-          categoryId: "food",
-          amount: 50000,
-          month: "2026-02",
-          createdAt: "2026-02-01T00:00:00.000Z",
-          updatedAt: "2026-02-01T00:00:00.000Z",
-          deletedAt: null,
-        },
-        {
-          id: "budget-2",
-          userId: "user-1",
-          categoryId: "transport",
-          amount: 20000,
-          month: "2026-02",
-          createdAt: "2026-02-01T00:00:00.000Z",
-          updatedAt: "2026-02-01T00:00:00.000Z",
-          deletedAt: null,
-        },
-      ];
-      const existingTargetRows = [
-        {
-          id: "budget-existing",
-          userId: "user-1",
-          categoryId: "food",
-          amount: 45000,
-          month: "2026-03",
-          createdAt: "2026-03-01T00:00:00.000Z",
-          updatedAt: "2026-03-01T00:00:00.000Z",
-          deletedAt: null,
-        },
-      ];
-
-      // First call: source → sourceRows; second call: target → existingTargetRows
-      mockAll.mockReturnValueOnce(sourceRows).mockReturnValueOnce(existingTargetRows);
-
-      const { copyBudgetsToMonth } = await import("@/features/budget/lib/repository");
-      let counter = 0;
-      const generateId = vi.fn(() => `new-${++counter}` as BudgetId);
-
-      const newIds = copyBudgetsToMonth(
-        mockDb,
-        "user-1" as UserId,
-        "2026-02" as Month,
-        "2026-03" as Month,
-        "2026-03-01T00:00:00.000Z" as IsoDateTime,
-        generateId
+      mockCopySourceAndTarget(
+        [
+          makeBudgetRow({ month: SOURCE_MONTH }),
+          makeBudgetRow({
+            id: "budget-2" as BudgetId,
+            categoryId: "transport" as CategoryId,
+            amount: 20000 as CopAmount,
+            month: SOURCE_MONTH,
+          }),
+        ],
+        [makeBudgetRow({ id: "budget-existing" as BudgetId, amount: 45000 as CopAmount })]
       );
 
-      // Only "transport" should be copied; "food" already exists in target
+      let counter = 0;
+      const generateId = vi.fn(() => `new-${++counter}` as BudgetId);
+      const newIds = await runCopyBudgets(generateId);
+
       expect(newIds).toHaveLength(1);
       expect(generateId).toHaveBeenCalledTimes(1);
       expect(mockInsert).toHaveBeenCalledTimes(1);
       expect(mockValues).toHaveBeenCalledWith(
         expect.objectContaining({
           categoryId: "transport",
-          month: "2026-03",
+          month: TARGET_MONTH,
         })
       );
     });

--- a/apps/mobile/__tests__/budget/store.test.ts
+++ b/apps/mobile/__tests__/budget/store.test.ts
@@ -51,6 +51,36 @@ vi.mock("@/features/budget/lib/notifications", () => ({
 const USER_ID = "user-1" as UserId;
 const mockDb = {} as any;
 
+type BudgetRefreshSnapshot = {
+  budgets: any[];
+  budgetProgress: any[];
+  summary: { totalBudget: number; totalSpent: number; percentUsed: number };
+  autoSuggestions: any[];
+  pendingAlerts: any[];
+  pendingPermissionRequest: boolean;
+};
+
+const EMPTY_BUDGET_REFRESH_SNAPSHOT: BudgetRefreshSnapshot = {
+  budgets: [{ id: "budget-1", categoryId: "food", month: "2026-03" as Month }],
+  budgetProgress: [],
+  summary: { totalBudget: 0, totalSpent: 0, percentUsed: 0 },
+  autoSuggestions: [],
+  pendingAlerts: [],
+  pendingPermissionRequest: false,
+};
+
+const MARCH_STALE_SNAPSHOT: BudgetRefreshSnapshot = {
+  ...EMPTY_BUDGET_REFRESH_SNAPSHOT,
+  budgets: [{ id: "budget-march", categoryId: "food", month: "2026-03" as Month }],
+  summary: { totalBudget: 100000, totalSpent: 85000, percentUsed: 85 },
+};
+
+const APRIL_FRESH_SNAPSHOT: BudgetRefreshSnapshot = {
+  ...EMPTY_BUDGET_REFRESH_SNAPSHOT,
+  budgets: [{ id: "budget-april", categoryId: "transport", month: "2026-04" as Month }],
+  summary: { totalBudget: 120000, totalSpent: 10000, percentUsed: 8 },
+};
+
 function createDeferred<T>() {
   let resolve!: (value: T) => void;
   let reject!: (error?: unknown) => void;
@@ -65,6 +95,13 @@ async function getBudgetModule() {
   return import("@/features/budget/store");
 }
 
+async function initializeBudgetStore(month: Month = "2026-03" as Month) {
+  const module = await getBudgetModule();
+  module.initializeBudgetSession(USER_ID);
+  module.useBudgetStore.getState().setMonth(month);
+  return module;
+}
+
 describe("useBudgetStore", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -75,97 +112,50 @@ describe("useBudgetStore", () => {
   });
 
   it("ignores stale budget refresh results after the month changes", async () => {
-    const staleSnapshot = {
-      budgets: [{ id: "budget-march", categoryId: "food", month: "2026-03" as Month }] as any[],
-      budgetProgress: [],
-      summary: { totalBudget: 100000, totalSpent: 85000, percentUsed: 85 },
-      autoSuggestions: [],
-      pendingAlerts: [],
-      pendingPermissionRequest: false,
-    };
-    const freshSnapshot = {
-      budgets: [
-        { id: "budget-april", categoryId: "transport", month: "2026-04" as Month },
-      ] as any[],
-      budgetProgress: [],
-      summary: { totalBudget: 120000, totalSpent: 10000, percentUsed: 8 },
-      autoSuggestions: [],
-      pendingAlerts: [],
-      pendingPermissionRequest: false,
-    };
-    const deferredMarch = createDeferred<typeof staleSnapshot>();
+    const deferredMarch = createDeferred<BudgetRefreshSnapshot>();
 
     mockRefreshMonth.mockImplementation(({ month }: { month: Month }) =>
-      month === ("2026-03" as Month) ? deferredMarch.promise : Promise.resolve(freshSnapshot)
+      month === ("2026-03" as Month) ? deferredMarch.promise : Promise.resolve(APRIL_FRESH_SNAPSHOT)
     );
 
-    const { initializeBudgetSession, loadBudgetsForUser, useBudgetStore } = await getBudgetModule();
-    initializeBudgetSession(USER_ID);
-    useBudgetStore.getState().setMonth("2026-03" as Month);
-
+    const { loadBudgetsForUser, useBudgetStore } = await initializeBudgetStore("2026-03" as Month);
     const staleLoad = loadBudgetsForUser(mockDb, USER_ID);
 
     useBudgetStore.getState().setMonth("2026-04" as Month);
     const freshLoad = loadBudgetsForUser(mockDb, USER_ID);
 
     await freshLoad;
-    deferredMarch.resolve(staleSnapshot);
+    deferredMarch.resolve(MARCH_STALE_SNAPSHOT);
     await staleLoad;
 
     expect(useBudgetStore.getState().currentMonth).toBe("2026-04");
-    expect(useBudgetStore.getState().budgets).toEqual(freshSnapshot.budgets);
-    expect(useBudgetStore.getState().summary).toEqual(freshSnapshot.summary);
+    expect(useBudgetStore.getState().budgets).toEqual(APRIL_FRESH_SNAPSHOT.budgets);
+    expect(useBudgetStore.getState().summary).toEqual(APRIL_FRESH_SNAPSHOT.summary);
     expect(useBudgetStore.getState().isLoading).toBe(false);
   });
 
   it("clears loading when context changes without starting a newer refresh", async () => {
-    const deferredSnapshot = createDeferred<{
-      budgets: any[];
-      budgetProgress: any[];
-      summary: { totalBudget: number; totalSpent: number; percentUsed: number };
-      autoSuggestions: any[];
-      pendingAlerts: any[];
-      pendingPermissionRequest: boolean;
-    }>();
-
+    const deferredSnapshot = createDeferred<BudgetRefreshSnapshot>();
     mockRefreshMonth.mockReturnValueOnce(deferredSnapshot.promise);
 
-    const { initializeBudgetSession, loadBudgetsForUser, useBudgetStore } = await getBudgetModule();
-    initializeBudgetSession(USER_ID);
-    useBudgetStore.getState().setMonth("2026-03" as Month);
-
+    const { initializeBudgetSession, loadBudgetsForUser, useBudgetStore } =
+      await initializeBudgetStore("2026-03" as Month);
     const load = loadBudgetsForUser(mockDb, USER_ID);
 
     initializeBudgetSession("user-2" as UserId);
-    deferredSnapshot.resolve({
-      budgets: [],
-      budgetProgress: [],
-      summary: { totalBudget: 0, totalSpent: 0, percentUsed: 0 },
-      autoSuggestions: [],
-      pendingAlerts: [],
-      pendingPermissionRequest: false,
-    });
+    deferredSnapshot.resolve(EMPTY_BUDGET_REFRESH_SNAPSHOT);
     await load;
 
     expect(useBudgetStore.getState().isLoading).toBe(false);
   });
 
   it("drops stale notification side effects after the active user changes", async () => {
-    const deferredSnapshot = createDeferred<{
-      budgets: any[];
-      budgetProgress: any[];
-      summary: { totalBudget: number; totalSpent: number; percentUsed: number };
-      autoSuggestions: any[];
-      pendingAlerts: any[];
-      pendingPermissionRequest: boolean;
-    }>();
-
+    const deferredSnapshot = createDeferred<BudgetRefreshSnapshot>();
     mockRefreshMonth.mockReturnValueOnce(deferredSnapshot.promise);
 
-    const { initializeBudgetSession, loadBudgetsForUser, useBudgetStore } = await getBudgetModule();
-    initializeBudgetSession(USER_ID);
-    useBudgetStore.getState().setMonth("2026-03" as Month);
-
+    const { initializeBudgetSession, loadBudgetsForUser } = await initializeBudgetStore(
+      "2026-03" as Month
+    );
     const monitoringCallsBeforeLoad = mockCreateBudgetMonitoringModule.mock.calls.length;
     const load = loadBudgetsForUser(mockDb, USER_ID);
     const initialMonitoringPorts =
@@ -174,7 +164,6 @@ describe("useBudgetStore", () => {
     expect(initialMonitoringPorts).toBeDefined();
 
     initializeBudgetSession("user-2" as UserId);
-
     initialMonitoringPorts.insertNotification({
       type: "budget_alert",
       dedupKey: "budget_alert:food:80:2026-03",
@@ -187,14 +176,7 @@ describe("useBudgetStore", () => {
 
     expect(mockInsertNotificationRecord).not.toHaveBeenCalled();
 
-    deferredSnapshot.resolve({
-      budgets: [],
-      budgetProgress: [],
-      summary: { totalBudget: 0, totalSpent: 0, percentUsed: 0 },
-      autoSuggestions: [],
-      pendingAlerts: [],
-      pendingPermissionRequest: false,
-    });
+    deferredSnapshot.resolve(EMPTY_BUDGET_REFRESH_SNAPSHOT);
     await load;
   });
 
@@ -207,9 +189,7 @@ describe("useBudgetStore", () => {
     ];
     mockLoadAutoSuggestions.mockReturnValue(suggestions);
 
-    const { initializeBudgetSession, loadBudgetAutoSuggestions, useBudgetStore } =
-      await getBudgetModule();
-    initializeBudgetSession(USER_ID);
+    const { loadBudgetAutoSuggestions, useBudgetStore } = await initializeBudgetStore();
     useBudgetStore.setState({
       currentMonth: "2026-03" as Month,
       budgets: [{ id: "budget-1", categoryId: "food" as CategoryId }] as any[],

--- a/apps/mobile/__tests__/capture-evidence/repository.test.ts
+++ b/apps/mobile/__tests__/capture-evidence/repository.test.ts
@@ -27,6 +27,9 @@ let db: ReturnType<typeof drizzle>;
 
 const USER_ID = "user-1" as UserId;
 const NOW = "2026-04-19T10:00:00.000Z" as IsoDateTime;
+const LATER = "2026-04-19T11:00:00.000Z" as IsoDateTime;
+
+type CaptureEvidenceInput = Parameters<typeof saveCaptureEvidence>[1];
 
 beforeEach(() => {
   sqlite = new Database(":memory:");
@@ -38,121 +41,93 @@ afterEach(() => {
   sqlite.close();
 });
 
+function makeCaptureEvidence(overrides: Partial<CaptureEvidenceInput> = {}): CaptureEvidenceInput {
+  return {
+    id: "ce-1" as CaptureEvidenceId,
+    userId: USER_ID,
+    sourceFamily: "bancolombia",
+    evidenceType: "last4",
+    scope: "notification:bancolombia:last4",
+    value: "1234",
+    transactionId: "tx-1" as TransactionId,
+    transferId: null,
+    processedEmailId: null,
+    processedCaptureId: "pc-1" as ProcessedCaptureId,
+    createdAt: NOW,
+    updatedAt: NOW,
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+function saveEvidence(overrides: Partial<CaptureEvidenceInput> = {}) {
+  saveCaptureEvidence(db as any, makeCaptureEvidence(overrides));
+}
+
+function expectQueuedEvidence(...rowIds: string[]) {
+  expect(getQueuedSyncEntries(db as any)).toEqual(
+    rowIds.map((rowId) =>
+      expect.objectContaining({
+        tableName: "captureEvidence",
+        rowId,
+        operation: "insert",
+      })
+    )
+  );
+}
+
+function seedRepeatedCaptureEvidence() {
+  saveEvidence();
+  saveEvidence({
+    id: "ce-2" as CaptureEvidenceId,
+    transactionId: null,
+    processedCaptureId: "pc-2" as ProcessedCaptureId,
+    createdAt: LATER,
+    updatedAt: LATER,
+  });
+  saveEvidence({
+    id: "ce-3" as CaptureEvidenceId,
+    evidenceType: "sender_email",
+    scope: "email:bancolombia:sender",
+    value: "notificaciones@bancolombia.com.co",
+    transactionId: "tx-3" as TransactionId,
+    processedEmailId: "pe-1" as ProcessedEmailId,
+    processedCaptureId: null,
+  });
+  saveEvidence({
+    id: "ce-4" as CaptureEvidenceId,
+    transactionId: null,
+    processedCaptureId: "pc-4" as ProcessedCaptureId,
+    deletedAt: "2026-04-19T12:00:00.000Z" as IsoDateTime,
+  });
+}
+
+function expectRepeatedCaptureEvidenceCounts() {
+  expect(
+    countCaptureEvidenceOccurrences(db as any, USER_ID, "notification:bancolombia:last4", "1234")
+  ).toBe(2);
+  expect(getRepeatedCaptureEvidenceForUser(db as any, USER_ID, 2)).toEqual([
+    {
+      scope: "notification:bancolombia:last4",
+      value: "1234",
+      sourceFamily: "bancolombia",
+      evidenceType: "last4",
+      occurrences: 2,
+    },
+  ]);
+  expectQueuedEvidence("ce-1", "ce-2", "ce-3", "ce-4");
+}
+
 describe("capture evidence repository", () => {
   it("saves evidence, enqueues sync, and counts repeated scoped evidence for one user", () => {
-    saveCaptureEvidence(db as any, {
-      id: "ce-1" as CaptureEvidenceId,
-      userId: USER_ID,
-      sourceFamily: "bancolombia",
-      evidenceType: "last4",
-      scope: "notification:bancolombia:last4",
-      value: "1234",
-      transactionId: "tx-1" as TransactionId,
-      processedEmailId: null,
-      processedCaptureId: "pc-1" as ProcessedCaptureId,
-      createdAt: NOW,
-      updatedAt: NOW,
-      deletedAt: null,
-    });
-
-    saveCaptureEvidence(db as any, {
-      id: "ce-2" as CaptureEvidenceId,
-      userId: USER_ID,
-      sourceFamily: "bancolombia",
-      evidenceType: "last4",
-      scope: "notification:bancolombia:last4",
-      value: "1234",
-      transactionId: null,
-      processedEmailId: null,
-      processedCaptureId: "pc-2" as ProcessedCaptureId,
-      createdAt: "2026-04-19T11:00:00.000Z" as IsoDateTime,
-      updatedAt: "2026-04-19T11:00:00.000Z" as IsoDateTime,
-      deletedAt: null,
-    });
-
-    saveCaptureEvidence(db as any, {
-      id: "ce-3" as CaptureEvidenceId,
-      userId: USER_ID,
-      sourceFamily: "bancolombia",
-      evidenceType: "sender_email",
-      scope: "email:bancolombia:sender",
-      value: "notificaciones@bancolombia.com.co",
-      transactionId: "tx-3" as TransactionId,
-      processedEmailId: "pe-1" as ProcessedEmailId,
-      processedCaptureId: null,
-      createdAt: NOW,
-      updatedAt: NOW,
-      deletedAt: null,
-    });
-
-    saveCaptureEvidence(db as any, {
-      id: "ce-4" as CaptureEvidenceId,
-      userId: USER_ID,
-      sourceFamily: "bancolombia",
-      evidenceType: "last4",
-      scope: "notification:bancolombia:last4",
-      value: "1234",
-      transactionId: null,
-      processedEmailId: null,
-      processedCaptureId: "pc-4" as ProcessedCaptureId,
-      createdAt: NOW,
-      updatedAt: NOW,
-      deletedAt: "2026-04-19T12:00:00.000Z" as IsoDateTime,
-    });
-
-    expect(
-      countCaptureEvidenceOccurrences(db as any, USER_ID, "notification:bancolombia:last4", "1234")
-    ).toBe(2);
-
-    expect(getRepeatedCaptureEvidenceForUser(db as any, USER_ID, 2)).toEqual([
-      {
-        scope: "notification:bancolombia:last4",
-        value: "1234",
-        sourceFamily: "bancolombia",
-        evidenceType: "last4",
-        occurrences: 2,
-      },
-    ]);
-
-    expect(getQueuedSyncEntries(db as any)).toEqual([
-      expect.objectContaining({
-        tableName: "captureEvidence",
-        rowId: "ce-1",
-        operation: "insert",
-      }),
-      expect.objectContaining({
-        tableName: "captureEvidence",
-        rowId: "ce-2",
-        operation: "insert",
-      }),
-      expect.objectContaining({
-        tableName: "captureEvidence",
-        rowId: "ce-3",
-        operation: "insert",
-      }),
-      expect.objectContaining({
-        tableName: "captureEvidence",
-        rowId: "ce-4",
-        operation: "insert",
-      }),
-    ]);
+    seedRepeatedCaptureEvidence();
+    expectRepeatedCaptureEvidenceCounts();
   });
 
   it("ignores stale relink-to-transfer updates", () => {
-    saveCaptureEvidence(db as any, {
+    saveEvidence({
       id: "ce-stale" as CaptureEvidenceId,
-      userId: USER_ID,
-      sourceFamily: "bancolombia",
-      evidenceType: "last4",
-      scope: "notification:bancolombia:last4",
-      value: "1234",
-      transactionId: "tx-1" as TransactionId,
-      transferId: null,
-      processedEmailId: null,
       processedCaptureId: "pc-stale" as ProcessedCaptureId,
-      createdAt: NOW,
-      updatedAt: NOW,
-      deletedAt: null,
     });
 
     relinkCaptureEvidenceToTransfer(
@@ -174,21 +149,15 @@ describe("capture evidence repository", () => {
 
   it("rejects evidence rows linked to both a transaction and a transfer", () => {
     expect(() =>
-      saveCaptureEvidence(db as any, {
-        id: "ce-invalid" as CaptureEvidenceId,
-        userId: USER_ID,
-        sourceFamily: "bancolombia",
-        evidenceType: "last4",
-        scope: "notification:bancolombia:last4",
-        value: "9999",
-        transactionId: "tx-1" as TransactionId,
-        transferId: "tr-1" as TransferId,
-        processedEmailId: null,
-        processedCaptureId: "pc-invalid" as ProcessedCaptureId,
-        createdAt: NOW,
-        updatedAt: NOW,
-        deletedAt: null,
-      })
+      saveCaptureEvidence(
+        db as any,
+        makeCaptureEvidence({
+          id: "ce-invalid" as CaptureEvidenceId,
+          value: "9999",
+          transferId: "tr-1" as TransferId,
+          processedCaptureId: "pc-invalid" as ProcessedCaptureId,
+        })
+      )
     ).toThrow();
   });
 });

--- a/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
@@ -46,6 +46,26 @@ const mockBuildEmailCaptureEvidence = vi.fn().mockReturnValue([
 const mockSaveCaptureEvidenceRows = vi.fn();
 const mockLinkCaptureEvidenceToTransaction = vi.fn();
 
+function buildCaptureEvidenceRow(
+  row: Record<string, unknown>,
+  index: number,
+  link: Record<string, unknown>
+) {
+  return {
+    id: `ce-${index + 1}`,
+    ...row,
+    ...link,
+    deletedAt: null,
+  };
+}
+
+function materializeCaptureEvidenceRowsFixture(
+  evidence: Record<string, unknown>[],
+  link: Record<string, unknown>
+) {
+  return evidence.map((row, index) => buildCaptureEvidenceRow(row, index, link));
+}
+
 vi.mock("@/features/capture-sources/lib/dedup", () => ({
   findDuplicateTransaction: (...args: unknown[]) => mockFindDuplicateTransaction(...args),
 }));
@@ -84,12 +104,7 @@ vi.mock("@/features/financial-accounts", () => ({
 vi.mock("@/features/capture-evidence", () => ({
   buildEmailCaptureEvidence: (...args: unknown[]) => mockBuildEmailCaptureEvidence(...args),
   materializeCaptureEvidenceRows: (evidence: any[], link: Record<string, unknown>) =>
-    evidence.map((row, index) => ({
-      id: `ce-${index + 1}`,
-      ...row,
-      ...link,
-      deletedAt: null,
-    })),
+    materializeCaptureEvidenceRowsFixture(evidence, link),
   saveCaptureEvidenceRows: (...args: unknown[]) => mockSaveCaptureEvidenceRows(...args),
   linkCaptureEvidenceToTransaction: (...args: unknown[]) =>
     mockLinkCaptureEvidenceToTransaction(...args),
@@ -111,6 +126,7 @@ vi.mock("@/shared/lib/generate-id", () => ({
 
 const mockDb = {} as any;
 const USER_ID = requireUserId("user-1");
+let idCounter = 0;
 
 function makeRawEmail(overrides: Partial<RawEmail> = {}): RawEmail {
   return {
@@ -124,45 +140,122 @@ function makeRawEmail(overrides: Partial<RawEmail> = {}): RawEmail {
   };
 }
 
-describe("email processing pipeline", () => {
-  let idCounter: number;
+function makeParsedEmailResult(overrides: Record<string, unknown> = {}) {
+  return {
+    type: "expense",
+    amount: 50000,
+    categoryId: "other",
+    description: "Compra en Exito",
+    date: "2026-03-05",
+    confidence: 0.9,
+    ...overrides,
+  };
+}
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-    idCounter = 0;
-    mockGenerateId.mockImplementation((prefix: string) => {
-      idCounter++;
-      return `${prefix}-${idCounter}`;
-    });
-    mockGetProcessedExternalIds.mockResolvedValue(new Set<string>());
-    mockInsertProcessedEmail.mockResolvedValue(undefined);
-    mockInsertTransaction.mockResolvedValue(undefined);
-    mockEnqueueSync.mockResolvedValue(undefined);
-    mockLookupMerchantRule.mockResolvedValue(null);
-    mockInsertMerchantRule.mockResolvedValue(undefined);
-    mockParseEmailApi.mockResolvedValue(null);
-    mockFindDuplicateTransaction.mockResolvedValue(null);
-    mockGetPendingRetryEmails.mockResolvedValue([]);
-    mockMarkForRetry.mockResolvedValue(undefined);
-    mockMarkPermanentlyFailed.mockResolvedValue(undefined);
-    mockMarkRetrySuccess.mockResolvedValue(undefined);
-    mockUpdateProcessedEmailStatus.mockResolvedValue(undefined);
-    mockBuildEmailCaptureEvidence.mockReturnValue([
-      {
-        sourceFamily: "bancolombia",
-        evidenceType: "sender_email",
+function resetGeneratedIds() {
+  idCounter = 0;
+  mockGenerateId.mockImplementation((prefix: string) => {
+    idCounter += 1;
+    return `${prefix}-${idCounter}`;
+  });
+}
+
+function resetPipelineMocks() {
+  mockGetProcessedExternalIds.mockResolvedValue(new Set<string>());
+  mockInsertProcessedEmail.mockResolvedValue(undefined);
+  mockInsertTransaction.mockResolvedValue(undefined);
+  mockEnqueueSync.mockResolvedValue(undefined);
+  mockLookupMerchantRule.mockResolvedValue(null);
+  mockInsertMerchantRule.mockResolvedValue(undefined);
+  mockParseEmailApi.mockResolvedValue(null);
+  mockFindDuplicateTransaction.mockResolvedValue(null);
+  mockGetPendingRetryEmails.mockResolvedValue([]);
+  mockMarkForRetry.mockResolvedValue(undefined);
+  mockMarkPermanentlyFailed.mockResolvedValue(undefined);
+  mockMarkRetrySuccess.mockResolvedValue(undefined);
+  mockUpdateProcessedEmailStatus.mockResolvedValue(undefined);
+}
+
+function resetCaptureEvidenceMocks() {
+  mockBuildEmailCaptureEvidence.mockReturnValue([
+    {
+      sourceFamily: "bancolombia",
+      evidenceType: "sender_email",
+      scope: "email:bancolombia:sender",
+      value: "notificaciones@bancolombia.com.co",
+    },
+    {
+      sourceFamily: "bancolombia",
+      evidenceType: "sender_domain",
+      scope: "email:bancolombia:domain",
+      value: "bancolombia.com.co",
+    },
+  ]);
+  mockSaveCaptureEvidenceRows.mockResolvedValue(undefined);
+  mockLinkCaptureEvidenceToTransaction.mockResolvedValue(undefined);
+}
+
+function expectSavedTransaction(matcher: Record<string, unknown>) {
+  expect(mockInsertTransaction).toHaveBeenCalledWith(mockDb, expect.objectContaining(matcher));
+}
+
+function expectProcessedEmailSaved(matcher: Record<string, unknown>) {
+  expect(mockInsertProcessedEmail).toHaveBeenCalledWith(mockDb, expect.objectContaining(matcher));
+}
+
+function expectCaptureEvidenceSaved(transactionId: string | null) {
+  expect(mockSaveCaptureEvidenceRows).toHaveBeenCalledWith(
+    mockDb,
+    expect.arrayContaining([
+      expect.objectContaining({
+        userId: USER_ID,
+        processedEmailId: expect.any(String),
+        processedCaptureId: null,
+        transactionId,
         scope: "email:bancolombia:sender",
         value: "notificaciones@bancolombia.com.co",
-      },
-      {
-        sourceFamily: "bancolombia",
-        evidenceType: "sender_domain",
-        scope: "email:bancolombia:domain",
-        value: "bancolombia.com.co",
-      },
-    ]);
-    mockSaveCaptureEvidenceRows.mockResolvedValue(undefined);
-    mockLinkCaptureEvidenceToTransaction.mockResolvedValue(undefined);
+      }),
+    ])
+  );
+}
+
+function mockNeedsReviewThenSavedParseResults() {
+  mockParseEmailApi
+    .mockResolvedValueOnce(makeParsedEmailResult({ description: "Compra 1", confidence: 0.5 }))
+    .mockResolvedValueOnce(
+      makeParsedEmailResult({
+        amount: 30000,
+        categoryId: "food",
+        description: "Compra 2",
+      })
+    );
+}
+
+function expectProgressIncludesNeedsReview(
+  progressCalls: {
+    total: number;
+    completed: number;
+    saved: number;
+    failed: number;
+    needsReview: number;
+  }[]
+) {
+  expect(progressCalls.length).toBeGreaterThanOrEqual(3);
+  expect(progressCalls[0]).toEqual(
+    expect.objectContaining({ total: 2, completed: 0, saved: 0, failed: 0, needsReview: 0 })
+  );
+  expect(progressCalls[1]?.needsReview).toBe(1);
+  expect(progressCalls[1]?.saved).toBe(0);
+  expect(progressCalls.at(-1)?.needsReview).toBe(1);
+  expect(progressCalls.at(-1)?.saved).toBe(1);
+}
+
+describe("email processing pipeline", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetGeneratedIds();
+    resetPipelineMocks();
+    resetCaptureEvidenceMocks();
   });
 
   it("skips already processed emails", async () => {
@@ -210,53 +303,28 @@ describe("email processing pipeline", () => {
 
   it("saves transaction and caches merchant rule when LLM returns high confidence", async () => {
     const emails = [makeRawEmail()];
-    mockParseEmailApi.mockResolvedValueOnce({
-      type: "expense",
-      amount: 50000,
-      categoryId: "other",
-      description: "Compra en Exito",
-      date: "2026-03-05",
-      confidence: 0.9,
-    });
+    mockParseEmailApi.mockResolvedValueOnce(makeParsedEmailResult());
 
     const result = await processEmails(mockDb, USER_ID, emails);
 
     expect(result.saved).toBe(1);
     expect(result.needsReview).toBe(0);
     expect(result.failed).toBe(0);
-    expect(mockInsertTransaction).toHaveBeenCalledWith(
-      mockDb,
-      expect.objectContaining({
-        userId: USER_ID,
-        type: "expense",
-        amount: 50000,
-        accountId: "fa-default-user-1",
-        accountAttributionState: "unresolved",
-        source: "email_gmail",
-      })
-    );
+    expectSavedTransaction({
+      userId: USER_ID,
+      type: "expense",
+      amount: 50000,
+      accountId: "fa-default-user-1",
+      accountAttributionState: "unresolved",
+      source: "email_gmail",
+    });
     expect(mockEnqueueSync).toHaveBeenCalled();
-    expect(mockInsertProcessedEmail).toHaveBeenCalledWith(
-      mockDb,
-      expect.objectContaining({
-        externalId: "ext-1",
-        status: "success",
-        confidence: 0.9,
-      })
-    );
-    expect(mockSaveCaptureEvidenceRows).toHaveBeenCalledWith(
-      mockDb,
-      expect.arrayContaining([
-        expect.objectContaining({
-          userId: USER_ID,
-          processedEmailId: expect.any(String),
-          processedCaptureId: null,
-          transactionId: "tx-1",
-          scope: "email:bancolombia:sender",
-          value: "notificaciones@bancolombia.com.co",
-        }),
-      ])
-    );
+    expectProcessedEmailSaved({
+      externalId: "ext-1",
+      status: "success",
+      confidence: 0.9,
+    });
+    expectCaptureEvidenceSaved("tx-1");
     expect(mockInsertMerchantRule).toHaveBeenCalledWith(
       mockDb,
       USER_ID,
@@ -485,24 +553,7 @@ describe("email processing pipeline", () => {
 
   it("includes needsReview in progress callback", async () => {
     const emails = [makeRawEmail({ externalId: "ext-1" }), makeRawEmail({ externalId: "ext-2" })];
-    // First email: low confidence → needs_review
-    mockParseEmailApi.mockResolvedValueOnce({
-      type: "expense",
-      amount: 50000,
-      categoryId: "other",
-      description: "Compra 1",
-      date: "2026-03-05",
-      confidence: 0.5,
-    });
-    // Second email: high confidence → saved
-    mockParseEmailApi.mockResolvedValueOnce({
-      type: "expense",
-      amount: 30000,
-      categoryId: "food",
-      description: "Compra 2",
-      date: "2026-03-05",
-      confidence: 0.9,
-    });
+    mockNeedsReviewThenSavedParseResults();
 
     const progressCalls: {
       total: number;
@@ -514,20 +565,7 @@ describe("email processing pipeline", () => {
 
     await processEmails(mockDb, USER_ID, emails, (p) => progressCalls.push(p));
 
-    // Initial call + one per email
-    expect(progressCalls.length).toBeGreaterThanOrEqual(3);
-    // First call is initial: all zeros
-    expect(progressCalls[0]).toEqual(
-      expect.objectContaining({ total: 2, completed: 0, saved: 0, failed: 0, needsReview: 0 })
-    );
-    // After first email (needs_review): needsReview = 1
-    const afterFirst = progressCalls[1]!;
-    expect(afterFirst.needsReview).toBe(1);
-    expect(afterFirst.saved).toBe(0);
-    // After second email (saved): saved = 1
-    const last = progressCalls[progressCalls.length - 1]!;
-    expect(last.needsReview).toBe(1);
-    expect(last.saved).toBe(1);
+    expectProgressIncludesNeedsReview(progressCalls);
   });
 
   it("returns zero counts for empty input", async () => {

--- a/apps/mobile/__tests__/email-capture/schema-compat.test.ts
+++ b/apps/mobile/__tests__/email-capture/schema-compat.test.ts
@@ -50,12 +50,11 @@ function extractCategoryIds(source: string): string[] {
 }
 
 /** Extract type enum values from FULL_PARSE_SCHEMA */
+const TYPE_ENUM_PATTERN =
+  /FULL_PARSE_SCHEMA[\s\S]*?type:\s*\{\s*type:\s*"string",\s*enum:\s*\[([\s\S]*?)\]/;
+
 function extractTypeEnum(source: string): string[] {
-  const typeMatch = source.match(
-    /FULL_PARSE_SCHEMA[\s\S]*?type:\s*\{\s*type:\s*"string",\s*enum:\s*\[([\s\S]*?)\]/
-  );
-  if (!typeMatch) return [];
-  const typeBlock = typeMatch[1] ?? "";
+  const typeBlock = source.match(TYPE_ENUM_PATTERN)?.[1] ?? "";
   return [...typeBlock.matchAll(/"(\w+)"/g)].map((m) => m[1] ?? "").filter(Boolean);
 }
 

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -145,24 +145,63 @@ const mockDb = {
 } as any;
 const mockUserId = "user-1";
 
+type TestEmailAccount = {
+  id: EmailAccountId;
+  userId: UserId;
+  provider: string;
+  email: string;
+  lastFetchedAt: IsoDateTime | null;
+  createdAt: IsoDateTime;
+};
+
+type RawEmail = {
+  externalId: string;
+  from: string;
+  subject: string;
+  body: string;
+  receivedAt: string;
+  provider: "gmail" | "outlook";
+};
+
+type ProcessSummary = {
+  filtered: number;
+  skippedDuplicate: number;
+  skippedCrossSource: number;
+  saved: number;
+  failed: number;
+  needsReview: number;
+};
+
+const DEFAULT_ACCOUNT: TestEmailAccount = {
+  id: "ea-1" as EmailAccountId,
+  userId: mockUserId as UserId,
+  provider: "gmail",
+  email: "test@gmail.com",
+  lastFetchedAt: null,
+  createdAt: "2026-03-05T10:00:00Z" as IsoDateTime,
+};
+
+const DEFAULT_RAW_EMAIL: RawEmail = {
+  externalId: "ext-1",
+  from: "bank@example.com",
+  subject: "Alert",
+  body: "body",
+  receivedAt: "2026-03-05T10:00:00Z",
+  provider: "gmail",
+};
+
+const EMPTY_PROCESS_SUMMARY: ProcessSummary = {
+  filtered: 0,
+  skippedDuplicate: 0,
+  skippedCrossSource: 0,
+  saved: 0,
+  failed: 0,
+  needsReview: 0,
+};
+
 /** Helper to build a typed email account object for tests */
-function makeAccount(
-  overrides: {
-    id?: string;
-    provider?: string;
-    email?: string;
-    lastFetchedAt?: string | null;
-    createdAt?: string;
-  } = {}
-) {
-  return {
-    id: (overrides.id ?? "ea-1") as EmailAccountId,
-    userId: mockUserId as UserId,
-    provider: overrides.provider ?? "gmail",
-    email: overrides.email ?? "test@gmail.com",
-    lastFetchedAt: (overrides.lastFetchedAt ?? null) as IsoDateTime | null,
-    createdAt: (overrides.createdAt ?? "2026-03-05T10:00:00Z") as IsoDateTime,
-  };
+function makeAccount(overrides: Partial<TestEmailAccount> = {}): TestEmailAccount {
+  return { ...DEFAULT_ACCOUNT, ...overrides };
 }
 
 /** Helper to build a typed processed email object for tests */
@@ -194,6 +233,33 @@ function createDeferred<T>() {
     reject = rej;
   });
   return { promise, resolve, reject };
+}
+
+function makeRawEmail(overrides: Partial<RawEmail> = {}): RawEmail {
+  return { ...DEFAULT_RAW_EMAIL, ...overrides };
+}
+
+function setAccounts(accounts: TestEmailAccount[] = [makeAccount()]) {
+  useEmailCaptureStore.setState({ accounts });
+}
+
+function mockEmptyReviewLoads() {
+  vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
+  vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
+}
+
+function mockProcessResult(overrides: Partial<ProcessSummary> = {}) {
+  vi.mocked(processEmails).mockResolvedValueOnce({ ...EMPTY_PROCESS_SUMMARY, ...overrides });
+}
+
+function runFetchAndProcess(gmailClientId = "g", outlookClientId = "o", refresh = mockRefresh) {
+  return fetchAndProcessEmails(
+    mockDb,
+    mockUserId as UserId,
+    gmailClientId,
+    outlookClientId,
+    refresh
+  );
 }
 
 describe("email capture boundary", () => {
@@ -388,39 +454,13 @@ describe("email capture boundary", () => {
 
   describe("fetchAndProcess", () => {
     it("fetches emails and runs pipeline", async () => {
-      useEmailCaptureStore.setState({
-        accounts: [makeAccount()],
-      });
-
-      const mockRawEmails = [
-        {
-          externalId: "ext-1",
-          from: "bank@example.com",
-          subject: "Alert",
-          body: "body",
-          receivedAt: "2026-03-05T10:00:00Z",
-          provider: "gmail" as const,
-        },
-      ];
+      setAccounts();
+      const mockRawEmails = [makeRawEmail()];
       mockAdapter.fetchEmails.mockResolvedValueOnce(mockRawEmails);
-      vi.mocked(processEmails).mockResolvedValueOnce({
-        filtered: 0,
-        skippedDuplicate: 0,
-        skippedCrossSource: 0,
-        saved: 1,
-        failed: 0,
-        needsReview: 0,
-      });
-      vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
-      vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
+      mockProcessResult({ saved: 1 });
+      mockEmptyReviewLoads();
 
-      await fetchAndProcessEmails(
-        mockDb,
-        mockUserId as UserId,
-        "gmail-client-id",
-        "outlook-client-id",
-        mockRefresh
-      );
+      await runFetchAndProcess("gmail-client-id", "outlook-client-id");
 
       expect(mockEnsureBankSenders).toHaveBeenCalledTimes(1);
       expect(mockAdapter.fetchEmails).toHaveBeenCalled();
@@ -430,36 +470,29 @@ describe("email capture boundary", () => {
     });
 
     it("fetches emails for outlook accounts", async () => {
-      useEmailCaptureStore.setState({
-        accounts: [makeAccount({ id: "ea-2", provider: "outlook", email: "test@outlook.com" })],
-      });
+      setAccounts([
+        makeAccount({
+          id: "ea-2" as EmailAccountId,
+          provider: "outlook",
+          email: "test@outlook.com",
+        }),
+      ]);
 
       mockAdapter.fetchEmails.mockResolvedValueOnce([]);
-      vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
-      vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
+      mockEmptyReviewLoads();
 
-      await fetchAndProcessEmails(
-        mockDb,
-        mockUserId as UserId,
-        "gmail-client-id",
-        "outlook-client-id",
-        mockRefresh
-      );
+      await runFetchAndProcess("gmail-client-id", "outlook-client-id");
 
       expect(getAdapter).toHaveBeenCalledWith("outlook");
       expect(mockAdapter.fetchEmails).toHaveBeenCalled();
     });
 
     it("sets isFetching during execution", async () => {
-      useEmailCaptureStore.setState({
-        accounts: [makeAccount({ email: "u@g.com", createdAt: "" })],
-      });
+      setAccounts([makeAccount({ email: "u@g.com", createdAt: "" as IsoDateTime })]);
       mockAdapter.fetchEmails.mockResolvedValueOnce([]);
-      // No processEmails mock needed — 0 emails with first fetch goes to zero-emails early return
-      vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
-      vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
+      mockEmptyReviewLoads();
 
-      const promise = fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
+      const promise = runFetchAndProcess();
       expect(useEmailCaptureStore.getState().isFetching).toBe(true);
 
       await promise;
@@ -468,7 +501,7 @@ describe("email capture boundary", () => {
 
     it("warns when the requested email capture session is no longer active", async () => {
       initializeEmailCaptureSession("user-2" as UserId);
-      await fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
+      await runFetchAndProcess();
 
       expect(mockAdapter.fetchEmails).not.toHaveBeenCalled();
       expect(mockCaptureWarning).toHaveBeenCalledWith("email_capture_fetch_missing_context", {
@@ -484,65 +517,40 @@ describe("email capture boundary", () => {
         accounts: [makeAccount()],
       });
 
-      await fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
+      await runFetchAndProcess();
 
       expect(mockAdapter.fetchEmails).not.toHaveBeenCalled();
     });
 
     it("continues processing other accounts when one fails", async () => {
-      useEmailCaptureStore.setState({
-        accounts: [
-          makeAccount(),
-          makeAccount({ id: "ea-2", provider: "outlook", email: "test@outlook.com" }),
-        ],
-      });
+      setAccounts([
+        makeAccount(),
+        makeAccount({
+          id: "ea-2" as EmailAccountId,
+          provider: "outlook",
+          email: "test@outlook.com",
+        }),
+      ]);
 
       mockAdapter.fetchEmails
         .mockRejectedValueOnce(new Error("network error"))
         .mockResolvedValueOnce([]);
-      vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
-      vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
+      mockEmptyReviewLoads();
 
-      await fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
+      await runFetchAndProcess();
 
       expect(mockAdapter.fetchEmails).toHaveBeenCalledTimes(2);
       expect(useEmailCaptureStore.getState().isFetching).toBe(false);
     });
 
     it("calls processEmails with correct arguments", async () => {
-      useEmailCaptureStore.setState({
-        accounts: [makeAccount()],
-      });
-
-      const mockRawEmails = [
-        {
-          externalId: "ext-1",
-          from: "bank@example.com",
-          subject: "Alert",
-          body: "body",
-          receivedAt: "2026-03-05T10:00:00Z",
-          provider: "gmail" as const,
-        },
-      ];
+      setAccounts();
+      const mockRawEmails = [makeRawEmail()];
       mockAdapter.fetchEmails.mockResolvedValueOnce(mockRawEmails);
-      vi.mocked(processEmails).mockResolvedValueOnce({
-        filtered: 0,
-        skippedDuplicate: 0,
-        skippedCrossSource: 0,
-        saved: 1,
-        failed: 0,
-        needsReview: 0,
-      });
-      vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
-      vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
+      mockProcessResult({ saved: 1 });
+      mockEmptyReviewLoads();
 
-      await fetchAndProcessEmails(
-        mockDb,
-        mockUserId as UserId,
-        "gmail-client-id",
-        "outlook-client-id",
-        mockRefresh
-      );
+      await runFetchAndProcess("gmail-client-id", "outlook-client-id");
 
       expect(processEmails).toHaveBeenCalledWith(
         mockDb,
@@ -553,20 +561,8 @@ describe("email capture boundary", () => {
     });
 
     it("sets phase to processing when showing progress", async () => {
-      useEmailCaptureStore.setState({
-        accounts: [makeAccount()],
-      });
-
-      const mockRawEmails = [
-        {
-          externalId: "ext-1",
-          from: "bank@example.com",
-          subject: "Alert",
-          body: "body",
-          receivedAt: "2026-03-05T10:00:00Z",
-          provider: "gmail" as const,
-        },
-      ];
+      setAccounts();
+      const mockRawEmails = [makeRawEmail()];
       mockAdapter.fetchEmails.mockResolvedValueOnce(mockRawEmails);
 
       const phases: (string | null)[] = [];
@@ -582,64 +578,46 @@ describe("email capture boundary", () => {
           needsReview: 0,
         };
       });
-      vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
-      vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
+      mockEmptyReviewLoads();
 
-      await fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
+      await runFetchAndProcess();
 
       expect(phases).toContain("processing");
       expect(useEmailCaptureStore.getState().phase).toBe("complete");
     });
 
     it("skips progress state when below threshold on subsequent sync", async () => {
-      useEmailCaptureStore.setState({
-        accounts: [makeAccount({ lastFetchedAt: "2026-03-10T00:00:00Z" })],
-      });
-
+      setAccounts([makeAccount({ lastFetchedAt: "2026-03-10T00:00:00Z" as IsoDateTime })]);
       mockAdapter.fetchEmails.mockResolvedValueOnce([
-        {
-          externalId: "ext-1",
+        makeRawEmail({
           from: "b@b.com",
           subject: "A",
           body: "b",
           receivedAt: "2026-03-10T00:00:00Z",
-          provider: "gmail",
-        },
-        {
+        }),
+        makeRawEmail({
           externalId: "ext-2",
           from: "b@b.com",
           subject: "B",
           body: "b",
           receivedAt: "2026-03-10T00:00:00Z",
-          provider: "gmail",
-        },
+        }),
       ]);
-      vi.mocked(processEmails).mockResolvedValueOnce({
-        filtered: 0,
-        skippedDuplicate: 0,
-        skippedCrossSource: 0,
-        saved: 2,
-        failed: 0,
-        needsReview: 0,
-      });
-      vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
-      vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
+      mockProcessResult({ saved: 2 });
+      mockEmptyReviewLoads();
 
-      await fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
+      await runFetchAndProcess();
 
       expect(useEmailCaptureStore.getState().phase).toBeNull();
     });
 
     it("updates in-memory accounts lastFetchedAt after fetch", async () => {
-      useEmailCaptureStore.setState({
-        accounts: [makeAccount()],
-      });
+      setAccounts();
 
       mockAdapter.fetchEmails.mockResolvedValueOnce([]);
-      vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
-      vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
+      mockEmptyReviewLoads();
 
-      await fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
+      await runFetchAndProcess();
 
       const updatedAccount = useEmailCaptureStore.getState().accounts[0]!;
       expect(updatedAccount.lastFetchedAt).not.toBeNull();
@@ -649,37 +627,20 @@ describe("email capture boundary", () => {
       vi.useFakeTimers();
 
       try {
-        useEmailCaptureStore.setState({
-          accounts: [makeAccount()],
-        });
-
+        setAccounts();
         mockAdapter.fetchEmails.mockResolvedValueOnce([
-          {
-            externalId: "ext-1",
+          makeRawEmail({
             from: "b@b.com",
             subject: "A",
             body: "b",
             receivedAt: "2026-03-10T00:00:00Z",
-            provider: "gmail",
-          },
+          }),
         ]);
-        vi.mocked(processEmails).mockResolvedValueOnce({
-          filtered: 0,
-          skippedDuplicate: 0,
-          skippedCrossSource: 0,
-          saved: 1,
-          failed: 0,
-          needsReview: 0,
-        });
-        vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
-        vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
+        mockProcessResult({ saved: 1 });
+        mockEmptyReviewLoads();
 
-        await fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
-
-        // Phase should be "complete" immediately after
+        await runFetchAndProcess();
         expect(useEmailCaptureStore.getState().phase).toBe("complete");
-
-        // After 2s, phase should auto-clear
         vi.advanceTimersByTime(2000);
         expect(useEmailCaptureStore.getState().phase).toBeNull();
         expect(useEmailCaptureStore.getState().progress).toBeNull();
@@ -689,51 +650,33 @@ describe("email capture boundary", () => {
     });
 
     it("preserves complete phase immediately after fetchAndProcess", async () => {
-      useEmailCaptureStore.setState({
-        accounts: [makeAccount()],
-      });
-
+      setAccounts();
       mockAdapter.fetchEmails.mockResolvedValueOnce([
-        {
-          externalId: "ext-1",
+        makeRawEmail({
           from: "b@b.com",
           subject: "A",
           body: "b",
           receivedAt: "2026-03-10T00:00:00Z",
-          provider: "gmail",
-        },
+        }),
       ]);
-      vi.mocked(processEmails).mockResolvedValueOnce({
-        filtered: 0,
-        skippedDuplicate: 0,
-        skippedCrossSource: 0,
-        saved: 1,
-        failed: 0,
-        needsReview: 0,
-      });
-      vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
-      vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
+      mockProcessResult({ saved: 1 });
+      mockEmptyReviewLoads();
 
-      await fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
+      await runFetchAndProcess();
 
       expect(useEmailCaptureStore.getState().phase).toBe("complete");
       expect(useEmailCaptureStore.getState().isFetching).toBe(false);
     });
 
     it("shows progress on first fetch even with 1 email", async () => {
-      useEmailCaptureStore.setState({
-        accounts: [makeAccount()],
-      });
-
+      setAccounts();
       mockAdapter.fetchEmails.mockResolvedValueOnce([
-        {
-          externalId: "ext-1",
+        makeRawEmail({
           from: "b@b.com",
           subject: "A",
           body: "b",
           receivedAt: "2026-03-10T00:00:00Z",
-          provider: "gmail",
-        },
+        }),
       ]);
 
       const phases: (string | null)[] = [];
@@ -749,24 +692,20 @@ describe("email capture boundary", () => {
           needsReview: 0,
         };
       });
-      vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
-      vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
+      mockEmptyReviewLoads();
 
-      await fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
+      await runFetchAndProcess();
 
       expect(phases).toContain("processing");
     });
 
     it("sets complete with zero results when first fetch has 0 emails", async () => {
-      useEmailCaptureStore.setState({
-        accounts: [makeAccount()],
-      });
+      setAccounts();
 
       mockAdapter.fetchEmails.mockResolvedValueOnce([]);
-      vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
-      vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
+      mockEmptyReviewLoads();
 
-      await fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
+      await runFetchAndProcess();
 
       expect(useEmailCaptureStore.getState().phase).toBe("complete");
       expect(useEmailCaptureStore.getState().progress).toEqual(
@@ -776,23 +715,18 @@ describe("email capture boundary", () => {
     });
 
     it("clears phase and progress on error in finally block", async () => {
-      useEmailCaptureStore.setState({
-        accounts: [makeAccount()],
-      });
-
+      setAccounts();
       mockAdapter.fetchEmails.mockResolvedValueOnce([
-        {
-          externalId: "ext-1",
+        makeRawEmail({
           from: "b@b.com",
           subject: "A",
           body: "b",
           receivedAt: "2026-03-10T00:00:00Z",
-          provider: "gmail",
-        },
+        }),
       ]);
       vi.mocked(processEmails).mockRejectedValueOnce(new Error("pipeline crash"));
 
-      await fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
+      await runFetchAndProcess();
 
       expect(useEmailCaptureStore.getState().phase).toBeNull();
       expect(useEmailCaptureStore.getState().progress).toBeNull();
@@ -800,37 +734,21 @@ describe("email capture boundary", () => {
     });
 
     it("drops stale fetch completions after the active user changes", async () => {
-      const deferred =
-        createDeferred<
-          readonly [
-            {
-              readonly externalId: string;
-              readonly from: string;
-              readonly subject: string;
-              readonly body: string;
-              readonly receivedAt: string;
-              readonly provider: "gmail";
-            },
-          ]
-        >();
-      useEmailCaptureStore.setState({
-        accounts: [makeAccount()],
-      });
+      const deferred = createDeferred<readonly [RawEmail]>();
+      setAccounts();
       mockAdapter.fetchEmails.mockReturnValueOnce(deferred.promise);
 
-      const fetch = fetchAndProcessEmails(mockDb, mockUserId as UserId, "g", "o", mockRefresh);
+      const fetch = runFetchAndProcess();
       expect(useEmailCaptureStore.getState().isFetching).toBe(true);
 
       initializeEmailCaptureSession("user-2" as UserId);
       deferred.resolve([
-        {
-          externalId: "ext-1",
+        makeRawEmail({
           from: "b@b.com",
           subject: "A",
           body: "b",
           receivedAt: "2026-03-10T00:00:00Z",
-          provider: "gmail",
-        },
+        }),
       ]);
 
       await fetch;

--- a/apps/mobile/__tests__/financial-accounts/balance-repository.test.ts
+++ b/apps/mobile/__tests__/financial-accounts/balance-repository.test.ts
@@ -14,13 +14,17 @@ import type {
   OpeningBalanceId,
   TransactionId,
   TransferId,
-  UserId,
 } from "@/shared/types/branded";
+import {
+  createBalanceTransactionFixture,
+  createBalanceTransferFixture,
+  FIXTURE_USER_ID,
+} from "./fixtures";
 
 let sqlite: InstanceType<typeof Database>;
 let db: ReturnType<typeof drizzle>;
 
-const USER_ID = "user-1" as UserId;
+const USER_ID = FIXTURE_USER_ID;
 const NOW = "2026-04-19T10:00:00.000Z" as IsoDateTime;
 
 beforeEach(() => {
@@ -63,71 +67,43 @@ function saveAccountOpeningBalance(accountId: string, amount: number, effectiveD
     .run();
 }
 
-function saveAccountTransaction({
-  id,
-  accountId,
-  type,
-  amount,
-  date,
-  accountAttributionState = "confirmed",
-  supersededAt = null,
-}: {
-  readonly id: string;
-  readonly accountId: string;
-  readonly type: "expense" | "income";
-  readonly amount: number;
-  readonly date: string;
-  readonly accountAttributionState?: "confirmed" | "unresolved";
-  readonly supersededAt?: IsoDateTime | null;
-}) {
+function saveAccountTransaction(
+  entry: ReturnType<typeof createBalanceTransactionFixture> = createBalanceTransactionFixture()
+) {
   db.insert(transactions)
     .values({
-      id: id as TransactionId,
+      id: entry.id as TransactionId,
       userId: USER_ID,
-      type,
-      amount: amount as CopAmount,
+      type: entry.type,
+      amount: entry.amount as CopAmount,
       categoryId: "other" as never,
-      accountId: accountId as FinancialAccountId,
-      accountAttributionState,
-      description: id,
-      date: date as IsoDate,
+      accountId: entry.accountId as FinancialAccountId,
+      accountAttributionState: entry.accountAttributionState ?? "confirmed",
+      description: entry.id,
+      date: entry.date as IsoDate,
       createdAt: NOW,
       updatedAt: NOW,
       deletedAt: null,
-      supersededAt,
-      source: accountAttributionState === "unresolved" ? "gmail" : "manual",
+      supersededAt: entry.supersededAt ?? null,
+      source: entry.accountAttributionState === "unresolved" ? "gmail" : "manual",
     })
     .run();
 }
 
-function saveAccountTransfer({
-  id,
-  amount,
-  date,
-  fromAccountId,
-  toAccountId,
-  fromExternalLabel = null,
-  toExternalLabel = null,
-}: {
-  readonly id: string;
-  readonly amount: number;
-  readonly date: string;
-  readonly fromAccountId: string | null;
-  readonly toAccountId: string | null;
-  readonly fromExternalLabel?: string | null;
-  readonly toExternalLabel?: string | null;
-}) {
+function saveAccountTransfer(
+  entry: ReturnType<typeof createBalanceTransferFixture> = createBalanceTransferFixture()
+) {
   db.insert(transfers)
     .values({
-      id: id as TransferId,
+      id: entry.id as TransferId,
       userId: USER_ID,
-      amount: amount as CopAmount,
-      fromAccountId: fromAccountId as FinancialAccountId | null,
-      toAccountId: toAccountId as FinancialAccountId | null,
-      fromExternalLabel,
-      toExternalLabel,
-      description: id,
-      date: date as IsoDate,
+      amount: entry.amount as CopAmount,
+      fromAccountId: entry.fromAccountId as FinancialAccountId | null,
+      toAccountId: entry.toAccountId as FinancialAccountId | null,
+      fromExternalLabel: entry.fromExternalLabel,
+      toExternalLabel: entry.toExternalLabel,
+      description: entry.id,
+      date: entry.date as IsoDate,
       createdAt: NOW,
       updatedAt: NOW,
       deletedAt: null,
@@ -135,120 +111,135 @@ function saveAccountTransfer({
     .run();
 }
 
-describe("financial account balance repository", () => {
-  it("derives balances from opening balances, confirmed transactions, and transfers", () => {
-    saveAccount("fa-checking", "checking");
-    saveAccount("fa-card", "credit_card");
-    saveAccountOpeningBalance("fa-checking", 1_000_000, "2026-04-01");
-    saveAccountOpeningBalance("fa-card", 800_000, "2026-04-01");
+function expectBalances(asOf: IsoDate, balances: Record<string, number>) {
+  expect(getFinancialAccountBalancesForUser(db as any, USER_ID, asOf)).toEqual(balances);
+}
 
-    saveAccountTransaction({
+function seedAccountsAndOpeningBalances() {
+  (
+    [
+      ["fa-checking", "checking"],
+      ["fa-card", "credit_card"],
+    ] as const
+  ).forEach(([id, kind]) => {
+    saveAccount(id, kind as "checking" | "credit_card");
+  });
+  saveAccountOpeningBalance("fa-checking", 1_000_000, "2026-04-01");
+  saveAccountOpeningBalance("fa-card", 800_000, "2026-04-01");
+}
+
+function seedBalanceTransactions() {
+  [
+    createBalanceTransactionFixture({
       id: "tx-checking-expense",
       accountId: "fa-checking",
-      type: "expense",
       amount: 200_000,
-      date: "2026-04-10",
-    });
-    saveAccountTransaction({
+    }),
+    createBalanceTransactionFixture({
       id: "tx-checking-income",
       accountId: "fa-checking",
       type: "income",
       amount: 50_000,
       date: "2026-04-12",
-    });
-    saveAccountTransaction({
+    }),
+    createBalanceTransactionFixture({
       id: "tx-checking-unresolved",
       accountId: "fa-checking",
       type: "income",
       amount: 999_999,
       date: "2026-04-13",
       accountAttributionState: "unresolved",
-    });
-    saveAccountTransaction({
+    }),
+    createBalanceTransactionFixture({
       id: "tx-card-expense",
       accountId: "fa-card",
-      type: "expense",
       amount: 300_000,
       date: "2026-04-11",
-    });
+    }),
+  ].forEach(saveAccountTransaction);
+}
 
-    saveAccountTransfer({
+function seedBalanceTransfers() {
+  [
+    createBalanceTransferFixture({
       id: "tr-to-card",
       amount: 450_000,
       date: "2026-04-18",
       fromAccountId: "fa-checking",
       toAccountId: "fa-card",
-    });
-    saveAccountTransfer({
+    }),
+    createBalanceTransferFixture({
       id: "tr-from-outside",
       amount: 120_000,
       date: "2026-04-17",
       fromAccountId: null,
       toAccountId: "fa-checking",
       fromExternalLabel: "Outside Fidy",
-    });
+    }),
+  ].forEach(saveAccountTransfer);
+}
 
-    expect(getFinancialAccountBalancesForUser(db as any, USER_ID, "2026-04-19" as IsoDate)).toEqual(
-      {
-        "fa-card": -650_000,
-        "fa-checking": 520_000,
-      }
-    );
+function seedDerivedBalanceScenario() {
+  seedAccountsAndOpeningBalances();
+  seedBalanceTransactions();
+  seedBalanceTransfers();
+}
+
+describe("financial account balance repository", () => {
+  it("derives balances from opening balances, confirmed transactions, and transfers", () => {
+    seedDerivedBalanceScenario();
+    expectBalances("2026-04-19" as IsoDate, {
+      "fa-card": -650_000,
+      "fa-checking": 520_000,
+    });
   });
 
   it("ignores future-dated balance effects until their effective date", () => {
     saveAccount("fa-wallet", "checking");
     saveAccountOpeningBalance("fa-wallet", 300_000, "2026-04-20");
-    saveAccountTransaction({
-      id: "tx-future",
-      accountId: "fa-wallet",
-      type: "income",
-      amount: 100_000,
-      date: "2026-04-20",
-    });
-    saveAccountTransfer({
-      id: "tr-future",
-      amount: 40_000,
-      date: "2026-04-20",
-      fromAccountId: null,
-      toAccountId: "fa-wallet",
-      fromExternalLabel: "Outside Fidy",
-    });
+    saveAccountTransaction(
+      createBalanceTransactionFixture({
+        id: "tx-future",
+        accountId: "fa-wallet",
+        type: "income",
+        amount: 100_000,
+        date: "2026-04-20",
+      })
+    );
+    saveAccountTransfer(
+      createBalanceTransferFixture({
+        id: "tr-future",
+        amount: 40_000,
+        date: "2026-04-20",
+        fromAccountId: null,
+        toAccountId: "fa-wallet",
+        fromExternalLabel: "Outside Fidy",
+      })
+    );
 
-    expect(getFinancialAccountBalancesForUser(db as any, USER_ID, "2026-04-19" as IsoDate)).toEqual(
-      {
-        "fa-wallet": 0,
-      }
-    );
-    expect(getFinancialAccountBalancesForUser(db as any, USER_ID, "2026-04-20" as IsoDate)).toEqual(
-      {
-        "fa-wallet": 440_000,
-      }
-    );
+    expectBalances("2026-04-19" as IsoDate, { "fa-wallet": 0 });
+    expectBalances("2026-04-20" as IsoDate, { "fa-wallet": 440_000 });
   });
 
   it("ignores superseded transactions when deriving balances", () => {
     saveAccount("fa-checking", "checking");
-    saveAccountTransaction({
-      id: "tx-active",
-      accountId: "fa-checking",
-      type: "expense",
-      amount: 100_000,
-      date: "2026-04-10",
-    });
-    saveAccountTransaction({
-      id: "tx-superseded",
-      accountId: "fa-checking",
-      type: "expense",
-      amount: 350_000,
-      date: "2026-04-11",
-      supersededAt: "2026-04-12T09:00:00.000Z" as IsoDateTime,
-    });
-
-    expect(getFinancialAccountBalancesForUser(db as any, USER_ID, "2026-04-19" as IsoDate)).toEqual(
-      {
-        "fa-checking": -100_000,
-      }
+    saveAccountTransaction(
+      createBalanceTransactionFixture({
+        id: "tx-active",
+        accountId: "fa-checking",
+        amount: 100_000,
+      })
     );
+    saveAccountTransaction(
+      createBalanceTransactionFixture({
+        id: "tx-superseded",
+        accountId: "fa-checking",
+        amount: 350_000,
+        date: "2026-04-11",
+        supersededAt: "2026-04-12T09:00:00.000Z" as IsoDateTime,
+      })
+    );
+
+    expectBalances("2026-04-19" as IsoDate, { "fa-checking": -100_000 });
   });
 });

--- a/apps/mobile/__tests__/financial-accounts/fixtures.ts
+++ b/apps/mobile/__tests__/financial-accounts/fixtures.ts
@@ -1,0 +1,138 @@
+import type {
+  CopAmount,
+  FinancialAccountId,
+  FinancialAccountIdentifierId,
+  IsoDate,
+  IsoDateTime,
+  OpeningBalanceId,
+  UserId,
+} from "@/shared/types/branded";
+
+type FinancialAccountFixture = {
+  readonly id: FinancialAccountId;
+  readonly userId: UserId;
+  readonly name: string;
+  readonly kind: "wallet" | "cash" | "checking" | "credit_card";
+  readonly isDefault: boolean;
+  readonly createdAt: IsoDateTime;
+  readonly updatedAt: IsoDateTime;
+  readonly deletedAt: IsoDateTime | null;
+  readonly statementClosingDay?: number | null;
+  readonly paymentDueDay?: number | null;
+};
+
+type OpeningBalanceFixture = {
+  readonly id: OpeningBalanceId;
+  readonly userId: UserId;
+  readonly accountId: FinancialAccountId;
+  readonly amount: CopAmount;
+  readonly effectiveDate: IsoDate;
+  readonly createdAt: IsoDateTime;
+  readonly updatedAt: IsoDateTime;
+  readonly deletedAt: IsoDateTime | null;
+};
+
+type IdentifierFixture = {
+  readonly id: FinancialAccountIdentifierId;
+  readonly userId: UserId;
+  readonly accountId: FinancialAccountId;
+  readonly scope: string;
+  readonly value: string;
+  readonly createdAt: IsoDateTime;
+  readonly updatedAt: IsoDateTime;
+  readonly deletedAt: IsoDateTime | null;
+};
+
+type BalanceTransactionFixture = {
+  readonly id: string;
+  readonly accountId: string;
+  readonly type: "expense" | "income";
+  readonly amount: number;
+  readonly date: string;
+  readonly accountAttributionState?: "confirmed" | "unresolved";
+  readonly supersededAt?: IsoDateTime | null;
+};
+
+type BalanceTransferFixture = {
+  readonly id: string;
+  readonly amount: number;
+  readonly date: string;
+  readonly fromAccountId: string | null;
+  readonly toAccountId: string | null;
+  readonly fromExternalLabel?: string | null;
+  readonly toExternalLabel?: string | null;
+};
+
+export const FIXTURE_USER_ID = "user-1" as UserId;
+export const FIXTURE_NOW = "2026-04-18T10:00:00.000Z" as IsoDateTime;
+export const FIXTURE_ACCOUNT_ID = "fa-1" as FinancialAccountId;
+
+export const createFinancialAccountFixture = (
+  overrides: Partial<FinancialAccountFixture> = {}
+): FinancialAccountFixture => ({
+  id: "fa-1" as FinancialAccountId,
+  userId: FIXTURE_USER_ID,
+  name: "Main wallet",
+  kind: "wallet",
+  isDefault: true,
+  createdAt: FIXTURE_NOW,
+  updatedAt: FIXTURE_NOW,
+  deletedAt: null,
+  statementClosingDay: null,
+  paymentDueDay: null,
+  ...overrides,
+});
+
+export const createOpeningBalanceFixture = (
+  overrides: Partial<OpeningBalanceFixture> = {}
+): OpeningBalanceFixture => ({
+  id: "ob-1" as OpeningBalanceId,
+  userId: FIXTURE_USER_ID,
+  accountId: FIXTURE_ACCOUNT_ID,
+  amount: 500000 as CopAmount,
+  effectiveDate: "2026-04-01" as IsoDate,
+  createdAt: FIXTURE_NOW,
+  updatedAt: FIXTURE_NOW,
+  deletedAt: null,
+  ...overrides,
+});
+
+export const createIdentifierFixture = (
+  overrides: Partial<IdentifierFixture> = {}
+): IdentifierFixture => ({
+  id: "fai-1" as FinancialAccountIdentifierId,
+  userId: FIXTURE_USER_ID,
+  accountId: FIXTURE_ACCOUNT_ID,
+  scope: "email:bancolombia:last4",
+  value: "1234",
+  createdAt: FIXTURE_NOW,
+  updatedAt: FIXTURE_NOW,
+  deletedAt: null,
+  ...overrides,
+});
+
+export const createBalanceTransactionFixture = (
+  overrides: Partial<BalanceTransactionFixture> = {}
+): BalanceTransactionFixture => ({
+  id: "tx-1",
+  accountId: "fa-1",
+  type: "expense",
+  amount: 1000,
+  date: "2026-04-10",
+  accountAttributionState: "confirmed",
+  supersededAt: null,
+  ...overrides,
+});
+
+export const createBalanceTransferFixture = (
+  overrides: Partial<BalanceTransferFixture> = {}
+): BalanceTransferFixture => ({
+  id: "tr-1",
+  amount: 1000,
+  date: "2026-04-10",
+  fromAccountId: "fa-1",
+  toAccountId: "fa-2",
+  fromExternalLabel: null,
+  toExternalLabel: null,
+  ...overrides,
+});

--- a/apps/mobile/__tests__/financial-accounts/identifiers.test.ts
+++ b/apps/mobile/__tests__/financial-accounts/identifiers.test.ts
@@ -10,19 +10,14 @@ import {
   upsertFinancialAccountIdentifier,
 } from "@/features/financial-accounts";
 import { getQueuedSyncEntries } from "@/features/transactions/lib/repository";
-import type {
-  FinancialAccountId,
-  FinancialAccountIdentifierId,
-  IsoDateTime,
-  UserId,
-} from "@/shared/types/branded";
+import type { FinancialAccountIdentifierId, IsoDateTime } from "@/shared/types/branded";
+import { createIdentifierFixture, FIXTURE_ACCOUNT_ID, FIXTURE_USER_ID } from "./fixtures";
 
 let sqlite: InstanceType<typeof Database>;
 let db: ReturnType<typeof drizzle>;
 
-const USER_ID = "user-1" as UserId;
-const NOW = "2026-04-18T10:00:00.000Z" as IsoDateTime;
-const ACCOUNT_ID = "fa-1" as FinancialAccountId;
+const USER_ID = FIXTURE_USER_ID;
+const ACCOUNT_ID = FIXTURE_ACCOUNT_ID;
 
 beforeEach(() => {
   sqlite = new Database(":memory:");
@@ -34,28 +29,31 @@ afterEach(() => {
   sqlite.close();
 });
 
+function saveIdentifier(overrides: Partial<ReturnType<typeof createIdentifierFixture>> = {}) {
+  saveFinancialAccountIdentifier(db as any, createIdentifierFixture(overrides));
+}
+
+function upsertIdentifier(overrides: Partial<ReturnType<typeof createIdentifierFixture>> = {}) {
+  upsertFinancialAccountIdentifier(db as any, createIdentifierFixture(overrides));
+}
+
+function expectIdentifiersForAccount(matcher: Record<string, unknown>) {
+  expect(getFinancialAccountIdentifiersForAccount(db as any, ACCOUNT_ID)).toEqual([
+    expect.objectContaining(matcher),
+  ]);
+}
+
 describe("financial account identifiers repository", () => {
   it("saves an identifier, reads it back, and enqueues sync", () => {
-    saveFinancialAccountIdentifier(db as any, {
-      id: "fai-1" as FinancialAccountIdentifierId,
+    saveIdentifier();
+
+    expectIdentifiersForAccount({
+      id: "fai-1",
       userId: USER_ID,
       accountId: ACCOUNT_ID,
       scope: "email:bancolombia:last4",
       value: "1234",
-      createdAt: NOW,
-      updatedAt: NOW,
-      deletedAt: null,
     });
-
-    expect(getFinancialAccountIdentifiersForAccount(db as any, ACCOUNT_ID)).toEqual([
-      expect.objectContaining({
-        id: "fai-1",
-        userId: USER_ID,
-        accountId: ACCOUNT_ID,
-        scope: "email:bancolombia:last4",
-        value: "1234",
-      }),
-    ]);
 
     expect(getQueuedSyncEntries(db as any)).toEqual([
       expect.objectContaining({
@@ -67,36 +65,18 @@ describe("financial account identifiers repository", () => {
   });
 
   it("enqueues the persisted row id when a unique identifier upsert reuses an existing record", () => {
-    saveFinancialAccountIdentifier(db as any, {
-      id: "fai-1" as FinancialAccountIdentifierId,
-      userId: USER_ID,
-      accountId: ACCOUNT_ID,
-      scope: "email:bancolombia:last4",
-      value: "1234",
-      createdAt: NOW,
-      updatedAt: NOW,
-      deletedAt: null,
-    });
-
-    saveFinancialAccountIdentifier(db as any, {
+    saveIdentifier();
+    saveIdentifier({
       id: "fai-2" as FinancialAccountIdentifierId,
-      userId: USER_ID,
-      accountId: ACCOUNT_ID,
-      scope: "email:bancolombia:last4",
-      value: "1234",
-      createdAt: NOW,
       updatedAt: "2026-04-18T11:00:00.000Z" as IsoDateTime,
-      deletedAt: null,
     });
 
-    expect(getFinancialAccountIdentifiersForAccount(db as any, ACCOUNT_ID)).toEqual([
-      expect.objectContaining({
-        id: "fai-1",
-        scope: "email:bancolombia:last4",
-        value: "1234",
-        updatedAt: "2026-04-18T11:00:00.000Z",
-      }),
-    ]);
+    expectIdentifiersForAccount({
+      id: "fai-1",
+      scope: "email:bancolombia:last4",
+      value: "1234",
+      updatedAt: "2026-04-18T11:00:00.000Z",
+    });
 
     expect(getQueuedSyncEntries(db as any)).toEqual([
       expect.objectContaining({
@@ -113,113 +93,55 @@ describe("financial account identifiers repository", () => {
   });
 
   it("replaces a local duplicate id with the pulled server row for the same unique identifier", () => {
-    saveFinancialAccountIdentifier(db as any, {
-      id: "fai-local" as FinancialAccountIdentifierId,
-      userId: USER_ID,
-      accountId: ACCOUNT_ID,
-      scope: "email:bancolombia:last4",
-      value: "1234",
-      createdAt: NOW,
-      updatedAt: NOW,
-      deletedAt: null,
-    });
-
-    upsertFinancialAccountIdentifier(db as any, {
+    saveIdentifier({ id: "fai-local" as FinancialAccountIdentifierId });
+    upsertIdentifier({
       id: "fai-server" as FinancialAccountIdentifierId,
-      userId: USER_ID,
-      accountId: ACCOUNT_ID,
-      scope: "email:bancolombia:last4",
-      value: "1234",
-      createdAt: NOW,
       updatedAt: "2026-04-18T11:00:00.000Z" as IsoDateTime,
-      deletedAt: null,
     });
 
-    expect(getFinancialAccountIdentifiersForAccount(db as any, ACCOUNT_ID)).toEqual([
-      expect.objectContaining({
-        id: "fai-server",
-        scope: "email:bancolombia:last4",
-        value: "1234",
-        updatedAt: "2026-04-18T11:00:00.000Z",
-      }),
-    ]);
+    expectIdentifiersForAccount({
+      id: "fai-server",
+      scope: "email:bancolombia:last4",
+      value: "1234",
+      updatedAt: "2026-04-18T11:00:00.000Z",
+    });
   });
 
   it("updates the same row id when the identifier moves onto an occupied unique key", () => {
-    saveFinancialAccountIdentifier(db as any, {
-      id: "fai-1" as FinancialAccountIdentifierId,
-      userId: USER_ID,
-      accountId: ACCOUNT_ID,
-      scope: "email:bancolombia:last4",
-      value: "1111",
-      createdAt: NOW,
-      updatedAt: NOW,
-      deletedAt: null,
-    });
-
-    saveFinancialAccountIdentifier(db as any, {
+    saveIdentifier({ value: "1111" });
+    saveIdentifier({
       id: "fai-2" as FinancialAccountIdentifierId,
-      userId: USER_ID,
-      accountId: ACCOUNT_ID,
-      scope: "email:bancolombia:last4",
       value: "2222",
       createdAt: "2026-04-18T10:30:00.000Z" as IsoDateTime,
       updatedAt: "2026-04-18T10:30:00.000Z" as IsoDateTime,
-      deletedAt: null,
+    });
+    saveIdentifier({
+      id: "fai-1" as FinancialAccountIdentifierId,
+      value: "2222",
+      updatedAt: "2026-04-18T11:00:00.000Z" as IsoDateTime,
     });
 
-    saveFinancialAccountIdentifier(db as any, {
-      id: "fai-1" as FinancialAccountIdentifierId,
-      userId: USER_ID,
-      accountId: ACCOUNT_ID,
+    expectIdentifiersForAccount({
+      id: "fai-1",
       scope: "email:bancolombia:last4",
       value: "2222",
-      createdAt: NOW,
-      updatedAt: "2026-04-18T11:00:00.000Z" as IsoDateTime,
-      deletedAt: null,
+      updatedAt: "2026-04-18T11:00:00.000Z",
     });
-
-    expect(getFinancialAccountIdentifiersForAccount(db as any, ACCOUNT_ID)).toEqual([
-      expect.objectContaining({
-        id: "fai-1",
-        scope: "email:bancolombia:last4",
-        value: "2222",
-        updatedAt: "2026-04-18T11:00:00.000Z",
-      }),
-    ]);
   });
 
   it("keeps a newer local duplicate when the pulled server row is older", () => {
-    saveFinancialAccountIdentifier(db as any, {
+    saveIdentifier({
       id: "fai-local" as FinancialAccountIdentifierId,
-      userId: USER_ID,
-      accountId: ACCOUNT_ID,
-      scope: "email:bancolombia:last4",
-      value: "1234",
-      createdAt: NOW,
       updatedAt: "2026-04-18T11:00:00.000Z" as IsoDateTime,
-      deletedAt: null,
     });
+    upsertIdentifier({ id: "fai-server" as FinancialAccountIdentifierId });
 
-    upsertFinancialAccountIdentifier(db as any, {
-      id: "fai-server" as FinancialAccountIdentifierId,
-      userId: USER_ID,
-      accountId: ACCOUNT_ID,
+    expectIdentifiersForAccount({
+      id: "fai-local",
       scope: "email:bancolombia:last4",
       value: "1234",
-      createdAt: NOW,
-      updatedAt: NOW,
-      deletedAt: null,
+      updatedAt: "2026-04-18T11:00:00.000Z",
     });
-
-    expect(getFinancialAccountIdentifiersForAccount(db as any, ACCOUNT_ID)).toEqual([
-      expect.objectContaining({
-        id: "fai-local",
-        scope: "email:bancolombia:last4",
-        value: "1234",
-        updatedAt: "2026-04-18T11:00:00.000Z",
-      }),
-    ]);
     expect(getQueuedSyncEntries(db as any)).toEqual([
       expect.objectContaining({
         tableName: "financialAccountIdentifiers",
@@ -230,46 +152,23 @@ describe("financial account identifiers repository", () => {
   });
 
   it("allows re-creating an identifier after soft delete", () => {
-    saveFinancialAccountIdentifier(db as any, {
+    saveIdentifier();
+    saveIdentifier({
       id: "fai-1" as FinancialAccountIdentifierId,
-      userId: USER_ID,
-      accountId: ACCOUNT_ID,
-      scope: "email:bancolombia:last4",
-      value: "1234",
-      createdAt: NOW,
-      updatedAt: NOW,
-      deletedAt: null,
-    });
-
-    saveFinancialAccountIdentifier(db as any, {
-      id: "fai-1" as FinancialAccountIdentifierId,
-      userId: USER_ID,
-      accountId: ACCOUNT_ID,
-      scope: "email:bancolombia:last4",
-      value: "1234",
-      createdAt: NOW,
       updatedAt: "2026-04-18T11:00:00.000Z" as IsoDateTime,
       deletedAt: "2026-04-18T11:00:00.000Z" as IsoDateTime,
     });
-
-    saveFinancialAccountIdentifier(db as any, {
+    saveIdentifier({
       id: "fai-2" as FinancialAccountIdentifierId,
-      userId: USER_ID,
-      accountId: ACCOUNT_ID,
-      scope: "email:bancolombia:last4",
-      value: "1234",
       createdAt: "2026-04-18T12:00:00.000Z" as IsoDateTime,
       updatedAt: "2026-04-18T12:00:00.000Z" as IsoDateTime,
-      deletedAt: null,
     });
 
-    expect(getFinancialAccountIdentifiersForAccount(db as any, ACCOUNT_ID)).toEqual([
-      expect.objectContaining({
-        id: "fai-2",
-        scope: "email:bancolombia:last4",
-        value: "1234",
-        updatedAt: "2026-04-18T12:00:00.000Z",
-      }),
-    ]);
+    expectIdentifiersForAccount({
+      id: "fai-2",
+      scope: "email:bancolombia:last4",
+      value: "1234",
+      updatedAt: "2026-04-18T12:00:00.000Z",
+    });
   });
 });

--- a/apps/mobile/__tests__/financial-accounts/management-service.test.ts
+++ b/apps/mobile/__tests__/financial-accounts/management-service.test.ts
@@ -15,12 +15,15 @@ import {
   MANUAL_FINANCIAL_ACCOUNT_IDENTIFIER_SCOPE,
 } from "@/features/financial-accounts/lib/management-service";
 import { getQueuedSyncEntries } from "@/features/transactions/lib/repository";
-import type { IsoDateTime, UserId } from "@/shared/types/branded";
+import type { FinancialAccountId, IsoDateTime, UserId } from "@/shared/types/branded";
 
 let sqlite: InstanceType<typeof Database>;
 let db: ReturnType<typeof drizzle>;
 
 const USER_ID = "user-1" as UserId;
+
+type FinancialAccountService = ReturnType<typeof createFinancialAccountManagementService>;
+type CreateAccountInput = Parameters<FinancialAccountService["createAccount"]>[0];
 
 beforeEach(() => {
   sqlite = new Database(":memory:");
@@ -32,26 +35,142 @@ afterEach(() => {
   sqlite.close();
 });
 
+function createService(overrides: Record<string, unknown> = {}) {
+  return createFinancialAccountManagementService({
+    now: () => "2026-04-19T10:00:00.000Z" as IsoDateTime,
+    createAccountId: () => "fa-new" as never,
+    createOpeningBalanceId: () => "ob-new" as never,
+    createIdentifierId: () => "fai-new" as never,
+    ...overrides,
+  });
+}
+
+function createAccountInput(overrides: Record<string, unknown> = {}) {
+  return {
+    db: db as any,
+    userId: USER_ID,
+    name: "Main wallet",
+    kind: "wallet" as const,
+    openingBalanceAmount: 850000 as never,
+    openingBalanceEffectiveDate: "2026-04-01" as never,
+    manualIdentifierValue: "Ahorros casa",
+    statementClosingDay: null,
+    paymentDueDay: null,
+    ...overrides,
+  } as CreateAccountInput;
+}
+
+function expectManualAccountRecord(accountId: FinancialAccountId) {
+  expect(getFinancialAccountById(db as any, accountId)).toMatchObject({
+    id: "fa-new",
+    name: "Main wallet",
+    kind: "wallet",
+  });
+}
+
+function expectManualOpeningBalance(accountId: FinancialAccountId) {
+  expect(getOpeningBalanceForAccount(db as any, accountId)).toMatchObject({
+    id: "ob-new",
+    amount: 850000,
+    effectiveDate: "2026-04-01",
+  });
+}
+
+function expectManualIdentifier(accountId: FinancialAccountId) {
+  expect(getFinancialAccountIdentifiersForAccount(db as any, accountId)).toEqual([
+    expect.objectContaining({
+      id: "fai-new",
+      scope: MANUAL_FINANCIAL_ACCOUNT_IDENTIFIER_SCOPE,
+      value: "Ahorros casa",
+    }),
+  ]);
+}
+
+function expectManualAccountSyncEntries() {
+  expect(getQueuedSyncEntries(db as any)).toEqual([
+    expect.objectContaining({
+      tableName: "financialAccounts",
+      rowId: "fa-new",
+      operation: "insert",
+    }),
+    expect.objectContaining({
+      tableName: "openingBalances",
+      rowId: "ob-new",
+      operation: "insert",
+    }),
+    expect.objectContaining({
+      tableName: "financialAccountIdentifiers",
+      rowId: "fai-new",
+      operation: "insert",
+    }),
+  ]);
+}
+
+function expectUpdatedCreditCardAccount(accountId: FinancialAccountId, openingBalanceId: string) {
+  expect(getFinancialAccountById(db as any, accountId)).toMatchObject({
+    id: "fa-card-2",
+    statementClosingDay: 14,
+    paymentDueDay: 29,
+  });
+  expect(getFinancialAccountIdentifiersForAccount(db as any, accountId)).toEqual([
+    expect.objectContaining({
+      id: "fai-later",
+      scope: MANUAL_FINANCIAL_ACCOUNT_IDENTIFIER_SCOPE,
+      value: "MC gold",
+    }),
+  ]);
+  expect(getOpeningBalanceForAccount(db as any, accountId)).toBeNull();
+  expect(getOpeningBalanceById(db as any, openingBalanceId as never)).toMatchObject({
+    id: "ob-card-2",
+    deletedAt: "2026-04-19T13:00:00.000Z",
+  });
+}
+
+function createManagedCreditCard(service: ReturnType<typeof createService>) {
+  return service.createAccount(
+    createAccountInput({
+      name: "Mastercard Gold",
+      kind: "credit_card" as const,
+      openingBalanceAmount: 420000 as never,
+      openingBalanceEffectiveDate: "2026-04-05" as never,
+      manualIdentifierValue: null,
+    })
+  );
+}
+
+function addCreditCardIdentifier(
+  service: ReturnType<typeof createService>,
+  accountId: FinancialAccountId
+) {
+  service.addManualIdentifier({
+    db: db as any,
+    userId: USER_ID,
+    accountId,
+    value: "MC gold",
+  });
+}
+
+function updateCreditCardBillingProfile(
+  service: ReturnType<typeof createService>,
+  accountId: FinancialAccountId
+) {
+  service.updateAccount({
+    db: db as any,
+    userId: USER_ID,
+    accountId,
+    name: "Mastercard Gold",
+    kind: "credit_card",
+    openingBalanceAmount: null,
+    openingBalanceEffectiveDate: null,
+    statementClosingDay: 14,
+    paymentDueDay: 29,
+  });
+}
+
 describe("financial account management service", () => {
   it("creates a manual account with an optional opening balance and identifier", () => {
-    const service = createFinancialAccountManagementService({
-      now: () => "2026-04-19T10:00:00.000Z" as IsoDateTime,
-      createAccountId: () => "fa-new" as never,
-      createOpeningBalanceId: () => "ob-new" as never,
-      createIdentifierId: () => "fai-new" as never,
-    });
-
-    const result = service.createAccount({
-      db: db as any,
-      userId: USER_ID,
-      name: "Main wallet",
-      kind: "wallet",
-      openingBalanceAmount: 850000 as never,
-      openingBalanceEffectiveDate: "2026-04-01" as never,
-      manualIdentifierValue: "Ahorros casa",
-      statementClosingDay: null,
-      paymentDueDay: null,
-    });
+    const service = createService();
+    const result = service.createAccount(createAccountInput());
 
     expect(result.account).toMatchObject({
       id: "fa-new",
@@ -60,40 +179,10 @@ describe("financial account management service", () => {
       kind: "wallet",
       isDefault: false,
     });
-    expect(getFinancialAccountById(db as any, result.account.id)).toMatchObject({
-      id: "fa-new",
-      name: "Main wallet",
-      kind: "wallet",
-    });
-    expect(getOpeningBalanceForAccount(db as any, result.account.id)).toMatchObject({
-      id: "ob-new",
-      amount: 850000,
-      effectiveDate: "2026-04-01",
-    });
-    expect(getFinancialAccountIdentifiersForAccount(db as any, result.account.id)).toEqual([
-      expect.objectContaining({
-        id: "fai-new",
-        scope: MANUAL_FINANCIAL_ACCOUNT_IDENTIFIER_SCOPE,
-        value: "Ahorros casa",
-      }),
-    ]);
-    expect(getQueuedSyncEntries(db as any)).toEqual([
-      expect.objectContaining({
-        tableName: "financialAccounts",
-        rowId: "fa-new",
-        operation: "insert",
-      }),
-      expect.objectContaining({
-        tableName: "openingBalances",
-        rowId: "ob-new",
-        operation: "insert",
-      }),
-      expect.objectContaining({
-        tableName: "financialAccountIdentifiers",
-        rowId: "fai-new",
-        operation: "insert",
-      }),
-    ]);
+    expectManualAccountRecord(result.account.id);
+    expectManualOpeningBalance(result.account.id);
+    expectManualIdentifier(result.account.id);
+    expectManualAccountSyncEntries();
   });
 
   it("allows creating a credit-card account without a billing profile and reports the gap", () => {
@@ -128,65 +217,22 @@ describe("financial account management service", () => {
   });
 
   it("updates the billing profile, removes the opening balance, and lets users add identifiers later", () => {
-    const service = createFinancialAccountManagementService({
+    const service = createService({
       now: () => "2026-04-19T13:00:00.000Z" as IsoDateTime,
       createAccountId: () => "fa-card-2" as never,
       createOpeningBalanceId: () => "ob-card-2" as never,
       createIdentifierId: () => "fai-later" as never,
     });
+    const created = createManagedCreditCard(service);
+    const existingOpeningBalanceId = getOpeningBalanceForAccount(db as any, created.account.id)?.id;
 
-    const created = service.createAccount({
-      db: db as any,
-      userId: USER_ID,
-      name: "Mastercard Gold",
-      kind: "credit_card",
-      openingBalanceAmount: 420000 as never,
-      openingBalanceEffectiveDate: "2026-04-05" as never,
-      manualIdentifierValue: null,
-      statementClosingDay: null,
-      paymentDueDay: null,
-    });
+    addCreditCardIdentifier(service, created.account.id);
+    updateCreditCardBillingProfile(service, created.account.id);
 
-    const existingOpeningBalance = getOpeningBalanceForAccount(db as any, created.account.id);
-
-    service.addManualIdentifier({
-      db: db as any,
-      userId: USER_ID,
-      accountId: created.account.id,
-      value: "MC gold",
-    });
-
-    service.updateAccount({
-      db: db as any,
-      userId: USER_ID,
-      accountId: created.account.id,
-      name: "Mastercard Gold",
-      kind: "credit_card",
-      openingBalanceAmount: null,
-      openingBalanceEffectiveDate: null,
-      statementClosingDay: 14,
-      paymentDueDay: 29,
-    });
-
-    expect(getFinancialAccountById(db as any, created.account.id)).toMatchObject({
-      id: "fa-card-2",
-      statementClosingDay: 14,
-      paymentDueDay: 29,
-    });
-    expect(getFinancialAccountIdentifiersForAccount(db as any, created.account.id)).toEqual([
-      expect.objectContaining({
-        id: "fai-later",
-        scope: MANUAL_FINANCIAL_ACCOUNT_IDENTIFIER_SCOPE,
-        value: "MC gold",
-      }),
-    ]);
-    expect(getOpeningBalanceForAccount(db as any, created.account.id)).toBeNull();
-    expect(
-      getOpeningBalanceById(db as any, existingOpeningBalance?.id ?? ("missing" as never))
-    ).toMatchObject({
-      id: "ob-card-2",
-      deletedAt: "2026-04-19T13:00:00.000Z",
-    });
+    expectUpdatedCreditCardAccount(
+      created.account.id,
+      existingOpeningBalanceId ?? ("missing" as never)
+    );
     expect(
       service.getAccountDetails({ db: db as any, accountId: created.account.id })
     ).toMatchObject({

--- a/apps/mobile/__tests__/financial-accounts/opening-balances.test.ts
+++ b/apps/mobile/__tests__/financial-accounts/opening-balances.test.ts
@@ -16,15 +16,14 @@ import type {
   IsoDate,
   IsoDateTime,
   OpeningBalanceId,
-  UserId,
 } from "@/shared/types/branded";
+import { createOpeningBalanceFixture, FIXTURE_ACCOUNT_ID, FIXTURE_USER_ID } from "./fixtures";
 
 let sqlite: InstanceType<typeof Database>;
 let db: ReturnType<typeof drizzle>;
 
-const USER_ID = "user-1" as UserId;
-const NOW = "2026-04-18T10:00:00.000Z" as IsoDateTime;
-const ACCOUNT_ID = "fa-1" as FinancialAccountId;
+const USER_ID = FIXTURE_USER_ID;
+const ACCOUNT_ID = FIXTURE_ACCOUNT_ID;
 
 beforeEach(() => {
   sqlite = new Database(":memory:");
@@ -36,20 +35,26 @@ afterEach(() => {
   sqlite.close();
 });
 
+function saveBalance(overrides: Partial<ReturnType<typeof createOpeningBalanceFixture>> = {}) {
+  saveOpeningBalance(db as any, createOpeningBalanceFixture(overrides));
+}
+
+function upsertBalance(overrides: Partial<ReturnType<typeof createOpeningBalanceFixture>> = {}) {
+  upsertOpeningBalance(db as any, createOpeningBalanceFixture(overrides));
+}
+
+function expectOpeningBalanceForAccount(
+  accountId: FinancialAccountId,
+  matcher: Record<string, unknown>
+) {
+  expect(getOpeningBalanceForAccount(db as any, accountId)).toMatchObject(matcher);
+}
+
 describe("opening balances repository", () => {
   it("saves an opening balance, reads it back, and enqueues sync", () => {
-    saveOpeningBalance(db as any, {
-      id: "ob-1" as OpeningBalanceId,
-      userId: USER_ID,
-      accountId: ACCOUNT_ID,
-      amount: 500000 as CopAmount,
-      effectiveDate: "2026-04-01" as IsoDate,
-      createdAt: NOW,
-      updatedAt: NOW,
-      deletedAt: null,
-    });
+    saveBalance();
 
-    expect(getOpeningBalanceForAccount(db as any, ACCOUNT_ID)).toMatchObject({
+    expectOpeningBalanceForAccount(ACCOUNT_ID, {
       id: "ob-1",
       userId: USER_ID,
       accountId: ACCOUNT_ID,
@@ -67,29 +72,15 @@ describe("opening balances repository", () => {
   });
 
   it("enqueues the persisted row id when a unique-account upsert reuses an existing record", () => {
-    saveOpeningBalance(db as any, {
-      id: "ob-1" as OpeningBalanceId,
-      userId: USER_ID,
-      accountId: ACCOUNT_ID,
-      amount: 500000 as CopAmount,
-      effectiveDate: "2026-04-01" as IsoDate,
-      createdAt: NOW,
-      updatedAt: NOW,
-      deletedAt: null,
-    });
-
-    saveOpeningBalance(db as any, {
+    saveBalance();
+    saveBalance({
       id: "ob-2" as OpeningBalanceId,
-      userId: USER_ID,
-      accountId: ACCOUNT_ID,
       amount: 750000 as CopAmount,
       effectiveDate: "2026-04-02" as IsoDate,
-      createdAt: NOW,
       updatedAt: "2026-04-18T11:00:00.000Z" as IsoDateTime,
-      deletedAt: null,
     });
 
-    expect(getOpeningBalanceForAccount(db as any, ACCOUNT_ID)).toMatchObject({
+    expectOpeningBalanceForAccount(ACCOUNT_ID, {
       id: "ob-1",
       amount: 750000,
       effectiveDate: "2026-04-02",
@@ -110,29 +101,15 @@ describe("opening balances repository", () => {
   });
 
   it("replaces a local duplicate id with the pulled server row for the same account", () => {
-    saveOpeningBalance(db as any, {
-      id: "ob-local" as OpeningBalanceId,
-      userId: USER_ID,
-      accountId: ACCOUNT_ID,
-      amount: 500000 as CopAmount,
-      effectiveDate: "2026-04-01" as IsoDate,
-      createdAt: NOW,
-      updatedAt: NOW,
-      deletedAt: null,
-    });
-
-    upsertOpeningBalance(db as any, {
+    saveBalance({ id: "ob-local" as OpeningBalanceId });
+    upsertBalance({
       id: "ob-server" as OpeningBalanceId,
-      userId: USER_ID,
-      accountId: ACCOUNT_ID,
       amount: 750000 as CopAmount,
       effectiveDate: "2026-04-02" as IsoDate,
-      createdAt: NOW,
       updatedAt: "2026-04-18T11:00:00.000Z" as IsoDateTime,
-      deletedAt: null,
     });
 
-    expect(getOpeningBalanceForAccount(db as any, ACCOUNT_ID)).toMatchObject({
+    expectOpeningBalanceForAccount(ACCOUNT_ID, {
       id: "ob-server",
       amount: 750000,
       effectiveDate: "2026-04-02",
@@ -140,30 +117,16 @@ describe("opening balances repository", () => {
   });
 
   it("updates the same row id when an opening balance moves to a different account", () => {
-    saveOpeningBalance(db as any, {
-      id: "ob-1" as OpeningBalanceId,
-      userId: USER_ID,
-      accountId: ACCOUNT_ID,
-      amount: 500000 as CopAmount,
-      effectiveDate: "2026-04-01" as IsoDate,
-      createdAt: NOW,
-      updatedAt: NOW,
-      deletedAt: null,
-    });
-
-    saveOpeningBalance(db as any, {
-      id: "ob-1" as OpeningBalanceId,
-      userId: USER_ID,
+    saveBalance();
+    saveBalance({
       accountId: "fa-2" as FinancialAccountId,
       amount: 750000 as CopAmount,
       effectiveDate: "2026-04-02" as IsoDate,
-      createdAt: NOW,
       updatedAt: "2026-04-18T11:00:00.000Z" as IsoDateTime,
-      deletedAt: null,
     });
 
     expect(getOpeningBalanceForAccount(db as any, ACCOUNT_ID)).toBeNull();
-    expect(getOpeningBalanceForAccount(db as any, "fa-2" as FinancialAccountId)).toMatchObject({
+    expectOpeningBalanceForAccount("fa-2" as FinancialAccountId, {
       id: "ob-1",
       amount: 750000,
       effectiveDate: "2026-04-02",
@@ -171,29 +134,15 @@ describe("opening balances repository", () => {
   });
 
   it("keeps a newer local duplicate when the pulled server row is older", () => {
-    saveOpeningBalance(db as any, {
+    saveBalance({
       id: "ob-local" as OpeningBalanceId,
-      userId: USER_ID,
-      accountId: ACCOUNT_ID,
       amount: 750000 as CopAmount,
       effectiveDate: "2026-04-02" as IsoDate,
-      createdAt: NOW,
       updatedAt: "2026-04-18T11:00:00.000Z" as IsoDateTime,
-      deletedAt: null,
     });
+    upsertBalance({ id: "ob-server" as OpeningBalanceId });
 
-    upsertOpeningBalance(db as any, {
-      id: "ob-server" as OpeningBalanceId,
-      userId: USER_ID,
-      accountId: ACCOUNT_ID,
-      amount: 500000 as CopAmount,
-      effectiveDate: "2026-04-01" as IsoDate,
-      createdAt: NOW,
-      updatedAt: NOW,
-      deletedAt: null,
-    });
-
-    expect(getOpeningBalanceForAccount(db as any, ACCOUNT_ID)).toMatchObject({
+    expectOpeningBalanceForAccount(ACCOUNT_ID, {
       id: "ob-local",
       amount: 750000,
       effectiveDate: "2026-04-02",
@@ -208,40 +157,21 @@ describe("opening balances repository", () => {
   });
 
   it("allows re-creating an opening balance after soft delete", () => {
-    saveOpeningBalance(db as any, {
+    saveBalance();
+    saveBalance({
       id: "ob-1" as OpeningBalanceId,
-      userId: USER_ID,
-      accountId: ACCOUNT_ID,
-      amount: 500000 as CopAmount,
-      effectiveDate: "2026-04-01" as IsoDate,
-      createdAt: NOW,
-      updatedAt: NOW,
-      deletedAt: null,
-    });
-
-    saveOpeningBalance(db as any, {
-      id: "ob-1" as OpeningBalanceId,
-      userId: USER_ID,
-      accountId: ACCOUNT_ID,
-      amount: 500000 as CopAmount,
-      effectiveDate: "2026-04-01" as IsoDate,
-      createdAt: NOW,
       updatedAt: "2026-04-18T11:00:00.000Z" as IsoDateTime,
       deletedAt: "2026-04-18T11:00:00.000Z" as IsoDateTime,
     });
-
-    saveOpeningBalance(db as any, {
+    saveBalance({
       id: "ob-2" as OpeningBalanceId,
-      userId: USER_ID,
-      accountId: ACCOUNT_ID,
       amount: 750000 as CopAmount,
       effectiveDate: "2026-04-02" as IsoDate,
       createdAt: "2026-04-18T12:00:00.000Z" as IsoDateTime,
       updatedAt: "2026-04-18T12:00:00.000Z" as IsoDateTime,
-      deletedAt: null,
     });
 
-    expect(getOpeningBalanceForAccount(db as any, ACCOUNT_ID)).toMatchObject({
+    expectOpeningBalanceForAccount(ACCOUNT_ID, {
       id: "ob-2",
       amount: 750000,
       effectiveDate: "2026-04-02",

--- a/apps/mobile/__tests__/financial-accounts/repository.test.ts
+++ b/apps/mobile/__tests__/financial-accounts/repository.test.ts
@@ -11,13 +11,14 @@ import {
   saveFinancialAccount,
 } from "@/features/financial-accounts";
 import { getQueuedSyncEntries } from "@/features/transactions/lib/repository";
-import type { FinancialAccountId, IsoDateTime, UserId } from "@/shared/types/branded";
+import type { FinancialAccountId, IsoDateTime } from "@/shared/types/branded";
+import { createFinancialAccountFixture, FIXTURE_NOW, FIXTURE_USER_ID } from "./fixtures";
 
 let sqlite: InstanceType<typeof Database>;
 let db: ReturnType<typeof drizzle>;
 
-const USER_ID = "user-1" as UserId;
-const NOW = "2026-04-18T10:00:00.000Z" as IsoDateTime;
+const USER_ID = FIXTURE_USER_ID;
+const NOW = FIXTURE_NOW;
 
 beforeEach(() => {
   sqlite = new Database(":memory:");
@@ -29,18 +30,25 @@ afterEach(() => {
   sqlite.close();
 });
 
+function saveAccount(overrides: Partial<ReturnType<typeof createFinancialAccountFixture>> = {}) {
+  saveFinancialAccount(db as any, createFinancialAccountFixture(overrides));
+}
+
+function expectFinancialAccountSyncEntries(...entries: readonly [string, string][]) {
+  expect(getQueuedSyncEntries(db as any)).toEqual(
+    entries.map(([rowId, operation]) =>
+      expect.objectContaining({
+        tableName: "financialAccounts",
+        rowId,
+        operation,
+      })
+    )
+  );
+}
+
 describe("financial accounts repository", () => {
   it("saves an account, reads it back, and enqueues sync", () => {
-    saveFinancialAccount(db as any, {
-      id: "fa-1" as FinancialAccountId,
-      userId: USER_ID,
-      name: "Main wallet",
-      kind: "wallet",
-      isDefault: true,
-      createdAt: NOW,
-      updatedAt: NOW,
-      deletedAt: null,
-    });
+    saveAccount();
 
     expect(getFinancialAccountsForUser(db as any, USER_ID)).toEqual([
       expect.objectContaining({
@@ -84,15 +92,10 @@ describe("financial accounts repository", () => {
   });
 
   it("reuses an existing default account instead of creating a new canonical one", () => {
-    saveFinancialAccount(db as any, {
+    saveAccount({
       id: "fa-bank-1" as FinancialAccountId,
-      userId: USER_ID,
       name: "Bancolombia",
       kind: "checking",
-      isDefault: true,
-      createdAt: NOW,
-      updatedAt: NOW,
-      deletedAt: null,
     });
 
     const defaultAccount = ensureDefaultFinancialAccount(db as any, USER_ID, {
@@ -110,15 +113,11 @@ describe("financial accounts repository", () => {
   });
 
   it("promotes an existing canonical account to the actual default when the flag is missing", () => {
-    saveFinancialAccount(db as any, {
+    saveAccount({
       id: "fa-default-user-1" as FinancialAccountId,
-      userId: USER_ID,
       name: "Cash",
       kind: "cash",
       isDefault: false,
-      createdAt: NOW,
-      updatedAt: NOW,
-      deletedAt: null,
     });
 
     const defaultAccount = ensureDefaultFinancialAccount(db as any, USER_ID, {
@@ -136,17 +135,9 @@ describe("financial accounts repository", () => {
       id: "fa-default-user-1",
       isDefault: true,
     });
-    expect(getQueuedSyncEntries(db as any)).toEqual([
-      expect.objectContaining({
-        tableName: "financialAccounts",
-        rowId: "fa-default-user-1",
-        operation: "insert",
-      }),
-      expect.objectContaining({
-        tableName: "financialAccounts",
-        rowId: "fa-default-user-1",
-        operation: "update",
-      }),
-    ]);
+    expectFinancialAccountSyncEntries(
+      ["fa-default-user-1", "insert"],
+      ["fa-default-user-1", "update"]
+    );
   });
 });

--- a/apps/mobile/__tests__/sync/fixtures.ts
+++ b/apps/mobile/__tests__/sync/fixtures.ts
@@ -1,10 +1,15 @@
 type Overrides = Record<string, unknown>;
-type ConflictOverrides = {
+type ConflictData = Record<string, unknown>;
+type ParsedConflictOverrides = {
   id?: string;
   transactionId?: string;
-  localData?: Record<string, unknown>;
-  serverData?: Record<string, unknown>;
+  localData?: ConflictData;
+  serverData?: ConflictData;
   detectedAt?: string;
+};
+type ConflictRowOverrides = Omit<ParsedConflictOverrides, "localData" | "serverData"> & {
+  localData?: ConflictData | string;
+  serverData?: ConflictData | string;
 };
 
 export const SYNC_USER_ID = "user-1";
@@ -222,7 +227,7 @@ const DEFAULT_SERVER_CONFLICT_DATA = createLocalTransaction({
   source: "email",
 });
 
-export const createParsedConflict = (overrides: ConflictOverrides = {}) => ({
+export const createParsedConflict = (overrides: ParsedConflictOverrides = {}) => ({
   id: "conflict-1",
   transactionId: "tx-1",
   localData: createLocalTransaction(),
@@ -231,13 +236,17 @@ export const createParsedConflict = (overrides: ConflictOverrides = {}) => ({
   ...overrides,
 });
 
-export const createConflictRow = (overrides: ConflictOverrides = {}) => {
-  const conflict = createParsedConflict(overrides);
+const serializeConflictData = (value: ConflictData | string) =>
+  typeof value === "string" ? value : JSON.stringify(value);
+
+export const createConflictRow = (overrides: ConflictRowOverrides = {}) => {
+  const { localData, serverData, ...rest } = overrides;
+  const conflict = createParsedConflict(rest);
   return {
     id: conflict.id,
     transactionId: conflict.transactionId,
-    localData: JSON.stringify(conflict.localData),
-    serverData: JSON.stringify(conflict.serverData),
+    localData: serializeConflictData(localData ?? conflict.localData),
+    serverData: serializeConflictData(serverData ?? conflict.serverData),
     detectedAt: conflict.detectedAt,
   };
 };

--- a/apps/mobile/__tests__/sync/fixtures.ts
+++ b/apps/mobile/__tests__/sync/fixtures.ts
@@ -1,0 +1,256 @@
+type Overrides = Record<string, unknown>;
+type ConflictOverrides = {
+  id?: string;
+  transactionId?: string;
+  localData?: Record<string, unknown>;
+  serverData?: Record<string, unknown>;
+  detectedAt?: string;
+};
+
+export const SYNC_USER_ID = "user-1";
+export const DEFAULT_SYNC_TIMESTAMP = "2026-03-04T10:00:00.000Z";
+export const DEFAULT_CONFLICT_DETECTED_AT = "2026-03-15T10:00:00.000Z";
+
+export const createSyncQueueEntry = (overrides: Overrides = {}) => ({
+  id: "sq-1",
+  tableName: "transactions",
+  rowId: "tx-1",
+  operation: "insert",
+  createdAt: DEFAULT_SYNC_TIMESTAMP,
+  ...overrides,
+});
+
+export const createLocalTransaction = (overrides: Overrides = {}) => ({
+  id: "tx-1",
+  userId: SYNC_USER_ID,
+  type: "expense",
+  amount: 1000,
+  categoryId: "food",
+  accountId: "fa-default-user-1",
+  accountAttributionState: "confirmed",
+  supersededAt: null,
+  description: "Local merchant",
+  date: "2026-03-10",
+  createdAt: "2026-03-10T08:00:00.000Z",
+  updatedAt: "2026-03-10T10:00:00.000Z",
+  deletedAt: null,
+  source: "manual",
+  ...overrides,
+});
+
+export const createServerTransactionRow = (overrides: Overrides = {}) => ({
+  id: "tx-1",
+  user_id: SYNC_USER_ID,
+  type: "expense",
+  amount: 2000,
+  category_id: "food",
+  account_id: "fa-default-user-1",
+  account_attribution_state: "confirmed",
+  superseded_at: null,
+  description: "Server merchant",
+  date: "2026-03-10",
+  created_at: "2026-03-10T08:00:00.000Z",
+  updated_at: "2026-03-10T14:00:00.000Z",
+  deleted_at: null,
+  ...overrides,
+});
+
+export const createLocalFinancialAccount = (overrides: Overrides = {}) => ({
+  id: "fa-1",
+  userId: SYNC_USER_ID,
+  name: "Main wallet",
+  kind: "wallet",
+  isDefault: true,
+  createdAt: DEFAULT_SYNC_TIMESTAMP,
+  updatedAt: DEFAULT_SYNC_TIMESTAMP,
+  deletedAt: null,
+  ...overrides,
+});
+
+export const createServerFinancialAccountRow = (overrides: Overrides = {}) => ({
+  id: "fa-1",
+  user_id: SYNC_USER_ID,
+  name: "Main wallet",
+  kind: "wallet",
+  is_default: true,
+  created_at: "2026-04-18T08:00:00.000Z",
+  updated_at: "2026-04-18T09:00:00.000Z",
+  deleted_at: null,
+  ...overrides,
+});
+
+export const createLocalAccountSuggestionDismissal = (overrides: Overrides = {}) => ({
+  id: "asd-1",
+  userId: SYNC_USER_ID,
+  scope: "notification:bancolombia:last4",
+  value: "1234",
+  dismissedScore: 200,
+  createdAt: "2026-04-19T10:00:00.000Z",
+  updatedAt: "2026-04-19T10:00:00.000Z",
+  deletedAt: null,
+  ...overrides,
+});
+
+export const createServerAccountSuggestionDismissalRow = (overrides: Overrides = {}) => ({
+  id: "asd-1",
+  user_id: SYNC_USER_ID,
+  scope: "notification:bancolombia:last4",
+  value: "1234",
+  dismissed_score: 200,
+  created_at: "2026-04-19T10:00:00.000Z",
+  updated_at: "2026-04-19T11:00:00.000Z",
+  deleted_at: null,
+  ...overrides,
+});
+
+export const createLocalTransfer = (overrides: Overrides = {}) => ({
+  id: "tr-1",
+  userId: SYNC_USER_ID,
+  amount: 250000,
+  fromAccountId: "fa-1",
+  toAccountId: "fa-2",
+  fromExternalLabel: null,
+  toExternalLabel: null,
+  description: "Move to savings",
+  date: "2026-04-18",
+  createdAt: "2026-04-18T10:00:00.000Z",
+  updatedAt: "2026-04-18T10:00:00.000Z",
+  deletedAt: null,
+  ...overrides,
+});
+
+export const createServerTransferRow = (overrides: Overrides = {}) => ({
+  id: "tr-1",
+  user_id: SYNC_USER_ID,
+  amount: 250000,
+  from_account_id: "fa-1",
+  to_account_id: "fa-2",
+  from_external_label: null,
+  to_external_label: null,
+  description: "Move to savings",
+  date: "2026-04-18",
+  created_at: "2026-04-18T09:30:00.000Z",
+  updated_at: "2026-04-18T10:00:00.000Z",
+  deleted_at: null,
+  ...overrides,
+});
+
+export const createLocalOpeningBalance = (overrides: Overrides = {}) => ({
+  id: "ob-1",
+  userId: SYNC_USER_ID,
+  accountId: "fa-1",
+  amount: 500000,
+  effectiveDate: "2026-04-01",
+  createdAt: "2026-04-18T10:00:00.000Z",
+  updatedAt: "2026-04-18T10:00:00.000Z",
+  deletedAt: null,
+  ...overrides,
+});
+
+export const createServerOpeningBalanceRow = (overrides: Overrides = {}) => ({
+  id: "ob-1",
+  user_id: SYNC_USER_ID,
+  account_id: "fa-1",
+  amount: 500000,
+  effective_date: "2026-04-01",
+  created_at: "2026-04-18T10:30:00.000Z",
+  updated_at: "2026-04-18T11:00:00.000Z",
+  deleted_at: null,
+  ...overrides,
+});
+
+export const createLocalFinancialAccountIdentifier = (overrides: Overrides = {}) => ({
+  id: "fai-1",
+  userId: SYNC_USER_ID,
+  accountId: "fa-1",
+  scope: "email:bancolombia:last4",
+  value: "1234",
+  createdAt: "2026-04-18T10:00:00.000Z",
+  updatedAt: "2026-04-18T10:00:00.000Z",
+  deletedAt: null,
+  ...overrides,
+});
+
+export const createServerFinancialAccountIdentifierRow = (overrides: Overrides = {}) => ({
+  id: "fai-1",
+  user_id: SYNC_USER_ID,
+  account_id: "fa-1",
+  scope: "email:bancolombia:last4",
+  value: "1234",
+  created_at: "2026-04-18T11:30:00.000Z",
+  updated_at: "2026-04-18T12:00:00.000Z",
+  deleted_at: null,
+  ...overrides,
+});
+
+export const createLocalCaptureEvidence = (overrides: Overrides = {}) => ({
+  id: "ce-1",
+  userId: SYNC_USER_ID,
+  sourceFamily: "bancolombia",
+  evidenceType: "last4",
+  scope: "notification:bancolombia:last4",
+  value: "1234",
+  transactionId: "tx-1",
+  processedEmailId: null,
+  processedCaptureId: "pc-1",
+  createdAt: "2026-04-19T10:00:00.000Z",
+  updatedAt: "2026-04-19T10:00:00.000Z",
+  deletedAt: null,
+  ...overrides,
+});
+
+export const createServerCaptureEvidenceRow = (overrides: Overrides = {}) => ({
+  id: "ce-1",
+  user_id: SYNC_USER_ID,
+  source_family: "bancolombia",
+  evidence_type: "last4",
+  scope: "notification:bancolombia:last4",
+  value: "1234",
+  transaction_id: "tx-1",
+  processed_email_id: null,
+  processed_capture_id: "pc-1",
+  created_at: "2026-04-18T07:30:00.000Z",
+  updated_at: "2026-04-18T08:00:00.000Z",
+  deleted_at: null,
+  ...overrides,
+});
+
+const DEFAULT_SERVER_CONFLICT_DATA = createLocalTransaction({
+  amount: 2000,
+  description: "Server merchant",
+  updatedAt: "2026-03-10T14:00:00.000Z",
+  source: "email",
+});
+
+export const createParsedConflict = (overrides: ConflictOverrides = {}) => ({
+  id: "conflict-1",
+  transactionId: "tx-1",
+  localData: createLocalTransaction(),
+  serverData: DEFAULT_SERVER_CONFLICT_DATA,
+  detectedAt: DEFAULT_CONFLICT_DETECTED_AT,
+  ...overrides,
+});
+
+export const createConflictRow = (overrides: ConflictOverrides = {}) => {
+  const conflict = createParsedConflict(overrides);
+  return {
+    id: conflict.id,
+    transactionId: conflict.transactionId,
+    localData: JSON.stringify(conflict.localData),
+    serverData: JSON.stringify(conflict.serverData),
+    detectedAt: conflict.detectedAt,
+  };
+};
+
+export const createSequentialServerTransactions = (count: number) =>
+  Array.from({ length: count }, (_, index) =>
+    createServerTransactionRow({
+      id: `tx-${index + 1}`,
+      amount: 1000,
+      description: null,
+      created_at: `2026-04-18T${String(index).padStart(4, "0")}:00:00.000Z`,
+      updated_at: `2026-04-18T${String(index).padStart(4, "0")}:00:00.000Z`,
+    })
+  );
+
+export const createCursor = (updatedAt: string, id: string) => ({ updatedAt, id });

--- a/apps/mobile/__tests__/sync/sync-conflict-state.test.ts
+++ b/apps/mobile/__tests__/sync/sync-conflict-state.test.ts
@@ -1,11 +1,11 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: sync conflict state tests use flexible mock db
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
 import {
   loadSyncConflicts,
   resolveSyncConflictSelection,
   useSyncConflictStore,
 } from "@/features/sync/store";
+import { createParsedConflict } from "./fixtures";
 
 const mockListConflicts = vi.fn();
 const mockResolveConflict = vi.fn();
@@ -22,39 +22,7 @@ describe("sync conflict state", () => {
   });
 
   it("loads conflicts into the store from the sync boundary", async () => {
-    mockListConflicts.mockResolvedValueOnce([
-      {
-        id: "conflict-1",
-        transactionId: "tx-1",
-        localData: {
-          id: "tx-1",
-          userId: "user-1",
-          type: "expense",
-          amount: 1000,
-          categoryId: "food",
-          description: "Local merchant",
-          date: "2026-03-10",
-          createdAt: "2026-03-10T08:00:00.000Z",
-          updatedAt: "2026-03-10T10:00:00.000Z",
-          deletedAt: null,
-          source: "manual",
-        },
-        serverData: {
-          id: "tx-1",
-          userId: "user-1",
-          type: "expense",
-          amount: 2000,
-          categoryId: "food",
-          description: "Server merchant",
-          date: "2026-03-10",
-          createdAt: "2026-03-10T08:00:00.000Z",
-          updatedAt: "2026-03-10T14:00:00.000Z",
-          deletedAt: null,
-          source: "email",
-        },
-        detectedAt: "2026-03-15T10:00:00.000Z",
-      },
-    ]);
+    mockListConflicts.mockResolvedValueOnce([createParsedConflict()]);
 
     await loadSyncConflicts({} as any);
 

--- a/apps/mobile/__tests__/sync/sync-module.test.ts
+++ b/apps/mobile/__tests__/sync/sync-module.test.ts
@@ -1,6 +1,8 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: sync boundary test uses flexible mock ports
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { createConflictRow } from "./fixtures";
+
 const mockGetSupabase = vi.fn();
 const mockIsOnline = vi.fn();
 const mockSyncPull = vi.fn();
@@ -87,39 +89,7 @@ describe("sync module", () => {
   });
 
   it("lists unresolved conflicts through the boundary", async () => {
-    mockGetUnresolvedConflicts.mockReturnValueOnce([
-      {
-        id: "conflict-1",
-        transactionId: "tx-1",
-        localData: JSON.stringify({
-          id: "tx-1",
-          userId: "user-1",
-          type: "expense",
-          amount: 1000,
-          categoryId: "food",
-          description: "Local merchant",
-          date: "2026-03-10",
-          createdAt: "2026-03-10T08:00:00.000Z",
-          updatedAt: "2026-03-10T10:00:00.000Z",
-          deletedAt: null,
-          source: "manual",
-        }),
-        serverData: JSON.stringify({
-          id: "tx-1",
-          userId: "user-1",
-          type: "expense",
-          amount: 2000,
-          categoryId: "food",
-          description: "Server merchant",
-          date: "2026-03-10",
-          createdAt: "2026-03-10T08:00:00.000Z",
-          updatedAt: "2026-03-10T14:00:00.000Z",
-          deletedAt: null,
-          source: "email",
-        }),
-        detectedAt: "2026-03-15T10:00:00.000Z",
-      },
-    ]);
+    mockGetUnresolvedConflicts.mockReturnValueOnce([createConflictRow()]);
 
     const { listConflicts } = await import("@/features/sync/services/sync");
     const conflicts = await listConflicts({ db: {} as any });

--- a/apps/mobile/__tests__/sync/sync-pull-integration.test.ts
+++ b/apps/mobile/__tests__/sync/sync-pull-integration.test.ts
@@ -114,6 +114,32 @@ function mockSupabase(rows: Record<string, unknown>[]) {
   return chain as any;
 }
 
+function expectStoredAmount(transactionId: TransactionId, amount: number) {
+  const tx = getTransactionById(db as any, transactionId);
+  expect(tx).not.toBeNull();
+  expect(tx?.amount).toBe(amount);
+}
+
+function readLoggedConflict() {
+  const conflicts = getUnresolvedConflicts(db as any);
+  expect(conflicts).toHaveLength(1);
+  const [conflict] = conflicts;
+  expect(conflict).toBeDefined();
+
+  return {
+    conflict,
+    localData: JSON.parse(conflict?.localData ?? "{}"),
+    serverData: JSON.parse(conflict?.serverData ?? "{}"),
+  };
+}
+
+function expectLoggedConflict(transactionId: string, localAmount: number, serverAmount: number) {
+  const { conflict, localData, serverData } = readLoggedConflict();
+  expect(conflict?.transactionId).toBe(transactionId);
+  expect(localData.amount).toBe(localAmount);
+  expect(serverData.amount).toBe(serverAmount);
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -128,21 +154,8 @@ describe("syncPull integration (real SQLite)", () => {
 
     const ok = await syncPull(db as any, supabase, USER_ID);
     expect(ok).toBe(true);
-
-    // Local row should now have the server's amount
-    const tx = getTransactionById(db as any, "tx-1" as TransactionId);
-    expect(tx).not.toBeNull();
-    expect(tx?.amount).toBe(2000);
-
-    // A conflict should be logged
-    const conflicts = getUnresolvedConflicts(db as any);
-    expect(conflicts).toHaveLength(1);
-    expect(conflicts[0]?.transactionId).toBe("tx-1");
-
-    const localData = JSON.parse(conflicts[0]?.localData ?? "{}");
-    const serverData = JSON.parse(conflicts[0]?.serverData ?? "{}");
-    expect(localData.amount).toBe(1000);
-    expect(serverData.amount).toBe(2000);
+    expectStoredAmount("tx-1" as TransactionId, 2000);
+    expectLoggedConflict("tx-1", 1000, 2000);
   });
 
   it("local newer → preserved, no conflict", async () => {

--- a/apps/mobile/__tests__/sync/sync-service.test.ts
+++ b/apps/mobile/__tests__/sync/sync-service.test.ts
@@ -1,64 +1,39 @@
 import { describe, expect, it, vi } from "vitest";
-
 import { createSyncService } from "@/features/sync/services/create-sync-service";
 import { requireIsoDateTime } from "@/shared/types/assertions";
+import { createConflictRow } from "./fixtures";
+
+const TEST_DB = {} as never;
+const TEST_USER_ID = "user-1";
+
+const createSyncPorts = (overrides: Record<string, unknown> = {}) => ({
+  network: { isOnline: vi.fn().mockResolvedValue(true) },
+  supabase: { getSupabase: vi.fn() },
+  syncPull: vi.fn(),
+  syncPush: vi.fn(),
+  refreshTransactions: vi.fn(),
+  getConflictRows: vi.fn().mockResolvedValue([]),
+  upsertTransaction: vi.fn(),
+  enqueueTransactionSync: vi.fn(),
+  resolveConflictRow: vi.fn(),
+  ...overrides,
+});
+
+const createService = (overrides: Record<string, unknown> = {}) => {
+  const ports = createSyncPorts(overrides);
+  return { service: createSyncService(ports), ports };
+};
 
 describe("createSyncService", () => {
   it("returns skipped_offline and does not touch remote sync when offline", async () => {
-    const isOnline = vi.fn().mockResolvedValue(false);
-    const getSupabase = vi.fn();
-    const syncPull = vi.fn();
-    const syncPush = vi.fn();
-    const refreshTransactions = vi.fn();
-    const getConflictRows = vi.fn().mockResolvedValue([
-      {
-        id: "conflict-1",
-        transactionId: "tx-1",
-        localData: JSON.stringify({
-          id: "tx-1",
-          userId: "user-1",
-          type: "expense",
-          amount: 1000,
-          categoryId: "food",
-          description: "Local merchant",
-          date: "2026-03-10",
-          createdAt: "2026-03-10T08:00:00.000Z",
-          updatedAt: "2026-03-10T10:00:00.000Z",
-          deletedAt: null,
-          source: "manual",
-        }),
-        serverData: JSON.stringify({
-          id: "tx-1",
-          userId: "user-1",
-          type: "expense",
-          amount: 2000,
-          categoryId: "food",
-          description: "Server merchant",
-          date: "2026-03-10",
-          createdAt: "2026-03-10T08:00:00.000Z",
-          updatedAt: "2026-03-10T14:00:00.000Z",
-          deletedAt: null,
-          source: "email",
-        }),
-        detectedAt: "2026-03-15T10:00:00.000Z",
-      },
-    ]);
-
-    const service = createSyncService({
-      syncPull,
-      syncPush,
-      refreshTransactions,
-      getConflictRows,
-      upsertTransaction: vi.fn(),
-      enqueueTransactionSync: vi.fn(),
-      resolveConflictRow: vi.fn(),
-      network: { isOnline },
-      supabase: { getSupabase },
+    const { service, ports } = createService({
+      network: { isOnline: vi.fn().mockResolvedValue(false) },
+      getConflictRows: vi.fn().mockResolvedValue([createConflictRow()]),
     });
 
     const result = await service.run({
-      db: {} as never,
-      userId: "user-1",
+      db: TEST_DB,
+      userId: TEST_USER_ID,
       reason: "foreground",
     });
 
@@ -66,58 +41,18 @@ describe("createSyncService", () => {
       status: "skipped_offline",
       unresolvedConflicts: 1,
     });
-    expect(getSupabase).not.toHaveBeenCalled();
-    expect(syncPull).not.toHaveBeenCalled();
-    expect(syncPush).not.toHaveBeenCalled();
-    expect(refreshTransactions).not.toHaveBeenCalled();
+    expect(ports.supabase.getSupabase).not.toHaveBeenCalled();
+    expect(ports.syncPull).not.toHaveBeenCalled();
+    expect(ports.syncPush).not.toHaveBeenCalled();
+    expect(ports.refreshTransactions).not.toHaveBeenCalled();
   });
 
   it("maps unresolved conflict rows into sync conflict records", async () => {
-    const service = createSyncService({
-      network: { isOnline: vi.fn().mockResolvedValue(true) },
-      supabase: { getSupabase: vi.fn() },
-      syncPull: vi.fn(),
-      syncPush: vi.fn(),
-      refreshTransactions: vi.fn(),
-      getConflictRows: vi.fn().mockResolvedValue([
-        {
-          id: "conflict-1",
-          transactionId: "tx-1",
-          localData: JSON.stringify({
-            id: "tx-1",
-            userId: "user-1",
-            type: "expense",
-            amount: 1000,
-            categoryId: "food",
-            description: "Local merchant",
-            date: "2026-03-10",
-            createdAt: "2026-03-10T08:00:00.000Z",
-            updatedAt: "2026-03-10T10:00:00.000Z",
-            deletedAt: null,
-            source: "manual",
-          }),
-          serverData: JSON.stringify({
-            id: "tx-1",
-            userId: "user-1",
-            type: "expense",
-            amount: 2000,
-            categoryId: "food",
-            description: "Server merchant",
-            date: "2026-03-10",
-            createdAt: "2026-03-10T08:00:00.000Z",
-            updatedAt: "2026-03-10T14:00:00.000Z",
-            deletedAt: null,
-            source: "email",
-          }),
-          detectedAt: "2026-03-15T10:00:00.000Z",
-        },
-      ]),
-      upsertTransaction: vi.fn(),
-      enqueueTransactionSync: vi.fn(),
-      resolveConflictRow: vi.fn(),
+    const { service } = createService({
+      getConflictRows: vi.fn().mockResolvedValue([createConflictRow()]),
     });
 
-    const conflicts = await service.listConflicts({ db: {} as never });
+    const conflicts = await service.listConflicts({ db: TEST_DB });
 
     expect(conflicts).toHaveLength(1);
     expect(conflicts[0]).toEqual({
@@ -131,57 +66,15 @@ describe("createSyncService", () => {
 
   it("re-enqueues the local transaction when resolving a conflict in favor of local data", async () => {
     const resolvedAt = requireIsoDateTime("2026-04-18T12:34:56.000Z");
-    const upsertTransaction = vi.fn();
-    const enqueueTransactionSync = vi.fn();
-    const resolveConflictRow = vi.fn();
-    const refreshTransactions = vi.fn();
-    const getConflictRows = vi
-      .fn()
-      .mockResolvedValueOnce([
-        {
-          id: "conflict-1",
-          transactionId: "tx-1",
-          localData: JSON.stringify({
-            id: "tx-1",
-            userId: "user-1",
-            type: "expense",
-            amount: 1000,
-            categoryId: "food",
-            description: "Local merchant",
-            date: "2026-03-10",
-            createdAt: "2026-03-10T08:00:00.000Z",
-            updatedAt: "2026-03-10T10:00:00.000Z",
-            deletedAt: null,
-            source: "manual",
-          }),
-          serverData: JSON.stringify({
-            id: "tx-1",
-            userId: "user-1",
-            type: "expense",
-            amount: 2000,
-            categoryId: "food",
-            description: "Server merchant",
-            date: "2026-03-10",
-            createdAt: "2026-03-10T08:00:00.000Z",
-            updatedAt: "2026-03-10T14:00:00.000Z",
-            deletedAt: null,
-            source: "email",
-          }),
-          detectedAt: "2026-03-15T10:00:00.000Z",
-        },
-      ])
-      .mockResolvedValueOnce([]);
-
-    const service = createSyncService({
-      network: { isOnline: vi.fn().mockResolvedValue(true) },
-      supabase: { getSupabase: vi.fn() },
-      syncPull: vi.fn(),
-      syncPush: vi.fn(),
-      refreshTransactions,
-      getConflictRows,
-      upsertTransaction,
-      enqueueTransactionSync,
-      resolveConflictRow,
+    const { service, ports } = createService({
+      refreshTransactions: vi.fn(),
+      getConflictRows: vi
+        .fn()
+        .mockResolvedValueOnce([createConflictRow()])
+        .mockResolvedValueOnce([]),
+      upsertTransaction: vi.fn(),
+      enqueueTransactionSync: vi.fn(),
+      resolveConflictRow: vi.fn(),
       clock: {
         now: () => new Date(resolvedAt),
         nowIsoDateTime: () => resolvedAt,
@@ -189,13 +82,13 @@ describe("createSyncService", () => {
     });
 
     const result = await service.resolveConflict({
-      db: {} as never,
+      db: TEST_DB,
       conflictId: "conflict-1" as never,
       resolution: "local",
     });
 
-    expect(upsertTransaction).toHaveBeenCalledWith(
-      {} as never,
+    expect(ports.upsertTransaction).toHaveBeenCalledWith(
+      TEST_DB,
       expect.objectContaining({
         id: "tx-1",
         amount: 1000,
@@ -203,69 +96,44 @@ describe("createSyncService", () => {
         updatedAt: resolvedAt,
       })
     );
-    expect(enqueueTransactionSync).toHaveBeenCalledWith({} as never, "tx-1", resolvedAt);
-    expect(resolveConflictRow).toHaveBeenCalledWith({} as never, "conflict-1", "local", resolvedAt);
-    expect(refreshTransactions).toHaveBeenCalledTimes(1);
+    expect(ports.enqueueTransactionSync).toHaveBeenCalledWith(TEST_DB, "tx-1", resolvedAt);
+    expect(ports.resolveConflictRow).toHaveBeenCalledWith(
+      TEST_DB,
+      "conflict-1",
+      "local",
+      resolvedAt
+    );
+    expect(ports.refreshTransactions).toHaveBeenCalledTimes(1);
     expect(result).toEqual({ unresolvedConflicts: 0 });
   });
 
   it("still resolves server conflicts when localData is malformed", async () => {
-    const upsertTransaction = vi.fn();
-    const enqueueTransactionSync = vi.fn();
-    const resolveConflictRow = vi.fn();
-    const refreshTransactions = vi.fn();
-    const getConflictRows = vi
-      .fn()
-      .mockResolvedValueOnce([
-        {
-          id: "conflict-1",
-          transactionId: "tx-1",
-          localData: "{not-json",
-          serverData: JSON.stringify({
-            id: "tx-1",
-            userId: "user-1",
-            type: "expense",
-            amount: 2000,
-            categoryId: "food",
-            description: "Server merchant",
-            date: "2026-03-10",
-            createdAt: "2026-03-10T08:00:00.000Z",
-            updatedAt: "2026-03-10T14:00:00.000Z",
-            deletedAt: null,
-            source: "email",
-          }),
-          detectedAt: "2026-03-15T10:00:00.000Z",
-        },
-      ])
-      .mockResolvedValueOnce([]);
-
-    const service = createSyncService({
-      network: { isOnline: vi.fn().mockResolvedValue(true) },
-      supabase: { getSupabase: vi.fn() },
-      syncPull: vi.fn(),
-      syncPush: vi.fn(),
-      refreshTransactions,
-      getConflictRows,
-      upsertTransaction,
-      enqueueTransactionSync,
-      resolveConflictRow,
+    const { service, ports } = createService({
+      refreshTransactions: vi.fn(),
+      getConflictRows: vi
+        .fn()
+        .mockResolvedValueOnce([createConflictRow({ localData: "{not-json" as never })])
+        .mockResolvedValueOnce([]),
+      upsertTransaction: vi.fn(),
+      enqueueTransactionSync: vi.fn(),
+      resolveConflictRow: vi.fn(),
     });
 
     const result = await service.resolveConflict({
-      db: {} as never,
+      db: TEST_DB,
       conflictId: "conflict-1" as never,
       resolution: "server",
     });
 
-    expect(upsertTransaction).not.toHaveBeenCalled();
-    expect(enqueueTransactionSync).not.toHaveBeenCalled();
-    expect(resolveConflictRow).toHaveBeenCalledWith(
-      {} as never,
+    expect(ports.upsertTransaction).not.toHaveBeenCalled();
+    expect(ports.enqueueTransactionSync).not.toHaveBeenCalled();
+    expect(ports.resolveConflictRow).toHaveBeenCalledWith(
+      TEST_DB,
       "conflict-1",
       "server",
       expect.any(String)
     );
-    expect(refreshTransactions).toHaveBeenCalledWith({ db: {} as never, userId: "user-1" });
+    expect(ports.refreshTransactions).toHaveBeenCalledWith({ db: TEST_DB, userId: TEST_USER_ID });
     expect(result).toEqual({ unresolvedConflicts: 0 });
   });
 });

--- a/apps/mobile/__tests__/sync/syncEngine.test.ts
+++ b/apps/mobile/__tests__/sync/syncEngine.test.ts
@@ -2,6 +2,27 @@
 // biome-ignore-all lint/style/useNamingConvention: snake_case matches Supabase API column names
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  createCursor,
+  createLocalAccountSuggestionDismissal,
+  createLocalCaptureEvidence,
+  createLocalFinancialAccount,
+  createLocalFinancialAccountIdentifier,
+  createLocalOpeningBalance,
+  createLocalTransaction,
+  createLocalTransfer,
+  createSequentialServerTransactions,
+  createServerAccountSuggestionDismissalRow,
+  createServerCaptureEvidenceRow,
+  createServerFinancialAccountIdentifierRow,
+  createServerFinancialAccountRow,
+  createServerOpeningBalanceRow,
+  createServerTransactionRow,
+  createServerTransferRow,
+  createSyncQueueEntry,
+  SYNC_USER_ID,
+} from "./fixtures";
+
 const mockGetQueuedSyncEntries = vi.fn().mockReturnValue([]);
 const mockClearSyncEntries = vi.fn();
 const mockGetAccountSuggestionDismissalById = vi.fn().mockReturnValue(null);
@@ -134,6 +155,267 @@ function getLastSetSyncMetaValue(key: string) {
   return typeof lastCall?.[2] === "string" ? lastCall[2] : null;
 }
 
+function createTransactionPullSupabase(overrides: Record<string, unknown> = {}) {
+  return createMockSupabase({
+    data: [createServerTransactionRow(overrides)],
+    error: null,
+  });
+}
+
+function createFinancialTablesSupabase() {
+  return createMockSupabase({
+    transactions: { data: [], error: null },
+    capture_evidence: { data: [createServerCaptureEvidenceRow()], error: null },
+    financial_accounts: { data: [createServerFinancialAccountRow()], error: null },
+    transfers: { data: [createServerTransferRow()], error: null },
+    opening_balances: { data: [createServerOpeningBalanceRow()], error: null },
+    financial_account_identifiers: {
+      data: [createServerFinancialAccountIdentifierRow()],
+      error: null,
+    },
+  });
+}
+
+function createDismissalPullSupabase() {
+  return createMockSupabase({
+    account_suggestion_dismissals: {
+      data: [createServerAccountSuggestionDismissalRow()],
+      error: null,
+    },
+    capture_evidence: { data: [], error: null },
+    financial_accounts: { data: [], error: null },
+    transfers: { data: [], error: null },
+    opening_balances: { data: [], error: null },
+    financial_account_identifiers: { data: [], error: null },
+    transactions: { data: [], error: null },
+  });
+}
+
+function createSecondaryFailureSupabase() {
+  return createMockSupabase({
+    transactions: {
+      data: [
+        createServerTransactionRow({
+          id: "tx-remote-1",
+          type: "income",
+          amount: 5000,
+          category_id: "salary",
+          description: "Pay",
+          date: "2026-03-04",
+          created_at: "2026-03-04T10:00:00.000Z",
+          updated_at: "2026-03-04T12:00:00.000Z",
+        }),
+      ],
+      error: null,
+    },
+    financial_accounts: {
+      data: null,
+      error: { message: "accounts unavailable", code: "500" },
+    },
+    transfers: { data: [], error: null },
+    opening_balances: { data: [], error: null },
+    financial_account_identifiers: { data: [], error: null },
+  });
+}
+
+function createSameTimestampTransactionSupabase() {
+  return createMockSupabase({
+    transactions: {
+      data: [
+        createServerTransactionRow({
+          id: "tx-1001",
+          amount: 1000,
+          description: null,
+          created_at: "2026-04-18T12:00:00.000Z",
+          updated_at: "2026-04-18T12:00:00.000Z",
+        }),
+        createServerTransactionRow({
+          id: "tx-1002",
+          amount: 1000,
+          description: null,
+          created_at: "2026-04-18T12:00:00.000Z",
+          updated_at: "2026-04-18T12:00:00.000Z",
+        }),
+      ],
+      error: null,
+    },
+  });
+}
+
+function createCompositeSyncMeta(updatedAt: string, id: string) {
+  const syncMeta = new Map<string, string>([
+    ["last_sync_at_transactions", JSON.stringify(createCursor(updatedAt, id))],
+  ]);
+  mockGetSyncMeta.mockImplementation((_, key: string) => syncMeta.get(key) ?? null);
+  mockSetSyncMeta.mockImplementation((_, key: string, value: string) => {
+    syncMeta.set(key, value);
+  });
+  return syncMeta;
+}
+
+async function runSyncPush(mockSupabase: any, userId = SYNC_USER_ID) {
+  const { syncPush } = await import("@/features/sync/services/syncEngine");
+  await syncPush(mockDb, mockSupabase, userId);
+}
+
+async function runSyncPull(mockSupabase: any, userId = SYNC_USER_ID) {
+  const { syncPull } = await import("@/features/sync/services/syncEngine");
+  return syncPull(mockDb, mockSupabase, userId);
+}
+
+function expectQueueCleared(...entryIds: string[]) {
+  expect(mockClearSyncEntries).toHaveBeenCalledWith(mockDb, entryIds);
+}
+
+function expectCursorToEqual(key: string, cursor: Record<string, string>) {
+  expect(JSON.parse(getLastSetSyncMetaValue(key)!)).toEqual(cursor);
+}
+
+function expectUpsertedTransaction(matcher: Record<string, unknown>) {
+  expect(mockUpsertTransaction).toHaveBeenCalledWith(mockDb, expect.objectContaining(matcher));
+}
+
+function expectLastSyncAt(value: string) {
+  expect(mockSetSyncMeta).toHaveBeenCalledWith(mockDb, "last_sync_at", value);
+}
+
+function expectConflictLogged(transactionId: string) {
+  expect(mockInsertConflict).toHaveBeenCalledWith(
+    mockDb,
+    expect.objectContaining({ transactionId })
+  );
+}
+
+function expectCaptureEvidencePulled() {
+  expect(mockUpsertCaptureEvidence).toHaveBeenCalledWith(
+    mockDb,
+    expect.objectContaining({
+      id: "ce-1",
+      scope: "notification:bancolombia:last4",
+      value: "1234",
+      processedCaptureId: "pc-1",
+    })
+  );
+}
+
+function expectFinancialAccountPulled() {
+  expect(mockUpsertFinancialAccount).toHaveBeenCalledWith(
+    mockDb,
+    expect.objectContaining({
+      id: "fa-1",
+      userId: "user-1",
+      isDefault: true,
+    })
+  );
+}
+
+function expectTransferPulled() {
+  expect(mockUpsertTransfer).toHaveBeenCalledWith(
+    mockDb,
+    expect.objectContaining({
+      id: "tr-1",
+      fromAccountId: "fa-1",
+      toAccountId: "fa-2",
+    })
+  );
+}
+
+function createBusyTableCursorSupabase() {
+  return createMockSupabase({
+    transactions: { data: createSequentialServerTransactions(1000), error: null },
+    financial_accounts: {
+      data: [
+        createServerFinancialAccountRow({
+          created_at: "2026-04-19T00:00:00.000Z",
+          updated_at: "2026-04-19T00:00:00.000Z",
+        }),
+      ],
+      error: null,
+    },
+  });
+}
+
+function expectBusyTableCursorIsolation() {
+  expectCursorToEqual(
+    "last_sync_at_transactions",
+    createCursor("2026-04-18T0999:00:00.000Z", "tx-1000")
+  );
+  expect(mockSetSyncMeta).toHaveBeenCalledWith(
+    mockDb,
+    "last_sync_at",
+    "2026-04-18T0999:00:00.000Z"
+  );
+  expectCursorToEqual(
+    "last_sync_at_financial_accounts",
+    createCursor("2026-04-19T00:00:00.000Z", "fa-1")
+  );
+  expect(getLastSetSyncMetaValue("last_sync_at_transactions")).not.toContain(
+    "2026-04-19T00:00:00.000Z"
+  );
+}
+
+function expectOpeningBalancePulled() {
+  expect(mockUpsertOpeningBalance).toHaveBeenCalledWith(
+    mockDb,
+    expect.objectContaining({
+      id: "ob-1",
+      accountId: "fa-1",
+      amount: 500000,
+    })
+  );
+}
+
+function expectFinancialAccountIdentifierPulled() {
+  expect(mockUpsertFinancialAccountIdentifier).toHaveBeenCalledWith(
+    mockDb,
+    expect.objectContaining({
+      id: "fai-1",
+      accountId: "fa-1",
+      value: "1234",
+    })
+  );
+}
+
+function expectFinancialTableCursors() {
+  expectCursorToEqual(
+    "last_sync_at_financial_account_identifiers",
+    createCursor("2026-04-18T12:00:00.000Z", "fai-1")
+  );
+  expectCursorToEqual(
+    "last_sync_at_capture_evidence",
+    createCursor("2026-04-18T08:00:00.000Z", "ce-1")
+  );
+}
+
+function expectDismissalPulled() {
+  expect(mockUpsertAccountSuggestionDismissal).toHaveBeenCalledWith(
+    mockDb,
+    expect.objectContaining({
+      id: "asd-1",
+      userId: "user-1",
+      scope: "notification:bancolombia:last4",
+      value: "1234",
+      dismissedScore: 200,
+    })
+  );
+  expectCursorToEqual(
+    "last_sync_at_account_suggestion_dismissals",
+    createCursor("2026-04-19T11:00:00.000Z", "asd-1")
+  );
+}
+
+function expectCompositeTransactionsQuery(mockSupabase: any) {
+  expect(mockSupabase._getChain("transactions").or).toHaveBeenCalledWith(
+    "updated_at.gt.2026-04-18T12:00:00.000Z,and(updated_at.eq.2026-04-18T12:00:00.000Z,id.gt.tx-1000)"
+  );
+  expect(mockSupabase._getChain("transactions").order).toHaveBeenNthCalledWith(1, "updated_at", {
+    ascending: true,
+  });
+  expect(mockSupabase._getChain("transactions").order).toHaveBeenNthCalledWith(2, "id", {
+    ascending: true,
+  });
+}
+
 describe("syncEngine", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -152,35 +434,20 @@ describe("syncEngine", () => {
     });
 
     it("upserts transaction row to supabase and clears queue on success", async () => {
-      mockGetQueuedSyncEntries.mockReturnValueOnce([
-        {
-          id: "sq-1",
-          tableName: "transactions",
-          rowId: "tx-1",
-          operation: "insert",
+      mockGetQueuedSyncEntries.mockReturnValueOnce([createSyncQueueEntry()]);
+      mockGetTransactionById.mockReturnValueOnce(
+        createLocalTransaction({
+          amount: 1500,
+          description: "Lunch",
+          date: "2026-03-04",
           createdAt: "2026-03-04T10:00:00.000Z",
-        },
-      ]);
-      mockGetTransactionById.mockReturnValueOnce({
-        id: "tx-1",
-        userId: "user-1",
-        type: "expense",
-        amount: 1500,
-        categoryId: "food",
-        accountId: "fa-default-user-1",
-        accountAttributionState: "confirmed",
-        supersededAt: null,
-        description: "Lunch",
-        date: "2026-03-04",
-        createdAt: "2026-03-04T10:00:00.000Z",
-        updatedAt: "2026-03-04T10:00:00.000Z",
-        deletedAt: null,
-      });
+          updatedAt: "2026-03-04T10:00:00.000Z",
+        })
+      );
       mockUpsert.mockReturnValueOnce({ error: null });
       const mockSupabase = createMockSupabase();
 
-      const { syncPush } = await import("@/features/sync/services/syncEngine");
-      await syncPush(mockDb, mockSupabase, "user-1");
+      await runSyncPush(mockSupabase);
 
       expect(mockSupabase.from).toHaveBeenCalledWith("transactions");
       expect(mockUpsert).toHaveBeenCalledWith(
@@ -193,7 +460,7 @@ describe("syncEngine", () => {
           superseded_at: null,
         })
       );
-      expect(mockClearSyncEntries).toHaveBeenCalledWith(mockDb, ["sq-1"]);
+      expectQueueCleared("sq-1");
     });
 
     it("keeps entry in queue when supabase returns error", async () => {
@@ -229,29 +496,17 @@ describe("syncEngine", () => {
 
     it("upserts financial account rows and clears the queue entry on success", async () => {
       mockGetQueuedSyncEntries.mockReturnValueOnce([
-        {
+        createSyncQueueEntry({
           id: "sq-accounts-1",
           tableName: "financialAccounts",
           rowId: "fa-1",
-          operation: "insert",
-          createdAt: "2026-03-04T10:00:00.000Z",
-        },
+        }),
       ]);
-      mockGetFinancialAccountById.mockReturnValueOnce({
-        id: "fa-1",
-        userId: "user-1",
-        name: "Main wallet",
-        kind: "wallet",
-        isDefault: true,
-        createdAt: "2026-03-04T10:00:00.000Z",
-        updatedAt: "2026-03-04T10:00:00.000Z",
-        deletedAt: null,
-      });
+      mockGetFinancialAccountById.mockReturnValueOnce(createLocalFinancialAccount());
       mockUpsert.mockReturnValueOnce({ error: null });
       const mockSupabase = createMockSupabase();
 
-      const { syncPush } = await import("@/features/sync/services/syncEngine");
-      await syncPush(mockDb, mockSupabase, "user-1");
+      await runSyncPush(mockSupabase);
 
       expect(mockSupabase.from).toHaveBeenCalledWith("financial_accounts");
       expect(mockUpsert).toHaveBeenCalledWith(
@@ -263,34 +518,25 @@ describe("syncEngine", () => {
           is_default: true,
         })
       );
-      expect(mockClearSyncEntries).toHaveBeenCalledWith(mockDb, ["sq-accounts-1"]);
+      expectQueueCleared("sq-accounts-1");
     });
 
     it("upserts account suggestion dismissal rows and clears the queue entry on success", async () => {
       mockGetQueuedSyncEntries.mockReturnValueOnce([
-        {
+        createSyncQueueEntry({
           id: "sq-dismissal-1",
           tableName: "accountSuggestionDismissals",
           rowId: "asd-1",
-          operation: "insert",
           createdAt: "2026-04-19T10:00:00.000Z",
-        },
+        }),
       ]);
-      mockGetAccountSuggestionDismissalById.mockReturnValueOnce({
-        id: "asd-1",
-        userId: "user-1",
-        scope: "notification:bancolombia:last4",
-        value: "1234",
-        dismissedScore: 200,
-        createdAt: "2026-04-19T10:00:00.000Z",
-        updatedAt: "2026-04-19T10:00:00.000Z",
-        deletedAt: null,
-      });
+      mockGetAccountSuggestionDismissalById.mockReturnValueOnce(
+        createLocalAccountSuggestionDismissal()
+      );
       mockUpsert.mockReturnValueOnce({ error: null });
       const mockSupabase = createMockSupabase();
 
-      const { syncPush } = await import("@/features/sync/services/syncEngine");
-      await syncPush(mockDb, mockSupabase, "user-1");
+      await runSyncPush(mockSupabase);
 
       expect(mockSupabase.from).toHaveBeenCalledWith("account_suggestion_dismissals");
       expect(mockUpsert).toHaveBeenCalledWith(
@@ -303,38 +549,22 @@ describe("syncEngine", () => {
         }),
         { onConflict: "user_id,scope,value" }
       );
-      expect(mockClearSyncEntries).toHaveBeenCalledWith(mockDb, ["sq-dismissal-1"]);
+      expectQueueCleared("sq-dismissal-1");
     });
 
     it("upserts transfer rows and clears the queue entry on success", async () => {
       mockGetQueuedSyncEntries.mockReturnValueOnce([
-        {
+        createSyncQueueEntry({
           id: "sq-transfer-1",
           tableName: "transfers",
           rowId: "tr-1",
-          operation: "insert",
-          createdAt: "2026-03-04T10:00:00.000Z",
-        },
+        }),
       ]);
-      mockGetTransferById.mockReturnValueOnce({
-        id: "tr-1",
-        userId: "user-1",
-        amount: 250000,
-        fromAccountId: "fa-1",
-        toAccountId: "fa-2",
-        fromExternalLabel: null,
-        toExternalLabel: null,
-        description: "Move to savings",
-        date: "2026-04-18",
-        createdAt: "2026-04-18T10:00:00.000Z",
-        updatedAt: "2026-04-18T10:00:00.000Z",
-        deletedAt: null,
-      });
+      mockGetTransferById.mockReturnValueOnce(createLocalTransfer());
       mockUpsert.mockReturnValueOnce({ error: null });
       const mockSupabase = createMockSupabase();
 
-      const { syncPush } = await import("@/features/sync/services/syncEngine");
-      await syncPush(mockDb, mockSupabase, "user-1");
+      await runSyncPush(mockSupabase);
 
       expect(mockSupabase.from).toHaveBeenCalledWith("transfers");
       expect(mockUpsert).toHaveBeenCalledWith(
@@ -346,34 +576,22 @@ describe("syncEngine", () => {
           to_account_id: "fa-2",
         })
       );
-      expect(mockClearSyncEntries).toHaveBeenCalledWith(mockDb, ["sq-transfer-1"]);
+      expectQueueCleared("sq-transfer-1");
     });
 
     it("upserts opening balance rows and clears the queue entry on success", async () => {
       mockGetQueuedSyncEntries.mockReturnValueOnce([
-        {
+        createSyncQueueEntry({
           id: "sq-opening-balance-1",
           tableName: "openingBalances",
           rowId: "ob-1",
-          operation: "insert",
-          createdAt: "2026-03-04T10:00:00.000Z",
-        },
+        }),
       ]);
-      mockGetOpeningBalanceById.mockReturnValueOnce({
-        id: "ob-1",
-        userId: "user-1",
-        accountId: "fa-1",
-        amount: 500000,
-        effectiveDate: "2026-04-01",
-        createdAt: "2026-04-18T10:00:00.000Z",
-        updatedAt: "2026-04-18T10:00:00.000Z",
-        deletedAt: null,
-      });
+      mockGetOpeningBalanceById.mockReturnValueOnce(createLocalOpeningBalance());
       mockUpsert.mockReturnValueOnce({ error: null });
       const mockSupabase = createMockSupabase();
 
-      const { syncPush } = await import("@/features/sync/services/syncEngine");
-      await syncPush(mockDb, mockSupabase, "user-1");
+      await runSyncPush(mockSupabase);
 
       expect(mockSupabase.from).toHaveBeenCalledWith("opening_balances");
       expect(mockUpsert).toHaveBeenCalledWith(
@@ -386,34 +604,24 @@ describe("syncEngine", () => {
         }),
         { onConflict: "account_id" }
       );
-      expect(mockClearSyncEntries).toHaveBeenCalledWith(mockDb, ["sq-opening-balance-1"]);
+      expectQueueCleared("sq-opening-balance-1");
     });
 
     it("upserts financial account identifier rows and clears the queue entry on success", async () => {
       mockGetQueuedSyncEntries.mockReturnValueOnce([
-        {
+        createSyncQueueEntry({
           id: "sq-financial-identifier-1",
           tableName: "financialAccountIdentifiers",
           rowId: "fai-1",
-          operation: "insert",
-          createdAt: "2026-03-04T10:00:00.000Z",
-        },
+        }),
       ]);
-      mockGetFinancialAccountIdentifierById.mockReturnValueOnce({
-        id: "fai-1",
-        userId: "user-1",
-        accountId: "fa-1",
-        scope: "email:bancolombia:last4",
-        value: "1234",
-        createdAt: "2026-04-18T10:00:00.000Z",
-        updatedAt: "2026-04-18T10:00:00.000Z",
-        deletedAt: null,
-      });
+      mockGetFinancialAccountIdentifierById.mockReturnValueOnce(
+        createLocalFinancialAccountIdentifier()
+      );
       mockUpsert.mockReturnValueOnce({ error: null });
       const mockSupabase = createMockSupabase();
 
-      const { syncPush } = await import("@/features/sync/services/syncEngine");
-      await syncPush(mockDb, mockSupabase, "user-1");
+      await runSyncPush(mockSupabase);
 
       expect(mockSupabase.from).toHaveBeenCalledWith("financial_account_identifiers");
       expect(mockUpsert).toHaveBeenCalledWith(
@@ -426,38 +634,23 @@ describe("syncEngine", () => {
         }),
         { onConflict: "user_id,account_id,scope,value" }
       );
-      expect(mockClearSyncEntries).toHaveBeenCalledWith(mockDb, ["sq-financial-identifier-1"]);
+      expectQueueCleared("sq-financial-identifier-1");
     });
 
     it("upserts capture evidence rows and clears the queue entry on success", async () => {
       mockGetQueuedSyncEntries.mockReturnValueOnce([
-        {
+        createSyncQueueEntry({
           id: "sq-capture-evidence-1",
           tableName: "captureEvidence",
           rowId: "ce-1",
-          operation: "insert",
           createdAt: "2026-04-19T10:00:00.000Z",
-        },
+        }),
       ]);
-      mockGetCaptureEvidenceById.mockReturnValueOnce({
-        id: "ce-1",
-        userId: "user-1",
-        sourceFamily: "bancolombia",
-        evidenceType: "last4",
-        scope: "notification:bancolombia:last4",
-        value: "1234",
-        transactionId: "tx-1",
-        processedEmailId: null,
-        processedCaptureId: "pc-1",
-        createdAt: "2026-04-19T10:00:00.000Z",
-        updatedAt: "2026-04-19T10:00:00.000Z",
-        deletedAt: null,
-      });
+      mockGetCaptureEvidenceById.mockReturnValueOnce(createLocalCaptureEvidence());
       mockUpsert.mockReturnValueOnce({ error: null });
       const mockSupabase = createMockSupabase();
 
-      const { syncPush } = await import("@/features/sync/services/syncEngine");
-      await syncPush(mockDb, mockSupabase, "user-1");
+      await runSyncPush(mockSupabase);
 
       expect(mockSupabase.from).toHaveBeenCalledWith("capture_evidence");
       expect(mockUpsert).toHaveBeenCalledWith(
@@ -471,7 +664,7 @@ describe("syncEngine", () => {
           processed_capture_id: "pc-1",
         })
       );
-      expect(mockClearSyncEntries).toHaveBeenCalledWith(mockDb, ["sq-capture-evidence-1"]);
+      expectQueueCleared("sq-capture-evidence-1");
     });
 
     it("clears queue entry when local row is missing", async () => {
@@ -497,376 +690,87 @@ describe("syncEngine", () => {
   describe("syncPull", () => {
     it("fetches all rows on first sync and sets last_sync_at to max updated_at", async () => {
       mockGetSyncMeta.mockReturnValueOnce(null);
-      const serverRows = [
-        {
-          id: "tx-remote-1",
-          user_id: "user-1",
-          type: "income",
-          amount: 5000,
-          category_id: "salary",
-          account_id: "fa-default-user-1",
-          account_attribution_state: "confirmed",
-          superseded_at: null,
-          description: "Pay",
-          date: "2026-03-04",
-          created_at: "2026-03-04T10:00:00.000Z",
-          updated_at: "2026-03-04T12:00:00.000Z",
-          deleted_at: null,
-        },
-      ];
-      const mockSupabase = createMockSupabase({ data: serverRows, error: null });
+      const mockSupabase = createTransactionPullSupabase({
+        id: "tx-remote-1",
+        type: "income",
+        amount: 5000,
+        category_id: "salary",
+        description: "Pay",
+        date: "2026-03-04",
+        created_at: "2026-03-04T10:00:00.000Z",
+        updated_at: "2026-03-04T12:00:00.000Z",
+      });
       mockGetTransactionById.mockReturnValueOnce(null);
 
-      const { syncPull } = await import("@/features/sync/services/syncEngine");
-      const result = await syncPull(mockDb, mockSupabase, "user-1");
+      const result = await runSyncPull(mockSupabase);
 
       expect(result).toBe(true);
-      expect(mockUpsertTransaction).toHaveBeenCalledWith(
-        mockDb,
-        expect.objectContaining({
-          id: "tx-remote-1",
-          userId: "user-1",
-          accountId: "fa-default-user-1",
-          accountAttributionState: "confirmed",
-          supersededAt: null,
-        })
-      );
-      expect(mockSetSyncMeta).toHaveBeenCalledWith(
-        mockDb,
-        "last_sync_at",
-        "2026-03-04T12:00:00.000Z"
-      );
+      expectUpsertedTransaction({
+        id: "tx-remote-1",
+        userId: "user-1",
+        accountId: "fa-default-user-1",
+        accountAttributionState: "confirmed",
+        supersededAt: null,
+      });
+      expectLastSyncAt("2026-03-04T12:00:00.000Z");
     });
 
     it("pulls financial-account tables and advances the shared sync cursor", async () => {
       mockGetSyncMeta.mockReturnValueOnce(null);
-      const mockSupabase = createMockSupabase({
-        transactions: { data: [], error: null },
-        capture_evidence: {
-          data: [
-            {
-              id: "ce-1",
-              user_id: "user-1",
-              source_family: "bancolombia",
-              evidence_type: "last4",
-              scope: "notification:bancolombia:last4",
-              value: "1234",
-              transaction_id: "tx-1",
-              processed_email_id: null,
-              processed_capture_id: "pc-1",
-              created_at: "2026-04-18T07:30:00.000Z",
-              updated_at: "2026-04-18T08:00:00.000Z",
-              deleted_at: null,
-            },
-          ],
-          error: null,
-        },
-        financial_accounts: {
-          data: [
-            {
-              id: "fa-1",
-              user_id: "user-1",
-              name: "Main wallet",
-              kind: "wallet",
-              is_default: true,
-              created_at: "2026-04-18T08:00:00.000Z",
-              updated_at: "2026-04-18T09:00:00.000Z",
-              deleted_at: null,
-            },
-          ],
-          error: null,
-        },
-        transfers: {
-          data: [
-            {
-              id: "tr-1",
-              user_id: "user-1",
-              amount: 250000,
-              from_account_id: "fa-1",
-              to_account_id: "fa-2",
-              from_external_label: null,
-              to_external_label: null,
-              description: "Move to savings",
-              date: "2026-04-18",
-              created_at: "2026-04-18T09:30:00.000Z",
-              updated_at: "2026-04-18T10:00:00.000Z",
-              deleted_at: null,
-            },
-          ],
-          error: null,
-        },
-        opening_balances: {
-          data: [
-            {
-              id: "ob-1",
-              user_id: "user-1",
-              account_id: "fa-1",
-              amount: 500000,
-              effective_date: "2026-04-01",
-              created_at: "2026-04-18T10:30:00.000Z",
-              updated_at: "2026-04-18T11:00:00.000Z",
-              deleted_at: null,
-            },
-          ],
-          error: null,
-        },
-        financial_account_identifiers: {
-          data: [
-            {
-              id: "fai-1",
-              user_id: "user-1",
-              account_id: "fa-1",
-              scope: "email:bancolombia:last4",
-              value: "1234",
-              created_at: "2026-04-18T11:30:00.000Z",
-              updated_at: "2026-04-18T12:00:00.000Z",
-              deleted_at: null,
-            },
-          ],
-          error: null,
-        },
-      });
+      const mockSupabase = createFinancialTablesSupabase();
       mockGetCaptureEvidenceById.mockReturnValueOnce(null);
       mockGetFinancialAccountById.mockReturnValueOnce(null);
       mockGetTransferById.mockReturnValueOnce(null);
       mockGetOpeningBalanceById.mockReturnValueOnce(null);
       mockGetFinancialAccountIdentifierById.mockReturnValueOnce(null);
 
-      const { syncPull } = await import("@/features/sync/services/syncEngine");
-      const result = await syncPull(mockDb, mockSupabase, "user-1");
+      const result = await runSyncPull(mockSupabase);
 
       expect(result).toBe(true);
-      expect(mockUpsertCaptureEvidence).toHaveBeenCalledWith(
-        mockDb,
-        expect.objectContaining({
-          id: "ce-1",
-          scope: "notification:bancolombia:last4",
-          value: "1234",
-          processedCaptureId: "pc-1",
-        })
-      );
-      expect(mockUpsertFinancialAccount).toHaveBeenCalledWith(
-        mockDb,
-        expect.objectContaining({
-          id: "fa-1",
-          userId: "user-1",
-          isDefault: true,
-        })
-      );
-      expect(mockUpsertTransfer).toHaveBeenCalledWith(
-        mockDb,
-        expect.objectContaining({
-          id: "tr-1",
-          fromAccountId: "fa-1",
-          toAccountId: "fa-2",
-        })
-      );
-      expect(mockUpsertOpeningBalance).toHaveBeenCalledWith(
-        mockDb,
-        expect.objectContaining({
-          id: "ob-1",
-          accountId: "fa-1",
-          amount: 500000,
-        })
-      );
-      expect(mockUpsertFinancialAccountIdentifier).toHaveBeenCalledWith(
-        mockDb,
-        expect.objectContaining({
-          id: "fai-1",
-          accountId: "fa-1",
-          value: "1234",
-        })
-      );
-      expect(
-        JSON.parse(getLastSetSyncMetaValue("last_sync_at_financial_account_identifiers")!)
-      ).toEqual({
-        updatedAt: "2026-04-18T12:00:00.000Z",
-        id: "fai-1",
-      });
-      expect(JSON.parse(getLastSetSyncMetaValue("last_sync_at_capture_evidence")!)).toEqual({
-        updatedAt: "2026-04-18T08:00:00.000Z",
-        id: "ce-1",
-      });
+      expectCaptureEvidencePulled();
+      expectFinancialAccountPulled();
+      expectTransferPulled();
+      expectOpeningBalancePulled();
+      expectFinancialAccountIdentifierPulled();
+      expectFinancialTableCursors();
     });
 
     it("pulls account suggestion dismissals and advances their cursor", async () => {
-      const mockSupabase = createMockSupabase({
-        account_suggestion_dismissals: {
-          data: [
-            {
-              id: "asd-1",
-              user_id: "user-1",
-              scope: "notification:bancolombia:last4",
-              value: "1234",
-              dismissed_score: 200,
-              created_at: "2026-04-19T10:00:00.000Z",
-              updated_at: "2026-04-19T11:00:00.000Z",
-              deleted_at: null,
-            },
-          ],
-          error: null,
-        },
-        capture_evidence: { data: [], error: null },
-        financial_accounts: { data: [], error: null },
-        transfers: { data: [], error: null },
-        opening_balances: { data: [], error: null },
-        financial_account_identifiers: { data: [], error: null },
-        transactions: { data: [], error: null },
-      });
+      const mockSupabase = createDismissalPullSupabase();
       mockGetAccountSuggestionDismissalById.mockReturnValueOnce(null);
 
-      const { syncPull } = await import("@/features/sync/services/syncEngine");
-      const result = await syncPull(mockDb, mockSupabase, "user-1");
+      const result = await runSyncPull(mockSupabase);
 
       expect(result).toBe(true);
-      expect(mockUpsertAccountSuggestionDismissal).toHaveBeenCalledWith(
-        mockDb,
-        expect.objectContaining({
-          id: "asd-1",
-          userId: "user-1",
-          scope: "notification:bancolombia:last4",
-          value: "1234",
-          dismissedScore: 200,
-        })
-      );
-      expect(
-        JSON.parse(getLastSetSyncMetaValue("last_sync_at_account_suggestion_dismissals")!)
-      ).toEqual({
-        updatedAt: "2026-04-19T11:00:00.000Z",
-        id: "asd-1",
-      });
+      expectDismissalPulled();
     });
 
     it("tracks per-table cursors so a busy table is not skipped by a newer row elsewhere", async () => {
       mockGetSyncMeta.mockImplementation((_, key: string) =>
         key === "last_sync_at" ? "2026-04-01T00:00:00.000Z" : null
       );
-      const transactionRows = Array.from({ length: 1000 }, (_, index) => {
-        const hour = String(index).padStart(4, "0");
-        return {
-          id: `tx-${index + 1}`,
-          user_id: "user-1",
-          type: "expense",
-          amount: 1000,
-          category_id: "food",
-          description: null,
-          date: "2026-04-18",
-          created_at: `2026-04-18T${hour}:00:00.000Z`,
-          updated_at: `2026-04-18T${hour}:00:00.000Z`,
-          deleted_at: null,
-        };
-      });
-      const mockSupabase = createMockSupabase({
-        transactions: { data: transactionRows, error: null },
-        financial_accounts: {
-          data: [
-            {
-              id: "fa-1",
-              user_id: "user-1",
-              name: "Main wallet",
-              kind: "wallet",
-              is_default: true,
-              created_at: "2026-04-19T00:00:00.000Z",
-              updated_at: "2026-04-19T00:00:00.000Z",
-              deleted_at: null,
-            },
-          ],
-          error: null,
-        },
-      });
+      const mockSupabase = createBusyTableCursorSupabase();
       mockGetTransactionById.mockReturnValue(null);
       mockGetFinancialAccountById.mockReturnValue(null);
 
-      const { syncPull } = await import("@/features/sync/services/syncEngine");
-      const result = await syncPull(mockDb, mockSupabase, "user-1");
+      const result = await runSyncPull(mockSupabase);
 
       expect(result).toBe(true);
-      expect(JSON.parse(getLastSetSyncMetaValue("last_sync_at_transactions")!)).toEqual({
-        updatedAt: "2026-04-18T0999:00:00.000Z",
-        id: "tx-1000",
-      });
-      expect(mockSetSyncMeta).toHaveBeenCalledWith(
-        mockDb,
-        "last_sync_at",
-        "2026-04-18T0999:00:00.000Z"
-      );
-      expect(JSON.parse(getLastSetSyncMetaValue("last_sync_at_financial_accounts")!)).toEqual({
-        updatedAt: "2026-04-19T00:00:00.000Z",
-        id: "fa-1",
-      });
-      expect(getLastSetSyncMetaValue("last_sync_at_transactions")).not.toContain(
-        "2026-04-19T00:00:00.000Z"
-      );
+      expectBusyTableCursorIsolation();
     });
 
     it("uses a composite cursor to continue past rows that share the same updated_at", async () => {
-      const syncMeta = new Map<string, string>([
-        [
-          "last_sync_at_transactions",
-          JSON.stringify({
-            updatedAt: "2026-04-18T12:00:00.000Z",
-            id: "tx-1000",
-          }),
-        ],
-      ]);
-      mockGetSyncMeta.mockImplementation((_, key: string) => syncMeta.get(key) ?? null);
-      mockSetSyncMeta.mockImplementation((_, key: string, value: string) => {
-        syncMeta.set(key, value);
-      });
-      const mockSupabase = createMockSupabase({
-        transactions: {
-          data: [
-            {
-              id: "tx-1001",
-              user_id: "user-1",
-              type: "expense",
-              amount: 1000,
-              category_id: "food",
-              description: null,
-              date: "2026-04-18",
-              created_at: "2026-04-18T12:00:00.000Z",
-              updated_at: "2026-04-18T12:00:00.000Z",
-              deleted_at: null,
-            },
-            {
-              id: "tx-1002",
-              user_id: "user-1",
-              type: "expense",
-              amount: 1000,
-              category_id: "food",
-              description: null,
-              date: "2026-04-18",
-              created_at: "2026-04-18T12:00:00.000Z",
-              updated_at: "2026-04-18T12:00:00.000Z",
-              deleted_at: null,
-            },
-          ],
-          error: null,
-        },
-      });
+      const syncMeta = createCompositeSyncMeta("2026-04-18T12:00:00.000Z", "tx-1000");
+      const mockSupabase = createSameTimestampTransactionSupabase();
       mockGetTransactionById.mockReturnValue(null);
 
-      const { syncPull } = await import("@/features/sync/services/syncEngine");
-      const result = await syncPull(mockDb, mockSupabase, "user-1");
+      const result = await runSyncPull(mockSupabase);
 
       expect(result).toBe(true);
-      expect(mockSupabase._getChain("transactions").or).toHaveBeenCalledWith(
-        "updated_at.gt.2026-04-18T12:00:00.000Z,and(updated_at.eq.2026-04-18T12:00:00.000Z,id.gt.tx-1000)"
+      expectCompositeTransactionsQuery(mockSupabase);
+      expect(JSON.parse(syncMeta.get("last_sync_at_transactions")!)).toEqual(
+        createCursor("2026-04-18T12:00:00.000Z", "tx-1002")
       );
-      expect(mockSupabase._getChain("transactions").order).toHaveBeenNthCalledWith(
-        1,
-        "updated_at",
-        {
-          ascending: true,
-        }
-      );
-      expect(mockSupabase._getChain("transactions").order).toHaveBeenNthCalledWith(2, "id", {
-        ascending: true,
-      });
-      expect(JSON.parse(syncMeta.get("last_sync_at_transactions")!)).toEqual({
-        updatedAt: "2026-04-18T12:00:00.000Z",
-        id: "tx-1002",
-      });
     });
 
     it("uses last_sync_at for incremental pull and skips setSyncMeta when no rows", async () => {
@@ -898,123 +802,73 @@ describe("syncEngine", () => {
 
     it("continues when a secondary table fetch fails and still advances transactions", async () => {
       mockGetSyncMeta.mockReturnValue(null);
-      const mockSupabase = createMockSupabase({
-        transactions: {
-          data: [
-            {
-              id: "tx-remote-1",
-              user_id: "user-1",
-              type: "income",
-              amount: 5000,
-              category_id: "salary",
-              account_id: "fa-default-user-1",
-              account_attribution_state: "confirmed",
-              superseded_at: null,
-              description: "Pay",
-              date: "2026-03-04",
-              created_at: "2026-03-04T10:00:00.000Z",
-              updated_at: "2026-03-04T12:00:00.000Z",
-              deleted_at: null,
-            },
-          ],
-          error: null,
-        },
-        financial_accounts: {
-          data: null,
-          error: { message: "accounts unavailable", code: "500" },
-        },
-        transfers: { data: [], error: null },
-        opening_balances: { data: [], error: null },
-        financial_account_identifiers: { data: [], error: null },
-      });
+      const mockSupabase = createSecondaryFailureSupabase();
       mockGetTransactionById.mockReturnValueOnce(null);
 
-      const { syncPull } = await import("@/features/sync/services/syncEngine");
-      const result = await syncPull(mockDb, mockSupabase, "user-1");
+      const result = await runSyncPull(mockSupabase);
 
       expect(result).toBe(true);
-      expect(mockUpsertTransaction).toHaveBeenCalledWith(
-        mockDb,
-        expect.objectContaining({
-          id: "tx-remote-1",
-          userId: "user-1",
-        })
-      );
+      expectUpsertedTransaction({ id: "tx-remote-1", userId: "user-1" });
       expect(getLastSetSyncMetaValue("last_sync_at_financial_accounts")).toBeNull();
-      expect(JSON.parse(getLastSetSyncMetaValue("last_sync_at_transactions")!)).toEqual({
-        updatedAt: "2026-03-04T12:00:00.000Z",
-        id: "tx-remote-1",
-      });
+      expectCursorToEqual(
+        "last_sync_at_transactions",
+        createCursor("2026-03-04T12:00:00.000Z", "tx-remote-1")
+      );
     });
 
     it("skips upsert when local row is newer (LWW)", async () => {
       mockGetSyncMeta.mockReturnValueOnce(null);
-      const serverRows = [
-        {
-          id: "tx-1",
-          user_id: "user-1",
-          type: "expense",
-          amount: 1000,
-          category_id: "food",
+      const mockSupabase = createMockSupabase({
+        data: [
+          createServerTransactionRow({
+            amount: 1000,
+            description: null,
+            date: "2026-03-04",
+            created_at: "2026-03-04T10:00:00.000Z",
+            updated_at: "2026-03-04T10:00:00.000Z",
+          }),
+        ],
+        error: null,
+      });
+      mockGetTransactionById.mockReturnValueOnce(
+        createLocalTransaction({
+          amount: 2000,
           description: null,
           date: "2026-03-04",
-          created_at: "2026-03-04T10:00:00.000Z",
-          updated_at: "2026-03-04T10:00:00.000Z",
-          deleted_at: null,
-        },
-      ];
-      const mockSupabase = createMockSupabase({ data: serverRows, error: null });
-      mockGetTransactionById.mockReturnValueOnce({
-        id: "tx-1",
-        userId: "user-1",
-        type: "expense",
-        amount: 2000,
-        categoryId: "food",
-        description: null,
-        date: "2026-03-04",
-        createdAt: "2026-03-04T10:00:00.000Z",
-        updatedAt: "2026-03-04T12:00:00.000Z",
-        deletedAt: null,
-      });
+          createdAt: "2026-03-04T10:00:00.000Z",
+          updatedAt: "2026-03-04T12:00:00.000Z",
+        })
+      );
 
-      const { syncPull } = await import("@/features/sync/services/syncEngine");
-      await syncPull(mockDb, mockSupabase, "user-1");
+      await runSyncPull(mockSupabase);
 
       expect(mockUpsertTransaction).not.toHaveBeenCalled();
     });
 
     it("upserts when server row is newer", async () => {
       mockGetSyncMeta.mockReturnValueOnce(null);
-      const serverRows = [
-        {
-          id: "tx-1",
-          user_id: "user-1",
-          type: "expense",
-          amount: 3000,
-          category_id: "food",
-          description: "Updated",
-          date: "2026-03-04",
-          created_at: "2026-03-04T10:00:00.000Z",
-          updated_at: "2026-03-04T14:00:00.000Z",
-          deleted_at: null,
-        },
-      ];
-      const mockSupabase = createMockSupabase({ data: serverRows, error: null });
-      mockGetTransactionById.mockReturnValueOnce({
-        id: "tx-1",
-        userId: "user-1",
-        type: "expense",
-        amount: 1000,
-        categoryId: "food",
-        description: null,
-        date: "2026-03-04",
-        createdAt: "2026-03-04T10:00:00.000Z",
-        updatedAt: "2026-03-04T10:00:00.000Z",
-        deletedAt: null,
+      const mockSupabase = createMockSupabase({
+        data: [
+          createServerTransactionRow({
+            amount: 3000,
+            description: "Updated",
+            date: "2026-03-04",
+            created_at: "2026-03-04T10:00:00.000Z",
+            updated_at: "2026-03-04T14:00:00.000Z",
+          }),
+        ],
+        error: null,
       });
+      mockGetTransactionById.mockReturnValueOnce(
+        createLocalTransaction({
+          description: null,
+          date: "2026-03-04",
+          createdAt: "2026-03-04T10:00:00.000Z",
+          updatedAt: "2026-03-04T10:00:00.000Z",
+        })
+      );
 
-      const { syncPull } = await import("@/features/sync/services/syncEngine");
-      await syncPull(mockDb, mockSupabase, "user-1");
+      await runSyncPull(mockSupabase);
 
       expect(mockUpsertTransaction).toHaveBeenCalledWith(
         mockDb,
@@ -1087,80 +941,53 @@ describe("syncEngine", () => {
   describe("conflict logging", () => {
     it("logs conflict when server overwrites local with different data", async () => {
       mockGetSyncMeta.mockReturnValueOnce(null);
-      const serverRows = [
-        {
-          id: "tx-1",
-          user_id: "user-1",
-          type: "expense",
-          amount: 2000,
-          category_id: "food",
-          description: "Updated by server",
-          date: "2026-03-04",
-          created_at: "2026-03-04T10:00:00.000Z",
-          updated_at: "2026-03-04T14:00:00.000Z",
-          deleted_at: null,
-        },
-      ];
-      const mockSupabase = createMockSupabase({ data: serverRows, error: null });
-      mockGetTransactionById.mockReturnValueOnce({
-        id: "tx-1",
-        userId: "user-1",
-        type: "expense",
-        amount: 1000,
-        categoryId: "food",
-        description: "Local version",
+      const mockSupabase = createTransactionPullSupabase({
+        amount: 2000,
+        description: "Updated by server",
         date: "2026-03-04",
-        createdAt: "2026-03-04T10:00:00.000Z",
-        updatedAt: "2026-03-04T10:00:00.000Z",
-        deletedAt: null,
-        source: "manual",
+        created_at: "2026-03-04T10:00:00.000Z",
+        updated_at: "2026-03-04T14:00:00.000Z",
       });
-
-      const { syncPull } = await import("@/features/sync/services/syncEngine");
-      await syncPull(mockDb, mockSupabase, "user-1");
-
-      expect(mockInsertConflict).toHaveBeenCalledWith(
-        mockDb,
-        expect.objectContaining({
-          transactionId: "tx-1",
+      mockGetTransactionById.mockReturnValueOnce(
+        createLocalTransaction({
+          description: "Local version",
+          date: "2026-03-04",
+          createdAt: "2026-03-04T10:00:00.000Z",
+          updatedAt: "2026-03-04T10:00:00.000Z",
         })
       );
+
+      await runSyncPull(mockSupabase);
+
+      expectConflictLogged("tx-1");
       expect(mockUpsertTransaction).toHaveBeenCalled();
     });
 
     it("does not log conflict when data matches (only timestamp differs)", async () => {
       mockGetSyncMeta.mockReturnValueOnce(null);
-      const serverRows = [
-        {
-          id: "tx-1",
-          user_id: "user-1",
-          type: "expense",
+      const mockSupabase = createMockSupabase({
+        data: [
+          createServerTransactionRow({
+            amount: 1000,
+            description: "Same data",
+            date: "2026-03-04",
+            created_at: "2026-03-04T10:00:00.000Z",
+            updated_at: "2026-03-04T14:00:00.000Z",
+          }),
+        ],
+        error: null,
+      });
+      mockGetTransactionById.mockReturnValueOnce(
+        createLocalTransaction({
           amount: 1000,
-          category_id: "food",
           description: "Same data",
           date: "2026-03-04",
-          created_at: "2026-03-04T10:00:00.000Z",
-          updated_at: "2026-03-04T14:00:00.000Z",
-          deleted_at: null,
-        },
-      ];
-      const mockSupabase = createMockSupabase({ data: serverRows, error: null });
-      mockGetTransactionById.mockReturnValueOnce({
-        id: "tx-1",
-        userId: "user-1",
-        type: "expense",
-        amount: 1000,
-        categoryId: "food",
-        description: "Same data",
-        date: "2026-03-04",
-        createdAt: "2026-03-04T10:00:00.000Z",
-        updatedAt: "2026-03-04T10:00:00.000Z",
-        deletedAt: null,
-        source: "manual",
-      });
+          createdAt: "2026-03-04T10:00:00.000Z",
+          updatedAt: "2026-03-04T10:00:00.000Z",
+        })
+      );
 
-      const { syncPull } = await import("@/features/sync/services/syncEngine");
-      await syncPull(mockDb, mockSupabase, "user-1");
+      await runSyncPull(mockSupabase);
 
       expect(mockInsertConflict).not.toHaveBeenCalled();
       expect(mockUpsertTransaction).toHaveBeenCalled();

--- a/apps/mobile/__tests__/transfers/reclassify-transaction-as-transfer.test.ts
+++ b/apps/mobile/__tests__/transfers/reclassify-transaction-as-transfer.test.ts
@@ -42,6 +42,7 @@ const TRANSFER_ID = "tr-1" as TransferId;
 const ACCOUNT_ID = "fa-1" as FinancialAccountId;
 const SAVINGS_ACCOUNT_ID = "fa-2" as FinancialAccountId;
 const NOW = "2026-04-19T14:00:00.000Z" as IsoDateTime;
+const ORIGINAL_CREATED_AT = "2026-04-18T12:00:00.000Z" as IsoDateTime;
 
 beforeEach(() => {
   sqlite = new Database(":memory:");
@@ -53,80 +54,155 @@ afterEach(() => {
   sqlite.close();
 });
 
+function insertOriginalTransactionRecord() {
+  insertTransaction(db as any, {
+    id: ORIGINAL_TRANSACTION_ID,
+    userId: USER_ID,
+    type: "expense",
+    amount: 350000 as CopAmount,
+    categoryId: "shopping" as CategoryId,
+    description: "Transfer to savings",
+    date: "2026-04-18" as IsoDate,
+    accountId: ACCOUNT_ID,
+    accountAttributionState: "confirmed",
+    createdAt: ORIGINAL_CREATED_AT,
+    updatedAt: ORIGINAL_CREATED_AT,
+    deletedAt: null,
+    supersededAt: null,
+    source: "email_gmail",
+  });
+}
+
+function insertTransferEvidence() {
+  saveCaptureEvidence(db as any, {
+    id: "ce-1" as CaptureEvidenceId,
+    userId: USER_ID,
+    sourceFamily: "bancolombia",
+    evidenceType: "subject",
+    scope: "email:subject",
+    value: "transfer to savings",
+    transactionId: ORIGINAL_TRANSACTION_ID,
+    transferId: null,
+    processedEmailId: "pe-1" as ProcessedEmailId,
+    processedCaptureId: null,
+    createdAt: ORIGINAL_CREATED_AT,
+    updatedAt: ORIGINAL_CREATED_AT,
+    deletedAt: null,
+  });
+}
+
+async function insertPendingProcessedEmail() {
+  await insertProcessedEmail(db as any, {
+    id: "pe-1" as ProcessedEmailId,
+    externalId: "ext-1",
+    provider: "gmail",
+    status: "needs_review",
+    failureReason: null,
+    subject: "Transfer alert",
+    rawBodyPreview: "Transfer to savings",
+    receivedAt: ORIGINAL_CREATED_AT,
+    transactionId: ORIGINAL_TRANSACTION_ID,
+    confidence: 0.52,
+    createdAt: ORIGINAL_CREATED_AT,
+    rawBody: null,
+    retryCount: 0,
+    nextRetryAt: null,
+  });
+}
+
+function clearExistingSyncEntries() {
+  clearSyncEntries(
+    db as any,
+    getQueuedSyncEntries(db as any).map((entry) => entry.id)
+  );
+}
+
+function seedReclassificationScenario() {
+  insertOriginalTransactionRecord();
+  insertTransferEvidence();
+  return insertPendingProcessedEmail().then(() => clearExistingSyncEntries());
+}
+
+function runReclassification() {
+  return reclassifyTransactionAsTransfer(
+    db as any,
+    {
+      userId: USER_ID,
+      transactionId: ORIGINAL_TRANSACTION_ID,
+      digits: "350000",
+      fromSide: { kind: "account", accountId: ACCOUNT_ID },
+      toSide: { kind: "account", accountId: SAVINGS_ACCOUNT_ID },
+      description: "Move to savings",
+      date: new Date("2026-04-18T12:00:00.000Z"),
+      processedEmailId: "pe-1" as ProcessedEmailId,
+    },
+    {
+      now: () => new Date(NOW),
+      createId: () => TRANSFER_ID,
+    }
+  );
+}
+
+function expectTransferReclassificationSync() {
+  expect(getQueuedSyncEntries(db as any)).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        tableName: "transfers",
+        rowId: TRANSFER_ID,
+        operation: "insert",
+      }),
+      expect.objectContaining({
+        tableName: "transactions",
+        rowId: ORIGINAL_TRANSACTION_ID,
+        operation: "update",
+      }),
+      expect.objectContaining({
+        tableName: "captureEvidence",
+        rowId: "ce-1",
+        operation: "update",
+      }),
+    ])
+  );
+}
+
+function expectCreatedTransferState() {
+  expect(getTransferById(db as any, TRANSFER_ID)).toMatchObject({
+    id: TRANSFER_ID,
+    userId: USER_ID,
+    amount: 350000,
+    fromAccountId: ACCOUNT_ID,
+    toAccountId: SAVINGS_ACCOUNT_ID,
+    description: "Move to savings",
+    date: "2026-04-18",
+  });
+  expect(getTransactionById(db as any, ORIGINAL_TRANSACTION_ID)).toMatchObject({
+    id: ORIGINAL_TRANSACTION_ID,
+    supersededAt: NOW,
+    deletedAt: null,
+    updatedAt: NOW,
+  });
+  expect(getCaptureEvidenceById(db as any, "ce-1" as CaptureEvidenceId)).toMatchObject({
+    id: "ce-1",
+    transactionId: null,
+    transferId: TRANSFER_ID,
+    updatedAt: NOW,
+  });
+}
+
+async function expectProcessedEmailSucceeded() {
+  await expect(getProcessedEmailById(db as any, "pe-1" as ProcessedEmailId)).resolves.toEqual(
+    expect.objectContaining({
+      id: "pe-1",
+      status: "success",
+      transactionId: ORIGINAL_TRANSACTION_ID,
+    })
+  );
+}
+
 describe("reclassifyTransactionAsTransfer", () => {
   it("creates a transfer, supersedes the original transaction, relinks capture evidence, and enqueues sync", async () => {
-    insertTransaction(db as any, {
-      id: ORIGINAL_TRANSACTION_ID,
-      userId: USER_ID,
-      type: "expense",
-      amount: 350000 as CopAmount,
-      categoryId: "shopping" as CategoryId,
-      description: "Transfer to savings",
-      date: "2026-04-18" as IsoDate,
-      accountId: ACCOUNT_ID,
-      accountAttributionState: "confirmed",
-      createdAt: "2026-04-18T12:00:00.000Z" as IsoDateTime,
-      updatedAt: "2026-04-18T12:00:00.000Z" as IsoDateTime,
-      deletedAt: null,
-      supersededAt: null,
-      source: "email_gmail",
-    });
-
-    saveCaptureEvidence(db as any, {
-      id: "ce-1" as CaptureEvidenceId,
-      userId: USER_ID,
-      sourceFamily: "bancolombia",
-      evidenceType: "subject",
-      scope: "email:subject",
-      value: "transfer to savings",
-      transactionId: ORIGINAL_TRANSACTION_ID,
-      transferId: null,
-      processedEmailId: "pe-1" as ProcessedEmailId,
-      processedCaptureId: null,
-      createdAt: "2026-04-18T12:00:00.000Z" as IsoDateTime,
-      updatedAt: "2026-04-18T12:00:00.000Z" as IsoDateTime,
-      deletedAt: null,
-    });
-
-    await insertProcessedEmail(db as any, {
-      id: "pe-1" as ProcessedEmailId,
-      externalId: "ext-1",
-      provider: "gmail",
-      status: "needs_review",
-      failureReason: null,
-      subject: "Transfer alert",
-      rawBodyPreview: "Transfer to savings",
-      receivedAt: "2026-04-18T12:00:00.000Z" as IsoDateTime,
-      transactionId: ORIGINAL_TRANSACTION_ID,
-      confidence: 0.52,
-      createdAt: "2026-04-18T12:00:00.000Z" as IsoDateTime,
-      rawBody: null,
-      retryCount: 0,
-      nextRetryAt: null,
-    });
-
-    clearSyncEntries(
-      db as any,
-      getQueuedSyncEntries(db as any).map((entry) => entry.id)
-    );
-
-    const result = reclassifyTransactionAsTransfer(
-      db as any,
-      {
-        userId: USER_ID,
-        transactionId: ORIGINAL_TRANSACTION_ID,
-        digits: "350000",
-        fromSide: { kind: "account", accountId: ACCOUNT_ID },
-        toSide: { kind: "account", accountId: SAVINGS_ACCOUNT_ID },
-        description: "Move to savings",
-        date: new Date("2026-04-18T12:00:00.000Z"),
-        processedEmailId: "pe-1" as ProcessedEmailId,
-      },
-      {
-        now: () => new Date(NOW),
-        createId: () => TRANSFER_ID,
-      }
-    );
+    await seedReclassificationScenario();
+    const result = runReclassification();
 
     expect(result).toEqual({
       success: true,
@@ -135,57 +211,8 @@ describe("reclassifyTransactionAsTransfer", () => {
         amount: 350000,
       }),
     });
-
-    expect(getTransferById(db as any, TRANSFER_ID)).toMatchObject({
-      id: TRANSFER_ID,
-      userId: USER_ID,
-      amount: 350000,
-      fromAccountId: ACCOUNT_ID,
-      toAccountId: SAVINGS_ACCOUNT_ID,
-      description: "Move to savings",
-      date: "2026-04-18",
-    });
-
-    expect(getTransactionById(db as any, ORIGINAL_TRANSACTION_ID)).toMatchObject({
-      id: ORIGINAL_TRANSACTION_ID,
-      supersededAt: NOW,
-      deletedAt: null,
-      updatedAt: NOW,
-    });
-
-    expect(getCaptureEvidenceById(db as any, "ce-1" as CaptureEvidenceId)).toMatchObject({
-      id: "ce-1",
-      transactionId: null,
-      transferId: TRANSFER_ID,
-      updatedAt: NOW,
-    });
-
-    await expect(getProcessedEmailById(db as any, "pe-1" as ProcessedEmailId)).resolves.toEqual(
-      expect.objectContaining({
-        id: "pe-1",
-        status: "success",
-        transactionId: ORIGINAL_TRANSACTION_ID,
-      })
-    );
-
-    expect(getQueuedSyncEntries(db as any)).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          tableName: "transfers",
-          rowId: TRANSFER_ID,
-          operation: "insert",
-        }),
-        expect.objectContaining({
-          tableName: "transactions",
-          rowId: ORIGINAL_TRANSACTION_ID,
-          operation: "update",
-        }),
-        expect.objectContaining({
-          tableName: "captureEvidence",
-          rowId: "ce-1",
-          operation: "update",
-        }),
-      ])
-    );
+    expectCreatedTransferState();
+    await expectProcessedEmailSucceeded();
+    expectTransferReclassificationSync();
   });
 });

--- a/apps/mobile/__tests__/transfers/repository.test.ts
+++ b/apps/mobile/__tests__/transfers/repository.test.ts
@@ -20,6 +20,9 @@ let db: ReturnType<typeof drizzle>;
 
 const USER_ID = "user-1" as UserId;
 const NOW = "2026-04-18T10:00:00.000Z" as IsoDateTime;
+const TRANSFER_DATE = "2026-04-18" as IsoDate;
+
+type TransferInput = Parameters<typeof saveTransfer>[1];
 
 beforeEach(() => {
   sqlite = new Database(":memory:");
@@ -31,22 +34,37 @@ afterEach(() => {
   sqlite.close();
 });
 
+function makeTransfer(overrides: Partial<TransferInput> = {}): TransferInput {
+  return {
+    id: "tr-1" as TransferId,
+    userId: USER_ID,
+    amount: 250000 as CopAmount,
+    fromAccountId: "fa-1" as FinancialAccountId,
+    toAccountId: "fa-2" as FinancialAccountId,
+    fromExternalLabel: null,
+    toExternalLabel: null,
+    description: "Move to savings",
+    date: TRANSFER_DATE,
+    createdAt: NOW,
+    updatedAt: NOW,
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+function expectQueuedTransfer(rowId: string, operation: "insert" | "update") {
+  expect(getQueuedSyncEntries(db as any)).toEqual([
+    expect.objectContaining({
+      tableName: "transfers",
+      rowId,
+      operation,
+    }),
+  ]);
+}
+
 describe("transfers repository", () => {
   it("saves a transfer, reads it back, and enqueues sync", () => {
-    saveTransfer(db as any, {
-      id: "tr-1" as TransferId,
-      userId: USER_ID,
-      amount: 250000 as CopAmount,
-      fromAccountId: "fa-1" as FinancialAccountId,
-      toAccountId: "fa-2" as FinancialAccountId,
-      fromExternalLabel: null,
-      toExternalLabel: null,
-      description: "Move to savings",
-      date: "2026-04-18" as IsoDate,
-      createdAt: NOW,
-      updatedAt: NOW,
-      deletedAt: null,
-    });
+    saveTransfer(db as any, makeTransfer());
 
     expect(getTransfersForUser(db as any, USER_ID)).toEqual([
       expect.objectContaining({
@@ -57,85 +75,44 @@ describe("transfers repository", () => {
         toAccountId: "fa-2",
       }),
     ]);
-
-    expect(getQueuedSyncEntries(db as any)).toEqual([
-      expect.objectContaining({
-        tableName: "transfers",
-        rowId: "tr-1",
-        operation: "insert",
-      }),
-    ]);
+    expectQueuedTransfer("tr-1", "insert");
   });
 
   it("requires a source and destination endpoint", () => {
     expect(() =>
-      saveTransfer(db as any, {
-        id: "tr-missing-from" as TransferId,
-        userId: USER_ID,
-        amount: 250000 as CopAmount,
-        fromAccountId: null,
-        toAccountId: "fa-2" as FinancialAccountId,
-        fromExternalLabel: null,
-        toExternalLabel: null,
-        description: "Invalid transfer",
-        date: "2026-04-18" as IsoDate,
-        createdAt: NOW,
-        updatedAt: NOW,
-        deletedAt: null,
-      })
+      saveTransfer(
+        db as any,
+        makeTransfer({ id: "tr-missing-from" as TransferId, fromAccountId: null })
+      )
     ).toThrow();
-
     expect(() =>
-      saveTransfer(db as any, {
-        id: "tr-missing-to" as TransferId,
-        userId: USER_ID,
-        amount: 250000 as CopAmount,
-        fromAccountId: "fa-1" as FinancialAccountId,
-        toAccountId: null,
-        fromExternalLabel: null,
-        toExternalLabel: null,
-        description: "Invalid transfer",
-        date: "2026-04-18" as IsoDate,
-        createdAt: NOW,
-        updatedAt: NOW,
-        deletedAt: null,
-      })
+      saveTransfer(
+        db as any,
+        makeTransfer({ id: "tr-missing-to" as TransferId, toAccountId: null })
+      )
     ).toThrow();
   });
 
   it("rejects blank external labels as endpoints", () => {
     expect(() =>
-      saveTransfer(db as any, {
-        id: "tr-blank-from" as TransferId,
-        userId: USER_ID,
-        amount: 250000 as CopAmount,
-        fromAccountId: null,
-        toAccountId: "fa-2" as FinancialAccountId,
-        fromExternalLabel: "   ",
-        toExternalLabel: null,
-        description: "Invalid transfer",
-        date: "2026-04-18" as IsoDate,
-        createdAt: NOW,
-        updatedAt: NOW,
-        deletedAt: null,
-      })
+      saveTransfer(
+        db as any,
+        makeTransfer({
+          id: "tr-blank-from" as TransferId,
+          fromAccountId: null,
+          fromExternalLabel: "   ",
+        })
+      )
     ).toThrow();
-
     expect(() =>
-      saveTransfer(db as any, {
-        id: "tr-blank-to" as TransferId,
-        userId: USER_ID,
-        amount: 250000 as CopAmount,
-        fromAccountId: "fa-1" as FinancialAccountId,
-        toAccountId: null,
-        fromExternalLabel: null,
-        toExternalLabel: "",
-        description: "Invalid transfer",
-        date: "2026-04-18" as IsoDate,
-        createdAt: NOW,
-        updatedAt: NOW,
-        deletedAt: null,
-      })
+      saveTransfer(
+        db as any,
+        makeTransfer({
+          id: "tr-blank-to" as TransferId,
+          toAccountId: null,
+          toExternalLabel: "",
+        })
+      )
     ).toThrow();
   });
 });

--- a/plans/lizard-complexity-debt.json
+++ b/plans/lizard-complexity-debt.json
@@ -6,67 +6,11 @@
   },
   "violations": [
     {
-      "key": "(anonymous)@106-140@apps/mobile/__tests__/transfers/repository.test.ts",
-      "file": "apps/mobile/__tests__/transfers/repository.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 34,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@1088-1129@apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "file": "apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 40,
-      "parameterCount": 0
-    },
-    {
       "key": "(anonymous)@111-144@apps/mobile/__tests__/ai-chat/user-memories.test.ts",
       "file": "apps/mobile/__tests__/ai-chat/user-memories.test.ts",
       "function": "(anonymous)",
       "cyclomaticComplexity": 1,
       "nloc": 32,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@112-151@apps/mobile/__tests__/financial-accounts/repository.test.ts",
-      "file": "apps/mobile/__tests__/financial-accounts/repository.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 38,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@1131-1167@apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "file": "apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 35,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@122-146@apps/mobile/__tests__/sync/sync-pull-integration.test.ts",
-      "file": "apps/mobile/__tests__/sync/sync-pull-integration.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 8,
-      "nloc": 18,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@130-166@apps/mobile/__tests__/email-capture/email-pipeline.test.ts",
-      "file": "apps/mobile/__tests__/email-capture/email-pipeline.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 34,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@132-189@apps/mobile/__tests__/sync/sync-service.test.ts",
-      "file": "apps/mobile/__tests__/sync/sync-service.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 57,
       "parameterCount": 0
     },
     {
@@ -78,51 +22,11 @@
       "parameterCount": 0
     },
     {
-      "key": "(anonymous)@139-197@apps/mobile/__tests__/financial-accounts/balance-repository.test.ts",
-      "file": "apps/mobile/__tests__/financial-accounts/balance-repository.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 56,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@141-173@apps/mobile/__tests__/capture-evidence/repository.test.ts",
-      "file": "apps/mobile/__tests__/capture-evidence/repository.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 31,
-      "parameterCount": 0
-    },
-    {
       "key": "(anonymous)@141-174@apps/mobile/__tests__/goals/repository.test.ts",
       "file": "apps/mobile/__tests__/goals/repository.test.ts",
       "function": "(anonymous)",
       "cyclomaticComplexity": 1,
       "nloc": 32,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@148-190@apps/mobile/__tests__/financial-accounts/identifiers.test.ts",
-      "file": "apps/mobile/__tests__/financial-accounts/identifiers.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 40,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@153-199@apps/mobile/__tests__/budget/store.test.ts",
-      "file": "apps/mobile/__tests__/budget/store.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 2,
-      "nloc": 39,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@154-197@apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "file": "apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 42,
       "parameterCount": 0
     },
     {
@@ -134,27 +38,11 @@
       "parameterCount": 0
     },
     {
-      "key": "(anonymous)@173-208@apps/mobile/__tests__/financial-accounts/opening-balances.test.ts",
-      "file": "apps/mobile/__tests__/financial-accounts/opening-balances.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 34,
-      "parameterCount": 0
-    },
-    {
       "key": "(anonymous)@191-230@apps/mobile/__tests__/transactions/mutation-service.test.ts",
       "file": "apps/mobile/__tests__/transactions/mutation-service.test.ts",
       "function": "(anonymous)",
       "cyclomaticComplexity": 1,
       "nloc": 38,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@192-230@apps/mobile/__tests__/financial-accounts/identifiers.test.ts",
-      "file": "apps/mobile/__tests__/financial-accounts/identifiers.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 37,
       "parameterCount": 0
     },
     {
@@ -166,139 +54,11 @@
       "parameterCount": 0
     },
     {
-      "key": "(anonymous)@203-250@apps/mobile/__tests__/budget/repository.test.ts",
-      "file": "apps/mobile/__tests__/budget/repository.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 41,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@210-249@apps/mobile/__tests__/financial-accounts/opening-balances.test.ts",
-      "file": "apps/mobile/__tests__/financial-accounts/opening-balances.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 37,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@211-267@apps/mobile/__tests__/email-capture/email-pipeline.test.ts",
-      "file": "apps/mobile/__tests__/email-capture/email-pipeline.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 55,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@212-252@apps/mobile/__tests__/sync/sync-service.test.ts",
-      "file": "apps/mobile/__tests__/sync/sync-service.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 40,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@230-267@apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "file": "apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 36,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@232-274@apps/mobile/__tests__/financial-accounts/identifiers.test.ts",
-      "file": "apps/mobile/__tests__/financial-accounts/identifiers.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 40,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@24-64@apps/mobile/__tests__/sync/sync-conflict-state.test.ts",
-      "file": "apps/mobile/__tests__/sync/sync-conflict-state.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 2,
-      "nloc": 39,
-      "parameterCount": 0
-    },
-    {
       "key": "(anonymous)@250-291@apps/mobile/features/calendar/lib/bill-mutation-service.ts",
       "file": "apps/mobile/features/calendar/lib/bill-mutation-service.ts",
       "function": "(anonymous)",
       "cyclomaticComplexity": 7,
       "nloc": 36,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@269-307@apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "file": "apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 37,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@273-313@apps/mobile/__tests__/budget/repository.test.ts",
-      "file": "apps/mobile/__tests__/budget/repository.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 36,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@294-369@apps/mobile/__tests__/account-suggestions/service.test.ts",
-      "file": "apps/mobile/__tests__/account-suggestions/service.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 74,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@309-350@apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "file": "apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 40,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@315-377@apps/mobile/__tests__/budget/repository.test.ts",
-      "file": "apps/mobile/__tests__/budget/repository.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 57,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@35-68@apps/mobile/__tests__/transfers/repository.test.ts",
-      "file": "apps/mobile/__tests__/transfers/repository.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 32,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@352-390@apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "file": "apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 37,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@390-430@apps/mobile/__tests__/email-capture/store.test.ts",
-      "file": "apps/mobile/__tests__/email-capture/store.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 38,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@392-430@apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "file": "apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 37,
       "parameterCount": 0
     },
     {
@@ -318,22 +78,6 @@
       "parameterCount": 0
     },
     {
-      "key": "(anonymous)@42-139@apps/mobile/__tests__/capture-evidence/repository.test.ts",
-      "file": "apps/mobile/__tests__/capture-evidence/repository.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 92,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@432-475@apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "file": "apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 42,
-      "parameterCount": 0
-    },
-    {
       "key": "(anonymous)@47-80@apps/mobile/__tests__/transactions/query-service.test.ts",
       "file": "apps/mobile/__tests__/transactions/query-service.test.ts",
       "function": "(anonymous)",
@@ -350,22 +94,6 @@
       "parameterCount": 0
     },
     {
-      "key": "(anonymous)@486-531@apps/mobile/__tests__/email-capture/email-pipeline.test.ts",
-      "file": "apps/mobile/__tests__/email-capture/email-pipeline.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 37,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@498-539@apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "file": "apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 40,
-      "parameterCount": 0
-    },
-    {
       "key": "(anonymous)@51-95@apps/mobile/__tests__/email-capture/financial-meaning-review.test.ts",
       "file": "apps/mobile/__tests__/email-capture/financial-meaning-review.test.ts",
       "function": "(anonymous)",
@@ -374,51 +102,11 @@
       "parameterCount": 0
     },
     {
-      "key": "(anonymous)@512-553@apps/mobile/__tests__/email-capture/store.test.ts",
-      "file": "apps/mobile/__tests__/email-capture/store.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 39,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@541-690@apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "file": "apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 148,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@57-190@apps/mobile/__tests__/transfers/reclassify-transaction-as-transfer.test.ts",
-      "file": "apps/mobile/__tests__/transfers/reclassify-transaction-as-transfer.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 121,
-      "parameterCount": 0
-    },
-    {
       "key": "(anonymous)@57-65@apps/mobile/__tests__/calendar/calendar-utils.test.ts",
       "file": "apps/mobile/__tests__/calendar/calendar-utils.test.ts",
       "function": "(anonymous)",
       "cyclomaticComplexity": 6,
       "nloc": 7,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@594-631@apps/mobile/__tests__/email-capture/store.test.ts",
-      "file": "apps/mobile/__tests__/email-capture/store.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 35,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@648-688@apps/mobile/__tests__/email-capture/store.test.ts",
-      "file": "apps/mobile/__tests__/email-capture/store.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 34,
       "parameterCount": 0
     },
     {
@@ -438,46 +126,6 @@
       "parameterCount": 0
     },
     {
-      "key": "(anonymous)@69-110@apps/mobile/__tests__/financial-accounts/opening-balances.test.ts",
-      "file": "apps/mobile/__tests__/financial-accounts/opening-balances.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 39,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@69-113@apps/mobile/__tests__/financial-accounts/identifiers.test.ts",
-      "file": "apps/mobile/__tests__/financial-accounts/identifiers.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 42,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@692-738@apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "file": "apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 45,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@7-57@apps/mobile/__tests__/sync/sync-service.test.ts",
-      "file": "apps/mobile/__tests__/sync/sync-service.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 50,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@70-104@apps/mobile/__tests__/transfers/repository.test.ts",
-      "file": "apps/mobile/__tests__/transfers/repository.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 34,
-      "parameterCount": 0
-    },
-    {
       "key": "(anonymous)@70-124@apps/mobile/__tests__/shared/write-through.test.ts",
       "file": "apps/mobile/__tests__/shared/write-through.test.ts",
       "function": "(anonymous)",
@@ -491,54 +139,6 @@
       "function": "(anonymous)",
       "cyclomaticComplexity": 1,
       "nloc": 75,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@74-123@apps/mobile/__tests__/account-suggestions/service.test.ts",
-      "file": "apps/mobile/__tests__/account-suggestions/service.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 45,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@740-800@apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "file": "apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 2,
-      "nloc": 45,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@75-118@apps/mobile/__tests__/sync/sync-service.test.ts",
-      "file": "apps/mobile/__tests__/sync/sync-service.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 44,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@77-119@apps/mobile/__tests__/budget/store.test.ts",
-      "file": "apps/mobile/__tests__/budget/store.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 2,
-      "nloc": 37,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@802-847@apps/mobile/__tests__/email-capture/store.test.ts",
-      "file": "apps/mobile/__tests__/email-capture/store.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 42,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@802-870@apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "file": "apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 65,
       "parameterCount": 0
     },
     {
@@ -558,43 +158,11 @@
       "parameterCount": 0
     },
     {
-      "key": "(anonymous)@89-130@apps/mobile/__tests__/sync/sync-module.test.ts",
-      "file": "apps/mobile/__tests__/sync/sync-module.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 3,
-      "nloc": 40,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@899-948@apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "file": "apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 48,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@950-984@apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "file": "apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 33,
-      "parameterCount": 0
-    },
-    {
       "key": "(anonymous)@97-204@apps/mobile/__tests__/email-capture/financial-meaning-review.test.ts",
       "file": "apps/mobile/__tests__/email-capture/financial-meaning-review.test.ts",
       "function": "(anonymous)",
       "cyclomaticComplexity": 1,
       "nloc": 102,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@986-1023@apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "file": "apps/mobile/__tests__/sync/syncEngine.test.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 1,
-      "nloc": 36,
       "parameterCount": 0
     },
     {
@@ -630,38 +198,6 @@
       "parameterCount": 3
     },
     {
-      "key": "createIdentifierId@135-195@apps/mobile/__tests__/financial-accounts/management-service.test.ts",
-      "file": "apps/mobile/__tests__/financial-accounts/management-service.test.ts",
-      "function": "createIdentifierId",
-      "cyclomaticComplexity": 3,
-      "nloc": 55,
-      "parameterCount": 0
-    },
-    {
-      "key": "createIdentifierId@247-292@apps/mobile/__tests__/account-suggestions/service.test.ts",
-      "file": "apps/mobile/__tests__/account-suggestions/service.test.ts",
-      "function": "createIdentifierId",
-      "cyclomaticComplexity": 1,
-      "nloc": 38,
-      "parameterCount": 0
-    },
-    {
-      "key": "createIdentifierId@409-457@apps/mobile/__tests__/account-suggestions/service.test.ts",
-      "file": "apps/mobile/__tests__/account-suggestions/service.test.ts",
-      "function": "createIdentifierId",
-      "cyclomaticComplexity": 1,
-      "nloc": 42,
-      "parameterCount": 0
-    },
-    {
-      "key": "createIdentifierId@41-97@apps/mobile/__tests__/financial-accounts/management-service.test.ts",
-      "file": "apps/mobile/__tests__/financial-accounts/management-service.test.ts",
-      "function": "createIdentifierId",
-      "cyclomaticComplexity": 1,
-      "nloc": 54,
-      "parameterCount": 0
-    },
-    {
       "key": "deriveEffectiveOnboardingComplete@55-62@apps/mobile/features/auth/lib/effective-auth.ts",
       "file": "apps/mobile/features/auth/lib/effective-auth.ts",
       "function": "deriveEffectiveOnboardingComplete",
@@ -694,28 +230,12 @@
       "parameterCount": 4
     },
     {
-      "key": "evidence.map@87-96@apps/mobile/__tests__/email-capture/email-pipeline.test.ts",
-      "file": "apps/mobile/__tests__/email-capture/email-pipeline.test.ts",
-      "function": "evidence.map",
-      "cyclomaticComplexity": 1,
-      "nloc": 9,
-      "parameterCount": 4
-    },
-    {
       "key": "extractAliasEvidence@55-80@apps/mobile/features/capture-evidence/lib/build-capture-evidence.ts",
       "file": "apps/mobile/features/capture-evidence/lib/build-capture-evidence.ts",
       "function": "extractAliasEvidence",
       "cyclomaticComplexity": 1,
       "nloc": 14,
       "parameterCount": 4
-    },
-    {
-      "key": "extractTypeEnum@52-99@apps/mobile/__tests__/email-capture/schema-compat.test.ts",
-      "file": "apps/mobile/__tests__/email-capture/schema-compat.test.ts",
-      "function": "extractTypeEnum",
-      "cyclomaticComplexity": 6,
-      "nloc": 9,
-      "parameterCount": 1
     },
     {
       "key": "getCaptureEvidenceRowsForScopeValue@204-223@apps/mobile/features/capture-evidence/lib/repository.ts",
@@ -756,22 +276,6 @@
       "cyclomaticComplexity": 6,
       "nloc": 7,
       "parameterCount": 1
-    },
-    {
-      "key": "getLocale@307-355@apps/mobile/__tests__/budget/monitoring.test.ts",
-      "file": "apps/mobile/__tests__/budget/monitoring.test.ts",
-      "function": "getLocale",
-      "cyclomaticComplexity": 1,
-      "nloc": 46,
-      "parameterCount": 0
-    },
-    {
-      "key": "getLocale@447-479@apps/mobile/__tests__/budget/monitoring.test.ts",
-      "file": "apps/mobile/__tests__/budget/monitoring.test.ts",
-      "function": "getLocale",
-      "cyclomaticComplexity": 1,
-      "nloc": 31,
-      "parameterCount": 0
     },
     {
       "key": "getNextOnboardingStep@26-40@apps/mobile/features/onboarding/lib/flow.ts",
@@ -819,14 +323,6 @@
       "function": "hydrate",
       "cyclomaticComplexity": 6,
       "nloc": 22,
-      "parameterCount": 0
-    },
-    {
-      "key": "id@159-165@apps/mobile/__tests__/email-capture/store.test.ts",
-      "file": "apps/mobile/__tests__/email-capture/store.test.ts",
-      "function": "id",
-      "cyclomaticComplexity": 11,
-      "nloc": 7,
       "parameterCount": 0
     },
     {
@@ -886,36 +382,12 @@
       "parameterCount": 0
     },
     {
-      "key": "saveAccountTransaction@66-101@apps/mobile/__tests__/financial-accounts/balance-repository.test.ts",
-      "file": "apps/mobile/__tests__/financial-accounts/balance-repository.test.ts",
-      "function": "saveAccountTransaction",
-      "cyclomaticComplexity": 2,
-      "nloc": 36,
-      "parameterCount": 8
-    },
-    {
-      "key": "saveAccountTransfer@103-136@apps/mobile/__tests__/financial-accounts/balance-repository.test.ts",
-      "file": "apps/mobile/__tests__/financial-accounts/balance-repository.test.ts",
-      "function": "saveAccountTransfer",
-      "cyclomaticComplexity": 1,
-      "nloc": 34,
-      "parameterCount": 8
-    },
-    {
       "key": "saveEvidence@39-68@apps/mobile/__tests__/review-queues/attribution-review-service.test.ts",
       "file": "apps/mobile/__tests__/review-queues/attribution-review-service.test.ts",
       "function": "saveEvidence",
       "cyclomaticComplexity": 1,
       "nloc": 30,
       "parameterCount": 6
-    },
-    {
-      "key": "saveEvidenceRow@44-71@apps/mobile/__tests__/account-suggestions/service.test.ts",
-      "file": "apps/mobile/__tests__/account-suggestions/service.test.ts",
-      "function": "saveEvidenceRow",
-      "cyclomaticComplexity": 11,
-      "nloc": 28,
-      "parameterCount": 2
     },
     {
       "key": "scheduleBudgetAlert@21-68@apps/mobile/features/budget/lib/notifications.ts",


### PR DESCRIPTION
- clean Wave 4 strict targets\n- refactor test helpers and fixtures\n- refresh complexity debt ledger

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the mobile test suite for Wave 4 to centralize fixtures and helpers, standardize typed inputs, and remove flaky logic for faster, more reliable tests. Preserved raw sync conflict fixtures to match database rows and make them reusable across sync tests. Also refreshed the complexity debt ledger to meet strict targets.

- **Refactors**
  - Added shared fixtures for financial accounts and sync tests: `apps/mobile/__tests__/financial-accounts/fixtures.ts`, `apps/mobile/__tests__/sync/fixtures.ts` (includes raw conflict row builders and parsed helpers).
  - Replaced inline data with typed builders and helpers (e.g., makeBudgetRow, buildCaptureEvidenceRow, expectLoggedConflict, createConflictRow).
  - Standardized IDs/timestamps and simplified mocks across budget, email capture, accounts, transfers, and sync tests.
  - Updated `plans/lizard-complexity-debt.json` to remove stale entries and align with strict targets.

<sup>Written for commit fc39a43eea75251e5281984e6223aff3cd2cb4db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

