### PR TITLE
refactor(mobile): split calendar store

### DIFF
--- a/apps/mobile/__tests__/calendar/store-source.test.ts
+++ b/apps/mobile/__tests__/calendar/store-source.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { expect, test } from "vitest";
+
+function readSource(relativePath: string) {
+  return readFileSync(resolve(__dirname, relativePath), "utf-8");
+}
+
+const storeSource = readSource("../../features/calendar/store.ts");
+const sessionSource = readSource("../../features/calendar/store/session.ts");
+const mutationsSource = readSource("../../features/calendar/store/live-bill-mutations.ts");
+
+test("keeps the calendar store routed through extracted session and mutation modules", () => {
+  expect(storeSource).toContain("beginBillsLoadRequest");
+  expect(storeSource).toContain("beginPaymentsLoadRequest");
+  expect(storeSource).toContain("createLiveCalendarBillMutations");
+  expect(storeSource).toContain('export { useCalendarStore } from "./store/state"');
+});
+
+test("keeps stale-request and session guards centralized in the session module", () => {
+  expect(sessionSource).toContain("loadBillsRequestId");
+  expect(sessionSource).toContain("loadPaymentsRequestId");
+  expect(sessionSource).toContain("calendarSessionId");
+  expect(sessionSource).toContain("applyMutationIfSessionIsActive");
+});
+
+test("keeps live calendar mutations wired to write-through and transaction cache updates", () => {
+  expect(mutationsSource).toContain("createWriteThroughMutationModule");
+  expect(mutationsSource).toContain("createCalendarBillMutationService");
+  expect(mutationsSource).toContain("useTransactionStore.getState().addToCache");
+  expect(mutationsSource).toContain("useTransactionStore.getState().removeFromCache");
+});

--- a/apps/mobile/features/calendar/store.ts
+++ b/apps/mobile/features/calendar/store.ts
@@ -1,230 +1,62 @@
 import { addMonths, subMonths } from "date-fns";
-import { create } from "zustand";
-import { useTransactionStore } from "@/features/transactions";
-import { createWriteThroughMutationModule } from "@/mutations";
 import type { AnyDb } from "@/shared/db";
-import { captureError, trackBillCreated, trackBillPaymentRecorded } from "@/shared/lib";
-import type { BillId, CategoryId, IsoDate, UserId } from "@/shared/types/branded";
-import { createCalendarBillMutationService } from "./lib/bill-mutation-service";
-import { requestNotificationPermissions, scheduleBillNotifications } from "./lib/notifications";
-import type { Bill, BillFrequency, BillPayment } from "./schema";
+import type { UserId } from "@/shared/types/branded";
 import { createCalendarQueryService } from "./services/create-calendar-query-service";
-
-let loadBillsRequestId = 0;
-let loadPaymentsRequestId = 0;
-let calendarSessionId = 0;
+import { createLiveCalendarBillMutations } from "./store/live-bill-mutations";
+import {
+  applyMutationIfSessionIsActive,
+  beginBillsLoadRequest,
+  beginCalendarSession,
+  beginPaymentsLoadRequest,
+  captureCalendarMutationSession,
+  isCurrentBillsRequest,
+  isCurrentPaymentsRequest,
+  stopBillsLoading,
+} from "./store/session";
+import {
+  type AddBillCommand,
+  type BillPaymentCommand,
+  type DeleteBillCommand,
+  type UpdateBillCommand,
+  useCalendarStore,
+} from "./store/state";
 
 const calendarQueryService = createCalendarQueryService();
 
