### PR TITLE
refactor(mobile): split budget store

### DIFF
--- a/apps/mobile/__tests__/budget/store-state.test.ts
+++ b/apps/mobile/__tests__/budget/store-state.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import { create } from "zustand";
+import { createBudgetStoreState } from "@/features/budget/store/state";
+import { requireUserId } from "@/shared/types/assertions";
+import type { BudgetId, Month } from "@/shared/types/branded";
+
+const INITIAL_MONTH = "2026-03" as Month;
+const ACKNOWLEDGED_ALERT_KEY = "budget-1:80";
+const BUDGET_ID = "budget-1" as BudgetId;
+
+function createStore(acknowledgeAlert = vi.fn()) {
+  return create(createBudgetStoreState(INITIAL_MONTH, { acknowledgeAlert }));
+}
+
+function applySnapshot(store: ReturnType<typeof createStore>) {
+  store.getState().setSnapshot({
+    budgets: [{ id: "budget-1", categoryId: "food", month: INITIAL_MONTH }] as never[],
+    budgetProgress: [] as never[],
+    summary: { totalBudget: 100000, totalSpent: 25000, percentUsed: 25 },
+    autoSuggestions: [] as never[],
+    pendingAlerts: [
+      {
+        budgetId: BUDGET_ID,
+        categoryId: "food" as never,
+        threshold: 80,
+        percentUsed: 80,
+        suggestionKey: "guidance.budgetAlert80.food",
+        remainingAmount: 20000 as never,
+        daysLeft: 5,
+      },
+    ],
+    pendingPermissionRequest: true,
+  });
+}
+
+describe("budget store state helper", () => {
+  it("begins a new session while preserving the active month baseline", () => {
+    const store = createStore();
+
+    store.getState().setMonth("2026-04" as Month);
+    store.getState().setIsLoading(true);
+    store.getState().beginSession(requireUserId("user-1"));
+
+    expect(store.getState()).toMatchObject({
+      activeUserId: requireUserId("user-1"),
+      currentMonth: "2026-04",
+      budgets: [],
+      hasLoadedOnce: false,
+      isLoading: false,
+    });
+  });
+
+  it("applies snapshots and clears pending permission requests", () => {
+    const store = createStore();
+
+    applySnapshot(store);
+    store.getState().clearPendingPermissionRequest();
+
+    expect(store.getState()).toMatchObject({
+      hasLoadedOnce: true,
+      pendingPermissionRequest: false,
+      summary: { totalBudget: 100000, totalSpent: 25000, percentUsed: 25 },
+      pendingAlerts: expect.arrayContaining([expect.objectContaining({ budgetId: BUDGET_ID })]),
+    });
+  });
+
+  it("delegates alert acknowledgement through the manager", () => {
+    const acknowledgeAlert = vi.fn().mockReturnValue({
+      acknowledgedAlerts: new Set([ACKNOWLEDGED_ALERT_KEY]),
+      pendingAlerts: [],
+    });
+    const store = createStore(acknowledgeAlert);
+
+    applySnapshot(store);
+    store.getState().acknowledgeAlert(BUDGET_ID, 80);
+
+    expect(acknowledgeAlert).toHaveBeenCalledWith({
+      budgetId: BUDGET_ID,
+      threshold: 80,
+      alertState: {
+        pendingAlerts: expect.arrayContaining([expect.objectContaining({ budgetId: BUDGET_ID })]),
+        acknowledgedAlerts: new Set(),
+      },
+    });
+    expect(Array.from(store.getState().acknowledgedAlerts)).toEqual([ACKNOWLEDGED_ALERT_KEY]);
+    expect(store.getState().pendingAlerts).toEqual([]);
+  });
+});

--- a/apps/mobile/features/budget/store.ts
+++ b/apps/mobile/features/budget/store.ts
@@ -1,32 +1,24 @@
-import { addMonths, subMonths } from "date-fns";
-import { create, type StateCreator } from "zustand";
+import { create } from "zustand";
 import { insertNotificationRecord } from "@/features/notifications";
 import { useSettingsStore } from "@/features/settings";
 import { CATEGORY_MAP } from "@/features/transactions";
 import { createWriteThroughMutationModule } from "@/mutations";
 import type { AnyDb } from "@/shared/db";
 import { getCategoryLabel, useLocaleStore } from "@/shared/i18n";
-import { generateBudgetId, toIsoDateTime, toMonth, trackBudgetCreated } from "@/shared/lib";
+import { generateBudgetId, toIsoDateTime, trackBudgetCreated } from "@/shared/lib";
 import type { BudgetId, CategoryId, CopAmount, Month, UserId } from "@/shared/types/branded";
