### PR TITLE
refactor(mobile): split ai chat store

### DIFF
--- a/apps/mobile/__tests__/ai-chat/store-state.test.ts
+++ b/apps/mobile/__tests__/ai-chat/store-state.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { create } from "zustand";
+import type { ChatMessage } from "@/features/ai-chat/schema";
+import { createChatStoreState } from "@/features/ai-chat/store/state";
+import { requireUserId } from "@/shared/types/assertions";
+import type { ChatMessageId, ChatSessionId, IsoDateTime } from "@/shared/types/branded";
+
+describe("ai chat store state helper", () => {
+  it("begins a session and clears current conversation state", () => {
+    const store = create(createChatStoreState);
+
+    store.getState().beginSession(requireUserId("user-1"));
+    store.getState().setCurrentSessionId("chat-1" as ChatSessionId);
+    store.getState().appendMessage({
+      id: "message-1" as ChatMessageId,
+      sessionId: "chat-1" as ChatSessionId,
+      role: "assistant",
+      content: "hello",
+      action: null,
+      actionStatus: null,
+      createdAt: "2026-04-18T10:15:00.000Z" as IsoDateTime,
+    });
+    store.getState().setStreaming(true);
+    store.getState().setStreamingContent("partial");
+
+    store.getState().clearCurrentConversation();
+
+    expect(store.getState()).toMatchObject({
+      activeUserId: requireUserId("user-1"),
+      currentSessionId: null,
+      messages: [],
+      isStreaming: false,
+      streamingContent: "",
+    });
+  });
+
+  it("removes the active session and updates only the matching action status", () => {
+    const store = create(createChatStoreState);
+    const activeSessionId = "chat-1" as ChatSessionId;
+    const otherSessionId = "chat-2" as ChatSessionId;
+    const activeMessage: ChatMessage = {
+      id: "message-active" as ChatMessageId,
+      sessionId: activeSessionId,
+      role: "assistant",
+      content: "hello",
+      action: null,
+      actionStatus: null,
+      createdAt: "2026-04-18T10:15:00.000Z" as IsoDateTime,
+    };
+    const otherMessage: ChatMessage = {
+      id: "message-other" as ChatMessageId,
+      sessionId: otherSessionId,
+      role: "assistant",
+      content: "hello",
+      action: null,
+      actionStatus: null,
+      createdAt: "2026-04-18T10:15:00.000Z" as IsoDateTime,
+    };
+
+    store.setState({
+      activeUserId: requireUserId("user-1"),
+      sessions: [
+        {
+          id: activeSessionId,
+          userId: requireUserId("user-1"),
+          title: "Active",
+          createdAt: "2026-04-18T10:00:00.000Z" as IsoDateTime,
+          expiresAt: "2026-05-18T10:00:00.000Z" as IsoDateTime,
+          deletedAt: null,
+        },
+      ],
+      currentSessionId: activeSessionId,
+      messages: [activeMessage, otherMessage],
+      isStreaming: false,
+      streamingContent: "",
+      expiredSessionCount: 0,
+    });
+
+    store.getState().setMessageActionStatus(activeMessage.id, "confirmed");
+    store.getState().removeSession(activeSessionId);
+
+    expect(store.getState()).toMatchObject({
+      currentSessionId: null,
+      messages: [],
+      sessions: [],
+    });
+    expect(otherMessage.actionStatus).toBeNull();
+  });
+});

--- a/apps/mobile/features/ai-chat/store.ts
+++ b/apps/mobile/features/ai-chat/store.ts
@@ -1,46 +1,18 @@
 import { and, asc, desc, eq, isNull } from "drizzle-orm";
-import { create, type StateCreator } from "zustand";
+import { create } from "zustand";
 import { type AnyDb, chatMessages, chatSessions } from "@/shared/db";
 import { generateChatMessageId, generateChatSessionId, toIsoDateTime } from "@/shared/lib";
 import type { ChatMessageId, ChatSessionId, UserId } from "@/shared/types/branded";
 import { mapChatMessageRow, mapChatSessionRow } from "./lib/chat-row-mappers";
 import { deriveConversationTitle, findExpiredSessions } from "./lib/sessions";
 import type { ActionStatus, ChatAction, ChatMessage, ChatSession } from "./schema";
+import { createChatStoreState } from "./store/state";
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 
 let chatStoreSessionId = 0;
 let loadChatSessionsRequestId = 0;
 let selectChatSessionRequestId = 0;