-type BillDraft = {
-  readonly name: string;
-  readonly amount: string;
-  readonly frequency: BillFrequency;
-  readonly categoryId: CategoryId;
-  readonly startDate: Date;
-};
-
-type BillChanges = Partial<
-  Pick<Bill, "name" | "amount" | "frequency" | "categoryId" | "startDate" | "isActive">
->;
-
-type CalendarActor = {
-  readonly db: AnyDb;
-  readonly userId: UserId;
-};
-
-type AddBillCommand = CalendarActor & {
-  readonly draft: BillDraft;
-};
-
-type UpdateBillCommand = CalendarActor & {
-  readonly billId: BillId;
-  readonly changes: BillChanges;
-};
-
-type DeleteBillCommand = CalendarActor & {
-  readonly billId: BillId;
-};
-
-type BillPaymentCommand = CalendarActor & {
-  readonly billId: BillId;
-  readonly dueDate: IsoDate;
-};
-
-type CalendarMutationSession = {
-  readonly userId: UserId;
-  readonly sessionId: number;
-};
-
-type CalendarState = {
-  readonly activeUserId: UserId | null;
-  readonly currentMonth: Date;
-  readonly bills: Bill[];
-  readonly payments: BillPayment[];
-  readonly isLoading: boolean;
-};
-
-type CalendarActions = {
-  beginSession: (userId: UserId) => void;
-  setCurrentMonth: (currentMonth: Date) => void;
-  setBills: (bills: readonly Bill[]) => void;
-  setPayments: (payments: readonly BillPayment[]) => void;
-  setIsLoading: (isLoading: boolean) => void;
-  appendBill: (bill: Bill) => void;
-  replaceBill: (id: BillId, fields: BillChanges) => void;
-  removeBill: (id: BillId) => void;
-  appendPayment: (payment: BillPayment) => void;
-  removePayment: (billId: BillId, dueDate: IsoDate) => void;
-};
-
-export const useCalendarStore = create<CalendarState & CalendarActions>((set) => ({
-  activeUserId: null,
-  currentMonth: new Date(),
-  bills: [],
-  payments: [],
-  isLoading: false,
-
-  beginSession: (userId) =>
-    set({
-      activeUserId: userId,
-      bills: [],
-      payments: [],
-      isLoading: false,
-    }),
-
-  setCurrentMonth: (currentMonth) => set({ currentMonth }),
-
-  setBills: (bills) => set({ bills: [...bills], isLoading: false }),
-
-  setPayments: (payments) => set({ payments: [...payments] }),
-
-  setIsLoading: (isLoading) => set({ isLoading }),
-
-  appendBill: (bill) => set((state) => ({ bills: [...state.bills, bill] })),
-
-  replaceBill: (id, fields) =>
-    set((state) => ({
-      bills: state.bills.map((bill) => (bill.id === id ? { ...bill, ...fields } : bill)),
-    })),
-
-  removeBill: (id) =>
-    set((state) => ({
-      bills: state.bills.filter((bill) => bill.id !== id),
-      payments: state.payments.filter((payment) => payment.billId !== id),
-    })),
-
-  appendPayment: (payment) => set((state) => ({ payments: [...state.payments, payment] })),
-
-  removePayment: (billId, dueDate) =>
-    set((state) => ({
-      payments: state.payments.filter(
-        (payment) => !(payment.billId === billId && payment.dueDate === dueDate)
-      ),
-    })),
-}));
-
-function isCurrentBillsRequest(requestId: number, userId: UserId, sessionId: number): boolean {
-  return (
-    loadBillsRequestId === requestId &&
-    useCalendarStore.getState().activeUserId === userId &&
-    calendarSessionId === sessionId
-  );
-}
-
-function isCurrentPaymentsRequest(
-  requestId: number,
-  userId: UserId,
-  requestedMonth: Date,
-  sessionId: number
-): boolean {
-  return (
-    loadPaymentsRequestId === requestId &&
-    useCalendarStore.getState().activeUserId === userId &&
-    useCalendarStore.getState().currentMonth.getTime() === requestedMonth.getTime() &&
-    calendarSessionId === sessionId
-  );
-}
-
-function isActiveCalendarSession(userId: UserId, sessionId: number): boolean {
-  return calendarSessionId === sessionId && useCalendarStore.getState().activeUserId === userId;
-}
-
-function captureMutationSession(userId: UserId): CalendarMutationSession {
-  return { userId, sessionId: calendarSessionId };
-}
-
-function applyMutationIfSessionIsActive(
-  session: CalendarMutationSession,
-  apply: () => void
-): boolean {
-  if (!isActiveCalendarSession(session.userId, session.sessionId)) {
-    return false;
-  }
-
-  apply();
-  return true;
-}
-
-function createLiveCalendarBillMutations({ db, userId }: CalendarActor) {
-  const mutations = createWriteThroughMutationModule(db);
-
-  return createCalendarBillMutationService({
-    getCommit: () => mutations.commit,
-    getUserId: () => userId,
-    requestNotificationPermissions,
-    scheduleBillNotifications,
-    reportAsyncError: captureError,
-    addTransactionToCache: (transaction) => useTransactionStore.getState().addToCache(transaction),
-    removeTransactionFromCache: (transactionId) =>
-      useTransactionStore.getState().removeFromCache(transactionId),
-    trackCreated: trackBillCreated,
-    trackPaymentRecorded: trackBillPaymentRecorded,
-  });
-}
+export { useCalendarStore } from "./store/state";
 
 export function initializeCalendarSession(userId: UserId): void {
-  calendarSessionId += 1;
-  loadBillsRequestId += 1;
-  loadPaymentsRequestId += 1;
-  useCalendarStore.getState().beginSession(userId);
+  beginCalendarSession(userId);
 }
 
 export async function loadBills(db: AnyDb, userId: UserId): Promise<void> {
-  const requestId = ++loadBillsRequestId;
-  const sessionId = calendarSessionId;
-  useCalendarStore.getState().setIsLoading(true);
+  const request = beginBillsLoadRequest(userId);
 
   try {
     const bills = await calendarQueryService.loadBills({ db, userId });
-    if (!isCurrentBillsRequest(requestId, userId, sessionId)) {
-      if (loadBillsRequestId === requestId) {
-        useCalendarStore.getState().setIsLoading(false);
-      }
+
+    if (!isCurrentBillsRequest(request)) {
+      stopBillsLoading(request.requestId);
       return;
     }
+
     useCalendarStore.getState().setBills(bills);
   } catch (error) {
-    if (loadBillsRequestId === requestId) {
-      useCalendarStore.getState().setIsLoading(false);
-    }
+    stopBillsLoading(request.requestId);
     throw error;
   }
 }
 
 export async function loadPaymentsForMonth(db: AnyDb): Promise<void> {
-  const userId = useCalendarStore.getState().activeUserId;
-  if (!userId) return;
-
-  const requestId = ++loadPaymentsRequestId;
-  const sessionId = calendarSessionId;
-  const requestedMonth = useCalendarStore.getState().currentMonth;
+  const request = beginPaymentsLoadRequest();
+  if (!request.userId) return;
 
   const payments = await calendarQueryService.loadPaymentsForMonth({
     db,
-    month: requestedMonth,
+    month: request.requestedMonth,
   });
 
-  if (!isCurrentPaymentsRequest(requestId, userId, requestedMonth, sessionId)) {
+  if (!isCurrentPaymentsRequest(request)) {
     return;
   }
 
@@ -245,7 +77,7 @@ export async function prevMonth(db: AnyDb): Promise<void> {
 
 export async function addBill(command: AddBillCommand): Promise<boolean> {
   const { db, userId, draft } = command;
-  const session = captureMutationSession(userId);
+  const session = captureCalendarMutationSession(userId);
   const result = await createLiveCalendarBillMutations({ db, userId }).addBill(draft);
   if (!result.success) return false;
 
@@ -256,7 +88,7 @@ export async function addBill(command: AddBillCommand): Promise<boolean> {
 
 export async function updateBill(command: UpdateBillCommand): Promise<boolean> {
   const { db, userId, billId, changes } = command;
-  const session = captureMutationSession(userId);
+  const session = captureCalendarMutationSession(userId);
   const didUpdate = await createLiveCalendarBillMutations({ db, userId }).updateBill(
     billId,
     changes
@@ -270,7 +102,7 @@ export async function updateBill(command: UpdateBillCommand): Promise<boolean> {
 
 export async function deleteBill(command: DeleteBillCommand): Promise<void> {
   const { db, userId, billId } = command;
-  const session = captureMutationSession(userId);
+  const session = captureCalendarMutationSession(userId);
   const didDelete = await createLiveCalendarBillMutations({ db, userId }).deleteBill(billId);
   if (!didDelete) return;
 
@@ -281,7 +113,7 @@ export async function deleteBill(command: DeleteBillCommand): Promise<void> {
 
 export async function markBillPaid(command: BillPaymentCommand): Promise<void> {
   const { db, userId, billId, dueDate } = command;
-  const session = captureMutationSession(userId);
+  const session = captureCalendarMutationSession(userId);
   const result = await createLiveCalendarBillMutations({ db, userId }).markBillPaid(
     useCalendarStore.getState().bills,
     billId,
@@ -296,7 +128,7 @@ export async function markBillPaid(command: BillPaymentCommand): Promise<void> {
 
 export async function unmarkBillPaid(command: BillPaymentCommand): Promise<void> {
   const { db, userId, billId, dueDate } = command;
-  const session = captureMutationSession(userId);
+  const session = captureCalendarMutationSession(userId);
   const result = await createLiveCalendarBillMutations({ db, userId }).unmarkBillPaid(
     useCalendarStore.getState().payments,
     billId,

--- a/apps/mobile/features/calendar/store/live-bill-mutations.ts
+++ b/apps/mobile/features/calendar/store/live-bill-mutations.ts
@@ -1,0 +1,23 @@
+import { useTransactionStore } from "@/features/transactions";
+import { createWriteThroughMutationModule } from "@/mutations";
+import { captureError, trackBillCreated, trackBillPaymentRecorded } from "@/shared/lib";
+import { createCalendarBillMutationService } from "../lib/bill-mutation-service";
+import { requestNotificationPermissions, scheduleBillNotifications } from "../lib/notifications";
+import type { CalendarActor } from "./state";
+
+export function createLiveCalendarBillMutations({ db, userId }: CalendarActor) {
+  const mutations = createWriteThroughMutationModule(db);
+
+  return createCalendarBillMutationService({
+    getCommit: () => mutations.commit,
+    getUserId: () => userId,
+    requestNotificationPermissions,
+    scheduleBillNotifications,
+    reportAsyncError: captureError,
+    addTransactionToCache: (transaction) => useTransactionStore.getState().addToCache(transaction),
+    removeTransactionFromCache: (transactionId) =>
+      useTransactionStore.getState().removeFromCache(transactionId),
+    trackCreated: trackBillCreated,
+    trackPaymentRecorded: trackBillPaymentRecorded,
+  });
+}

--- a/apps/mobile/features/calendar/store/session.ts
+++ b/apps/mobile/features/calendar/store/session.ts
@@ -1,0 +1,89 @@
+import type { UserId } from "@/shared/types/branded";
+import type { CalendarMutationSession } from "./state";
+import { useCalendarStore } from "./state";
+
+type BillsLoadRequest = {
+  readonly requestId: number;
+  readonly sessionId: number;
+  readonly userId: UserId;
+};
+
+type PaymentsLoadRequest = {
+  readonly requestId: number;
+  readonly requestedMonth: Date;
+  readonly sessionId: number;
+  readonly userId: UserId | null;
+};
+
+let loadBillsRequestId = 0;
+let loadPaymentsRequestId = 0;
+let calendarSessionId = 0;
+
+function isActiveCalendarSession(userId: UserId, sessionId: number): boolean {
+  return calendarSessionId === sessionId && useCalendarStore.getState().activeUserId === userId;
+}
+
+export function beginCalendarSession(userId: UserId): void {
+  calendarSessionId += 1;
+  loadBillsRequestId += 1;
+  loadPaymentsRequestId += 1;
+  useCalendarStore.getState().beginSession(userId);
+}
+
+export function beginBillsLoadRequest(userId: UserId): BillsLoadRequest {
+  const requestId = ++loadBillsRequestId;
+  const sessionId = calendarSessionId;
+
+  useCalendarStore.getState().setIsLoading(true);
+
+  return { requestId, sessionId, userId };
+}
+
+export function stopBillsLoading(requestId: number): void {
+  if (loadBillsRequestId === requestId) {
+    useCalendarStore.getState().setIsLoading(false);
+  }
+}
+
+export function beginPaymentsLoadRequest(): PaymentsLoadRequest {
+  return {
+    requestId: ++loadPaymentsRequestId,
+    requestedMonth: useCalendarStore.getState().currentMonth,
+    sessionId: calendarSessionId,
+    userId: useCalendarStore.getState().activeUserId,
+  };
+}
+
+export function isCurrentBillsRequest(request: BillsLoadRequest): boolean {
+  return (
+    loadBillsRequestId === request.requestId &&
+    useCalendarStore.getState().activeUserId === request.userId &&
+    calendarSessionId === request.sessionId
+  );
+}
+
+export function isCurrentPaymentsRequest(request: PaymentsLoadRequest): boolean {
+  return (
+    request.userId != null &&
+    loadPaymentsRequestId === request.requestId &&
+    useCalendarStore.getState().activeUserId === request.userId &&
+    useCalendarStore.getState().currentMonth.getTime() === request.requestedMonth.getTime() &&
+    calendarSessionId === request.sessionId
+  );
+}
+
+export function captureCalendarMutationSession(userId: UserId): CalendarMutationSession {
+  return { userId, sessionId: calendarSessionId };
+}
+
+export function applyMutationIfSessionIsActive(
+  session: CalendarMutationSession,
+  apply: () => void
+): boolean {
+  if (!isActiveCalendarSession(session.userId, session.sessionId)) {
+    return false;
+  }
+
+  apply();
+  return true;
+}

--- a/apps/mobile/features/calendar/store/state.ts
+++ b/apps/mobile/features/calendar/store/state.ts
@@ -1,0 +1,111 @@
+import { create } from "zustand";
+import type { AnyDb } from "@/shared/db";
+import type { BillId, CategoryId, IsoDate, UserId } from "@/shared/types/branded";
+import type { Bill, BillFrequency, BillPayment } from "../schema";
+
+export type BillDraft = {
+  readonly amount: string;
+  readonly categoryId: CategoryId;
+  readonly frequency: BillFrequency;
+  readonly name: string;
+  readonly startDate: Date;
+};
+
+export type BillChanges = Partial<
+  Pick<Bill, "name" | "amount" | "frequency" | "categoryId" | "startDate" | "isActive">
+>;
+
+export type CalendarActor = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+};
+
+export type AddBillCommand = CalendarActor & {
+  readonly draft: BillDraft;
+};
+
+export type UpdateBillCommand = CalendarActor & {
+  readonly billId: BillId;
+  readonly changes: BillChanges;
+};
+
+export type DeleteBillCommand = CalendarActor & {
+  readonly billId: BillId;
+};
+
+export type BillPaymentCommand = CalendarActor & {
+  readonly billId: BillId;
+  readonly dueDate: IsoDate;
+};
+
+export type CalendarMutationSession = {
+  readonly sessionId: number;
+  readonly userId: UserId;
+};
+
+type CalendarState = {
+  readonly activeUserId: UserId | null;
+  readonly bills: Bill[];
+  readonly currentMonth: Date;
+  readonly isLoading: boolean;
+  readonly payments: BillPayment[];
+};
+
+type CalendarActions = {
+  appendBill: (bill: Bill) => void;
+  appendPayment: (payment: BillPayment) => void;
+  beginSession: (userId: UserId) => void;
+  removeBill: (id: BillId) => void;
+  removePayment: (billId: BillId, dueDate: IsoDate) => void;
+  replaceBill: (id: BillId, fields: BillChanges) => void;
+  setBills: (bills: readonly Bill[]) => void;
+  setCurrentMonth: (currentMonth: Date) => void;
+  setIsLoading: (isLoading: boolean) => void;
+  setPayments: (payments: readonly BillPayment[]) => void;
+};
+
+export const useCalendarStore = create<CalendarState & CalendarActions>((set) => ({
+  activeUserId: null,
+  currentMonth: new Date(),
+  bills: [],
+  payments: [],
+  isLoading: false,
+
+  beginSession: (userId) =>
+    set({
+      activeUserId: userId,
+      bills: [],
+      payments: [],
+      isLoading: false,
+    }),
+
+  setCurrentMonth: (currentMonth) => set({ currentMonth }),
+
+  setBills: (bills) => set({ bills: [...bills], isLoading: false }),
+
+  setPayments: (payments) => set({ payments: [...payments] }),
+
+  setIsLoading: (isLoading) => set({ isLoading }),
+
+  appendBill: (bill) => set((state) => ({ bills: [...state.bills, bill] })),
+
+  replaceBill: (id, fields) =>
+    set((state) => ({
+      bills: state.bills.map((bill) => (bill.id === id ? { ...bill, ...fields } : bill)),
+    })),
+
+  removeBill: (id) =>
+    set((state) => ({
+      bills: state.bills.filter((bill) => bill.id !== id),
+      payments: state.payments.filter((payment) => payment.billId !== id),
+    })),
+
+  appendPayment: (payment) => set((state) => ({ payments: [...state.payments, payment] })),
+
+  removePayment: (billId, dueDate) =>
+    set((state) => ({
+      payments: state.payments.filter(
+        (payment) => !(payment.billId === billId && payment.dueDate === dueDate)
+      ),
+    })),
+}));


### PR DESCRIPTION
- extract session and state modules
- add store source-contract test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the calendar store into focused modules for state, session/request guards, and live bill mutations. This clarifies responsibilities and centralizes stale-request handling without changing the public API.

- **Refactors**
  - Extracted `store/state.ts` (Zustand store and command/types), `store/session.ts` (session IDs, load request guards, loading control), and `store/live-bill-mutations.ts` (write-through mutations, notifications, analytics).
  - Updated `store.ts` to delegate to these modules and re-export `useCalendarStore`.
  - Added a source-contract test to ensure store routing, centralized guards, and write-through mutation wiring remain intact.

<sup>Written for commit 3b3bf6e56b610aee0ebd8087d98d8f43bb9411b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

