### PR TITLE
refactor(mobile): split transaction store

### DIFF
--- a/apps/mobile/__tests__/transactions/store-state.test.ts
+++ b/apps/mobile/__tests__/transactions/store-state.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { create } from "zustand";
+import { createTransactionStoreState } from "@/features/transactions/store/state";
+import type {
+  CategoryId,
+  CopAmount,
+  FinancialAccountId,
+  IsoDate,
+  TransactionId,
+  UserId,
+} from "@/shared/types/branded";
+
+const DEFAULT_ACCOUNT_ID = "fa-default" as FinancialAccountId;
+
+function makeStoredTransaction(overrides: Partial<{ id: TransactionId }> = {}) {
+  return {
+    id: "tx-1" as TransactionId,
+    userId: "user-1" as UserId,
+    type: "expense" as const,
+    amount: 1000 as CopAmount,
+    categoryId: "food" as CategoryId,
+    description: "Lunch",
+    date: new Date("2026-03-04T00:00:00.000Z"),
+    createdAt: new Date("2026-03-04T10:00:00.000Z"),
+    updatedAt: new Date("2026-03-04T10:00:00.000Z"),
+    deletedAt: null,
+    accountId: DEFAULT_ACCOUNT_ID,
+    accountAttributionState: "confirmed" as const,
+    ...overrides,
+  };
+}
+
+describe("transaction store state helper", () => {
+  it("adopts the latest default account only while the draft is still following defaults", () => {
+    const store = create(createTransactionStoreState);
+
+    store.getState().setDefaultAccountId(DEFAULT_ACCOUNT_ID);
+    expect(store.getState().accountId).toBe(DEFAULT_ACCOUNT_ID);
+
+    store.getState().setAccountId("fa-custom" as FinancialAccountId);
+    store.getState().setDefaultAccountId("fa-next-default" as FinancialAccountId);
+
+    expect(store.getState()).toMatchObject({
+      defaultAccountId: "fa-next-default",
+      accountId: "fa-custom",
+    });
+  });
+
+  it("preserves current pages during same-data refreshes while bumping revision", () => {
+    const store = create(createTransactionStoreState);
+    const currentPage = makeStoredTransaction();
+
+    store.setState({
+      pages: [currentPage],
+      offset: 1,
+      hasMore: true,
+      dataRevision: 4,
+    });
+
+    store.getState().applyRefreshSnapshot({
+      pages: [makeStoredTransaction({ id: "tx-2" as TransactionId })],
+      offset: 1,
+      hasMore: false,
+      balance: 1000,
+      categorySpending: [{ categoryId: "food" as CategoryId, total: 1000 as CopAmount }],
+      dailySpending: [{ date: "2026-03-04" as IsoDate, total: 1000 as CopAmount }],
+      sameData: true,
+    });
+
+    expect(store.getState()).toMatchObject({
+      pages: [currentPage],
+      offset: 1,
+      hasMore: false,
+      dataRevision: 5,
+    });
+  });
+});

