### PR TITLE
refactor(mobile): split bill mutation

### DIFF
--- a/apps/mobile/__tests__/calendar/bill-mutation-service-source.test.ts
+++ b/apps/mobile/__tests__/calendar/bill-mutation-service-source.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { expect, test } from "vitest";
+
+function readSource(relativePath: string) {
+  return readFileSync(resolve(__dirname, relativePath), "utf-8");
+}
+
+const serviceSource = readSource("../../features/calendar/lib/bill-mutation-service.ts");
+const paymentCommitSource = readSource(
+  "../../features/calendar/lib/bill-mutation-service/commit-bill-payment.ts"
+);
+const notificationsSource = readSource(
+  "../../features/calendar/lib/bill-mutation-service/notifications.ts"
+);
+const updateFieldsSource = readSource(
+  "../../features/calendar/lib/bill-mutation-service/to-bill-update-fields.ts"
+);
+
+test("keeps bill mutation service routed through extracted helpers", () => {
+  expect(serviceSource).toContain("commitBillPaymentSafely");
+  expect(serviceSource).toContain("applyBillPaymentSideEffects");
+  expect(serviceSource).toContain("scheduleNotifications");
+  expect(serviceSource).toContain("toBillUpdateFields");
+});
+
+test("keeps payment commit logic responsible for transaction-row creation", () => {
+  expect(paymentCommitSource).toContain("buildDefaultFinancialAccountId");
+  expect(paymentCommitSource).toContain("toTransactionRow(transaction)");
+  expect(paymentCommitSource).toContain('kind: "calendar.bill.markPaid"');
+});
+
+test("keeps notification and update-field helpers as the side-effect and normalization seams", () => {
+  expect(notificationsSource).toContain("requestNotificationPermissions");
+  expect(notificationsSource).toContain("scheduleBillNotifications");
+  expect(updateFieldsSource).toContain("assertCopAmount");
+  expect(updateFieldsSource).toContain("fields.startDate.toISOString()");
+});

--- a/apps/mobile/__tests__/calendar/bill-mutation-service.test.ts
+++ b/apps/mobile/__tests__/calendar/bill-mutation-service.test.ts
@@ -337,7 +337,7 @@ describe("calendar bill mutation service", () => {
         kind: "calendar.bill.markPaid",
       })
     );
