### PR TITLE
refactor(mobile): finish lizard mr1 cleanup

### DIFF
--- a/apps/mobile/features/categories/store.ts
+++ b/apps/mobile/features/categories/store.ts
@@ -12,7 +12,7 @@ import {
   createCategoryRegistrySnapshot,
   isCategoryIdValid,
 } from "./lib/registry";
-import { getUserCategoriesForUser } from "./lib/repository";
+import { getUserCategoriesForUser, type UserCategoryRow } from "./lib/repository";
 
 const HEX_COLOR_REGEX = /^#[0-9A-Fa-f]{6}$/;
 
@@ -21,6 +21,12 @@ type CategoriesState = CategoryRegistrySnapshot;
 type CategoriesActions = {
   replaceSnapshot: (snapshot: CategoryRegistrySnapshot) => void;
   isValid(id: string, scope?: CategoryRegistryScope): boolean;
+};
+
+type CustomCategoryInput = {
+  readonly name: string;
+  readonly iconName: string;
+  readonly colorHex: string;
 };
 
 const toCustomCategoryRow = (row: {
@@ -43,11 +49,7 @@ export const useCategoriesStore = create<CategoriesState & CategoriesActions>((s
   isValid: (id, scope = "built_in") => isCategoryIdValid(get(), id, scope),
 }));
 
-function isValidCustomCategoryInput(input: {
-  name: string;
-  iconName: string;
-  colorHex: string;
-}): boolean {
+function isValidCustomCategoryInput(input: CustomCategoryInput): boolean {
   const trimmedName = input.name.trim();
   return (
     trimmedName.length >= MIN_NAME_LENGTH &&
@@ -59,6 +61,31 @@ function isValidCustomCategoryInput(input: {
 
 function createCategoryMutations(db: AnyDb): WriteThroughMutationModule {
   return createWriteThroughMutationModule(db);
+}
+
+function buildCustomCategoryRow(userId: UserId, input: CustomCategoryInput): UserCategoryRow {
+  const now = toIsoDateTime(new Date());
+  return {
+    id: generateUserCategoryId(),
+    userId,
+    name: input.name.trim(),
+    iconName: input.iconName,
+    colorHex: input.colorHex,
+    createdAt: now,
+    updatedAt: now,
+    deletedAt: null,
+  };
+}
+
+async function saveCustomCategory(
+  mutations: WriteThroughMutationModule,
+  row: UserCategoryRow
+): Promise<boolean> {
+  try {
+    return (await mutations.commit({ kind: "category.save", row })).success;
+  } catch {
+    return false;
+  }
 }
 
 export async function refreshCategories(db: AnyDb, userId: UserId): Promise<void> {
@@ -73,33 +100,16 @@ export async function refreshCategories(db: AnyDb, userId: UserId): Promise<void
 export async function createCustomCategory(
   db: AnyDb,
   userId: UserId,
-  input: { name: string; iconName: string; colorHex: string }
+  input: CustomCategoryInput
 ): Promise<boolean> {
   if (!isValidCustomCategoryInput(input)) return false;
 
-  const trimmedName = input.name.trim();
-  const now = toIsoDateTime(new Date());
-  const id = generateUserCategoryId();
-  const mutations = createCategoryMutations(db);
+  const didSave = await saveCustomCategory(
+    createCategoryMutations(db),
+    buildCustomCategoryRow(userId, input)
+  );
 
-  try {
-    const result = await mutations.commit({
-      kind: "category.save",
-      row: {
-        id,
-        userId,
-        name: trimmedName,
-        iconName: input.iconName,
-        colorHex: input.colorHex,
-        createdAt: now,
-        updatedAt: now,
-        deletedAt: null,
-      },
-    });
-    if (!result.success) return false;
-  } catch {
-    return false;
-  }
+  if (!didSave) return false;
 
   await refreshCategories(db, userId);
   return true;

--- a/apps/mobile/features/goals/lib/route-params.ts
+++ b/apps/mobile/features/goals/lib/route-params.ts
@@ -4,12 +4,10 @@ type GoalDetailRouteParams = {
 };
 
 function getFirstNonEmptyRouteParam(value: string | readonly string[] | undefined): string | null {
-  if (typeof value === "string") {
-    const trimmedValue = value.trim();
-    return trimmedValue.length > 0 ? trimmedValue : null;
-  }
+  const values = Array.isArray(value) ? value : value === undefined ? [] : [value];
+  const normalizedValues = values.map((entry) => entry.trim()).filter((entry) => entry.length > 0);
 
-  return value?.find((entry) => entry.trim().length > 0)?.trim() ?? null;
+  return normalizedValues[0] ?? null;
 }
 
 export function resolveGoalDetailGoalId(params: GoalDetailRouteParams): string | null {

--- a/apps/mobile/features/onboarding/lib/flow.ts
+++ b/apps/mobile/features/onboarding/lib/flow.ts
@@ -23,18 +23,14 @@ export function getVisibleOnboardingStepIndex(step: OnboardingStep, shouldReview
   return !shouldReviewAccounts && step >= ONBOARDING_STEP.budgetSetup ? step - 1 : step;
 }
 
-export function getNextOnboardingStep({
-  step,
-  emailSkipped,
-  shouldReviewAccounts,
-}: NextOnboardingStepInput): OnboardingStep {
-  if (step === ONBOARDING_STEP.connectEmail && emailSkipped) {
+export function getNextOnboardingStep(input: NextOnboardingStepInput): OnboardingStep {
+  if (input.step === ONBOARDING_STEP.connectEmail && input.emailSkipped) {
     return ONBOARDING_STEP.budgetSetup;
   }
 
-  if (step === ONBOARDING_STEP.sync) {
-    return shouldReviewAccounts ? ONBOARDING_STEP.accountReview : ONBOARDING_STEP.budgetSetup;
+  if (input.step === ONBOARDING_STEP.sync) {
+    return input.shouldReviewAccounts ? ONBOARDING_STEP.accountReview : ONBOARDING_STEP.budgetSetup;
   }
 
-  return Math.min(step + 1, ONBOARDING_STEP.complete) as OnboardingStep;
+  return Math.min(input.step + 1, ONBOARDING_STEP.complete) as OnboardingStep;
 }

--- a/apps/mobile/features/qa/lib/route-params.ts
+++ b/apps/mobile/features/qa/lib/route-params.ts
@@ -5,7 +5,9 @@ function getFirstArrayRouteParamValue(value: readonly string[] | null | undefine
   return value?.[0] ?? null;
 }
 
-function getFirstRouteParamValue(value: string | readonly string[] | null | undefined): string | null {
+function getFirstRouteParamValue(
+  value: string | readonly string[] | null | undefined
+): string | null {
   return typeof value === "string" ? value : getFirstArrayRouteParamValue(value);
 }
 

--- a/apps/mobile/features/qa/lib/route-params.ts
+++ b/apps/mobile/features/qa/lib/route-params.ts
@@ -1,16 +1,16 @@
 import { isLocalQaProfile, type LocalQaProfile } from "../local-session";
 import { getQaTargetFromKey, isQaTarget, isQaTargetKey, type QaTarget } from "./entry-points";
 
-function getFirstRouteParamValue(value: string | string[] | null | undefined): string | null {
-  if (Array.isArray(value)) {
-    return value[0] ?? null;
-  }
+function getFirstArrayRouteParamValue(value: readonly string[] | null | undefined): string | null {
+  return value?.[0] ?? null;
+}
 
-  return value ?? null;
+function getFirstRouteParamValue(value: string | readonly string[] | null | undefined): string | null {
+  return typeof value === "string" ? value : getFirstArrayRouteParamValue(value);
 }
 
 export function parseLocalQaProfileRouteParam(
-  value: string | string[] | null | undefined
+  value: string | readonly string[] | null | undefined
 ): LocalQaProfile | null {
   const normalizedValue = getFirstRouteParamValue(value)?.trim();
 
@@ -22,7 +22,7 @@ export function parseLocalQaProfileRouteParam(
 }
 
 export function parseQaTargetRouteParam(
-  value: string | string[] | null | undefined
+  value: string | readonly string[] | null | undefined
 ): QaTarget | null {
   const normalizedValue = getFirstRouteParamValue(value)?.trim();
 
@@ -34,7 +34,7 @@ export function parseQaTargetRouteParam(
 }
 
 export function parseQaTargetKeyRouteParam(
-  value: string | string[] | null | undefined
+  value: string | readonly string[] | null | undefined
 ): QaTarget | null {
   const normalizedValue = getFirstRouteParamValue(value)?.trim();
 

--- a/apps/mobile/features/search/lib/filters.ts
+++ b/apps/mobile/features/search/lib/filters.ts
@@ -1,24 +1,17 @@
 import type { SearchFilters } from "./types";
 
+const getActiveFilterDimensions = (filters: SearchFilters): readonly boolean[] => [
+  filters.query.trim().length > 0,
+  filters.categoryIds.length > 0,
+  filters.dateFrom !== null || filters.dateTo !== null,
+  filters.amountMin !== null || filters.amountMax !== null,
+  filters.type !== "all",
+];
+
 export function hasActiveFilters(filters: SearchFilters): boolean {
-  return (
-    filters.query.trim().length > 0 ||
-    filters.categoryIds.length > 0 ||
-    filters.dateFrom !== null ||
-    filters.dateTo !== null ||
-    filters.amountMin !== null ||
-    filters.amountMax !== null ||
-    filters.type !== "all"
-  );
+  return getActiveFilterDimensions(filters).some(Boolean);
 }
 
 export function countActiveFilters(filters: SearchFilters): number {
-  const dimensions = [
-    filters.query.trim().length > 0,
-    filters.categoryIds.length > 0,
-    filters.dateFrom !== null || filters.dateTo !== null,
-    filters.amountMin !== null || filters.amountMax !== null,
-    filters.type !== "all",
-  ];
-  return dimensions.filter(Boolean).length;
+  return getActiveFilterDimensions(filters).filter(Boolean).length;
 }

--- a/apps/mobile/features/search/lib/route-params.ts
+++ b/apps/mobile/features/search/lib/route-params.ts
@@ -6,12 +6,10 @@ type SearchRouteParams = {
 };
 
 function getFirstNonEmptyRouteParam(value: string | readonly string[] | undefined): string | null {
-  if (typeof value === "string") {
-    const trimmedValue = value.trim();
-    return trimmedValue.length > 0 ? trimmedValue : null;
-  }
+  const values = Array.isArray(value) ? value : value === undefined ? [] : [value];
+  const normalizedValues = values.map((entry) => entry.trim()).filter((entry) => entry.length > 0);
 
-  return value?.find((entry) => entry.trim().length > 0)?.trim() ?? null;
+  return normalizedValues[0] ?? null;
 }
 
 export function resolveSearchRouteFilters(params: SearchRouteParams): Partial<SearchFilters> {

--- a/apps/mobile/features/settings/store.ts
+++ b/apps/mobile/features/settings/store.ts
@@ -33,6 +33,7 @@ type SettingsActions = {
 };
 
 const PREFS_KEY = "notification_preferences";
+const THEME_PREFERENCE_KEY = "theme_preference";
 
 const toColorScheme = (pref: ThemePreference) => (pref === "system" ? "unspecified" : pref);
 
@@ -47,6 +48,23 @@ const persistPreferences = (prefs: NotificationPreferences): void => {
   });
 };
 
+const resolveThemePreference = (value: string | null): ThemePreference | null =>
+  value === "light" || value === "dark" || value === "system" ? value : null;
+
+const parseStoredNotificationPreferences = (
+  value: string | null
+): NotificationPreferences | null => {
+  if (!value) {
+    return null;
+  }
+
+  const raw: unknown = JSON.parse(value);
+  return {
+    ...DEFAULT_NOTIFICATION_PREFERENCES,
+    ...(typeof raw === "object" && raw !== null ? (raw as Partial<NotificationPreferences>) : {}),
+  };
+};
+
 export const useSettingsStore = create<SettingsState & SettingsActions>((set, get) => ({
   themePreference: "system",
   notificationPreferences: DEFAULT_NOTIFICATION_PREFERENCES,
@@ -55,7 +73,7 @@ export const useSettingsStore = create<SettingsState & SettingsActions>((set, ge
   setThemePreference: (pref) => {
     set({ themePreference: pref });
     Appearance.setColorScheme(toColorScheme(pref));
-    void SecureStore.setItemAsync("theme_preference", pref).catch((error) => {
+    void SecureStore.setItemAsync(THEME_PREFERENCE_KEY, pref).catch((error) => {
       captureWarning("theme_preference_persist_failed", {
         errorMessage: error instanceof Error ? error.message : "unknown",
       });
@@ -88,26 +106,26 @@ export const useSettingsStore = create<SettingsState & SettingsActions>((set, ge
   hydrate: async () => {
     try {
       const [storedTheme, storedPrefs] = await Promise.all([
-        SecureStore.getItemAsync("theme_preference"),
+        SecureStore.getItemAsync(THEME_PREFERENCE_KEY),
         SecureStore.getItemAsync(PREFS_KEY),
       ]);
+      const themePreference = resolveThemePreference(storedTheme);
 
-      if (storedTheme === "light" || storedTheme === "dark" || storedTheme === "system") {
-        set({ themePreference: storedTheme });
-        Appearance.setColorScheme(toColorScheme(storedTheme));
+      if (themePreference) {
+        set({ themePreference });
+        Appearance.setColorScheme(toColorScheme(themePreference));
       }
 
-      if (storedPrefs) {
-        const raw: unknown = JSON.parse(storedPrefs);
-        const parsed: NotificationPreferences = {
-          ...DEFAULT_NOTIFICATION_PREFERENCES,
-          ...(typeof raw === "object" && raw !== null ? (raw as Record<string, unknown>) : {}),
-        };
-        set({
-          notificationPreferences: parsed,
-          areAllNotificationsOff: computeAllOff(parsed),
-        });
+      const notificationPreferences = parseStoredNotificationPreferences(storedPrefs);
+
+      if (!notificationPreferences) {
+        return;
       }
+
+      set({
+        notificationPreferences,
+        areAllNotificationsOff: computeAllOff(notificationPreferences),
+      });
     } catch {
       // SecureStore unavailable (e.g., in tests)
     }

--- a/plans/lizard-complexity-debt.json
+++ b/plans/lizard-complexity-debt.json
@@ -190,14 +190,6 @@
       "parameterCount": 1
     },
     {
-      "key": "createCustomCategory@73-106@apps/mobile/features/categories/store.ts",
-      "file": "apps/mobile/features/categories/store.ts",
-      "function": "createCustomCategory",
-      "cyclomaticComplexity": 4,
-      "nloc": 31,
-      "parameterCount": 3
-    },
-    {
       "key": "deriveEffectiveOnboardingComplete@55-62@apps/mobile/features/auth/lib/effective-auth.ts",
       "file": "apps/mobile/features/auth/lib/effective-auth.ts",
       "function": "deriveEffectiveOnboardingComplete",
@@ -254,38 +246,6 @@
       "parameterCount": 4
     },
     {
-      "key": "getFirstNonEmptyRouteParam@6-15@apps/mobile/features/goals/lib/route-params.ts",
-      "file": "apps/mobile/features/goals/lib/route-params.ts",
-      "function": "getFirstNonEmptyRouteParam",
-      "cyclomaticComplexity": 6,
-      "nloc": 8,
-      "parameterCount": 1
-    },
-    {
-      "key": "getFirstNonEmptyRouteParam@8-17@apps/mobile/features/search/lib/route-params.ts",
-      "file": "apps/mobile/features/search/lib/route-params.ts",
-      "function": "getFirstNonEmptyRouteParam",
-      "cyclomaticComplexity": 6,
-      "nloc": 8,
-      "parameterCount": 1
-    },
-    {
-      "key": "getFirstRouteParamValue@4-12@apps/mobile/features/qa/lib/route-params.ts",
-      "file": "apps/mobile/features/qa/lib/route-params.ts",
-      "function": "getFirstRouteParamValue",
-      "cyclomaticComplexity": 6,
-      "nloc": 7,
-      "parameterCount": 1
-    },
-    {
-      "key": "getNextOnboardingStep@26-40@apps/mobile/features/onboarding/lib/flow.ts",
-      "file": "apps/mobile/features/onboarding/lib/flow.ts",
-      "function": "getNextOnboardingStep",
-      "cyclomaticComplexity": 5,
-      "nloc": 13,
-      "parameterCount": 4
-    },
-    {
       "key": "getNow@27-73@apps/mobile/__tests__/analytics/service.test.ts",
       "file": "apps/mobile/__tests__/analytics/service.test.ts",
       "function": "getNow",
@@ -302,28 +262,12 @@
       "parameterCount": 4
     },
     {
-      "key": "hasActiveFilters@3-15@apps/mobile/features/search/lib/filters.ts",
-      "file": "apps/mobile/features/search/lib/filters.ts",
-      "function": "hasActiveFilters",
-      "cyclomaticComplexity": 7,
-      "nloc": 12,
-      "parameterCount": 1
-    },
-    {
       "key": "hasInvalidBillingDayInput@11-32@apps/mobile/features/financial-accounts/lib/form-screen.ts",
       "file": "apps/mobile/features/financial-accounts/lib/form-screen.ts",
       "function": "hasInvalidBillingDayInput",
       "cyclomaticComplexity": 5,
       "nloc": 20,
       "parameterCount": 4
-    },
-    {
-      "key": "hydrate@88-115@apps/mobile/features/settings/store.ts",
-      "file": "apps/mobile/features/settings/store.ts",
-      "function": "hydrate",
-      "cyclomaticComplexity": 6,
-      "nloc": 22,
-      "parameterCount": 0
     },
     {
       "key": "linkCaptureEvidenceToTransaction@116-148@apps/mobile/features/capture-evidence/lib/repository.ts",


### PR DESCRIPTION
- simplify route and filter helpers
- split settings and category persistence steps
- refresh strict complexity ledger


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce mobile code complexity by simplifying route/filter helpers and separating persistence from hydration across settings and categories. Improves reliability of state reads/writes and tightens types, then updates the complexity ledger.

- **Refactors**
  - Categories: add `CustomCategoryInput`, split row build/save helpers, and refresh after successful save.
  - Settings: introduce `THEME_PREFERENCE_KEY`, add `resolveThemePreference` and safe prefs parsing, and hydrate using these helpers.
  - Route params: unify “first non-empty” logic for goals/search/QA with stricter `readonly string[]` handling.
  - Search: centralize active filter checks via `getActiveFilterDimensions`; simplify `hasActiveFilters` and `countActiveFilters`.
  - Onboarding: simplify `getNextOnboardingStep` branching and input handling.
  - Complexity ledger: remove outdated entries and refresh metrics.

<sup>Written for commit 2945e36a69104ca058c0d99df195f10944e3ac37. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