-
-type ChatState = {
-  readonly activeUserId: UserId | null;
-  readonly sessions: readonly ChatSession[];
-  readonly currentSessionId: ChatSessionId | null;
-  readonly messages: readonly ChatMessage[];
-  readonly isStreaming: boolean;
-  readonly streamingContent: string;
-  readonly expiredSessionCount: number;
-};
-
-type ChatActions = {
-  beginSession: (userId: UserId) => void;
-  setSessions: (sessions: readonly ChatSession[]) => void;
-  prependSession: (session: ChatSession) => void;
-  removeSession: (sessionId: ChatSessionId) => void;
-  setCurrentSessionId: (sessionId: ChatSessionId | null) => void;
-  setMessages: (messages: readonly ChatMessage[]) => void;
-  appendMessage: (message: ChatMessage) => void;
-  setMessageActionStatus: (messageId: ChatMessageId, status: ActionStatus) => void;
-  setStreaming: (isStreaming: boolean) => void;
-  setStreamingContent: (content: string) => void;
-  setExpiredSessionCount: (count: number) => void;
-  clearCurrentConversation: () => void;
-  dismissExpiredBanner: () => void;
-};
-
-type ChatStore = ChatState & ChatActions;
-type ChatSetState = Parameters<StateCreator<ChatStore>>[0];
 type UpdateChatActionStatusInput = {
   readonly db: AnyDb;
   readonly userId: UserId;
@@ -48,82 +20,7 @@ type UpdateChatActionStatusInput = {
   readonly status: ActionStatus;
 };
 
-function createChatState(activeUserId: UserId | null): ChatState {
-  return {
-    activeUserId,
-    sessions: [],
-    currentSessionId: null,
-    messages: [],
-    isStreaming: false,
-    streamingContent: "",
-    expiredSessionCount: 0,
-  };
-}
-
-function beginChatSession(set: ChatSetState): ChatActions["beginSession"] {
-  return (userId) => set(createChatState(userId));
-}
-
-function prependChatSession(set: ChatSetState): ChatActions["prependSession"] {
-  return (session) =>
-    set((state) => ({
-      sessions: [session, ...state.sessions],
-      currentSessionId: session.id,
-      messages: [],
-    }));
-}
-
-function removeChatSession(set: ChatSetState): ChatActions["removeSession"] {
-  return (sessionId) =>
-    set((state) => ({
-      sessions: state.sessions.filter((session) => session.id !== sessionId),
-      currentSessionId: state.currentSessionId === sessionId ? null : state.currentSessionId,
-      messages: state.currentSessionId === sessionId ? [] : state.messages,
-    }));
-}
-
-function setChatMessageActionStatus(set: ChatSetState): ChatActions["setMessageActionStatus"] {
-  return (messageId, status) =>
-    set((state) => ({
-      messages: state.messages.map((message) =>
-        message.id === messageId ? { ...message, actionStatus: status } : message
-      ),
-    }));
-}
-
-function createChatActions(set: ChatSetState): ChatActions {
-  return {
-    beginSession: beginChatSession(set),
-    setSessions: (sessions) => set({ sessions: [...sessions] }),
-    prependSession: prependChatSession(set),
-    removeSession: removeChatSession(set),
-    setCurrentSessionId: (currentSessionId) => set({ currentSessionId, messages: [] }),
-    setMessages: (messages) => set({ messages: [...messages] }),
-    appendMessage: (message) =>
-      set((state) => ({
-        messages: [...state.messages, message],
-      })),
-    setMessageActionStatus: setChatMessageActionStatus(set),
-    setStreaming: (isStreaming) => set({ isStreaming }),
-    setStreamingContent: (streamingContent) => set({ streamingContent }),
-    setExpiredSessionCount: (expiredSessionCount) => set({ expiredSessionCount }),
-    clearCurrentConversation: () =>
-      set({
-        currentSessionId: null,
-        messages: [],
-        isStreaming: false,
-        streamingContent: "",
-      }),
-    dismissExpiredBanner: () => set({ expiredSessionCount: 0 }),
-  };
-}
-
-const createChatStoreState: StateCreator<ChatStore> = (set) => ({
-  ...createChatState(null),
-  ...createChatActions(set),
-});
-
-export const useChatStore = create<ChatStore>(createChatStoreState);
+export const useChatStore = create(createChatStoreState);
 
 function isActiveChatSession(userId: UserId, sessionId: number): boolean {
   return chatStoreSessionId === sessionId && useChatStore.getState().activeUserId === userId;

--- a/apps/mobile/features/ai-chat/store/state.ts
+++ b/apps/mobile/features/ai-chat/store/state.ts
@@ -1,0 +1,107 @@
+import type { StateCreator } from "zustand";
+import type { ChatMessageId, ChatSessionId, UserId } from "@/shared/types/branded";
+import type { ActionStatus, ChatMessage, ChatSession } from "../schema";
+
+export type ChatState = {
+  readonly activeUserId: UserId | null;
+  readonly sessions: readonly ChatSession[];
+  readonly currentSessionId: ChatSessionId | null;
+  readonly messages: readonly ChatMessage[];
+  readonly isStreaming: boolean;
+  readonly streamingContent: string;
+  readonly expiredSessionCount: number;
+};
+
+export type ChatActions = {
+  beginSession: (userId: UserId) => void;
+  setSessions: (sessions: readonly ChatSession[]) => void;
+  prependSession: (session: ChatSession) => void;
+  removeSession: (sessionId: ChatSessionId) => void;
+  setCurrentSessionId: (sessionId: ChatSessionId | null) => void;
+  setMessages: (messages: readonly ChatMessage[]) => void;
+  appendMessage: (message: ChatMessage) => void;
+  setMessageActionStatus: (messageId: ChatMessageId, status: ActionStatus) => void;
+  setStreaming: (isStreaming: boolean) => void;
+  setStreamingContent: (content: string) => void;
+  setExpiredSessionCount: (count: number) => void;
+  clearCurrentConversation: () => void;
+  dismissExpiredBanner: () => void;
+};
+
+export type ChatStore = ChatState & ChatActions;
+type ChatSetState = Parameters<StateCreator<ChatStore>>[0];
+
+export function createChatState(activeUserId: UserId | null): ChatState {
+  return {
+    activeUserId,
+    sessions: [],
+    currentSessionId: null,
+    messages: [],
+    isStreaming: false,
+    streamingContent: "",
+    expiredSessionCount: 0,
+  };
+}
+
+function beginChatSession(set: ChatSetState): ChatActions["beginSession"] {
+  return (userId) => set(createChatState(userId));
+}
+
+function prependChatSession(set: ChatSetState): ChatActions["prependSession"] {
+  return (session) =>
+    set((state) => ({
+      sessions: [session, ...state.sessions],
+      currentSessionId: session.id,
+      messages: [],
+    }));
+}
+
+function removeChatSession(set: ChatSetState): ChatActions["removeSession"] {
+  return (sessionId) =>
+    set((state) => ({
+      sessions: state.sessions.filter((session) => session.id !== sessionId),
+      currentSessionId: state.currentSessionId === sessionId ? null : state.currentSessionId,
+      messages: state.currentSessionId === sessionId ? [] : state.messages,
+    }));
+}
+
+function setChatMessageActionStatus(set: ChatSetState): ChatActions["setMessageActionStatus"] {
+  return (messageId, status) =>
+    set((state) => ({
+      messages: state.messages.map((message) =>
+        message.id === messageId ? { ...message, actionStatus: status } : message
+      ),
+    }));
+}
+
+export function createChatActions(set: ChatSetState): ChatActions {
+  return {
+    beginSession: beginChatSession(set),
+    setSessions: (sessions) => set({ sessions: [...sessions] }),
+    prependSession: prependChatSession(set),
+    removeSession: removeChatSession(set),
+    setCurrentSessionId: (currentSessionId) => set({ currentSessionId, messages: [] }),
+    setMessages: (messages) => set({ messages: [...messages] }),
+    appendMessage: (message) =>
+      set((state) => ({
+        messages: [...state.messages, message],
+      })),
+    setMessageActionStatus: setChatMessageActionStatus(set),
+    setStreaming: (isStreaming) => set({ isStreaming }),
+    setStreamingContent: (streamingContent) => set({ streamingContent }),
+    setExpiredSessionCount: (expiredSessionCount) => set({ expiredSessionCount }),
+    clearCurrentConversation: () =>
+      set({
+        currentSessionId: null,
+        messages: [],
+        isStreaming: false,
+        streamingContent: "",
+      }),
+    dismissExpiredBanner: () => set({ expiredSessionCount: 0 }),
+  };
+}
+
+export const createChatStoreState: StateCreator<ChatStore> = (set) => ({
+  ...createChatState(null),
+  ...createChatActions(set),
+});


### PR DESCRIPTION
- extract store state helper
- add store state tests


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the AI chat store state/actions into a dedicated module and wired `useChatStore` to it. Added unit tests for the store helper; no behavior changes.

- **Refactors**
  - Moved chat state, actions, and factory into apps/mobile/features/ai-chat/store/state.ts (`createChatStoreState`).
  - Simplified apps/mobile/features/ai-chat/store.ts to use `create(createChatStoreState)`.

<sup>Written for commit 960cbaf30acb1c5e44e5e1af0df8d658a86245a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

