### PR TITLE
refactor(mobile): split notify pipeline

### DIFF
--- a/apps/mobile/__tests__/capture-sources/notification-pipeline-context.test.ts
+++ b/apps/mobile/__tests__/capture-sources/notification-pipeline-context.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+import type { NotificationData } from "@/features/capture-sources/schema";
+import {
+  buildFailedFingerprint,
+  normalizeNotificationCommand,
+  resolveCategoryId,
+  selectAccountResolution,
+} from "@/features/capture-sources/services/notification-pipeline/context";
+
+vi.mock("@/features/email-capture/parsing.public", () => ({
+  stripPii: vi.fn((text: string) => `sanitized:${text}`),
+}));
+
+vi.mock("@/features/transactions/write.public", () => ({
+  isValidCategoryId: (value: string) => ["food", "other"].includes(value),
+}));
+
+const EVIDENCE = [
+  {
+    sourceFamily: "bancolombia",
+    evidenceType: "last4",
+    scope: "notification:bancolombia:last4",
+    value: "1234",
+  },
+] as const;
+
+function makeNotification(overrides: Partial<NotificationData> = {}): NotificationData {
+  return {
+    packageName: "com.todo1.mobile.co.bancolombia",
+    text: "Compra por $50,000",
+    timestamp: Date.UTC(2026, 3, 18, 10, 0, 0),
+    ...overrides,
+  };
+}
+
+describe("notification pipeline context helper", () => {
+  it("normalizes notification command fields and capture evidence", () => {
+    const context = normalizeNotificationCommand(
+      {
+        db: {} as never,
+        userId: "user-1" as never,
+        notification: makeNotification({ bigText: "Expanded purchase detail" }),
+      },
+      () => EVIDENCE
+    );
+
+    expect(context.notificationText).toBe("Expanded purchase detail");
+    expect(context.sanitizedText).toBe("sanitized:Expanded purchase detail");
+    expect(context.captureEvidence).toEqual(EVIDENCE);
+    expect(context.source).toBe("notification_android");
+    expect(context.notificationDate).toBe("2026-04-18");
+  });
+
+  it("falls back invalid categories to other", () => {
+    expect(resolveCategoryId("food")).toBe("food");
+    expect(resolveCategoryId("unknown-category")).toBe("other");
+  });
+
+  it("selects inferred vs unresolved account attribution", () => {
+    expect(selectAccountResolution("fa-card-1" as never, "fa-default-1" as never)).toEqual({
+      accountId: "fa-card-1",
+      accountAttributionState: "inferred",
+    });
+    expect(selectAccountResolution(null, "fa-default-1" as never)).toEqual({
+      accountId: "fa-default-1",
+      accountAttributionState: "unresolved",
+    });
+  });
+
+  it("builds failed fingerprints from package and timestamp", () => {
+    expect(buildFailedFingerprint(makeNotification({ timestamp: 123 }))).toBe(
+      "failed:com.todo1.mobile.co.bancolombia:123"
+    );
+  });
+});

--- a/apps/mobile/features/capture-sources/services/notification-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/notification-pipeline.ts
@@ -1,115 +1,42 @@
 import { findMatchingFinancialAccountId } from "@/features/account-suggestions";
-import type { CaptureEvidenceSeed } from "@/features/capture-evidence";
-import {
-  buildNotificationCaptureEvidence,
-  materializeCaptureEvidenceRows,
-  saveCaptureEvidenceRows,
-} from "@/features/capture-evidence";
-import {
-  insertMerchantRule,
-  lookupMerchantRule,
-} from "@/features/email-capture/merchant-rules.public";
-import { stripPii } from "@/features/email-capture/parsing.public";
+import { lookupMerchantRule } from "@/features/email-capture/merchant-rules.public";
 import { ensureDefaultFinancialAccount } from "@/features/financial-accounts";
-import { insertTransaction, isValidCategoryId } from "@/features/transactions/write.public";
 import type { AnyDb } from "@/shared/db";
