### PR TITLE
ci(repo): enforce file size gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
         run: bun run lint:mobile
       - name: Lizard strict complexity gate
         run: bun run lint:complexity
+      - name: File-size gate
+        run: bun run lint:file-size
 
   architecture:
     name: Architecture

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "build:packages": "bun run --cwd packages/assets --shell=bun build && bun run --cwd packages/types --shell=bun build && bun run --cwd packages/schemas --shell=bun build && bun run --cwd packages/utils --shell=bun build",
     "lint:mobile": "bun run --cwd apps/mobile --shell=bun lint",
     "lint:complexity": "./scripts/run-lizard-strict.sh",
+    "lint:file-size": "bun ./scripts/check-max-file-lines.ts --enforce",
     "lint:brands": "bun scripts/check-branded-boundaries.ts",
     "lint:architecture": "depcruise --config .dependency-cruiser.cjs apps/mobile packages",
     "lint:dead-code": "knip-bun --config knip.json",
@@ -46,7 +47,7 @@
     "perf:bundle:mobile": "bun run --cwd apps/mobile --shell=bun bundle:atlas",
     "lint": "bunx biome check .",
     "format": "bunx biome format --write .",
-    "verify": "bun run lint && bun run lint:brands && bun run lint:mobile && bun run lint:complexity && bun run lint:architecture && bun run typecheck && bun run test"
+    "verify": "bun run lint && bun run lint:brands && bun run lint:mobile && bun run lint:complexity && bun run lint:file-size && bun run lint:architecture && bun run typecheck && bun run test"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.4",

--- a/scripts/check-max-file-lines.test.ts
+++ b/scripts/check-max-file-lines.test.ts
@@ -90,3 +90,29 @@ test("does not overcount a file that ends with a trailing newline", () => {
   expect(result.stdout.toString()).toContain("No oversized files found.");
   expect(result.stdout.toString()).not.toContain("ThresholdScreen.tsx");
 });
+
+test("fails in enforce mode when oversized files are present", () => {
+  const root = createTempDir();
+  writeSourceFile(root, "apps/mobile/features/demo/components/LargeScreen.tsx", 6);
+
+  const result = Bun.spawnSync({
+    cmd: [
+      "bun",
+      "scripts/check-max-file-lines.ts",
+      "--root",
+      root,
+      "--max-lines",
+      "5",
+      "--enforce",
+    ],
+    cwd: process.cwd(),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  expect(result.exitCode).toBe(1);
+  expect(result.stdout.toString()).toContain("Oversized files: 1");
+  expect(result.stdout.toString()).toContain(
+    "apps/mobile/features/demo/components/LargeScreen.tsx"
+  );
+});

--- a/scripts/check-max-file-lines.ts
+++ b/scripts/check-max-file-lines.ts
@@ -4,6 +4,7 @@ import { readdirSync, readFileSync } from "node:fs";
 import { join, relative } from "node:path";
 
 type Args = {
+  enforce: boolean;
   root: string;
   maxLines: number;
 };
@@ -30,6 +31,7 @@ const IGNORED_DIRECTORIES = new Set([
 const normalizePath = (value: string): string => value.replaceAll("\\", "/");
 
 const parseArgs = (argv: string[]): Args => {
+  const enforce = argv.includes("--enforce");
   const rootIndex = argv.indexOf("--root");
   const maxLinesIndex = argv.indexOf("--max-lines");
   const root = rootIndex === -1 ? process.cwd() : argv[rootIndex + 1];
@@ -44,7 +46,7 @@ const parseArgs = (argv: string[]): Args => {
     throw new Error("--max-lines must be a positive integer");
   }
 
-  return { root, maxLines };
+  return { enforce, root, maxLines };
 };
 
 const hasSourceExtension = (relativePath: string): boolean =>
@@ -144,9 +146,13 @@ const formatReport = (root: string, maxLines: number, violations: readonly Viola
 };
 
 const main = () => {
-  const { root, maxLines } = parseArgs(process.argv.slice(2));
+  const { enforce, root, maxLines } = parseArgs(process.argv.slice(2));
   const violations = scanViolations(root, maxLines);
   console.log(formatReport(root, maxLines, violations));
+
+  if (enforce && violations.length > 0) {
+    process.exit(1);
+  }
 };
 
 try {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a file-size gate that fails when source files exceed the max line count. Hooked into `verify` and the CI workflow to block violations.

- **New Features**
  - Added `--enforce` flag to `scripts/check-max-file-lines.ts` to exit with code 1 on violations.
  - Added `lint:file-size` script; included in `verify` and as a CI step in `.github/workflows/ci.yml`.
  - Added a test to validate failure behavior in enforce mode.

<sup>Written for commit cb4b00379cb836a8be5388bdae6ad5dfb5c4ce4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