--- a/apps/mobile/features/transactions/store.ts
+++ b/apps/mobile/features/transactions/store.ts
@@ -1,4 +1,3 @@
-import { create } from "zustand";
 import { createWriteThroughMutationModule } from "@/mutations";
 import type { AnyDb } from "@/shared/db";
 import {
@@ -7,93 +6,19 @@ import {
   trackTransactionEdited,
 } from "@/shared/lib";
 import type { CategoryId, FinancialAccountId, TransactionId, UserId } from "@/shared/types/branded";
-import type { DigitsInput } from "./components/transaction-form/TransactionForm.types";
 import {
   createTransactionMutationService,
   type TransactionMutationResult,
 } from "./lib/mutation-service";
 import type { StoredTransaction, TransactionType } from "./schema";
-import {
-  type CategorySpendingItem,
-  createTransactionQueryService,
-  type DailySpendingItem,
-  type TransactionAggregateSnapshot,
-  type TransactionPageSnapshot,
-  type TransactionRefreshSnapshot,
-} from "./services/create-transaction-query-service";
-
-type FormStep = 1 | 2;
+import { createTransactionQueryService } from "./services/create-transaction-query-service";
+import { toTransactionFormInput } from "./store/form-input";
+import { useTransactionStore } from "./store/state";
 
 const PAGE_SIZE = 30;
 
 let transactionsSessionId = 0;
 let loadTransactionsRequestId = 0;
-
-type TransactionState = {
-  readonly activeUserId: UserId | null;
-  readonly step: FormStep;
-  readonly type: TransactionType;
-  readonly digits: string;
-  readonly categoryId: CategoryId | null;
-  readonly defaultAccountId: FinancialAccountId | null;
-  readonly accountId: FinancialAccountId | null;
-  readonly description: string;
-  readonly date: Date;
-  readonly pages: readonly StoredTransaction[];
-  readonly offset: number;
-  readonly hasMore: boolean;
-  readonly balance: number;
-  readonly categorySpending: readonly CategorySpendingItem[];
-  readonly dailySpending: readonly DailySpendingItem[];
-  readonly dataRevision: number;
-  readonly editingId: TransactionId | null;
-};
-
-type TransactionActions = {
-  beginSession: (userId: UserId) => void;
-  setStep: (step: FormStep) => void;
-  setType: (type: TransactionType) => void;
-  setDigits: (digits: DigitsInput) => void;
-  setCategoryId: (id: CategoryId) => void;
-  setDefaultAccountId: (id: FinancialAccountId | null) => void;
-  setAccountId: (id: FinancialAccountId | null) => void;
-  setDescription: (desc: string) => void;
-  setDate: (date: Date) => void;
-  setPageSnapshot: (snapshot: TransactionPageSnapshot) => void;
-  appendPageSnapshot: (snapshot: TransactionPageSnapshot) => void;
-  setAggregateSnapshot: (snapshot: TransactionAggregateSnapshot) => void;
-  applyRefreshSnapshot: (snapshot: TransactionRefreshSnapshot) => void;
-  hydrateEditingTransaction: (id: TransactionId, transaction: StoredTransaction) => void;
-  addToCache: (tx: StoredTransaction) => void;
-  removeFromCache: (id: TransactionId) => void;
-  resetForm: () => void;
-};
-
-const INITIAL_FORM: Pick<
-  TransactionState,
-  "step" | "type" | "digits" | "categoryId" | "accountId" | "description"
-> = {
-  step: 1,
-  type: "expense",
-  digits: "",
-  categoryId: null,
-  accountId: null,
-  description: "",
-};
-const INITIAL_PAGINATION_STATE: Pick<TransactionState, "pages" | "offset" | "hasMore"> = {
-  pages: [],
-  offset: 0,
-  hasMore: true,
-};
-const INITIAL_AGGREGATE_STATE: Pick<
-  TransactionState,
-  "balance" | "categorySpending" | "dailySpending" | "dataRevision"
-> = {
-  balance: 0,
-  categorySpending: [],
-  dailySpending: [],
-  dataRevision: 0,
-};
 type UpdateTransactionDirectInput = {
   readonly db: AnyDb;
   readonly userId: UserId;
@@ -107,34 +32,6 @@ type UpdateTransactionDirectInput = {
     readonly date: Date;
   };
 };
-
-function createInitialState(activeUserId: UserId | null): TransactionState {
-  return {
-    activeUserId,
-    ...INITIAL_FORM,
-    defaultAccountId: null,
-    date: new Date(),
-    ...INITIAL_PAGINATION_STATE,
-    ...INITIAL_AGGREGATE_STATE,
-    editingId: null,
-  };
-}
-
-function toTransactionFormInput(
-  state: Pick<
-    TransactionState,
-    "type" | "digits" | "categoryId" | "accountId" | "description" | "date"
-  >
-) {
-  return {
-    type: state.type,
-    digits: state.digits,
-    categoryId: state.categoryId,
-    accountId: state.accountId,
-    description: state.description,
-    date: state.date,
-  };
-}
 
 function isActiveTransactionSession(userId: UserId, sessionId: number): boolean {
   return (
@@ -170,101 +67,7 @@ function createLiveTransactionMutationService(db: AnyDb, userId: UserId, session
     createId: generateTransactionId,
   });
 }
-
-export const useTransactionStore = create<TransactionState & TransactionActions>((set) => ({
-  ...createInitialState(null),
-
-  beginSession: (userId) => set(createInitialState(userId)),
-  setStep: (step) => set({ step }),
-  setType: (type) => set({ type }),
-  setDigits: (digits) =>
-    set((state) => ({
-      digits: typeof digits === "function" ? digits(state.digits) : digits,
-    })),
-  setCategoryId: (categoryId) => set({ categoryId }),
-  setDefaultAccountId: (defaultAccountId) =>
-    set((state) => ({
-      defaultAccountId,
-      accountId:
-        state.editingId == null &&
-        (state.accountId == null || state.accountId === state.defaultAccountId)
-          ? defaultAccountId
-          : state.accountId,
-    })),
-  setAccountId: (accountId) => set({ accountId }),
-  setDescription: (description) => set({ description }),
-  setDate: (date) => set({ date }),
-
-  setPageSnapshot: (snapshot) =>
-    set({
-      pages: [...snapshot.pages],
-      offset: snapshot.offset,
-      hasMore: snapshot.hasMore,
-    }),
-
-  appendPageSnapshot: (snapshot) =>
-    set((state) => ({
-      pages: [...state.pages, ...snapshot.pages],
-      offset: state.offset + snapshot.pages.length,
-      hasMore: snapshot.hasMore,
-    })),
-
-  setAggregateSnapshot: (snapshot) =>
-    set({
-      balance: snapshot.balance,
-      categorySpending: [...snapshot.categorySpending],
-      dailySpending: [...snapshot.dailySpending],
-    }),
-
-  applyRefreshSnapshot: (snapshot) =>
-    set((state) => ({
-      ...(snapshot.sameData ? null : { pages: [...snapshot.pages] }),
-      offset: snapshot.offset,
-      hasMore: snapshot.hasMore,
-      balance: snapshot.balance,
-      categorySpending: [...snapshot.categorySpending],
-      dailySpending: [...snapshot.dailySpending],
-      dataRevision: state.dataRevision + 1,
-    })),
-
-  hydrateEditingTransaction: (id, transaction) =>
-    set({
-      editingId: id,
-      type: transaction.type,
-      digits: String(transaction.amount),
-      categoryId: transaction.categoryId,
-      accountId: transaction.accountId,
-      description: transaction.description,
-      date: transaction.date,
-    }),
-
-  addToCache: (transaction) =>
-    set((state) => ({
-      pages: [transaction, ...state.pages],
-      offset: state.offset + 1,
-      dataRevision: state.dataRevision + 1,
-    })),
-
-  removeFromCache: (id) =>
-    set((state) => {
-      const pages = state.pages.filter((transaction) => transaction.id !== id);
-      const removed = pages.length < state.pages.length;
-
-      return {
-        pages,
-        offset: removed ? Math.max(0, state.offset - 1) : state.offset,
-        dataRevision: removed ? state.dataRevision + 1 : state.dataRevision,
-      };
-    }),
-
-  resetForm: () =>
-    set((state) => ({
-      ...INITIAL_FORM,
-      accountId: state.defaultAccountId,
-      date: new Date(),
-      editingId: null,
-    })),
-}));
+export { useTransactionStore };
 
 export function initializeTransactionSession(userId: UserId): void {
   transactionsSessionId += 1;

--- a/apps/mobile/features/transactions/store/form-actions.ts
+++ b/apps/mobile/features/transactions/store/form-actions.ts
@@ -1,0 +1,126 @@
+import type { CategoryId, FinancialAccountId, TransactionId, UserId } from "@/shared/types/branded";
+import type { TransactionActions, TransactionSetState, TransactionState } from "./state";
+
+const INITIAL_FORM: Pick<
+  TransactionState,
+  "step" | "type" | "digits" | "categoryId" | "accountId" | "description"
+> = {
+  step: 1,
+  type: "expense",
+  digits: "",
+  categoryId: null,
+  accountId: null,
+  description: "",
+};
+
+const INITIAL_PAGINATION_STATE: Pick<TransactionState, "pages" | "offset" | "hasMore"> = {
+  pages: [],
+  offset: 0,
+  hasMore: true,
+};
+
+const INITIAL_AGGREGATE_STATE: Pick<
+  TransactionState,
+  "balance" | "categorySpending" | "dailySpending" | "dataRevision"
+> = {
+  balance: 0,
+  categorySpending: [],
+  dailySpending: [],
+  dataRevision: 0,
+};
+
+export function createInitialTransactionState(activeUserId: UserId | null): TransactionState {
+  return {
+    activeUserId,
+    ...INITIAL_FORM,
+    defaultAccountId: null,
+    date: new Date(),
+    ...INITIAL_PAGINATION_STATE,
+    ...INITIAL_AGGREGATE_STATE,
+    editingId: null,
+  };
+}
+
+export function beginTransactionSession(
+  set: TransactionSetState
+): TransactionActions["beginSession"] {
+  return function beginSession(userId) {
+    set(createInitialTransactionState(userId));
+  };
+}
+
+export function setTransactionStep(set: TransactionSetState): TransactionActions["setStep"] {
+  return function setStep(step) {
+    set({ step });
+  };
+}
+
+export function setTransactionType(set: TransactionSetState): TransactionActions["setType"] {
+  return function setType(type) {
+    set({ type });
+  };
+}
+
+export function setTransactionDigits(set: TransactionSetState): TransactionActions["setDigits"] {
+  return function setDigits(digits) {
+    set((state) => ({
+      digits: typeof digits === "function" ? digits(state.digits) : digits,
+    }));
+  };
+}
+
+export function setTransactionCategoryId(
+  set: TransactionSetState
+): TransactionActions["setCategoryId"] {
+  return function setCategoryId(categoryId: CategoryId) {
+    set({ categoryId });
+  };
+}
+
+export function setTransactionDefaultAccount(
+  set: TransactionSetState
+): TransactionActions["setDefaultAccountId"] {
+  return function setDefaultAccountId(defaultAccountId) {
+    set((state) => ({
+      defaultAccountId,
+      accountId:
+        state.editingId == null &&
+        (state.accountId == null || state.accountId === state.defaultAccountId)
+          ? defaultAccountId
+          : state.accountId,
+    }));
+  };
+}
+
+export function setTransactionAccountId(
+  set: TransactionSetState
+): TransactionActions["setAccountId"] {
+  return function setAccountId(accountId: FinancialAccountId | null) {
+    set({ accountId });
+  };
+}
+
+export function setTransactionDescription(
+  set: TransactionSetState
+): TransactionActions["setDescription"] {
+  return function setDescription(description) {
+    set({ description });
+  };
+}
+
+export function setTransactionDate(set: TransactionSetState): TransactionActions["setDate"] {
+  return function setDate(date) {
+    set({ date });
+  };
+}
+
+export function resetTransactionForm(set: TransactionSetState): TransactionActions["resetForm"] {
+  return function resetForm() {
+    set((state) => ({
+      ...INITIAL_FORM,
+      accountId: state.defaultAccountId,
+      date: new Date(),
+      editingId: null as TransactionId | null,
+    }));
+  };
+}

--- a/apps/mobile/features/transactions/store/form-input.ts
+++ b/apps/mobile/features/transactions/store/form-input.ts
@@ -1,0 +1,18 @@
+import type { TransactionFormInput } from "../lib/mutation-service";
+import type { TransactionState } from "./state";
+
+type TransactionFormState = Pick<
+  TransactionState,
+  "type" | "digits" | "categoryId" | "accountId" | "description" | "date"
+>;
+
+export function toTransactionFormInput(state: TransactionFormState): TransactionFormInput {
+  return {
+    type: state.type,
+    digits: state.digits,
+    categoryId: state.categoryId,
+    accountId: state.accountId,
+    description: state.description,
+    date: state.date,
+  };
+}

--- a/apps/mobile/features/transactions/store/page-actions.ts
+++ b/apps/mobile/features/transactions/store/page-actions.ts
@@ -1,0 +1,96 @@
+import type { TransactionActions, TransactionSetState } from "./state";
+
+export function setTransactionPageSnapshot(
+  set: TransactionSetState
+): TransactionActions["setPageSnapshot"] {
+  return function setPageSnapshot(snapshot) {
+    set({
+      pages: [...snapshot.pages],
+      offset: snapshot.offset,
+      hasMore: snapshot.hasMore,
+    });
+  };
+}
+
+export function appendTransactionPageSnapshot(
+  set: TransactionSetState
+): TransactionActions["appendPageSnapshot"] {
+  return function appendPageSnapshot(snapshot) {
+    set((state) => ({
+      pages: [...state.pages, ...snapshot.pages],
+      offset: state.offset + snapshot.pages.length,
+      hasMore: snapshot.hasMore,
+    }));
+  };
+}
+
+export function setTransactionAggregateSnapshot(
+  set: TransactionSetState
+): TransactionActions["setAggregateSnapshot"] {
+  return function setAggregateSnapshot(snapshot) {
+    set({
+      balance: snapshot.balance,
+      categorySpending: [...snapshot.categorySpending],
+      dailySpending: [...snapshot.dailySpending],
+    });
+  };
+}
+
+export function createHydrateEditingTransaction(
+  set: TransactionSetState
+): TransactionActions["hydrateEditingTransaction"] {
+  return function hydrateEditingTransaction(id, transaction) {
+    set({
+      editingId: id,
+      type: transaction.type,
+      digits: String(transaction.amount),
+      categoryId: transaction.categoryId,
+      accountId: transaction.accountId,
+      description: transaction.description,
+      date: transaction.date,
+    });
+  };
+}
+
+export function addTransactionToCache(set: TransactionSetState): TransactionActions["addToCache"] {
+  return function addToCache(transaction) {
+    set((state) => ({
+      pages: [transaction, ...state.pages],
+      offset: state.offset + 1,
+      dataRevision: state.dataRevision + 1,
+    }));
+  };
+}
+
+export function removeTransactionFromCache(
+  set: TransactionSetState
+): TransactionActions["removeFromCache"] {
+  return function removeFromCache(id) {
+    set((state) => {
+      const pages = state.pages.filter((transaction) => transaction.id !== id);
+      const removed = pages.length < state.pages.length;
+
+      return {
+        pages,
+        offset: removed ? Math.max(0, state.offset - 1) : state.offset,
+        dataRevision: removed ? state.dataRevision + 1 : state.dataRevision,
+      };
+    });
+  };
+}
+
+export function setTransactionRefreshSnapshot(
+  set: TransactionSetState
+): TransactionActions["applyRefreshSnapshot"] {
+  return function applyRefreshSnapshot(snapshot) {
+    set((state) => ({
+      ...(snapshot.sameData ? null : { pages: [...snapshot.pages] }),
+      offset: snapshot.offset,
+      hasMore: snapshot.hasMore,
+      balance: snapshot.balance,
+      categorySpending: [...snapshot.categorySpending],
+      dailySpending: [...snapshot.dailySpending],
+      dataRevision: state.dataRevision + 1,
+    }));
+  };
+}

--- a/apps/mobile/features/transactions/store/state.ts
+++ b/apps/mobile/features/transactions/store/state.ts
@@ -1,0 +1,101 @@
+import { create, type StateCreator } from "zustand";
+import type { CategoryId, FinancialAccountId, TransactionId, UserId } from "@/shared/types/branded";
+import type { DigitsInput } from "../components/transaction-form/TransactionForm.types";
+import type { StoredTransaction, TransactionType } from "../schema";
+import type {
+  CategorySpendingItem,
+  DailySpendingItem,
+  TransactionAggregateSnapshot,
+  TransactionPageSnapshot,
+  TransactionRefreshSnapshot,
+} from "../services/create-transaction-query-service";
+import {
+  beginTransactionSession,
+  createInitialTransactionState,
+  resetTransactionForm,
+  setTransactionAccountId,
+  setTransactionCategoryId,
+  setTransactionDate,
+  setTransactionDefaultAccount,
+  setTransactionDescription,
+  setTransactionDigits,
+  setTransactionStep,
+  setTransactionType,
+} from "./form-actions";
+import {
+  addTransactionToCache,
+  appendTransactionPageSnapshot,
+  createHydrateEditingTransaction,
+  removeTransactionFromCache,
+  setTransactionAggregateSnapshot,
+  setTransactionPageSnapshot,
+  setTransactionRefreshSnapshot,
+} from "./page-actions";
+
+export type FormStep = 1 | 2;
+
+export type TransactionState = {
+  readonly activeUserId: UserId | null;
+  readonly step: FormStep;
+  readonly type: TransactionType;
+  readonly digits: string;
+  readonly categoryId: CategoryId | null;
+  readonly defaultAccountId: FinancialAccountId | null;
+  readonly accountId: FinancialAccountId | null;
+  readonly description: string;
+  readonly date: Date;
+  readonly pages: readonly StoredTransaction[];
+  readonly offset: number;
+  readonly hasMore: boolean;
+  readonly balance: number;
+  readonly categorySpending: readonly CategorySpendingItem[];
+  readonly dailySpending: readonly DailySpendingItem[];
+  readonly dataRevision: number;
+  readonly editingId: TransactionId | null;
+};
+
+export type TransactionActions = {
+  beginSession: (userId: UserId) => void;
+  setStep: (step: FormStep) => void;
+  setType: (type: TransactionType) => void;
+  setDigits: (digits: DigitsInput) => void;
+  setCategoryId: (id: CategoryId) => void;
+  setDefaultAccountId: (id: FinancialAccountId | null) => void;
+  setAccountId: (id: FinancialAccountId | null) => void;
+  setDescription: (desc: string) => void;
+  setDate: (date: Date) => void;
+  setPageSnapshot: (snapshot: TransactionPageSnapshot) => void;
+  appendPageSnapshot: (snapshot: TransactionPageSnapshot) => void;
+  setAggregateSnapshot: (snapshot: TransactionAggregateSnapshot) => void;
+  applyRefreshSnapshot: (snapshot: TransactionRefreshSnapshot) => void;
+  hydrateEditingTransaction: (id: TransactionId, transaction: StoredTransaction) => void;
+  addToCache: (tx: StoredTransaction) => void;
+  removeFromCache: (id: TransactionId) => void;
+  resetForm: () => void;
+};
+
+export type TransactionStore = TransactionState & TransactionActions;
+export type TransactionSetState = Parameters<StateCreator<TransactionStore>>[0];
+
+export const createTransactionStoreState: StateCreator<TransactionStore> = (set) => ({
+  ...createInitialTransactionState(null),
+  beginSession: beginTransactionSession(set),
+  setStep: setTransactionStep(set),
+  setType: setTransactionType(set),
+  setDigits: setTransactionDigits(set),
+  setCategoryId: setTransactionCategoryId(set),
+  setDefaultAccountId: setTransactionDefaultAccount(set),
+  setAccountId: setTransactionAccountId(set),
+  setDescription: setTransactionDescription(set),
+  setDate: setTransactionDate(set),
+  setPageSnapshot: setTransactionPageSnapshot(set),
+  appendPageSnapshot: appendTransactionPageSnapshot(set),
+  setAggregateSnapshot: setTransactionAggregateSnapshot(set),
+  applyRefreshSnapshot: setTransactionRefreshSnapshot(set),
+  hydrateEditingTransaction: createHydrateEditingTransaction(set),
+  addToCache: addTransactionToCache(set),
+  removeFromCache: removeTransactionFromCache(set),
+  resetForm: resetTransactionForm(set),
+});
+
+export const useTransactionStore = create(createTransactionStoreState);


### PR DESCRIPTION
- extract transaction state helpers
- add transaction store state tests


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the mobile transactions Zustand store into smaller modules and added focused tests for state helpers. The public `useTransactionStore` API remains the same, but the state logic is now easier to test and maintain.

- **Refactors**
  - Moved store logic into `store/state.ts`, `store/form-actions.ts`, `store/page-actions.ts`, and `store/form-input.ts`.
  - Introduced `createTransactionStoreState` for isolated store creation; `useTransactionStore` is re-exported from `store/state`.
  - Added `__tests__/transactions/store-state.test.ts` to cover default account adoption and refresh snapshot behavior.
  - Slimmed `features/transactions/store.ts` by delegating to extracted helpers.

<sup>Written for commit c4fc80bb1851e6048035faa2d288fd64f4249453. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