-import { enqueueSync } from "@/shared/db/enqueue-sync";
-import {
-  capturePipelineEvent,
-  generateProcessedCaptureId,
-  generateSyncQueueId,
-  generateTransactionId,
-  normalizeMerchant,
-  toIsoDate,
-  toIsoDateTime,
-  trackTransactionCreated,
-} from "@/shared/lib";
-import { assertCopAmount, assertIsoDate, assertUserId } from "@/shared/types/assertions";
-import type {
-  CategoryId,
-  CopAmount,
-  FinancialAccountId,
-  IsoDate,
-  IsoDateTime,
-  TransactionId,
-  UserId,
-} from "@/shared/types/branded";
-import { captureFingerprint, findDuplicateTransaction, isCaptureProcessed } from "../lib/dedup";
+import { normalizeMerchant, toIsoDateTime } from "@/shared/lib";
+import { assertUserId } from "@/shared/types/assertions";
+import type { CategoryId } from "@/shared/types/branded";
+import { findDuplicateTransaction, isCaptureProcessed } from "../lib/dedup";
 import { parseNotificationLocally } from "../lib/notification-parser";
-import { insertProcessedCapture } from "../lib/repository";
 import type { NotificationData } from "../schema";
-import { resolveSource } from "../schema";
-import { parseNotificationApi } from "./parse-notification-api";
+import {
+  buildNotificationFingerprint,
+  FALLBACK_CATEGORY_ID,
+  normalizeNotificationCommand,
+  normalizeParsedNotification,
+  parseNotificationWithLlm,
+  resolveCategoryId,
+  selectAccountResolution,
+} from "./notification-pipeline/context";
+import {
+  persistDuplicateNotification,
+  persistFailedNotification,
+  persistSuccessfulNotification,
+  reportSkippedDuplicate,
+} from "./notification-pipeline/outcomes";
+import type {
+  DuplicateCheckResult,
+  NotificationContext,
+  NotificationParseMethod,
+  NotificationPipelineResult,
+  ParsedNotificationContext,
+  ParseStageResult,
+  ResolvedNotificationContext,
+} from "./notification-pipeline/types";
+
+export type { NotificationPipelineResult } from "./notification-pipeline/types";
 
 /** In-flight fingerprints guard against concurrent duplicate processing. */
 const inFlightFingerprints = new Set<string>();
-const FALLBACK_CATEGORY_ID = "other";
-
-type NotificationParseMethod = "regex" | "llm";
-type NotificationSource = ReturnType<typeof resolveSource>;
-type NotificationStageMetrics = {
-  saved: 0 | 1;
-  skippedDuplicate: 0 | 1;
-  parseFailed: 0 | 1;
-};
-type RawParsedNotification = {
-  amount: number;
-  merchant: string;
-  type: "expense" | "income";
-  categoryId: string;
-  date: string;
-  confidence: number;
-};
-type ParsedNotification = Omit<RawParsedNotification, "amount" | "date"> & {
-  amount: CopAmount;
-  date: IsoDate;
-};
-type NotificationCommand = {
-  db: AnyDb;
-  userId: UserId;
-  notification: NotificationData;
-};
-type NotificationContext = NotificationCommand & {
-  captureEvidence: readonly CaptureEvidenceSeed[];
-  notificationText: string;
-  sanitizedText: string;
-  receivedAt: IsoDateTime;
-  source: NotificationSource;
-  notificationDate: IsoDate;
-};
-type NotificationStageContext = NotificationContext & {
-  parseMethod: NotificationParseMethod;
-};
-type ParsedNotificationContext = NotificationStageContext & {
-  parsed: ParsedNotification;
-  fingerprint: string;
-};
-type ResolvedNotificationContext = ParsedNotificationContext & {
-  merchantKey: string;
-  categoryId: CategoryId;
-  accountId: FinancialAccountId;
-  accountAttributionState: "inferred" | "unresolved";
-  now: IsoDateTime;
-};
-type ParseStageResult =
-  | { kind: "failed"; context: NotificationStageContext }
-  | { kind: "parsed"; context: ParsedNotificationContext };
-type DuplicateCheckResult =
-  | { kind: "already_processed" }
-  | { kind: "cross_source"; transactionId: TransactionId };
-type PersistedCaptureOutcome = {
-  status: "failed" | "skipped_duplicate" | "success";
-  fingerprintHash: string;
-  transactionId: TransactionId | null;
-  confidence: number | null;
-  now: IsoDateTime;
-};
-
-export type NotificationPipelineResult = {
-  saved: boolean;
-  skippedDuplicate: boolean;
-  transactionId: TransactionId | null;
-};
 
 export async function processNotification(
   db: AnyDb,
@@ -152,43 +79,6 @@ async function parseNotificationStage(context: NotificationContext): Promise<Par
       fingerprint,
     },
   };
