### PR TITLE
refactor(mobile): split email store

### DIFF
--- a/apps/mobile/__tests__/email-capture/store-state.test.ts
+++ b/apps/mobile/__tests__/email-capture/store-state.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { create } from "zustand";
+import type { EmailAccountRow } from "@/features/email-capture/lib/repository";
+import { createEmailCaptureStoreState } from "@/features/email-capture/store/state";
+import { requireUserId } from "@/shared/types/assertions";
+import type { EmailAccountId, IsoDateTime, UserId } from "@/shared/types/branded";
+
+const USER_ID = requireUserId("user-1");
+
+function makeAccount(overrides: Partial<EmailAccountRow> = {}): EmailAccountRow {
+  return {
+    id: "ea-1" as EmailAccountId,
+    userId: USER_ID,
+    provider: "gmail",
+    email: "person@gmail.com",
+    lastFetchedAt: null,
+    createdAt: "2026-04-23T10:00:00.000Z" as IsoDateTime,
+    ...overrides,
+  };
+}
+
+describe("email capture store state helper", () => {
+  it("begins a new session and clears transient store state", () => {
+    const store = create(createEmailCaptureStoreState);
+
+    store.setState({
+      activeUserId: "user-0" as UserId,
+      accounts: [makeAccount()],
+      failedEmails: [{ id: "failed-1" }] as never[],
+      needsReviewEmails: [{ id: "review-1" }] as never[],
+      isFetching: true,
+      progress: { total: 2, completed: 1, saved: 1, failed: 0, needsReview: 0 },
+      phase: "processing",
+      bannerDismissed: true,
+    });
+
+    store.getState().beginSession(USER_ID);
+
+    expect(store.getState()).toMatchObject({
+      activeUserId: USER_ID,
+      accounts: [],
+      failedEmails: [],
+      needsReviewEmails: [],
+      isFetching: false,
+      progress: null,
+      phase: null,
+      bannerDismissed: false,
+    });
+  });
+
+  it("updates fetched accounts without mutating unrelated entries", () => {
+    const store = create(createEmailCaptureStoreState);
+    const accountOne = makeAccount();
+    const accountTwo = makeAccount({
+      id: "ea-2" as EmailAccountId,
+      email: "other@gmail.com",
+      lastFetchedAt: "2026-04-22T09:00:00.000Z" as IsoDateTime,
+    });
+    const fetchedAt = "2026-04-23T12:00:00.000Z" as IsoDateTime;
+
+    store.getState().setAccounts([accountOne, accountTwo]);
+    store.getState().markAccountsFetched(new Set([accountOne.id]), fetchedAt);
+
+    expect(store.getState().accounts).toEqual([
+      { ...accountOne, lastFetchedAt: fetchedAt },
+      accountTwo,
+    ]);
+  });
+});

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -1,5 +1,4 @@
 import { eq } from "drizzle-orm";
-import { create } from "zustand";
 import { isValidCategoryId } from "@/features/transactions/write.public";
 import type { AnyDb } from "@/shared/db";
 import { enqueueSync, transactions } from "@/shared/db";
@@ -11,11 +10,9 @@ import {
   normalizeMerchant,
   toIsoDateTime,
 } from "@/shared/lib";
-import { assertEmailAccountId } from "@/shared/types/assertions";
-import type { EmailAccountId, IsoDateTime, UserId } from "@/shared/types/branded";
+import type { UserId } from "@/shared/types/branded";
 import { insertMerchantRule } from "./lib/merchant-rules";
