### PR TITLE
refactor(mobile): finish lizard mr3 cleanup

### DIFF
--- a/apps/mobile/__tests__/sync/fixtures.ts
+++ b/apps/mobile/__tests__/sync/fixtures.ts
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/style/useNamingConvention: sync fixtures mirror server column names
 type Overrides = Record<string, unknown>;
 type ConflictData = Record<string, unknown>;
 type ParsedConflictOverrides = {

--- a/apps/mobile/features/ai-chat/hooks/use-streaming-chat.ts
+++ b/apps/mobile/features/ai-chat/hooks/use-streaming-chat.ts
@@ -37,6 +37,48 @@ export function cancelActiveStream(): void {
   streamingChatService.cancel();
 }
 
+type UserDb = NonNullable<ReturnType<typeof tryGetDb>>;
+type OptionalUserId = ReturnType<typeof useOptionalUserId>;
+type AddAction = Extract<ChatAction, { type: "add" }>;
+
+function populateTransactionDraft(action: AddAction) {
+  const store = useTransactionStore.getState();
+  store.setType(action.data.type);
+  store.setDigits(String(action.data.amount));
+  store.setCategoryId(action.data.categoryId);
+  store.setDescription(action.data.description);
+  store.setDate(parseIsoDate(action.data.date));
+  return store;
+}
+
+function trackAddActionCreated(action: AddAction) {
+  trackTransactionCreated({
+    type: action.data.type,
+    category: String(action.data.categoryId),
+    source: "ai_chat",
+  });
+}
+
+async function saveAddActionTransaction(
+  action: AddAction,
+  db: UserDb,
+  userId: NonNullable<OptionalUserId>
+) {
+  return (await saveCurrentTransaction(db, userId)).success
+    ? trackAddActionCreated(action)
+    : undefined;
+}
+
+async function executeAddAction(action: AddAction, db: UserDb | null, userId: OptionalUserId) {
+  if (!db || !userId) return;
+  const activeDb = db;
+  const activeUserId = userId;
+  const store = populateTransactionDraft(action);
+  return Promise.resolve(saveAddActionTransaction(action, activeDb, activeUserId)).finally(() =>
+    store.resetForm()
+  );
+}
+
 export function useStreamingChat() {
   const userId = useOptionalUserId();
   const db = userId ? tryGetDb(userId) : null;
@@ -45,38 +87,11 @@ export function useStreamingChat() {
 
   const executeAction = useCallback(
     async (action: ChatAction) => {
-      switch (action.type) {
-        case "add": {
-          const store = useTransactionStore.getState();
-          if (!db || !userId) return;
-          store.setType(action.data.type);
-          store.setDigits(String(action.data.amount));
-          store.setCategoryId(action.data.categoryId);
-          store.setDescription(action.data.description);
-          store.setDate(parseIsoDate(action.data.date));
-          try {
-            const result = await saveCurrentTransaction(db, userId);
-            if (result.success) {
-              trackTransactionCreated({
-                type: action.data.type,
-                category: String(action.data.categoryId),
-                source: "ai_chat",
-              });
-            }
-          } finally {
-            store.resetForm();
-          }
-          break;
-        }
-        case "edit": {
-          // Edit not yet fully wired
-          break;
-        }
-        case "delete": {
-          // Delete handled via updateActionStatus flow in ChatScreen
-          break;
-        }
+      if (action.type !== "add") {
+        return;
       }
+
+      await executeAddAction(action, db, userId);
     },
     [db, userId]
   );

--- a/apps/mobile/features/ai-chat/lib/parse-action.ts
+++ b/apps/mobile/features/ai-chat/lib/parse-action.ts
@@ -4,15 +4,22 @@ const ACTION_REGEX = /\[ACTION\]([\s\S]*?)\[\/ACTION\]/;
 
 export const ACTION_BLOCK_REGEX = /\[ACTION\][\s\S]*?\[\/ACTION\]/g;
 
-export function parseActionFromResponse(text: string): ChatAction | null {
+function extractActionPayload(text: string): string | null {
   const match = ACTION_REGEX.exec(text);
-  if (!match) return null;
+  return match?.[1] ?? null;
+}
 
+function parseChatAction(payload: string): ChatAction | null {
   try {
-    const parsed: unknown = JSON.parse(match[1] ?? "");
+    const parsed: unknown = JSON.parse(payload);
     const result = chatActionSchema.safeParse(parsed);
     return result.success ? result.data : null;
   } catch {
     return null;
   }
+}
+
+export function parseActionFromResponse(text: string): ChatAction | null {
+  const payload = extractActionPayload(text);
+  return payload == null ? null : parseChatAction(payload);
 }

--- a/apps/mobile/features/budget/lib/notifications.ts
+++ b/apps/mobile/features/budget/lib/notifications.ts
@@ -9,6 +9,16 @@ export type ScheduleResult =
   | { readonly type: "needs_permission" }
   | { readonly type: "skipped" };
 
+type NonScheduledResult = Exclude<
+  ScheduleResult,
+  { readonly type: "scheduled"; readonly id: string }
+>;
+
+const RESULT_BY_ACTION = {
+  prePermission: { type: "needs_permission" },
+  skip: { type: "skipped" },
+} as const satisfies Record<"prePermission" | "skip", NonScheduledResult>;
+
 async function readHasSeenPrePermission(): Promise<boolean> {
   try {
     const value = await SecureStore.getItemAsync(PRE_PERMISSION_KEY);
@@ -18,48 +28,75 @@ async function readHasSeenPrePermission(): Promise<boolean> {
   }
 }
 
+function buildBudgetAlertCopy(alert: BudgetAlert, categoryName: string) {
+  if (alert.threshold === 100) {
+    return {
+      title: i18n.t("budgets.alerts.overBudgetTitle"),
+      body: i18n.t("budgets.alerts.overBudget", {
+        category: categoryName,
+        percent: alert.percentUsed,
+      }),
+    };
+  }
+
+  return {
+    title: i18n.t("budgets.alerts.nearLimitTitle"),
+    body: i18n.t("budgets.alerts.nearLimit", {
+      category: categoryName,
+      percent: alert.percentUsed,
+    }),
+  };
+}
+
+function getImmediateScheduleResult(
+  actionType: ReturnType<typeof determineAlertAction>["type"]
+): NonScheduledResult | null {
+  if (actionType === "send") {
+    return null;
+  }
+
+  return actionType === "pre_permission" ? RESULT_BY_ACTION.prePermission : RESULT_BY_ACTION.skip;
+}
+
+async function getBudgetAlertAction(notificationsEnabled: boolean) {
+  const { status } = await Notifications.getPermissionsAsync();
+  const hasSeenPrePermission = await readHasSeenPrePermission();
+  return determineAlertAction(status, hasSeenPrePermission, notificationsEnabled);
+}
+
+async function scheduleBudgetNotification(
+  alert: BudgetAlert,
+  copy: ReturnType<typeof buildBudgetAlertCopy>
+) {
+  return Notifications.scheduleNotificationAsync({
+    content: {
+      title: copy.title,
+      body: copy.body,
+      data: {
+        budgetId: alert.budgetId,
+        categoryId: alert.categoryId,
+        threshold: alert.threshold,
+        route: "/(tabs)/(finance)",
+      },
+    },
+    trigger: null, // immediate
+  });
+}
+
 export async function scheduleBudgetAlert(
   alert: BudgetAlert,
   categoryName: string,
   notificationsEnabled = true
 ): Promise<ScheduleResult> {
   try {
-    const { status } = await Notifications.getPermissionsAsync();
-    const hasSeenPrePermission = await readHasSeenPrePermission();
-    const action = determineAlertAction(status, hasSeenPrePermission, notificationsEnabled);
+    const action = await getBudgetAlertAction(notificationsEnabled);
+    const immediateResult = getImmediateScheduleResult(action.type);
 
-    if (action.type === "pre_permission") return { type: "needs_permission" };
-    if (action.type === "skip") return { type: "skipped" };
+    if (immediateResult != null) {
+      return immediateResult;
+    }
 
-    // action.type === "send" — schedule the notification
-    const title =
-      alert.threshold === 100
-        ? i18n.t("budgets.alerts.overBudgetTitle")
-        : i18n.t("budgets.alerts.nearLimitTitle");
-    const body =
-      alert.threshold === 100
-        ? i18n.t("budgets.alerts.overBudget", {
-            category: categoryName,
-            percent: alert.percentUsed,
-          })
-        : i18n.t("budgets.alerts.nearLimit", {
-            category: categoryName,
-            percent: alert.percentUsed,
-          });
-
-    const id = await Notifications.scheduleNotificationAsync({
-      content: {
-        title,
-        body,
-        data: {
-          budgetId: alert.budgetId,
-          categoryId: alert.categoryId,
-          threshold: alert.threshold,
-          route: "/(tabs)/(finance)",
-        },
-      },
-      trigger: null, // immediate
-    });
+    const id = await scheduleBudgetNotification(alert, buildBudgetAlertCopy(alert, categoryName));
 
     return { type: "scheduled", id };
   } catch {

--- a/apps/mobile/features/calendar/lib/bill-mutation-service.ts
+++ b/apps/mobile/features/calendar/lib/bill-mutation-service.ts
@@ -153,6 +153,48 @@ async function commitBillPayment(
   return { transaction, payment };
 }
 
+function getBillForPayment(bills: readonly Bill[], billId: BillId): Bill | null {
+  return bills.find((candidate) => candidate.id === billId) ?? null;
+}
+
+async function commitBillPaymentSafely(input: {
+  readonly commit: WriteThroughMutationModule["commit"];
+  readonly bill: Bill;
+  readonly billId: BillId;
+  readonly dueDate: IsoDate;
+  readonly userId: UserId;
+  readonly timestamp: Date;
+  readonly createPaymentId: () => BillPaymentId;
+  readonly createTransactionId: () => TransactionId;
+}) {
+  try {
+    return await commitBillPayment(
+      input.commit,
+      input.bill,
+      input.billId,
+      input.dueDate,
+      input.userId,
+      input.timestamp,
+      input.createPaymentId,
+      input.createTransactionId
+    );
+  } catch {
+    return null;
+  }
+}
+
+function applyBillPaymentSideEffects(
+  deps: CreateCalendarBillMutationServiceDeps,
+  transaction: StoredTransaction
+) {
+  try {
+    deps.addTransactionToCache(transaction);
+    deps.trackPaymentRecorded();
+  } catch (error) {
+    deps.reportAsyncError(error);
+  }
+}
+
 export function createCalendarBillMutationService(
   deps: CreateCalendarBillMutationServiceDeps
 ): CalendarBillMutationService {
@@ -250,43 +292,26 @@ export function createCalendarBillMutationService(
     markBillPaid: async (bills, billId, dueDate) => {
       const userId = deps.getUserId();
       const commit = deps.getCommit();
-      if (!userId || !commit) {
+      const bill = getBillForPayment(bills, billId);
+      if (!userId || !commit || bill == null) {
         return { success: false };
       }
 
-      const bill = bills.find((candidate) => candidate.id === billId);
-      if (!bill) {
-        return { success: false };
-      }
-
-      let commitResult: { transaction: StoredTransaction; payment: BillPayment } | null = null;
-
-      try {
-        commitResult = await commitBillPayment(
-          commit,
-          bill,
-          billId,
-          dueDate,
-          userId,
-          now(),
-          createPaymentId,
-          createTransactionId
-        );
-      } catch {
-        return { success: false };
-      }
-
+      const commitResult = await commitBillPaymentSafely({
+        commit,
+        bill,
+        billId,
+        dueDate,
+        userId,
+        timestamp: now(),
+        createPaymentId,
+        createTransactionId,
+      });
       if (!commitResult) {
         return { success: false };
       }
 
-      try {
-        deps.addTransactionToCache(commitResult.transaction);
-        deps.trackPaymentRecorded();
-      } catch (error) {
-        deps.reportAsyncError(error);
-      }
-
+      applyBillPaymentSideEffects(deps, commitResult.transaction);
       return { success: true, payment: commitResult.payment };
     },
 

--- a/apps/mobile/features/capture-sources/hooks/setup.ts
+++ b/apps/mobile/features/capture-sources/hooks/setup.ts
@@ -3,34 +3,12 @@ import { processApplePayIntent } from "@/features/capture-sources/services/apple
 import { processNotification } from "@/features/capture-sources/services/notification-pipeline";
 import type { AnyDb } from "@/shared/db";
 import { captureError, generateDetectedSmsEventId, toIsoDateTime } from "@/shared/lib";
-import { requireIsoDateTime } from "@/shared/types/assertions";
-import type { IsoDateTime, UserId } from "@/shared/types/branded";
+import type { UserId } from "@/shared/types/branded";
+import { parseSmsDetectedAt } from "../lib/parse-sms-detected-at";
 import type { ApplePayIntentData, NotificationData } from "../schema";
 import { createCaptureIngestionPort } from "../services/capture-ingestion";
 
 const noop = () => undefined;
-const EPOCH_MILLISECONDS_PATTERN = /^\d{13}$/;
-const EPOCH_SECONDS_PATTERN = /^\d{10}$/;
-
-function parseSmsDetectedAt(timestamp: string): IsoDateTime | null {
-  const trimmedTimestamp = timestamp.trim();
-
-  if (trimmedTimestamp.length === 0) {
-    return null;
-  }
-
-  try {
-    return requireIsoDateTime(trimmedTimestamp);
-  } catch {
-    const parsedDate = EPOCH_MILLISECONDS_PATTERN.test(trimmedTimestamp)
-      ? new Date(Number(trimmedTimestamp))
-      : EPOCH_SECONDS_PATTERN.test(trimmedTimestamp)
-        ? new Date(Number(trimmedTimestamp) * 1000)
-        : new Date(trimmedTimestamp);
-
-    return Number.isNaN(parsedDate.getTime()) ? null : toIsoDateTime(parsedDate);
-  }
-}
 
 // Dynamic import to avoid Android bundle crash — this module calls
 // requireNativeModule("ExpoAppIntents") which only exists on iOS.

--- a/apps/mobile/features/capture-sources/lib/parse-sms-detected-at.ts
+++ b/apps/mobile/features/capture-sources/lib/parse-sms-detected-at.ts
@@ -1,0 +1,40 @@
+import { toIsoDateTime } from "@/shared/lib";
+import { requireIsoDateTime } from "@/shared/types/assertions";
+import type { IsoDateTime } from "@/shared/types/branded";
+
+const EPOCH_MILLISECONDS_PATTERN = /^\d{13}$/;
+const EPOCH_SECONDS_PATTERN = /^\d{10}$/;
+
+function tryRequireIsoDateTime(timestamp: string): IsoDateTime | null {
+  try {
+    return requireIsoDateTime(timestamp);
+  } catch {
+    return null;
+  }
+}
+
+function parseSmsDetectedDate(timestamp: string): Date {
+  if (EPOCH_MILLISECONDS_PATTERN.test(timestamp)) {
+    return new Date(Number(timestamp));
+  }
+
+  if (EPOCH_SECONDS_PATTERN.test(timestamp)) {
+    return new Date(Number(timestamp) * 1000);
+  }
+
+  return new Date(timestamp);
+}
+
+function toParsedIsoDateTime(timestamp: string): IsoDateTime | null {
+  const parsedDate = parseSmsDetectedDate(timestamp);
+  return Number.isNaN(parsedDate.getTime()) ? null : toIsoDateTime(parsedDate);
+}
+
+export function parseSmsDetectedAt(timestamp: string): IsoDateTime | null {
+  const trimmedTimestamp = timestamp.trim();
+  if (trimmedTimestamp.length === 0) {
+    return null;
+  }
+
+  return tryRequireIsoDateTime(trimmedTimestamp) ?? toParsedIsoDateTime(trimmedTimestamp);
+}

--- a/apps/mobile/features/financial-accounts/lib/identifiers-repository.ts
+++ b/apps/mobile/features/financial-accounts/lib/identifiers-repository.ts
@@ -68,6 +68,12 @@ function findActiveFinancialAccountIdentifierByUniqueKey(
   return rows[0] ?? null;
 }
 
+function getFinancialAccountIdentifierDuplicate(db: AnyDb, row: FinancialAccountIdentifierRow) {
+  const activeDuplicate =
+    row.deletedAt == null ? findActiveFinancialAccountIdentifierByUniqueKey(db, row) : null;
+  return activeDuplicate?.id !== row.id ? activeDuplicate : null;
+}
+
 function deleteFinancialAccountIdentifierDuplicate(
   db: AnyDb,
   duplicateId: FinancialAccountIdentifierRow["id"]
@@ -100,14 +106,41 @@ function persistFinancialAccountIdentifier(db: AnyDb, row: FinancialAccountIdent
     .run();
 }
 
+function shouldSkipFinancialAccountIdentifierUpsert(
+  existingRow: FinancialAccountIdentifierRow | null,
+  nextUpdatedAt: FinancialAccountIdentifierRow["updatedAt"]
+) {
+  return existingRow != null && existingRow.updatedAt >= nextUpdatedAt;
+}
+
+function upsertFinancialAccountIdentifierInTransaction(
+  db: AnyDb,
+  row: FinancialAccountIdentifierRow
+) {
+  const existingById = getFinancialAccountIdentifierById(db, row.id);
+  const duplicate = getFinancialAccountIdentifierDuplicate(db, row);
+
+  if (shouldSkipFinancialAccountIdentifierUpsert(existingById, row.updatedAt)) {
+    return;
+  }
+
+  if (shouldSkipFinancialAccountIdentifierUpsert(duplicate, row.updatedAt)) {
+    return;
+  }
+
+  if (duplicate != null) {
+    deleteFinancialAccountIdentifierDuplicate(db, duplicate.id);
+  }
+
+  persistFinancialAccountIdentifier(db, row);
+}
+
 export function saveFinancialAccountIdentifierInTransaction(
   db: AnyDb,
   row: FinancialAccountIdentifierRow
 ) {
   const existingById = getFinancialAccountIdentifierById(db, row.id);
-  const activeDuplicate =
-    row.deletedAt == null ? findActiveFinancialAccountIdentifierByUniqueKey(db, row) : null;
-  const duplicate = activeDuplicate?.id !== row.id ? activeDuplicate : null;
+  const duplicate = getFinancialAccountIdentifierDuplicate(db, row);
 
   if (existingById && duplicate) {
     deleteFinancialAccountIdentifierDuplicate(db, duplicate.id);
@@ -135,24 +168,7 @@ export function saveFinancialAccountIdentifierInTransaction(
 
 export function upsertFinancialAccountIdentifier(db: AnyDb, row: FinancialAccountIdentifierRow) {
   db.transaction((tx) => {
-    const existingById = getFinancialAccountIdentifierById(tx, row.id);
-    const activeDuplicate =
-      row.deletedAt == null ? findActiveFinancialAccountIdentifierByUniqueKey(tx, row) : null;
-    const duplicate = activeDuplicate?.id !== row.id ? activeDuplicate : null;
-
-    if (existingById && existingById.updatedAt >= row.updatedAt) {
-      return;
-    }
-
-    if (duplicate && duplicate.updatedAt >= row.updatedAt) {
-      return;
-    }
-
-    if (duplicate) {
-      deleteFinancialAccountIdentifierDuplicate(tx, duplicate.id);
-    }
-
-    persistFinancialAccountIdentifier(tx, row);
+    upsertFinancialAccountIdentifierInTransaction(tx, row);
   });
 }
 

--- a/apps/mobile/features/sync/services/create-sync-service.ts
+++ b/apps/mobile/features/sync/services/create-sync-service.ts
@@ -83,6 +83,11 @@ const getConflictRowsEffect = (db: SyncContext["db"]) =>
 const unresolvedConflictCountEffect = (db: SyncContext["db"]) =>
   Effect.map(listConflictsEffect({ db }), (conflicts) => conflicts.length);
 
+const unresolvedConflictResultEffect = (db: SyncContext["db"]) =>
+  Effect.map(unresolvedConflictCountEffect(db), (unresolvedConflicts) => ({
+    unresolvedConflicts,
+  }));
+
 function listConflictsEffect({ db }: SyncContext) {
   return Effect.flatMap(getConflictRowsEffect(db), (rows) =>
     Effect.forEach(rows, (row) =>
@@ -97,37 +102,96 @@ function listConflictsEffect({ db }: SyncContext) {
   );
 }
 
+function getConflictRow(
+  rows: readonly ConflictRow[],
+  conflictId: ResolveTransactionConflictInput["conflictId"]
+) {
+  return rows.find((conflict) => conflict.id === conflictId) ?? null;
+}
+
+function getLocalResolutionData(
+  row: ConflictRow,
+  resolution: ResolveTransactionConflictInput["resolution"]
+) {
+  return resolution === "local" ? (JSON.parse(row.localData) as TransactionSnapshot) : null;
+}
+
+const getRefreshUserId = (
+  localData: TransactionSnapshot | null,
+  serverData: TransactionSnapshot | null
+) => localData?.userId ?? serverData?.userId ?? null;
+
+function persistLocalResolutionEffect(input: {
+  readonly db: SyncContext["db"];
+  readonly row: ConflictRow;
+  readonly localData: TransactionSnapshot | null;
+  readonly resolvedAt: IsoDateTime;
+  readonly upsertTransaction: UpsertTransaction;
+  readonly enqueueTransactionSync: EnqueueTransactionSync;
+}) {
+  if (input.localData == null) {
+    return Effect.succeed(undefined);
+  }
+
+  const localData = input.localData;
+  return Effect.all([
+    fromThunk(() =>
+      input.upsertTransaction(input.db, {
+        ...localData,
+        updatedAt: input.resolvedAt,
+      })
+    ),
+    fromThunk(() =>
+      input.enqueueTransactionSync(input.db, input.row.transactionId, input.resolvedAt)
+    ),
+  ]);
+}
+
+function refreshResolvedConflictEffect(input: {
+  readonly db: SyncContext["db"];
+  readonly userId: string | null;
+  readonly refreshTransactions: RefreshTransactions;
+}) {
+  if (input.userId == null) {
+    return Effect.succeed(undefined);
+  }
+
+  const userId = input.userId;
+  return fromThunk(() => input.refreshTransactions({ db: input.db, userId }));
+}
+
 function resolveConflictEffect({ db, conflictId, resolution }: ResolveTransactionConflictInput) {
   return Effect.gen(function* () {
     const rows = yield* getConflictRowsEffect(db);
-    const row = rows.find((conflict) => conflict.id === conflictId);
+    const row = getConflictRow(rows, conflictId);
     if (!row) {
-      return {
-        unresolvedConflicts: yield* unresolvedConflictCountEffect(db),
-      };
+      return yield* unresolvedConflictResultEffect(db);
     }
 
     const { upsertTransaction, enqueueTransactionSync, resolveConflictRow, refreshTransactions } =
       yield* SyncDeps.tag;
     const resolvedAt = yield* currentIsoDateTimeEffect;
     const serverData = tryParseTransactionSnapshot(row.serverData);
-    const localData =
-      resolution === "local" ? (JSON.parse(row.localData) as TransactionSnapshot) : null;
-    const refreshUserId = localData?.userId ?? serverData?.userId ?? null;
+    const localData = getLocalResolutionData(row, resolution);
+    const refreshUserId = getRefreshUserId(localData, serverData);
 
-    if (resolution === "local" && localData) {
-      yield* fromThunk(() => upsertTransaction(db, { ...localData, updatedAt: resolvedAt }));
-      yield* fromThunk(() => enqueueTransactionSync(db, row.transactionId, resolvedAt));
-    }
+    yield* persistLocalResolutionEffect({
+      db,
+      row,
+      localData,
+      resolvedAt,
+      upsertTransaction,
+      enqueueTransactionSync,
+    });
 
     yield* fromThunk(() => resolveConflictRow(db, conflictId, resolution, resolvedAt));
-    if (refreshUserId != null) {
-      yield* fromThunk(() => refreshTransactions({ db, userId: refreshUserId }));
-    }
+    yield* refreshResolvedConflictEffect({
+      db,
+      userId: refreshUserId,
+      refreshTransactions,
+    });
 
-    return {
-      unresolvedConflicts: yield* unresolvedConflictCountEffect(db),
-    };
+    return yield* unresolvedConflictResultEffect(db);
   });
 }
 

--- a/plans/lizard-complexity-debt.json
+++ b/plans/lizard-complexity-debt.json
@@ -14,14 +14,6 @@
       "parameterCount": 0
     },
     {
-      "key": "(anonymous)@137-156@apps/mobile/features/financial-accounts/lib/identifiers-repository.ts",
-      "file": "apps/mobile/features/financial-accounts/lib/identifiers-repository.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 8,
-      "nloc": 16,
-      "parameterCount": 0
-    },
-    {
       "key": "(anonymous)@141-174@apps/mobile/__tests__/goals/repository.test.ts",
       "file": "apps/mobile/__tests__/goals/repository.test.ts",
       "function": "(anonymous)",
@@ -54,14 +46,6 @@
       "parameterCount": 0
     },
     {
-      "key": "(anonymous)@250-291@apps/mobile/features/calendar/lib/bill-mutation-service.ts",
-      "file": "apps/mobile/features/calendar/lib/bill-mutation-service.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 7,
-      "nloc": 36,
-      "parameterCount": 0
-    },
-    {
       "key": "(anonymous)@41-95@apps/mobile/__tests__/analytics/store.test.ts",
       "file": "apps/mobile/__tests__/analytics/store.test.ts",
       "function": "(anonymous)",
@@ -83,14 +67,6 @@
       "function": "(anonymous)",
       "cyclomaticComplexity": 2,
       "nloc": 31,
-      "parameterCount": 0
-    },
-    {
-      "key": "(anonymous)@47-80@apps/mobile/features/ai-chat/hooks/use-streaming-chat.ts",
-      "file": "apps/mobile/features/ai-chat/hooks/use-streaming-chat.ts",
-      "function": "(anonymous)",
-      "cyclomaticComplexity": 7,
-      "nloc": 32,
       "parameterCount": 0
     },
     {
@@ -238,22 +214,6 @@
       "parameterCount": 4
     },
     {
-      "key": "parseActionFromResponse@7-18@apps/mobile/features/ai-chat/lib/parse-action.ts",
-      "file": "apps/mobile/features/ai-chat/lib/parse-action.ts",
-      "function": "parseActionFromResponse",
-      "cyclomaticComplexity": 6,
-      "nloc": 11,
-      "parameterCount": 1
-    },
-    {
-      "key": "parseSmsDetectedAt@15-33@apps/mobile/features/capture-sources/hooks/setup.ts",
-      "file": "apps/mobile/features/capture-sources/hooks/setup.ts",
-      "function": "parseSmsDetectedAt",
-      "cyclomaticComplexity": 6,
-      "nloc": 16,
-      "parameterCount": 1
-    },
-    {
       "key": "resolveConflict@21-28@apps/mobile/features/sync/lib/conflict-repository.ts",
       "file": "apps/mobile/features/sync/lib/conflict-repository.ts",
       "function": "resolveConflict",
@@ -278,28 +238,12 @@
       "parameterCount": 6
     },
     {
-      "key": "scheduleBudgetAlert@21-68@apps/mobile/features/budget/lib/notifications.ts",
-      "file": "apps/mobile/features/budget/lib/notifications.ts",
-      "function": "scheduleBudgetAlert",
-      "cyclomaticComplexity": 6,
-      "nloc": 43,
-      "parameterCount": 3
-    },
-    {
       "key": "sessionId@66-72@apps/mobile/__tests__/ai-chat/store.test.ts",
       "file": "apps/mobile/__tests__/ai-chat/store.test.ts",
       "function": "sessionId",
       "cyclomaticComplexity": 7,
       "nloc": 7,
       "parameterCount": 0
-    },
-    {
-      "key": "unresolvedConflictCountEffect@106-132@apps/mobile/features/sync/services/create-sync-service.ts",
-      "file": "apps/mobile/features/sync/services/create-sync-service.ts",
-      "function": "unresolvedConflictCountEffect",
-      "cyclomaticComplexity": 9,
-      "nloc": 21,
-      "parameterCount": 1
     },
     {
       "key": "updateBudgetAmount@37-39@apps/mobile/features/budget/lib/repository.ts",


### PR DESCRIPTION
- split remaining strict hotspots\n- keep repo gates green\n- refresh strict debt ledger



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finish Lizard MR3 cleanup by splitting remaining strict hotspots and reducing complexity across mobile features. Improves safety and readability in chat actions, budget alerts, bill payments, capture parsing, identifiers upsert, and sync.

- **Refactors**
  - AI Chat: extracted “add” action flow and parsing helpers; track on success; always reset form; early-return for unsupported actions.
  - Budget alerts: split copy and scheduling; clearer permission/skip handling; consistent ScheduleResult responses.
  - Bills: added safe commit helper and side-effect applier; early exits when user/commit missing.
  - Identifiers repo: centralized duplicate detection and idempotent upsert with updatedAt guards; transactional delete-then-persist.
  - Sync service: refactored conflict resolution into effect helpers; unified unresolved-conflict result payload; refresh only when userId is available.
  - Shared cleanup: moved SMS detectedAt parsing to a reusable helper that handles ISO and epoch seconds/millis; added a lint-ignore in sync test fixtures; trimmed complexity entries in the debt ledger.

<sup>Written for commit e71f435a6f8017223eefeaa59cb5053561ae68e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