-}
-
-function buildNotificationFingerprint(context: NotificationContext, parsed: ParsedNotification) {
-  return captureFingerprint({
-    source: context.source,
-    amount: parsed.amount,
-    date: parsed.date,
-    merchant: parsed.merchant,
-  });
-}
-
-function normalizeParsedNotification(parsed: RawParsedNotification): ParsedNotification {
-  assertCopAmount(parsed.amount);
-  assertIsoDate(parsed.date);
-
-  return {
-    ...parsed,
-    amount: parsed.amount,
-    date: parsed.date,
-  };
-}
-
-async function parseNotificationWithLlm(
-  sanitizedText: string
-): Promise<RawParsedNotification | null> {
-  const llm = await parseNotificationApi(sanitizedText);
-
-  return llm
-    ? {
-        amount: llm.amount,
-        merchant: llm.description,
-        type: llm.type,
-        categoryId: llm.categoryId,
-        date: llm.date,
-        confidence: llm.confidence,
-      }
-    : null;
 }
 
 async function withFingerprintLock(
@@ -239,46 +129,6 @@ async function findDuplicateCapture(
   return transactionId ? { kind: "cross_source", transactionId } : null;
 }
 
-async function persistFailedNotification(
-  context: NotificationStageContext
-): Promise<NotificationPipelineResult> {
-  const now = toIsoDateTime(new Date());
-
-  await persistCaptureOutcome(context, {
-    status: "failed",
-    fingerprintHash: buildFailedFingerprint(context.notification),
-    transactionId: null,
-    confidence: null,
-    now,
-  });
-  trackNotificationPipeline(context, {
-    saved: 0,
-    skippedDuplicate: 0,
-    parseFailed: 1,
-  });
-
-  return { saved: false, skippedDuplicate: false, transactionId: null };
-}
-
-async function persistDuplicateNotification(
-  context: ParsedNotificationContext,
-  duplicate: DuplicateCheckResult
-): Promise<NotificationPipelineResult> {
-  if (duplicate.kind === "already_processed") {
-    return reportSkippedDuplicate(context, null);
-  }
-
-  await persistCaptureOutcome(context, {
-    status: "skipped_duplicate",
-    fingerprintHash: context.fingerprint,
-    transactionId: duplicate.transactionId,
-    confidence: context.parsed.confidence,
-    now: toIsoDateTime(new Date()),
-  });
-
-  return reportSkippedDuplicate(context, duplicate.transactionId);
-}
-
 async function resolveTransactionContext(
   context: ParsedNotificationContext
 ): Promise<ResolvedNotificationContext> {
@@ -308,176 +158,4 @@ async function resolveParsedCategoryId(
 ): Promise<CategoryId> {
   const cachedCategoryId = await lookupMerchantRule(context.db, context.userId, merchantKey);
   return resolveCategoryId(cachedCategoryId ?? context.parsed.categoryId);
-}
-
-async function persistSuccessfulNotification(
-  context: ResolvedNotificationContext
-): Promise<NotificationPipelineResult> {
-  const transactionId = saveTransactionRecord(context);
-
-  await persistCaptureOutcome(context, {
-    status: "success",
-    fingerprintHash: context.fingerprint,
-    transactionId,
-    confidence: context.parsed.confidence,
-    now: context.now,
-  });
-  await cacheMerchantRuleIfEligible(context);
-  await trackSuccessfulNotification(context);
-
-  return { saved: true, skippedDuplicate: false, transactionId };
-}
-
-async function persistCaptureOutcome(
-  context: NotificationContext,
-  outcome: PersistedCaptureOutcome
-) {
-  const processedCaptureId = generateProcessedCaptureId();
-
-  await insertProcessedCapture(context.db, {
-    id: processedCaptureId,
-    fingerprintHash: outcome.fingerprintHash,
-    source: context.source,
-    status: outcome.status,
-    rawText: context.sanitizedText,
-    transactionId: outcome.transactionId,
-    confidence: outcome.confidence,
-    receivedAt: context.receivedAt,
-    createdAt: outcome.now,
-  });
-
-  await saveCaptureEvidenceRows(
-    context.db,
-    materializeCaptureEvidenceRows(context.captureEvidence, {
-      userId: context.userId,
-      transactionId: outcome.transactionId,
-      processedEmailId: null,
-      processedCaptureId,
-      createdAt: outcome.now,
-      updatedAt: outcome.now,
-    })
-  );
-}
-
-async function cacheMerchantRuleIfEligible(context: ResolvedNotificationContext) {
-  if (context.parsed.confidence < 0.7) {
-    return;
-  }
-
-  await insertMerchantRule(
-    context.db,
-    context.userId,
-    context.merchantKey,
-    context.categoryId,
-    context.now
-  );
-}
-
-function normalizeNotificationCommand(command: NotificationCommand): NotificationContext {
-  const notificationText = command.notification.bigText ?? command.notification.text;
-
-  return {
-    ...command,
-    captureEvidence: buildNotificationCaptureEvidence(command.notification),
-    notificationText,
-    sanitizedText: stripPii(notificationText).slice(0, 500),
-    receivedAt: toIsoDateTime(new Date(command.notification.timestamp)),
-    source: resolveSource(command.notification.packageName),
-    notificationDate: toIsoDate(new Date(command.notification.timestamp)),
-  };
-}
-
-function resolveCategoryId(rawCategoryId: string): CategoryId {
-  if (isValidCategoryId(rawCategoryId)) {
-    return rawCategoryId;
-  }
-
-  if (!isValidCategoryId(FALLBACK_CATEGORY_ID)) {
-    throw new Error("Missing fallback category");
-  }
-
-  return FALLBACK_CATEGORY_ID;
-}
-
-async function reportSkippedDuplicate(
-  context: NotificationStageContext,
-  transactionId: TransactionId | null
-): Promise<NotificationPipelineResult> {
-  trackNotificationPipeline(context, {
-    saved: 0,
-    skippedDuplicate: 1,
-    parseFailed: 0,
-  });
-
-  return { saved: false, skippedDuplicate: true, transactionId };
-}
-
-function selectAccountResolution(
-  matchedAccountId: FinancialAccountId | null,
-  defaultAccountId: FinancialAccountId
-) {
-  return {
-    accountId: matchedAccountId ?? defaultAccountId,
-    accountAttributionState: matchedAccountId ? "inferred" : "unresolved",
-  } as const;
-}
-
-async function trackSuccessfulNotification(context: ResolvedNotificationContext) {
-  trackTransactionCreated({
-    type: context.parsed.type,
-    category: String(context.categoryId),
-    source: "notification",
-  });
-
-  trackNotificationPipeline(context, {
-    saved: 1,
-    skippedDuplicate: 0,
-    parseFailed: 0,
-  });
-}
-
-function trackNotificationPipeline(
-  context: NotificationStageContext,
-  metrics: NotificationStageMetrics
-) {
-  capturePipelineEvent({
-    source: "notification",
-    bankSource: context.source,
-    parseMethod: context.parseMethod,
-    ...metrics,
-  });
-}
-
-function buildFailedFingerprint(notification: NotificationData) {
-  return `failed:${notification.packageName}:${notification.timestamp}`;
-}
-
-function saveTransactionRecord(context: ResolvedNotificationContext): TransactionId {
-  const transactionId = generateTransactionId();
-  const syncQueueId = generateSyncQueueId();
-
-  insertTransaction(context.db, {
-    id: transactionId,
-    userId: context.userId,
-    type: context.parsed.type,
-    amount: context.parsed.amount,
-    categoryId: context.categoryId,
-    description: context.parsed.merchant,
-    date: context.parsed.date,
-    accountId: context.accountId,
-    accountAttributionState: context.accountAttributionState,
-    source: context.source,
-    createdAt: context.now,
-    updatedAt: context.now,
-  });
-
-  enqueueSync(context.db, {
-    id: syncQueueId,
-    tableName: "transactions",
-    rowId: transactionId,
-    operation: "insert",
-    createdAt: context.now,
-  });
-
-  return transactionId;
 }

--- a/apps/mobile/features/capture-sources/services/notification-pipeline/context.ts
+++ b/apps/mobile/features/capture-sources/services/notification-pipeline/context.ts
@@ -1,0 +1,104 @@
+import type { CaptureEvidenceSeed } from "@/features/capture-evidence";
+import { buildNotificationCaptureEvidence } from "@/features/capture-evidence";
+import { stripPii } from "@/features/email-capture/parsing.public";
+import { isValidCategoryId } from "@/features/transactions/write.public";
+import { toIsoDate, toIsoDateTime } from "@/shared/lib";
+import { assertCopAmount, assertIsoDate } from "@/shared/types/assertions";
+import type { CategoryId, FinancialAccountId } from "@/shared/types/branded";
+import { captureFingerprint } from "../../lib/dedup";
+import type { NotificationData } from "../../schema";
+import { resolveSource } from "../../schema";
+import { parseNotificationApi } from "../parse-notification-api";
+import type {
+  NotificationCommand,
+  NotificationContext,
+  ParsedNotification,
+  RawParsedNotification,
+} from "./types";
+
+export const FALLBACK_CATEGORY_ID = "other";
+
+export function buildNotificationFingerprint(
+  context: NotificationContext,
+  parsed: ParsedNotification
+) {
+  return captureFingerprint({
+    source: context.source,
+    amount: parsed.amount,
+    date: parsed.date,
+    merchant: parsed.merchant,
+  });
+}
+
+export function normalizeParsedNotification(parsed: RawParsedNotification): ParsedNotification {
+  assertCopAmount(parsed.amount);
+  assertIsoDate(parsed.date);
+
+  return {
+    ...parsed,
+    amount: parsed.amount,
+    date: parsed.date,
+  };
+}
+
+export async function parseNotificationWithLlm(
+  sanitizedText: string
+): Promise<RawParsedNotification | null> {
+  const llm = await parseNotificationApi(sanitizedText);
+
+  return llm
+    ? {
+        amount: llm.amount,
+        merchant: llm.description,
+        type: llm.type,
+        categoryId: llm.categoryId,
+        date: llm.date,
+        confidence: llm.confidence,
+      }
+    : null;
+}
+
+export function normalizeNotificationCommand(
+  command: NotificationCommand,
+  buildEvidence: (
+    notification: NotificationData
+  ) => readonly CaptureEvidenceSeed[] = buildNotificationCaptureEvidence
+): NotificationContext {
+  const notificationText = command.notification.bigText ?? command.notification.text;
+
+  return {
+    ...command,
+    captureEvidence: buildEvidence(command.notification),
+    notificationText,
+    sanitizedText: stripPii(notificationText).slice(0, 500),
+    receivedAt: toIsoDateTime(new Date(command.notification.timestamp)),
+    source: resolveSource(command.notification.packageName),
+    notificationDate: toIsoDate(new Date(command.notification.timestamp)),
+  };
+}
+
+export function resolveCategoryId(rawCategoryId: string): CategoryId {
+  if (isValidCategoryId(rawCategoryId)) {
+    return rawCategoryId;
+  }
+
+  if (!isValidCategoryId(FALLBACK_CATEGORY_ID)) {
+    throw new Error("Missing fallback category");
+  }
+
+  return FALLBACK_CATEGORY_ID;
+}
+
+export function selectAccountResolution(
+  matchedAccountId: FinancialAccountId | null,
+  defaultAccountId: FinancialAccountId
+) {
+  return {
+    accountId: matchedAccountId ?? defaultAccountId,
+    accountAttributionState: matchedAccountId ? "inferred" : "unresolved",
+  } as const;
+}
+
+export function buildFailedFingerprint(notification: NotificationData) {
+  return `failed:${notification.packageName}:${notification.timestamp}`;
+}

--- a/apps/mobile/features/capture-sources/services/notification-pipeline/outcomes.ts
+++ b/apps/mobile/features/capture-sources/services/notification-pipeline/outcomes.ts
@@ -1,0 +1,198 @@
+import {
+  materializeCaptureEvidenceRows,
+  saveCaptureEvidenceRows,
+} from "@/features/capture-evidence";
+import { insertMerchantRule } from "@/features/email-capture/merchant-rules.public";
+import { insertTransaction } from "@/features/transactions/write.public";
+import { enqueueSync } from "@/shared/db/enqueue-sync";
+import {
+  capturePipelineEvent,
+  generateProcessedCaptureId,
+  generateSyncQueueId,
+  generateTransactionId,
+  toIsoDateTime,
+  trackTransactionCreated,
+} from "@/shared/lib";
+import { insertProcessedCapture } from "../../lib/repository";
+import { buildFailedFingerprint } from "./context";
+import type {
+  DuplicateCheckResult,
+  NotificationPipelineResult,
+  NotificationStageContext,
+  NotificationStageMetrics,
+  ParsedNotificationContext,
+  PersistedCaptureOutcome,
+  ResolvedNotificationContext,
+} from "./types";
+
+async function persistCaptureOutcome(
+  context: NotificationStageContext,
+  outcome: PersistedCaptureOutcome
+) {
+  const processedCaptureId = generateProcessedCaptureId();
+
+  await insertProcessedCapture(context.db, {
+    id: processedCaptureId,
+    fingerprintHash: outcome.fingerprintHash,
+    source: context.source,
+    status: outcome.status,
+    rawText: context.sanitizedText,
+    transactionId: outcome.transactionId,
+    confidence: outcome.confidence,
+    receivedAt: context.receivedAt,
+    createdAt: outcome.now,
+  });
+
+  await saveCaptureEvidenceRows(
+    context.db,
+    materializeCaptureEvidenceRows(context.captureEvidence, {
+      userId: context.userId,
+      transactionId: outcome.transactionId,
+      processedEmailId: null,
+      processedCaptureId,
+      createdAt: outcome.now,
+      updatedAt: outcome.now,
+    })
+  );
+}
+
+async function cacheMerchantRuleIfEligible(context: ResolvedNotificationContext) {
+  if (context.parsed.confidence < 0.7) {
+    return;
+  }
+
+  await insertMerchantRule(
+    context.db,
+    context.userId,
+    context.merchantKey,
+    context.categoryId,
+    context.now
+  );
+}
+
+function trackNotificationPipeline(
+  context: NotificationStageContext,
+  metrics: NotificationStageMetrics
+) {
+  capturePipelineEvent({
+    source: "notification",
+    bankSource: context.source,
+    parseMethod: context.parseMethod,
+    ...metrics,
+  });
+}
+
+export async function reportSkippedDuplicate(
+  context: NotificationStageContext,
+  transactionId: NotificationPipelineResult["transactionId"]
+): Promise<NotificationPipelineResult> {
+  trackNotificationPipeline(context, {
+    saved: 0,
+    skippedDuplicate: 1,
+    parseFailed: 0,
+  });
+
+  return { saved: false, skippedDuplicate: true, transactionId };
+}
+
+function saveTransactionRecord(context: ResolvedNotificationContext) {
+  const transactionId = generateTransactionId();
+  const syncQueueId = generateSyncQueueId();
+
+  insertTransaction(context.db, {
+    id: transactionId,
+    userId: context.userId,
+    type: context.parsed.type,
+    amount: context.parsed.amount,
+    categoryId: context.categoryId,
+    description: context.parsed.merchant,
+    date: context.parsed.date,
+    accountId: context.accountId,
+    accountAttributionState: context.accountAttributionState,
+    source: context.source,
+    createdAt: context.now,
+    updatedAt: context.now,
+  });
+
+  enqueueSync(context.db, {
+    id: syncQueueId,
+    tableName: "transactions",
+    rowId: transactionId,
+    operation: "insert",
+    createdAt: context.now,
+  });
+
+  return transactionId;
+}
+
+async function trackSuccessfulNotification(context: ResolvedNotificationContext) {
+  trackTransactionCreated({
+    type: context.parsed.type,
+    category: String(context.categoryId),
+    source: "notification",
+  });
+
+  trackNotificationPipeline(context, {
+    saved: 1,
+    skippedDuplicate: 0,
+    parseFailed: 0,
+  });
+}
+
+export async function persistFailedNotification(
+  context: NotificationStageContext
+): Promise<NotificationPipelineResult> {
+  const now = toIsoDateTime(new Date());
+
+  await persistCaptureOutcome(context, {
+    status: "failed",
+    fingerprintHash: buildFailedFingerprint(context.notification),
+    transactionId: null,
+    confidence: null,
+    now,
+  });
+  trackNotificationPipeline(context, {
+    saved: 0,
+    skippedDuplicate: 0,
+    parseFailed: 1,
+  });
+
+  return { saved: false, skippedDuplicate: false, transactionId: null };
+}
+
+export async function persistDuplicateNotification(
+  context: ParsedNotificationContext,
+  duplicate: DuplicateCheckResult
+): Promise<NotificationPipelineResult> {
+  if (duplicate.kind === "already_processed") {
+    return reportSkippedDuplicate(context, null);
+  }
+
+  await persistCaptureOutcome(context, {
+    status: "skipped_duplicate",
+    fingerprintHash: context.fingerprint,
+    transactionId: duplicate.transactionId,
+    confidence: context.parsed.confidence,
+    now: toIsoDateTime(new Date()),
+  });
+
+  return reportSkippedDuplicate(context, duplicate.transactionId);
+}
+
+export async function persistSuccessfulNotification(
+  context: ResolvedNotificationContext
+): Promise<NotificationPipelineResult> {
+  const transactionId = saveTransactionRecord(context);
+
+  await persistCaptureOutcome(context, {
+    status: "success",
+    fingerprintHash: context.fingerprint,
+    transactionId,
+    confidence: context.parsed.confidence,
+    now: context.now,
+  });
+  await cacheMerchantRuleIfEligible(context);
+  await trackSuccessfulNotification(context);
+
+  return { saved: true, skippedDuplicate: false, transactionId };
+}

--- a/apps/mobile/features/capture-sources/services/notification-pipeline/types.ts
+++ b/apps/mobile/features/capture-sources/services/notification-pipeline/types.ts
@@ -1,0 +1,88 @@
+import type { CaptureEvidenceSeed } from "@/features/capture-evidence";
+import type { AnyDb } from "@/shared/db";
+import type {
+  CategoryId,
+  CopAmount,
+  FinancialAccountId,
+  IsoDate,
+  IsoDateTime,
+  TransactionId,
+  UserId,
+} from "@/shared/types/branded";
+import type { NotificationData, resolveSource } from "../../schema";
+
+export type NotificationParseMethod = "regex" | "llm";
+export type NotificationSource = ReturnType<typeof resolveSource>;
+export type NotificationStageMetrics = {
+  saved: 0 | 1;
+  skippedDuplicate: 0 | 1;
+  parseFailed: 0 | 1;
+};
+
+export type RawParsedNotification = {
+  amount: number;
+  merchant: string;
+  type: "expense" | "income";
+  categoryId: string;
+  date: string;
+  confidence: number;
+};
+
+export type ParsedNotification = Omit<RawParsedNotification, "amount" | "date"> & {
+  amount: CopAmount;
+  date: IsoDate;
+};
+
+export type NotificationCommand = {
+  db: AnyDb;
+  userId: UserId;
+  notification: NotificationData;
+};
+
+export type NotificationContext = NotificationCommand & {
+  captureEvidence: readonly CaptureEvidenceSeed[];
+  notificationText: string;
+  sanitizedText: string;
+  receivedAt: IsoDateTime;
+  source: NotificationSource;
+  notificationDate: IsoDate;
+};
+
+export type NotificationStageContext = NotificationContext & {
+  parseMethod: NotificationParseMethod;
+};
+
+export type ParsedNotificationContext = NotificationStageContext & {
+  parsed: ParsedNotification;
+  fingerprint: string;
+};
+
+export type ResolvedNotificationContext = ParsedNotificationContext & {
+  merchantKey: string;
+  categoryId: CategoryId;
+  accountId: FinancialAccountId;
+  accountAttributionState: "inferred" | "unresolved";
+  now: IsoDateTime;
+};
+
+export type ParseStageResult =
+  | { kind: "failed"; context: NotificationStageContext }
+  | { kind: "parsed"; context: ParsedNotificationContext };
+
+export type DuplicateCheckResult =
+  | { kind: "already_processed" }
+  | { kind: "cross_source"; transactionId: TransactionId };
+
+export type PersistedCaptureOutcome = {
+  status: "failed" | "skipped_duplicate" | "success";
+  fingerprintHash: string;
+  transactionId: TransactionId | null;
+  confidence: number | null;
+  now: IsoDateTime;
+};
+
+export type NotificationPipelineResult = {
+  saved: boolean;
+  skippedDuplicate: boolean;
+  transactionId: TransactionId | null;
+};


### PR DESCRIPTION
- extract pipeline helpers
- add context helper tests


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the Android notification capture pipeline into focused modules for context parsing, outcomes persistence, and shared types. This reduces complexity in `notification-pipeline.ts` and improves testability; no behavior change expected.

- **Refactors**
  - Moved command normalization, fingerprinting, LLM parse wrapper, category/account helpers to `context.ts`.
  - Moved persistence, evidence writes, merchant rule caching, and analytics to `outcomes.ts`.
  - Centralized shared contracts in `types.ts` and re-exported `NotificationPipelineResult`.
  - Added unit tests for context helpers (`notification-pipeline-context.test.ts`).

<sup>Written for commit 8c1bca91fe02fb46a6c1a6a1b04abbc4f3833454. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