-import type { BudgetAlert, BudgetProgress, BudgetSuggestion } from "./lib/derive";
-import type { BudgetMonthSnapshot } from "./lib/monitoring";
 import { createBudgetMonitoringModule } from "./lib/monitoring";
 import { scheduleBudgetAlert } from "./lib/notifications";
-import type { Budget } from "./schema";
 import { createBudgetSchema } from "./schema";
+import {
+  formatBudgetMonth,
+  nextBudgetMonth as getNextBudgetMonth,
+  previousBudgetMonth,
+} from "./store/month";
+import { createBudgetStoreState } from "./store/state";
 
 let budgetSessionId = 0;
 let loadBudgetsRequestId = 0;
-
-const formatMonth = (date: Date): Month => toMonth(date);
-
-/** Parse "YYYY-MM" to a local-time Date (1st of month). Avoids UTC date-only parsing pitfall. */
-const parseMonth = (month: Month): Date => {
-  const parts = month.split("-").map(Number);
-  const year = parts[0] ?? 0;
-  const monthIndex = (parts[1] ?? 1) - 1;
-  return new Date(year, monthIndex, 1);
-};
 
 const createLiveBudgetMonitoring = (
   db: AnyDb,
@@ -57,37 +49,6 @@ const budgetAlertStateManager = createBudgetMonitoringModule({
   scheduleBudgetAlert: async () => ({ type: "skipped" }),
   insertNotification: () => undefined,
 });
-
-type BudgetState = {
-  readonly activeUserId: UserId | null;
-  readonly currentMonth: Month;
-  readonly budgets: readonly Budget[];
-  readonly budgetProgress: readonly BudgetProgress[];
-  readonly summary: {
-    readonly totalBudget: number;
-    readonly totalSpent: number;
-    readonly percentUsed: number;
-  };
-  readonly autoSuggestions: readonly BudgetSuggestion[];
-  readonly acknowledgedAlerts: ReadonlySet<string>;
-  readonly pendingAlerts: readonly BudgetAlert[];
-  readonly pendingPermissionRequest: boolean;
-  readonly hasLoadedOnce: boolean;
-  readonly isLoading: boolean;
-};
-
-type BudgetActions = {
-  beginSession: (userId: UserId) => void;
-  setMonth: (month: Month) => void;
-  setSnapshot: (snapshot: BudgetMonthSnapshot) => void;
-  setAutoSuggestions: (autoSuggestions: readonly BudgetSuggestion[]) => void;
-  setIsLoading: (isLoading: boolean) => void;
-  acknowledgeAlert: (budgetId: BudgetId, threshold: 80 | 100) => void;
-  clearPendingPermissionRequest: () => void;
-};
-
-type BudgetStore = BudgetState & BudgetActions;
-type BudgetSetState = Parameters<StateCreator<BudgetStore>>[0];
 type BudgetRequest = {
   readonly requestId: number;
   readonly userId: UserId;
@@ -101,80 +62,9 @@ type UpdateBudgetInput = {
   readonly amount: CopAmount;
 };
 
-function createBudgetState(currentMonth: Month, activeUserId: UserId | null): BudgetState {
-  return {
-    activeUserId,
-    currentMonth,
-    budgets: [],
-    budgetProgress: [],
-    summary: { totalBudget: 0, totalSpent: 0, percentUsed: 0 },
-    autoSuggestions: [],
-    acknowledgedAlerts: new Set(),
-    pendingAlerts: [],
-    pendingPermissionRequest: false,
-    hasLoadedOnce: false,
-    isLoading: false,
-  };
-}
-
-function beginBudgetSession(set: BudgetSetState): BudgetActions["beginSession"] {
-  return (userId) => set((state) => createBudgetState(state.currentMonth, userId));
-}
-
-function setBudgetSnapshot(set: BudgetSetState): BudgetActions["setSnapshot"] {
-  return (snapshot) =>
-    set((state) => ({
-      budgets: snapshot.budgets as Budget[],
-      budgetProgress: snapshot.budgetProgress as BudgetProgress[],
-      summary: snapshot.summary,
-      autoSuggestions: snapshot.autoSuggestions as BudgetSuggestion[],
-      pendingAlerts: snapshot.pendingAlerts,
-      pendingPermissionRequest: state.pendingPermissionRequest || snapshot.pendingPermissionRequest,
-      hasLoadedOnce: true,
-      isLoading: false,
-    }));
-}
-
-function acknowledgeBudgetAlert(set: BudgetSetState): BudgetActions["acknowledgeAlert"] {
-  return (budgetId, threshold) =>
-    set((state) => {
-      const nextState = budgetAlertStateManager.acknowledgeAlert({
-        budgetId,
-        threshold,
-        alertState: {
-          pendingAlerts: state.pendingAlerts,
-          acknowledgedAlerts: state.acknowledgedAlerts,
-        },
-      });
-
-      return {
-        acknowledgedAlerts: new Set(nextState.acknowledgedAlerts),
-        pendingAlerts: nextState.pendingAlerts,
-      };
-    });
-}
-
-function createBudgetActions(set: BudgetSetState): BudgetActions {
-  return {
-    beginSession: beginBudgetSession(set),
-    setMonth: (currentMonth) => set({ currentMonth }),
-    setSnapshot: setBudgetSnapshot(set),
-    setAutoSuggestions: (autoSuggestions) =>
-      set({ autoSuggestions: [...autoSuggestions] as BudgetSuggestion[] }),
-    setIsLoading: (isLoading) => set({ isLoading }),
-    acknowledgeAlert: acknowledgeBudgetAlert(set),
-    clearPendingPermissionRequest: () => {
-      set({ pendingPermissionRequest: false });
-    },
-  };
-}
-
-const createBudgetStoreState: StateCreator<BudgetStore> = (set) => ({
-  ...createBudgetState(formatMonth(new Date()), null),
-  ...createBudgetActions(set),
-});
-
-export const useBudgetStore = create<BudgetStore>(createBudgetStoreState);
+export const useBudgetStore = create(
+  createBudgetStoreState(formatBudgetMonth(new Date()), budgetAlertStateManager)
+);
 
 function isActiveBudgetSession(userId: UserId, sessionId: number): boolean {
   return budgetSessionId === sessionId && useBudgetStore.getState().activeUserId === userId;
@@ -238,13 +128,13 @@ export async function loadBudgetsForUser(db: AnyDb, userId: UserId): Promise<voi
 }
 
 export async function nextBudgetMonth(db: AnyDb, userId: UserId): Promise<void> {
-  const next = formatMonth(addMonths(parseMonth(useBudgetStore.getState().currentMonth), 1));
+  const next = getNextBudgetMonth(useBudgetStore.getState().currentMonth);
   useBudgetStore.getState().setMonth(next);
   await loadBudgetsForUser(db, userId);
 }
 
 export async function prevBudgetMonth(db: AnyDb, userId: UserId): Promise<void> {
-  const previous = formatMonth(subMonths(parseMonth(useBudgetStore.getState().currentMonth), 1));
+  const previous = previousBudgetMonth(useBudgetStore.getState().currentMonth);
   useBudgetStore.getState().setMonth(previous);
   await loadBudgetsForUser(db, userId);
 }

--- a/apps/mobile/features/budget/store/month.ts
+++ b/apps/mobile/features/budget/store/month.ts
@@ -1,0 +1,19 @@
+import { addMonths, subMonths } from "date-fns";
+import { toMonth } from "@/shared/lib";
+import type { Month } from "@/shared/types/branded";
+
+export const formatBudgetMonth = (date: Date): Month => toMonth(date);
+
+/** Parse "YYYY-MM" to a local-time Date (1st of month). Avoids UTC date-only parsing pitfall. */
+const parseBudgetMonth = (month: Month): Date => {
+  const parts = month.split("-").map(Number);
+  const year = parts[0] ?? 0;
+  const monthIndex = (parts[1] ?? 1) - 1;
+  return new Date(year, monthIndex, 1);
+};
+
+export const nextBudgetMonth = (month: Month): Month =>
+  formatBudgetMonth(addMonths(parseBudgetMonth(month), 1));
+
+export const previousBudgetMonth = (month: Month): Month =>
+  formatBudgetMonth(subMonths(parseBudgetMonth(month), 1));

--- a/apps/mobile/features/budget/store/state.ts
+++ b/apps/mobile/features/budget/store/state.ts
@@ -1,0 +1,129 @@
+import type { StateCreator } from "zustand";
+import type { BudgetId, Month, UserId } from "@/shared/types/branded";
+import type { BudgetAlert, BudgetProgress, BudgetSuggestion } from "../lib/derive";
+import type { BudgetAlertState, BudgetMonthSnapshot } from "../lib/monitoring";
+import type { Budget } from "../schema";
+
+export type BudgetState = {
+  readonly activeUserId: UserId | null;
+  readonly currentMonth: Month;
+  readonly budgets: readonly Budget[];
+  readonly budgetProgress: readonly BudgetProgress[];
+  readonly summary: {
+    readonly totalBudget: number;
+    readonly totalSpent: number;
+    readonly percentUsed: number;
+  };
+  readonly autoSuggestions: readonly BudgetSuggestion[];
+  readonly acknowledgedAlerts: ReadonlySet<string>;
+  readonly pendingAlerts: readonly BudgetAlert[];
+  readonly pendingPermissionRequest: boolean;
+  readonly hasLoadedOnce: boolean;
+  readonly isLoading: boolean;
+};
+
+export type BudgetActions = {
+  beginSession: (userId: UserId) => void;
+  setMonth: (month: Month) => void;
+  setSnapshot: (snapshot: BudgetMonthSnapshot) => void;
+  setAutoSuggestions: (autoSuggestions: readonly BudgetSuggestion[]) => void;
+  setIsLoading: (isLoading: boolean) => void;
+  acknowledgeAlert: (budgetId: BudgetId, threshold: 80 | 100) => void;
+  clearPendingPermissionRequest: () => void;
+};
+
+export type BudgetStore = BudgetState & BudgetActions;
+
+type BudgetSetState = Parameters<StateCreator<BudgetStore>>[0];
+
+type BudgetAlertStateManager = {
+  readonly acknowledgeAlert: (input: {
+    readonly budgetId: BudgetId;
+    readonly threshold: 80 | 100;
+    readonly alertState: BudgetAlertState;
+  }) => BudgetAlertState;
+};
+
+export function createBudgetState(currentMonth: Month, activeUserId: UserId | null): BudgetState {
+  return {
+    activeUserId,
+    currentMonth,
+    budgets: [],
+    budgetProgress: [],
+    summary: { totalBudget: 0, totalSpent: 0, percentUsed: 0 },
+    autoSuggestions: [],
+    acknowledgedAlerts: new Set(),
+    pendingAlerts: [],
+    pendingPermissionRequest: false,
+    hasLoadedOnce: false,
+    isLoading: false,
+  };
+}
+
+function beginBudgetSession(set: BudgetSetState): BudgetActions["beginSession"] {
+  return (userId) => set((state) => createBudgetState(state.currentMonth, userId));
+}
+
+function setBudgetSnapshot(set: BudgetSetState): BudgetActions["setSnapshot"] {
+  return (snapshot) =>
+    set((state) => ({
+      budgets: snapshot.budgets as Budget[],
+      budgetProgress: snapshot.budgetProgress as BudgetProgress[],
+      summary: snapshot.summary,
+      autoSuggestions: snapshot.autoSuggestions as BudgetSuggestion[],
+      pendingAlerts: snapshot.pendingAlerts,
+      pendingPermissionRequest: state.pendingPermissionRequest || snapshot.pendingPermissionRequest,
+      hasLoadedOnce: true,
+      isLoading: false,
+    }));
+}
+
+function acknowledgeBudgetAlert(
+  set: BudgetSetState,
+  budgetAlertStateManager: BudgetAlertStateManager
+): BudgetActions["acknowledgeAlert"] {
+  return (budgetId, threshold) =>
+    set((state) => {
+      const nextState = budgetAlertStateManager.acknowledgeAlert({
+        budgetId,
+        threshold,
+        alertState: {
+          pendingAlerts: state.pendingAlerts,
+          acknowledgedAlerts: state.acknowledgedAlerts,
+        },
+      });
+
+      return {
+        acknowledgedAlerts: new Set(nextState.acknowledgedAlerts),
+        pendingAlerts: nextState.pendingAlerts,
+      };
+    });
+}
+
+export function createBudgetActions(
+  set: BudgetSetState,
+  budgetAlertStateManager: BudgetAlertStateManager
+): BudgetActions {
+  return {
+    beginSession: beginBudgetSession(set),
+    setMonth: (currentMonth) => set({ currentMonth }),
+    setSnapshot: setBudgetSnapshot(set),
+    setAutoSuggestions: (autoSuggestions) =>
+      set({ autoSuggestions: [...autoSuggestions] as BudgetSuggestion[] }),
+    setIsLoading: (isLoading) => set({ isLoading }),
+    acknowledgeAlert: acknowledgeBudgetAlert(set, budgetAlertStateManager),
+    clearPendingPermissionRequest: () => {
+      set({ pendingPermissionRequest: false });
+    },
+  };
+}
+
+export function createBudgetStoreState(
+  initialMonth: Month,
+  budgetAlertStateManager: BudgetAlertStateManager
+): StateCreator<BudgetStore> {
+  return (set) => ({
+    ...createBudgetState(initialMonth, null),
+    ...createBudgetActions(set, budgetAlertStateManager),
+  });
+}


### PR DESCRIPTION
- extract store state helper
- add budget store tests


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the budget store into a reusable state helper and month utilities to reduce complexity and improve testability. Added tests for the new store state; no user-facing changes.

- **Refactors**
  - Moved state and actions to `store/state.ts` via `createBudgetStoreState(...)`; alert acknowledgement now delegates through an injected `budgetAlertStateManager`.
  - Added `store/month.ts` with `formatBudgetMonth`, `nextBudgetMonth`, `previousBudgetMonth`; replaced inline parsing and math.
  - Updated `store.ts` to use the new state factory and month helpers; removed duplicated state logic and simplified next/prev month handling.

<sup>Written for commit ba4d94cf056c64f2ddf5ca412bd1bc4698fcabcf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

