### PR TITLE
refactor(tooling): split post-tool defender

### DIFF
--- a/.ai-hooks/hooks/post-tool-defender-hook.ts
+++ b/.ai-hooks/hooks/post-tool-defender-hook.ts
@@ -37,7 +37,8 @@ export function extractTextContent(toolResult: unknown): string {
             }
 
             if (typeof block === "object" && block && "text" in block) {
-              return String((block as Record<string, unknown>).text);
+              const text = (block as Record<string, unknown>).text;
+              return text == null ? "" : String(text);
             }
 
             return "";
@@ -68,7 +69,12 @@ export function normalizeHookInput(input: Record<string, unknown>): HookInput | 
   const toolName = input.tool_name;
   const toolInput = input.tool_input;
 
-  if (typeof toolName !== "string" || typeof toolInput !== "object" || toolInput === null) {
+  if (
+    typeof toolName !== "string" ||
+    typeof toolInput !== "object" ||
+    toolInput === null ||
+    Array.isArray(toolInput)
+  ) {
     return null;
   }
 

--- a/.ai-hooks/hooks/post-tool-defender-hook.ts
+++ b/.ai-hooks/hooks/post-tool-defender-hook.ts
@@ -1,0 +1,81 @@
+export interface HookInput {
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  toolResponse?: unknown;
+  toolResult?: unknown;
+}
+
+export const MONITORED_TOOLS = new Set(["Read", "WebFetch", "Bash", "Grep", "Glob", "Task"]);
+
+export function extractTextContent(toolResult: unknown): string {
+  if (toolResult === null || toolResult === undefined) {
+    return "";
+  }
+
+  if (typeof toolResult === "string") {
+    return toolResult;
+  }
+
+  if (Array.isArray(toolResult)) {
+    return toolResult.map((item) => extractTextContent(item)).filter(Boolean).join("\n");
+  }
+
+  if (typeof toolResult === "object") {
+    const result = toolResult as Record<string, unknown>;
+
+    if ("content" in result) {
+      const content = result.content;
+      if (typeof content === "string") {
+        return content;
+      }
+
+      if (Array.isArray(content)) {
+        return content
+          .map((block) => {
+            if (typeof block === "string") {
+              return block;
+            }
+
+            if (typeof block === "object" && block && "text" in block) {
+              return String((block as Record<string, unknown>).text);
+            }
+
+            return "";
+          })
+          .filter(Boolean)
+          .join("\n");
+      }
+    }
+
+    for (const key of ["output", "result", "text", "stdout", "data"]) {
+      if (key in result && result[key] != null) {
+        const value = result[key];
+        return typeof value === "string" ? value : String(value);
+      }
+    }
+
+    try {
+      return JSON.stringify(result);
+    } catch {
+      return String(result);
+    }
+  }
+
+  return String(toolResult);
+}
+
+export function normalizeHookInput(input: Record<string, unknown>): HookInput | null {
+  const toolName = input.tool_name;
+  const toolInput = input.tool_input;
+
+  if (typeof toolName !== "string" || typeof toolInput !== "object" || toolInput === null) {
+    return null;
+  }
+
+  return {
+    toolName,
+    toolInput: toolInput as Record<string, unknown>,
+    toolResponse: input.tool_response,
+    toolResult: input.tool_result,
+  };
+}

--- a/.ai-hooks/hooks/post-tool-defender.test.ts
+++ b/.ai-hooks/hooks/post-tool-defender.test.ts
@@ -45,6 +45,7 @@ describe("normalizeHookInput", () => {
   it("rejects malformed hook payloads", () => {
     expect(normalizeHookInput({ tool_name: "Read", tool_input: null })).toBeNull();
     expect(normalizeHookInput({ tool_name: 42, tool_input: {} })).toBeNull();
+    expect(normalizeHookInput({ tool_name: "Read", tool_input: [] })).toBeNull();
   });
 });
 
@@ -55,6 +56,14 @@ describe("extractTextContent", () => {
         content: ["first", { text: "second" }, { ignored: true }],
       })
     ).toBe("first\nsecond");
+  });
+
+  it("skips nullish text blocks", () => {
+    expect(
+      extractTextContent({
+        content: [{ text: undefined }, { text: null }, { text: "kept" }],
+      })
+    ).toBe("kept");
   });
 
   it("normalizes nested array results", () => {

--- a/.ai-hooks/hooks/post-tool-defender.test.ts
+++ b/.ai-hooks/hooks/post-tool-defender.test.ts
@@ -1,4 +1,9 @@
 import { describe, expect, it } from "bun:test";
+import {
+  extractTextContent,
+  MONITORED_TOOLS,
+  normalizeHookInput,
+} from "./post-tool-defender-hook";
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports -- CommonJS helper for OpenCode.
 const { scanForInjections: scanForInjectionsJs } = require("./post-tool-defender-lib.js");
@@ -18,5 +23,52 @@ describe("scanForInjections", () => {
     expect(scanForInjectionsJs("DAN mode", config)).toEqual([
       ["Role-Playing/DAN", "DAN mode activation attempt", "high"],
     ]);
+  });
+});
+
+describe("normalizeHookInput", () => {
+  it("normalizes valid hook payloads", () => {
+    expect(
+      normalizeHookInput({
+        tool_name: "Read",
+        tool_input: { file_path: "/tmp/file.txt" },
+        tool_response: "content",
+      })
+    ).toEqual({
+      toolName: "Read",
+      toolInput: { file_path: "/tmp/file.txt" },
+      toolResponse: "content",
+      toolResult: undefined,
+    });
+  });
+
+  it("rejects malformed hook payloads", () => {
+    expect(normalizeHookInput({ tool_name: "Read", tool_input: null })).toBeNull();
+    expect(normalizeHookInput({ tool_name: 42, tool_input: {} })).toBeNull();
+  });
+});
+
+describe("extractTextContent", () => {
+  it("joins structured content blocks", () => {
+    expect(
+      extractTextContent({
+        content: ["first", { text: "second" }, { ignored: true }],
+      })
+    ).toBe("first\nsecond");
+  });
+
+  it("normalizes nested array results", () => {
+    expect(
+      extractTextContent([
+        { stdout: "alpha" },
+        ["beta", { content: [{ text: "gamma" }] }],
+      ])
+    ).toBe("alpha\nbeta\ngamma");
+  });
+});
+
+describe("MONITORED_TOOLS", () => {
+  it("covers the supported post-tool hook sources", () => {
+    expect(Array.from(MONITORED_TOOLS)).toEqual(["Read", "WebFetch", "Bash", "Grep", "Glob", "Task"]);
   });
 });