-    expect(trackPaymentRecordedMock).not.toHaveBeenCalled();
+    expect(trackPaymentRecordedMock).toHaveBeenCalledOnce();
   });
 
   it("returns false when markBillPaid receives an invalid bill amount", async () => {

--- a/apps/mobile/features/calendar/lib/bill-mutation-service.ts
+++ b/apps/mobile/features/calendar/lib/bill-mutation-service.ts
@@ -1,199 +1,22 @@
-import { buildDefaultFinancialAccountId } from "@/features/financial-accounts";
-import type { StoredTransaction } from "@/features/transactions/public";
-import { toTransactionRow } from "@/features/transactions/public";
 import {
   generateBillId,
   generateBillPaymentId,
   generateTransactionId,
   parseDigitsToAmount,
-  parseIsoDate,
   toIsoDateTime,
 } from "@/shared/lib";
-import type { WriteThroughMutationModule } from "@/shared/mutations";
-import { assertCopAmount } from "@/shared/types/assertions";
-import type {
-  BillId,
-  BillPaymentId,
-  CategoryId,
-  IsoDate,
-  TransactionId,
-  UserId,
-} from "@/shared/types/branded";
+import { createBillSchema, toBillRow } from "../schema";
+import { applyBillPaymentSideEffects } from "./bill-mutation-service/bill-payment-effects";
 import {
-  type Bill,
-  type BillFrequency,
-  type BillPayment,
-  createBillSchema,
-  toBillRow,
-} from "../schema";
-import type { BillUpdateFields } from "./repository";
-
-type AddBillInput = {
-  name: string;
-  amount: string;
-  frequency: BillFrequency;
-  categoryId: CategoryId;
-  startDate: Date;
-};
-
-type UpdateBillFields = Partial<
-  Pick<Bill, "name" | "amount" | "frequency" | "categoryId" | "startDate" | "isActive">
->;
-
-type AddBillResult = { success: true; bill: Bill } | { success: false };
-type MarkBillPaidResult = { success: true; payment: BillPayment } | { success: false };
-type UnmarkBillPaidResult = { success: true } | { success: false };
-
-type CreateCalendarBillMutationServiceDeps = {
-  getCommit: () => WriteThroughMutationModule["commit"] | null;
-  getUserId: () => UserId | null;
-  requestNotificationPermissions: () => Promise<boolean>;
-  scheduleBillNotifications: (bill: Bill) => unknown;
-  reportAsyncError: (error: unknown) => void;
-  addTransactionToCache: (transaction: StoredTransaction) => void;
-  removeTransactionFromCache: (transactionId: TransactionId) => void;
-  trackCreated: (input: { frequency: BillFrequency }) => void;
-  trackPaymentRecorded: () => void;
-  now?: () => Date;
-  createBillId?: () => BillId;
-  createPaymentId?: () => BillPaymentId;
-  createTransactionId?: () => TransactionId;
-};
-
-export type CalendarBillMutationService = {
-  addBill: (input: AddBillInput) => Promise<AddBillResult>;
-  updateBill: (id: BillId, fields: UpdateBillFields) => Promise<boolean>;
-  deleteBill: (id: BillId) => Promise<boolean>;
-  markBillPaid: (
-    bills: readonly Bill[],
-    billId: BillId,
-    dueDate: IsoDate
-  ) => Promise<MarkBillPaidResult>;
-  unmarkBillPaid: (
-    payments: readonly BillPayment[],
-    billId: BillId,
-    dueDate: IsoDate
-  ) => Promise<UnmarkBillPaidResult>;
-};
-
-function toBillUpdateFields(fields: UpdateBillFields): BillUpdateFields {
-  const amount = fields.amount;
-  if (amount != null) {
-    assertCopAmount(amount);
-  }
-
-  return {
-    ...(fields.name != null ? { name: fields.name } : {}),
-    ...(amount != null ? { amount } : {}),
-    ...(fields.frequency != null ? { frequency: fields.frequency } : {}),
-    ...(fields.categoryId != null ? { categoryId: fields.categoryId } : {}),
-    ...(fields.startDate != null ? { startDate: fields.startDate.toISOString() } : {}),
-    ...(fields.isActive != null ? { isActive: fields.isActive } : {}),
-  };
-}
-
-function scheduleNotifications(deps: CreateCalendarBillMutationServiceDeps, bill: Bill) {
-  void deps
-    .requestNotificationPermissions()
-    .then((granted) =>
-      granted ? Promise.resolve(deps.scheduleBillNotifications(bill)) : undefined
-    )
-    .catch(deps.reportAsyncError);
-}
-
-async function commitBillPayment(
-  commit: WriteThroughMutationModule["commit"],
-  bill: Bill,
-  billId: BillId,
-  dueDate: IsoDate,
-  userId: UserId,
-  timestamp: Date,
-  createPaymentId: () => BillPaymentId,
-  createTransactionId: () => TransactionId
-): Promise<{ transaction: StoredTransaction; payment: BillPayment } | null> {
-  const nowIso = toIsoDateTime(timestamp);
-  const transactionId = createTransactionId();
-  const amount = bill.amount;
-  assertCopAmount(amount);
-
-  const transaction: StoredTransaction = {
-    id: transactionId,
-    userId,
-    type: "expense",
-    amount,
-    categoryId: bill.categoryId,
-    description: bill.name,
-    date: parseIsoDate(dueDate),
-    createdAt: timestamp,
-    updatedAt: timestamp,
-    deletedAt: null,
-    accountId: buildDefaultFinancialAccountId(userId),
-    accountAttributionState: "confirmed",
-  };
-
-  const payment: BillPayment = {
-    id: createPaymentId(),
-    billId,
-    dueDate,
-    paidAt: nowIso,
-    transactionId,
-    createdAt: nowIso,
-  };
-
-  const result = await commit({
-    kind: "calendar.bill.markPaid",
-    transactionRow: toTransactionRow(transaction),
-    paymentRow: payment,
-  });
-
-  if (!result.success) {
-    return null;
-  }
-
-  return { transaction, payment };
-}
-
-function getBillForPayment(bills: readonly Bill[], billId: BillId): Bill | null {
-  return bills.find((candidate) => candidate.id === billId) ?? null;
-}
-
-async function commitBillPaymentSafely(input: {
-  readonly commit: WriteThroughMutationModule["commit"];
-  readonly bill: Bill;
-  readonly billId: BillId;
-  readonly dueDate: IsoDate;
-  readonly userId: UserId;
-  readonly timestamp: Date;
-  readonly createPaymentId: () => BillPaymentId;
-  readonly createTransactionId: () => TransactionId;
-}) {
-  try {
-    return await commitBillPayment(
-      input.commit,
-      input.bill,
-      input.billId,
-      input.dueDate,
-      input.userId,
-      input.timestamp,
-      input.createPaymentId,
-      input.createTransactionId
-    );
-  } catch {
-    return null;
-  }
-}
-
-function applyBillPaymentSideEffects(
-  deps: CreateCalendarBillMutationServiceDeps,
-  transaction: StoredTransaction
-) {
-  try {
-    deps.addTransactionToCache(transaction);
-    deps.trackPaymentRecorded();
-  } catch (error) {
-    deps.reportAsyncError(error);
-  }
-}
+  commitBillPaymentSafely,
+  getBillForPayment,
+} from "./bill-mutation-service/commit-bill-payment";
+import { scheduleNotifications } from "./bill-mutation-service/notifications";
+import { toBillUpdateFields } from "./bill-mutation-service/to-bill-update-fields";
+import type {
+  CalendarBillMutationService,
+  CreateCalendarBillMutationServiceDeps,
+} from "./bill-mutation-service/types";
 
 export function createCalendarBillMutationService(
   deps: CreateCalendarBillMutationServiceDeps
@@ -228,7 +51,7 @@ export function createCalendarBillMutationService(
         return { success: false };
       }
 
-      const bill: Bill = {
+      const bill = {
         id: createBillId(),
         ...parsed.data,
       };
@@ -257,11 +80,10 @@ export function createCalendarBillMutationService(
       }
 
       try {
-        const dbFields = toBillUpdateFields(fields);
         const result = await commit({
           kind: "calendar.bill.update",
           billId: id,
-          fields: dbFields,
+          fields: toBillUpdateFields(fields),
           now: toIsoDateTime(now()),
         });
 

--- a/apps/mobile/features/calendar/lib/bill-mutation-service/bill-payment-effects.ts
+++ b/apps/mobile/features/calendar/lib/bill-mutation-service/bill-payment-effects.ts
@@ -7,6 +7,11 @@ export function applyBillPaymentSideEffects(
 ) {
   try {
     deps.addTransactionToCache(transaction);
+  } catch (error) {
+    deps.reportAsyncError(error);
+  }
+
+  try {
     deps.trackPaymentRecorded();
   } catch (error) {
     deps.reportAsyncError(error);

--- a/apps/mobile/features/calendar/lib/bill-mutation-service/bill-payment-effects.ts
+++ b/apps/mobile/features/calendar/lib/bill-mutation-service/bill-payment-effects.ts
@@ -1,0 +1,14 @@
+import type { StoredTransaction } from "@/features/transactions/public";
+import type { CreateCalendarBillMutationServiceDeps } from "./types";
+
+export function applyBillPaymentSideEffects(
+  deps: CreateCalendarBillMutationServiceDeps,
+  transaction: StoredTransaction
+) {
+  try {
+    deps.addTransactionToCache(transaction);
+    deps.trackPaymentRecorded();
+  } catch (error) {
+    deps.reportAsyncError(error);
+  }
+}

--- a/apps/mobile/features/calendar/lib/bill-mutation-service/commit-bill-payment.ts
+++ b/apps/mobile/features/calendar/lib/bill-mutation-service/commit-bill-payment.ts
@@ -1,0 +1,86 @@
+import { buildDefaultFinancialAccountId } from "@/features/financial-accounts";
+import type { StoredTransaction } from "@/features/transactions/public";
+import { toTransactionRow } from "@/features/transactions/public";
+import { parseIsoDate, toIsoDateTime } from "@/shared/lib";
+import type { WriteThroughMutationModule } from "@/shared/mutations";
+import { assertCopAmount } from "@/shared/types/assertions";
+import type { BillId, BillPaymentId, IsoDate, TransactionId, UserId } from "@/shared/types/branded";
+import type { Bill, BillPayment } from "../../schema";
+
+type CommitBillPaymentInput = {
+  readonly bill: Bill;
+  readonly billId: BillId;
+  readonly commit: WriteThroughMutationModule["commit"];
+  readonly createPaymentId: () => BillPaymentId;
+  readonly createTransactionId: () => TransactionId;
+  readonly dueDate: IsoDate;
+  readonly timestamp: Date;
+  readonly userId: UserId;
+};
+
+export function getBillForPayment(bills: readonly Bill[], billId: BillId): Bill | null {
+  return bills.find((candidate) => candidate.id === billId) ?? null;
+}
+
+async function commitBillPayment({
+  bill,
+  billId,
+  commit,
+  createPaymentId,
+  createTransactionId,
+  dueDate,
+  timestamp,
+  userId,
+}: CommitBillPaymentInput): Promise<{
+  transaction: StoredTransaction;
+  payment: BillPayment;
+} | null> {
+  const nowIso = toIsoDateTime(timestamp);
+  const transactionId = createTransactionId();
+  const amount = bill.amount;
+  assertCopAmount(amount);
+
+  const transaction: StoredTransaction = {
+    id: transactionId,
+    userId,
+    type: "expense",
+    amount,
+    categoryId: bill.categoryId,
+    description: bill.name,
+    date: parseIsoDate(dueDate),
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    deletedAt: null,
+    accountId: buildDefaultFinancialAccountId(userId),
+    accountAttributionState: "confirmed",
+  };
+
+  const payment: BillPayment = {
+    id: createPaymentId(),
+    billId,
+    dueDate,
+    paidAt: nowIso,
+    transactionId,
+    createdAt: nowIso,
+  };
+
+  const result = await commit({
+    kind: "calendar.bill.markPaid",
+    transactionRow: toTransactionRow(transaction),
+    paymentRow: payment,
+  });
+
+  if (!result.success) {
+    return null;
+  }
+
+  return { transaction, payment };
+}
+
+export async function commitBillPaymentSafely(input: CommitBillPaymentInput) {
+  try {
+    return await commitBillPayment(input);
+  } catch {
+    return null;
+  }
+}

--- a/apps/mobile/features/calendar/lib/bill-mutation-service/notifications.ts
+++ b/apps/mobile/features/calendar/lib/bill-mutation-service/notifications.ts
@@ -1,0 +1,11 @@
+import type { Bill } from "../../schema";
+import type { CreateCalendarBillMutationServiceDeps } from "./types";
+
+export function scheduleNotifications(deps: CreateCalendarBillMutationServiceDeps, bill: Bill) {
+  void deps
+    .requestNotificationPermissions()
+    .then((granted) =>
+      granted ? Promise.resolve(deps.scheduleBillNotifications(bill)) : undefined
+    )
+    .catch(deps.reportAsyncError);
+}

--- a/apps/mobile/features/calendar/lib/bill-mutation-service/to-bill-update-fields.ts
+++ b/apps/mobile/features/calendar/lib/bill-mutation-service/to-bill-update-fields.ts
@@ -1,0 +1,19 @@
+import { assertCopAmount } from "@/shared/types/assertions";
+import type { BillUpdateFields as RepositoryBillUpdateFields } from "../repository";
+import type { UpdateBillFields } from "./types";
+
+export function toBillUpdateFields(fields: UpdateBillFields): RepositoryBillUpdateFields {
+  const amount = fields.amount;
+  if (amount != null) {
+    assertCopAmount(amount);
+  }
+
+  return {
+    ...(fields.name != null ? { name: fields.name } : {}),
+    ...(amount != null ? { amount } : {}),
+    ...(fields.frequency != null ? { frequency: fields.frequency } : {}),
+    ...(fields.categoryId != null ? { categoryId: fields.categoryId } : {}),
+    ...(fields.startDate != null ? { startDate: fields.startDate.toISOString() } : {}),
+    ...(fields.isActive != null ? { isActive: fields.isActive } : {}),
+  };
+}

--- a/apps/mobile/features/calendar/lib/bill-mutation-service/types.ts
+++ b/apps/mobile/features/calendar/lib/bill-mutation-service/types.ts
@@ -1,0 +1,59 @@
+import type { StoredTransaction } from "@/features/transactions/public";
+import type { WriteThroughMutationModule } from "@/shared/mutations";
+import type {
+  BillId,
+  BillPaymentId,
+  CategoryId,
+  IsoDate,
+  TransactionId,
+  UserId,
+} from "@/shared/types/branded";
+import type { Bill, BillFrequency, BillPayment } from "../../schema";
+
+export type AddBillInput = {
+  readonly amount: string;
+  readonly categoryId: CategoryId;
+  readonly frequency: BillFrequency;
+  readonly name: string;
+  readonly startDate: Date;
+};
+
+export type UpdateBillFields = Partial<
+  Pick<Bill, "name" | "amount" | "frequency" | "categoryId" | "startDate" | "isActive">
+>;
+
+export type AddBillResult = { success: true; bill: Bill } | { success: false };
+export type MarkBillPaidResult = { success: true; payment: BillPayment } | { success: false };
+export type UnmarkBillPaidResult = { success: true } | { success: false };
+
+export type CreateCalendarBillMutationServiceDeps = {
+  getCommit: () => WriteThroughMutationModule["commit"] | null;
+  getUserId: () => UserId | null;
+  requestNotificationPermissions: () => Promise<boolean>;
+  scheduleBillNotifications: (bill: Bill) => unknown;
+  reportAsyncError: (error: unknown) => void;
+  addTransactionToCache: (transaction: StoredTransaction) => void;
+  removeTransactionFromCache: (transactionId: TransactionId) => void;
+  trackCreated: (input: { frequency: BillFrequency }) => void;
+  trackPaymentRecorded: () => void;
+  now?: () => Date;
+  createBillId?: () => BillId;
+  createPaymentId?: () => BillPaymentId;
+  createTransactionId?: () => TransactionId;
+};
+
+export type CalendarBillMutationService = {
+  addBill: (input: AddBillInput) => Promise<AddBillResult>;
+  updateBill: (id: BillId, fields: UpdateBillFields) => Promise<boolean>;
+  deleteBill: (id: BillId) => Promise<boolean>;
+  markBillPaid: (
+    bills: readonly Bill[],
+    billId: BillId,
+    dueDate: IsoDate
+  ) => Promise<MarkBillPaidResult>;
+  unmarkBillPaid: (
+    payments: readonly BillPayment[],
+    billId: BillId,
+    dueDate: IsoDate
+  ) => Promise<UnmarkBillPaidResult>;
+};


### PR DESCRIPTION
- extract payment and notification helpers
- add mutation source-contract test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the calendar bill mutation service into focused helpers (payment commit, side effects, notifications, field normalization, and types). Also isolated bill-payment side effects so analytics still fire even if cache updates fail.

- **Refactors**
  - Extracted `commitBillPaymentSafely`, `getBillForPayment`, `applyBillPaymentSideEffects`, `scheduleNotifications`, and `toBillUpdateFields`.
  - Added a `types` module and routed the service through these helpers.
  - Added a source‑contract test to verify the service calls the helpers and that commit logic creates the transaction row.

- **Bug Fixes**
  - Separated cache and analytics guards in `applyBillPaymentSideEffects` so `trackPaymentRecorded` runs even if `addTransactionToCache` throws; updated test to cover this.

<sup>Written for commit 669021eab62dbe143395617e838138d653cab0ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