-import type { ProgressPhase } from "./lib/progress-phases";
-import type { EmailAccountRow, ProcessedEmailRow } from "./lib/repository";
+import type { EmailAccountRow } from "./lib/repository";
 import {
   deleteEmailAccount,
   dismissProcessedEmail,
@@ -25,16 +22,13 @@ import {
   insertEmailAccount,
   updateProcessedEmailStatus,
 } from "./lib/repository";
-import type { ProgressCallback } from "./pipeline.public";
 import type { EmailProvider } from "./schema";
 import { getAdapter } from "./services/email-adapter";
 import {
   createEmailFetchClientIds,
-  type EmailCaptureQueues,
   fetchEmailAccountBatch,
   ingestFetchedEmails,
   loadEmailCaptureQueues,
-  type PersistedFetchedAccounts,
   persistFetchedAccounts,
 } from "./services/email-capture-fetch-service";
 import {
@@ -43,137 +37,24 @@ import {
   beginEmailCaptureRequest,
   createEmailCaptureFetchProgressHandler,
   createEmailCaptureSession,
-  type EmailCaptureFetchRun,
   finalizeEmailCaptureFetchRun,
   initializeEmailCaptureStoreSession,
   isActiveEmailCaptureSession,
-  isCurrentEmailCaptureFetchRun,
   isCurrentEmailCaptureRequest,
   registerEmailCaptureStoreRuntime,
 } from "./services/email-capture-store-runtime";
-
-type ProgressSnapshot = Parameters<ProgressCallback>[0];
-type RefreshTransactions = () => Promise<void> | void;
+import {
+  applyEmailCaptureFetchOutcome,
+  isManagedEmailProvider,
+  type RefreshTransactions,
+  resolveEmailAccountId,
+  useEmailCaptureStore,
+  warnFetchMissingContext,
+} from "./store/state";
 
 const noopRefreshTransactions: RefreshTransactions = () => undefined;
 
-type ApplyFetchOutcomeInput = {
-  readonly run: EmailCaptureFetchRun;
-  readonly showProgress: boolean;
-  readonly persistedAccounts: PersistedFetchedAccounts;
-  readonly queues: EmailCaptureQueues;
-  readonly refreshTransactions: RefreshTransactions;
-};
-
-type EmailCaptureState = {
-  readonly activeUserId: UserId | null;
-  readonly accounts: readonly EmailAccountRow[];
-  readonly failedEmails: readonly ProcessedEmailRow[];
-  readonly needsReviewEmails: readonly ProcessedEmailRow[];
-  readonly isFetching: boolean;
-  readonly progress: ProgressSnapshot | null;
-  readonly phase: ProgressPhase | null;
-  readonly bannerDismissed: boolean;
-};
-
-type EmailCaptureActions = {
-  beginSession: (userId: UserId) => void;
-  setAccounts: (accounts: readonly EmailAccountRow[]) => void;
-  setFailedEmails: (failedEmails: readonly ProcessedEmailRow[]) => void;
-  setNeedsReviewEmails: (needsReviewEmails: readonly ProcessedEmailRow[]) => void;
-  setIsFetching: (isFetching: boolean) => void;
-  setProgress: (progress: ProgressSnapshot | null) => void;
-  setPhase: (phase: ProgressPhase | null) => void;
-  dismissBanner: () => void;
-  appendAccount: (account: EmailAccountRow) => void;
-  removeAccount: (accountId: string) => void;
-  removeFailedEmail: (processedEmailId: string) => void;
-  removeNeedsReviewEmail: (processedEmailId: string) => void;
-  markAccountsFetched: (accountIds: ReadonlySet<EmailAccountId>, fetchedAt: IsoDateTime) => void;
-};
-
-export const useEmailCaptureStore = create<EmailCaptureState & EmailCaptureActions>((set) => ({
-  activeUserId: null,
-  accounts: [],
-  failedEmails: [],
-  needsReviewEmails: [],
-  isFetching: false,
-  progress: null,
-  phase: null,
-  bannerDismissed: false,
-
-  beginSession: (userId) =>
-    set({
-      activeUserId: userId,
-      accounts: [],
-      failedEmails: [],
-      needsReviewEmails: [],
-      isFetching: false,
-      progress: null,
-      phase: null,
-      bannerDismissed: false,
-    }),
-
-  setAccounts: (accounts) => set({ accounts: [...accounts] }),
-
-  setFailedEmails: (failedEmails) => set({ failedEmails: [...failedEmails] }),
-
-  setNeedsReviewEmails: (needsReviewEmails) => set({ needsReviewEmails: [...needsReviewEmails] }),
-
-  setIsFetching: (isFetching) => set({ isFetching }),
-
-  setProgress: (progress) => set({ progress }),
-
-  setPhase: (phase) => set({ phase }),
-
-  dismissBanner: () => set({ bannerDismissed: true }),
-
-  appendAccount: (account) => set((state) => ({ accounts: [...state.accounts, account] })),
-
-  removeAccount: (accountId) =>
-    set((state) => ({
-      accounts: state.accounts.filter((account) => account.id !== accountId),
-    })),
-
-  removeFailedEmail: (processedEmailId) =>
-    set((state) => ({
-      failedEmails: state.failedEmails.filter((email) => email.id !== processedEmailId),
-    })),
-
-  removeNeedsReviewEmail: (processedEmailId) =>
-    set((state) => ({
-      needsReviewEmails: state.needsReviewEmails.filter((email) => email.id !== processedEmailId),
-    })),
-
-  markAccountsFetched: (accountIds, fetchedAt) =>
-    set((state) => ({
-      accounts: state.accounts.map((account) =>
-        accountIds.has(account.id) ? { ...account, lastFetchedAt: fetchedAt } : account
-      ),
-    })),
-}));
-
-function resolveEmailAccountId(
-  account: EmailAccountRow | undefined,
-  emailAccountId: string
-): EmailAccountId {
-  if (account) return account.id;
-  assertEmailAccountId(emailAccountId);
-  return emailAccountId;
-}
-
-function isManagedEmailProvider(provider: string | undefined): provider is EmailProvider {
-  return provider === "gmail" || provider === "outlook";
-}
-
-function warnFetchMissingContext(userId: UserId): void {
-  const activeUserId = useEmailCaptureStore.getState().activeUserId;
-  captureWarning("email_capture_fetch_missing_context", {
-    hasActiveSession: activeUserId !== null,
-    matchesActiveSession: activeUserId === userId,
-    activeSessionUserId: activeUserId ?? "none",
-  });
-}
+export { useEmailCaptureStore };
 
 registerEmailCaptureStoreRuntime({
   beginSession: (userId) => useEmailCaptureStore.getState().beginSession(userId),
@@ -187,22 +68,6 @@ registerEmailCaptureStoreRuntime({
 
 export function initializeEmailCaptureSession(userId: UserId): void {
   initializeEmailCaptureStoreSession(userId);
-}
-
-async function applyFetchOutcome(input: ApplyFetchOutcomeInput): Promise<void> {
-  if (!isCurrentEmailCaptureFetchRun(input.run)) return;
-
-  const state = useEmailCaptureStore.getState();
-  state.markAccountsFetched(
-    input.persistedAccounts.updatedAccountIds,
-    input.persistedAccounts.fetchedAt
-  );
-  state.setFailedEmails(input.queues.failedEmails);
-  state.setNeedsReviewEmails(input.queues.needsReviewEmails);
-  if (input.showProgress) {
-    state.setPhase("complete");
-  }
-  await input.refreshTransactions();
 }
 
 export async function loadEmailAccounts(db: AnyDb, userId: UserId): Promise<void> {
@@ -352,7 +217,7 @@ export async function fetchAndProcessEmails(
       onProgress: createEmailCaptureFetchProgressHandler(run, refreshTransactions),
     });
 
-    await applyFetchOutcome({
+    await applyEmailCaptureFetchOutcome({
       run,
       showProgress: summary.showProgress,
       persistedAccounts: await persistFetchedAccounts({ db, fetchResults: summary.fetchResults }),

--- a/apps/mobile/features/email-capture/store/state.ts
+++ b/apps/mobile/features/email-capture/store/state.ts
@@ -1,0 +1,151 @@
+import { create, type StateCreator } from "zustand";
+import { captureWarning } from "@/shared/lib";
+import { assertEmailAccountId } from "@/shared/types/assertions";
+import type { EmailAccountId, IsoDateTime, UserId } from "@/shared/types/branded";
+import type { ProgressPhase } from "../lib/progress-phases";
+import type { EmailAccountRow, ProcessedEmailRow } from "../lib/repository";
+import type { ProgressCallback } from "../pipeline.public";
+import type { EmailProvider } from "../schema";
+import type {
+  EmailCaptureQueues,
+  PersistedFetchedAccounts,
+} from "../services/email-capture-fetch-service";
+import {
+  type EmailCaptureFetchRun,
+  isCurrentEmailCaptureFetchRun,
+} from "../services/email-capture-store-runtime";
+
+export type ProgressSnapshot = Parameters<ProgressCallback>[0];
+export type RefreshTransactions = () => Promise<void> | void;
+
+export type EmailCaptureState = {
+  readonly activeUserId: UserId | null;
+  readonly accounts: readonly EmailAccountRow[];
+  readonly failedEmails: readonly ProcessedEmailRow[];
+  readonly needsReviewEmails: readonly ProcessedEmailRow[];
+  readonly isFetching: boolean;
+  readonly progress: ProgressSnapshot | null;
+  readonly phase: ProgressPhase | null;
+  readonly bannerDismissed: boolean;
+};
+
+export type EmailCaptureActions = {
+  beginSession: (userId: UserId) => void;
+  setAccounts: (accounts: readonly EmailAccountRow[]) => void;
+  setFailedEmails: (failedEmails: readonly ProcessedEmailRow[]) => void;
+  setNeedsReviewEmails: (needsReviewEmails: readonly ProcessedEmailRow[]) => void;
+  setIsFetching: (isFetching: boolean) => void;
+  setProgress: (progress: ProgressSnapshot | null) => void;
+  setPhase: (phase: ProgressPhase | null) => void;
+  dismissBanner: () => void;
+  appendAccount: (account: EmailAccountRow) => void;
+  removeAccount: (accountId: string) => void;
+  removeFailedEmail: (processedEmailId: string) => void;
+  removeNeedsReviewEmail: (processedEmailId: string) => void;
+  markAccountsFetched: (accountIds: ReadonlySet<EmailAccountId>, fetchedAt: IsoDateTime) => void;
+};
+
+export type EmailCaptureStore = EmailCaptureState & EmailCaptureActions;
+type EmailCaptureSetState = Parameters<StateCreator<EmailCaptureStore>>[0];
+
+export function createEmailCaptureState(activeUserId: UserId | null): EmailCaptureState {
+  return {
+    activeUserId,
+    accounts: [],
+    failedEmails: [],
+    needsReviewEmails: [],
+    isFetching: false,
+    progress: null,
+    phase: null,
+    bannerDismissed: false,
+  };
+}
+
+function beginEmailCaptureSession(set: EmailCaptureSetState): EmailCaptureActions["beginSession"] {
+  return (userId) => set(createEmailCaptureState(userId));
+}
+
+export function createEmailCaptureActions(set: EmailCaptureSetState): EmailCaptureActions {
+  return {
+    beginSession: beginEmailCaptureSession(set),
+    setAccounts: (accounts) => set({ accounts: [...accounts] }),
+    setFailedEmails: (failedEmails) => set({ failedEmails: [...failedEmails] }),
+    setNeedsReviewEmails: (needsReviewEmails) => set({ needsReviewEmails: [...needsReviewEmails] }),
+    setIsFetching: (isFetching) => set({ isFetching }),
+    setProgress: (progress) => set({ progress }),
+    setPhase: (phase) => set({ phase }),
+    dismissBanner: () => set({ bannerDismissed: true }),
+    appendAccount: (account) =>
+      set((state) => ({
+        accounts: [...state.accounts, account],
+      })),
+    removeAccount: (accountId) =>
+      set((state) => ({
+        accounts: state.accounts.filter((account) => account.id !== accountId),
+      })),
+    removeFailedEmail: (processedEmailId) =>
+      set((state) => ({
+        failedEmails: state.failedEmails.filter((email) => email.id !== processedEmailId),
+      })),
+    removeNeedsReviewEmail: (processedEmailId) =>
+      set((state) => ({
+        needsReviewEmails: state.needsReviewEmails.filter((email) => email.id !== processedEmailId),
+      })),
+    markAccountsFetched: (accountIds, fetchedAt) =>
+      set((state) => ({
+        accounts: state.accounts.map((account) =>
+          accountIds.has(account.id) ? { ...account, lastFetchedAt: fetchedAt } : account
+        ),
+      })),
+  };
+}
+
+export const createEmailCaptureStoreState: StateCreator<EmailCaptureStore> = (set) => ({
+  ...createEmailCaptureState(null),
+  ...createEmailCaptureActions(set),
+});
+
+export const useEmailCaptureStore = create(createEmailCaptureStoreState);
+
+export function resolveEmailAccountId(
+  account: EmailAccountRow | undefined,
+  emailAccountId: string
+): EmailAccountId {
+  if (account) return account.id;
+  assertEmailAccountId(emailAccountId);
+  return emailAccountId;
+}
+
+export function isManagedEmailProvider(provider: string | undefined): provider is EmailProvider {
+  return provider === "gmail" || provider === "outlook";
+}
+
+export function warnFetchMissingContext(userId: UserId): void {
+  const activeUserId = useEmailCaptureStore.getState().activeUserId;
+
+  captureWarning("email_capture_fetch_missing_context", {
+    hasActiveSession: activeUserId !== null,
+    matchesActiveSession: activeUserId === userId,
+    activeSessionUserId: activeUserId ?? "none",
+  });
+}
+
+export async function applyEmailCaptureFetchOutcome(input: {
+  readonly run: EmailCaptureFetchRun;
+  readonly showProgress: boolean;
+  readonly persistedAccounts: PersistedFetchedAccounts;
+  readonly queues: EmailCaptureQueues;
+  readonly refreshTransactions: RefreshTransactions;
+}): Promise<void> {
+  if (!isCurrentEmailCaptureFetchRun(input.run)) return;
+
+  const state = useEmailCaptureStore.getState();
+  state.markAccountsFetched(
+    input.persistedAccounts.updatedAccountIds,
+    input.persistedAccounts.fetchedAt
+  );
+  state.setFailedEmails(input.queues.failedEmails);
+  state.setNeedsReviewEmails(input.queues.needsReviewEmails);
+  if (input.showProgress) state.setPhase("complete");
+  await input.refreshTransactions();
+}


### PR DESCRIPTION
- extract email capture state module
- add store state helper tests


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the email capture store into a dedicated state module to make state/actions reusable, testable, and simpler to maintain. Also extracted fetch outcome handling and added unit tests.

- **Refactors**
  - Centralized `zustand` store creation and state/actions in `features/email-capture/store/state.ts`; `useEmailCaptureStore` now exported from there.
  - Moved helpers: `applyEmailCaptureFetchOutcome`, `resolveEmailAccountId`, `isManagedEmailProvider`, and `warnFetchMissingContext` into the state module.
  - Trimmed `store.ts` to focus on orchestration and re-export the store.
  - Added tests in `__tests__/email-capture/store-state.test.ts` for session reset and account fetch updates.

<sup>Written for commit 26050e897333ebeb2717c8d240591d74a2b948af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