--- a/.ai-hooks/hooks/post-tool-defender.ts
+++ b/.ai-hooks/hooks/post-tool-defender.ts
@@ -11,6 +11,12 @@
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { parse as parseYaml } from "yaml";
+import {
+  extractTextContent,
+  type HookInput,
+  MONITORED_TOOLS,
+  normalizeHookInput,
+} from "./post-tool-defender-hook";
 
 // Types
 interface Pattern {
@@ -24,13 +30,6 @@ interface Config {
   rolePlayingPatterns?: Pattern[];
   encodingPatterns?: Pattern[];
   contextManipulationPatterns?: Pattern[];
-}
-
-interface HookInput {
-  toolName: string;
-  toolInput: Record<string, unknown>;
-  toolResponse?: unknown;
-  toolResult?: unknown;
 }
 
 // Detection tuple: [category, reason, severity]
@@ -53,63 +52,6 @@ function loadConfig(): Config {
   }
 
   return {};
-}
-
-/**
- * Extract text content from tool result based on tool type.
- */
-function extractTextContent(toolName: string, toolResult: unknown): string {
-  if (toolResult === null || toolResult === undefined) {
-    return "";
-  }
-
-  if (typeof toolResult === "string") {
-    return toolResult;
-  }
-
-  if (typeof toolResult === "object") {
-    const result = toolResult as Record<string, unknown>;
-
-    if ("content" in result) {
-      const content = result.content;
-      if (typeof content === "string") return content;
-      if (Array.isArray(content)) {
-        return content
-          .map((block) => {
-            if (typeof block === "string") return block;
-            if (typeof block === "object" && block && "text" in block) {
-              return String((block as Record<string, unknown>).text);
-            }
-            return "";
-          })
-          .filter(Boolean)
-          .join("\n");
-      }
-    }
-
-    for (const key of ["output", "result", "text", "stdout", "data"]) {
-      if (key in result && result[key] != null) {
-        const value = result[key];
-        if (typeof value === "string") return value;
-        return String(value);
-      }
-    }
-
-    try {
-      return JSON.stringify(result);
-    } catch {
-      return String(result);
-    }
-  }
-
-  if (Array.isArray(toolResult)) {
-    return toolResult
-      .map((item) => extractTextContent(toolName, item))
-      .filter(Boolean)
-      .join("\n");
-  }
-
-  return String(toolResult);
 }
 
 /**
@@ -148,23 +90,6 @@ export function scanForInjections(text: string, config: Config): Detection[] {
 
   return detections;
 }
-
-function normalizeHookInput(input: Record<string, unknown>): HookInput | null {
-  const toolName = input.tool_name;
-  const toolInput = input.tool_input;
-
-  if (typeof toolName !== "string" || typeof toolInput !== "object" || toolInput === null) {
-    return null;
-  }
-
-  return {
-    toolName,
-    toolInput: toolInput as Record<string, unknown>,
-    toolResponse: input.tool_response,
-    toolResult: input.tool_result,
-  };
-}
-
 /**
  * Format detections into a warning message.
  */
@@ -281,13 +206,11 @@ async function main(): Promise<void> {
   const { toolName, toolInput, toolResponse, toolResult: toolResultFallback } = input;
   const toolResult = toolResponse ?? toolResultFallback;
 
-  const monitoredTools = new Set(["Read", "WebFetch", "Bash", "Grep", "Glob", "Task"]);
-
-  if (!monitoredTools.has(toolName)) {
+  if (!MONITORED_TOOLS.has(toolName)) {
     process.exit(0);
   }
 
-  const text = extractTextContent(toolName, toolResult);
+  const text = extractTextContent(toolResult);
 
   if (!text || text.length < 10) {
     process.exit(0);


### PR DESCRIPTION
- extract hook parsing helper
- add hook seam tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the post-tool defender into a helper for hook parsing and result normalization, and hardened parsing to skip nullish content blocks and reject array `tool_input`. Behavior remains the same with clearer monitored tools and safer input handling.

- **Refactors**
  - Added `post-tool-defender-hook.ts` with `normalizeHookInput`, `extractTextContent`, and `MONITORED_TOOLS`.
  - Updated `post-tool-defender.ts` to use the helper and remove duplicate logic; now gates by `MONITORED_TOOLS`.
  - Added tests for `normalizeHookInput`, `extractTextContent`, and `MONITORED_TOOLS`.

- **Bug Fixes**
  - `extractTextContent` now ignores null/undefined text blocks and handles nested arrays.
  - `normalizeHookInput` now rejects array `tool_input` to avoid malformed payloads.

<sup>Written for commit 5ff306248a204d8c3cef9bb8f343fa8f5eaa6c64. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

