### PR TITLE
docs(privacy): define private backup boundary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,7 +71,7 @@ docs/
 docs/*
 !docs/adr/
 docs/adr/*
-!docs/adr/0001-financial-accounts-and-transfers.md
+!docs/adr/*.md
 TODOS.md
 .context/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,20 +1,3 @@
-## Purpose
-
-Keep this file lean. Add only repo-specific rules and surprises that save future agents real time. If something costs you time twice, add a short note here.
-
-## Read First
-
-### Financial accounts
-
-For financial accounts, account attribution, post-sync account suggestions, transfers, or default-account bootstrap, read:
-
-- `CONTEXT.md`
-- `docs/adr/0001-financial-accounts-and-transfers.md`
-- `plans/financial-accounts-v1.md`
-- `plans/financial-accounts-prd.md`
-
-`CONTEXT.md` is the source of truth if they differ.
-
 ## Workflow Surprises
 
 - Vitest: do not use async `importOriginal` global mocks for heavy modules in `__tests__/setup.ts`; prefer sync or file-local mocks.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,247 +1,76 @@
 # Fidy
 
-Fidy tracks personal finance activity captured from manual entry and automatic ingestion sources. This context exists to keep product and code terminology aligned as multi-account behavior is introduced.
+Fidy keeps the user's financial source of truth on device while allowing explicit cloud AI processing for ingestion and advisor tasks. This context captures the privacy and recovery boundaries for replacing plaintext remote financial sync with encrypted backup.
 
 ## Language
 
-**Transaction**:
-A recorded money movement, expense or income, that belongs to one financial account.
-_Avoid_: Movement, operation
+**Capture Interpreter**:
+The AI-assisted ingestion boundary that turns capture evidence into a structured transaction, transfer, or review candidate.
+_Avoid_: Regex parser, email parser
 
-**Transfer**:
-A value movement that settles debt or moves money between accounts without creating new spending or income.
-_Avoid_: Expense, income, category
+**Local Ledger**:
+The on-device source of truth for financial records, capture evidence, and financial derivations.
+_Avoid_: Local cache, offline copy
 
-**External Funding Side**:
-The non-tracked side of a transfer when the money comes from or goes to something outside the user's tracked financial accounts, such as cash or someone else's funds.
-_Avoid_: Dummy account, fake account
+**Plaintext Financial Data**:
+Readable financial records or capture evidence that reveal a user's financial activity without user-held decryption material.
+_Avoid_: Synced data, normal app data
 
-**Card Statement Obligation**:
-The amount due for a credit-card cycle that is settled by transfer rather than recorded as new spending.
-_Avoid_: Bill, expense, payment transaction
+**Encrypted Backup**:
+An opaque device-created snapshot of the Local Ledger stored remotely only as ciphertext for recovery after app deletion or device loss.
+_Avoid_: Cloud sync, server ledger
 
-**Partial Settlement**:
-The state where a card statement obligation has been reduced by one or more transfers but is not yet fully cleared.
-_Avoid_: Partial expense, split purchase
+**Private Backup**:
+The user-facing recovery feature that creates and restores Encrypted Backups without exposing Plaintext Financial Data to Fidy servers.
+_Avoid_: Encryption setup, recovery-secret setup
 
-**Card Billing Profile**:
-The user-configured cycle settings for a credit-card financial account, including statement closing day and payment due day.
-_Avoid_: Bill, reminder settings
+**Recovery Secret**:
+User-held key material needed to decrypt an Encrypted Backup after reinstall.
+_Avoid_: Password reset, server key
 
-**Billing Profile Gap**:
-The missing billing-profile information that prevents cycle-aware credit-card features from working.
-_Avoid_: Error, invalid card
+**Cloud AI Processing**:
+Explicit, transient processing of selected capture evidence or financial context by a remote AI service.
+_Avoid_: Sync, backup, remote storage
 
-**Statement Closing Day**:
-The recurring day when a credit-card statement cycle closes.
-_Avoid_: Due date, payment date
+**Financial Context Packet**:
+A minimal, task-scoped summary built on device from the Local Ledger and sent for Cloud AI Processing.
+_Avoid_: Database dump, remote profile
 
-**Payment Due Day**:
-The recurring day by which a credit-card statement should be paid.
-_Avoid_: Closing day, transfer date
-
-**Financial Account Kind**:
-The type of financial account, such as checking, savings, wallet, cash, or credit card.
-_Avoid_: Category, source
-
-**Financial Account**:
-A money-holding instrument that owns a transaction, such as a bank account, wallet, or card.
-_Avoid_: Account, connected account, email account
-
-**Settlement Financial Account**:
-The financial account that actually sends or receives the money for a transaction.
-_Avoid_: Source account, app account
-
-**Capture Source**:
-An ingestion channel that provides evidence about a transaction, such as Gmail, Outlook, Android notifications, or Apple Pay intents.
-_Avoid_: Account, bank account
-
-**Financial Account Identifier Evidence**:
-Stable source evidence that can point to a financial account, such as bank sender, last 4 digits, or account alias.
-_Avoid_: Merchant, category
-
-**Financial Account Identifier**:
-A user-confirmed identifier owned by a financial account and used for attribution matching.
-_Avoid_: Merchant rule, source
-
-**Financial Account Identifier Scope**:
-The evidence context required to interpret an identifier safely, such as bank sender plus last 4 digits.
-_Avoid_: Global ID, raw identifier
-
-**Account Attribution**:
-The act of assigning a transaction to the financial account it belongs to.
-_Avoid_: Source mapping, account detection
-
-**Account Attribution State**:
-The confidence status of a transaction's financial-account assignment, such as confirmed, inferred, or unresolved.
-_Avoid_: Review status, sync status
-
-**Financial Meaning**:
-The classification of a captured item as a transaction, transfer, or non-trackable capture.
-_Avoid_: Account attribution, category
-
-**Financial Meaning Review Queue**:
-The dedicated queue of captured records whose financial meaning still needs user confirmation.
-_Avoid_: Attribution review queue, main feed
-
-**Attribution Review Queue**:
-The dedicated queue of captured records whose financial account assignment still needs user confirmation.
-_Avoid_: Main feed, sync queue
-
-**Dismissed Capture**:
-A captured item the user marked as not a trackable financial record, while preserving the underlying capture evidence.
-_Avoid_: Deleted transaction, resolved attribution
-
-**Fallback Financial Account**:
-The default financial account that temporarily owns a transaction when account attribution is unresolved.
-_Avoid_: Unknown account, unassigned
-
-**Default Financial Account**:
-The user's primary financial account used as the preselected account for manual entry and as the fallback for unresolved attribution.
-_Avoid_: Main category, default source
-
-**Financial Account Bootstrap**:
-The automatic creation of the user's default financial account at registration or onboarding start, before capture sync begins.
-_Avoid_: Manual first account, post-sync setup
-
-**Account Creation Suggestion**:
-An optional, user-confirmed prompt to create or link a financial account after sync based on repeated scoped identifier evidence.
-_Avoid_: Auto-created account, single-capture guess
-
-**Suggestion Reason**:
-The lightweight explanation shown to the user for why Fidy generated an account creation suggestion.
-_Avoid_: Black-box guess, debug dump
-
-**Opening Balance**:
-The starting amount or debt assigned to a financial account when tracking begins.
-_Avoid_: First transaction, imported income
-
-**Opening Balance Effective Date**:
-The date from which an opening balance starts affecting a financial account's balance.
-_Avoid_: Created at, statement date
-
-**Reclassification**:
-The user-driven act of changing a captured record from one financial meaning to another, such as transaction to transfer.
-_Avoid_: Retry, reparse
-
-**Superseded Financial Record**:
-A financial record that has been replaced by a corrected interpretation and no longer counts in active balances or analytics.
-_Avoid_: Duplicate, archived record
+**Remote Financial Sync**:
+Plaintext replication of financial records to Fidy-controlled server tables.
+_Avoid_: Backup, recovery
 
 ## Relationships
 
-- Every **Transaction** belongs to exactly one **Financial Account**
-- A **Transaction** belongs to its **Settlement Financial Account**
-- A **Transfer** does not create new spending or income
-- A **Transfer** may connect two tracked **Financial Accounts** or one tracked **Financial Account** plus one **External Funding Side**
-- A **Transfer** is stored as one atomic record with two sides
-- A **Transfer** affects account balances but not spending, income, or budget consumption
-- Moving value between bank, cash, wallet, and credit-card accounts is a **Transfer**
-- A **Transfer** has one amount in v1, with no embedded fee or split-amount structure
-- A **Transfer** in v1 represents completed money movement only
-- Users may create **Transfers** manually
-- A manual **Transfer** may use an explicit **External Funding Side**
-- **External Funding Side** is generic in MVP
-- Manual transfer entry shows **External Funding Side** only when the user explicitly chooses movement outside tracked accounts
-- The default manual **Transfer** flow assumes movement between tracked **Financial Accounts**
-- A **Card Statement Obligation** belongs to one credit-card **Financial Account**
-- A **Card Statement Obligation** is settled by **Transfer**, not by a new expense **Transaction**
-- A **Card Statement Obligation** may be settled by many **Transfers**
-- A **Card Statement Obligation** is in **Partial Settlement** until its remaining due reaches zero
-- Every **Financial Account** has one **Financial Account Kind**
-- A non-credit-card **Financial Account** represents money available
-- Every user has exactly one **Default Financial Account**
-- **Financial Account Bootstrap** creates the **Default Financial Account** before onboarding capture sync begins
-- An **Account Creation Suggestion** may appear after sync to improve attribution without blocking onboarding
-- An **Account Creation Suggestion** requires repeated **Financial Account Identifier Evidence** within one **Financial Account Identifier Scope**
-- A single capture or bank sender alone is insufficient for an **Account Creation Suggestion**
-- The onboarding flow may include a lightweight optional account-accuracy step immediately after sync and before budget setup
-- The onboarding account-accuracy step should show one consolidated review screen rather than one suggestion at a time
-- The onboarding account-accuracy step should show only **Account Creation Suggestions**
-- Unresolved captured records should be resolved later, after the user has experienced the app's value
-- Skipping the onboarding account-accuracy step must not discard **Account Creation Suggestions**
-- Deferred **Account Creation Suggestions** should remain available later in the product
-- Deferred **Account Creation Suggestions** should be surfaced later through a lightweight home/dashboard prompt rather than settings or review queues
-- The optional onboarding review and the later home prompt should open the same consolidated **Account Creation Suggestion** review screen
-- Creating an account from an **Account Creation Suggestion** should open a prefilled account form rather than an empty one
-- Linking an **Account Creation Suggestion** to an existing account should show a short filtered list of likely matching accounts before the full list
-- Creating or linking from an **Account Creation Suggestion** should immediately reprocess matching past unresolved records
-- Every **Account Creation Suggestion** should show one lightweight **Suggestion Reason** based on its supporting evidence
-- Dismissing an **Account Creation Suggestion** should suppress that exact suggestion until new stronger evidence appears later
-- The optional post-sync onboarding review should show only the top few highest-confidence **Account Creation Suggestions**
-- The onboarding account-accuracy step should show at most 3 **Account Creation Suggestions**
-- Lower-priority **Account Creation Suggestions** should be deferred to the later home/dashboard prompt
-- If no strong **Account Creation Suggestions** exist after sync, onboarding should skip the account-accuracy step entirely
-- If strong **Account Creation Suggestions** exist after sync, onboarding should automatically continue into the account-accuracy review
-- The onboarding account-accuracy step should be framed as an optional improvement rather than required setup
-- A credit-card **Financial Account** may have one **Card Billing Profile**
-- A credit-card **Financial Account** may exist without a **Card Billing Profile**
-- A **Card Billing Profile** contains one **Statement Closing Day** and one **Payment Due Day**
-- A **Card Billing Profile** is user-configured rather than inferred from a **Capture Source**
-- A missing **Card Billing Profile** creates a **Billing Profile Gap**
-- The user should be told which cycle-aware features are unavailable when a **Billing Profile Gap** exists
-- A credit-card **Financial Account** represents debt owed on that card
-- A credit-card expense **Transaction** counts as spending on the purchase date, not the later payment date
-- A **Billing Profile Gap** disables cycle-aware credit-card features but does not block normal card tracking
-- A **Financial Account** may start with one **Opening Balance**
-- **Opening Balance** is separate from **Transaction** and **Transfer**
-- **Opening Balance** begins affecting balances from one **Opening Balance Effective Date**
-- A **Financial Account** balance is derived from **Opening Balance**, **Transactions**, and **Transfers**
-- A **Capture Source** may produce transactions for many **Financial Accounts**
-- A **Capture Source** may create a **Transfer** directly only when the evidence identifies both sides of the movement
-- One-sided capture evidence is insufficient to infer a **Transfer** in v1
-- A **Capture Source** provides evidence about a **Financial Account** but is not itself a **Financial Account**
-- A **Capture Source** must not auto-create new **Financial Accounts**
-- A captured item whose **Financial Meaning** is unclear stays as capture evidence until user review
-- A captured item whose **Financial Meaning** is unclear appears in the **Financial Meaning Review Queue**
-- **Financial Meaning** is resolved before **Account Attribution** when both are unclear
-- Resolving **Financial Meaning** may continue directly into **Account Attribution** in the same user flow
-- Resolving **Financial Meaning** as a **Transfer** requires both explicit sides before saving
-- A **Financial Account** may own many **Financial Account Identifiers**
-- A **Financial Account** may collect optional **Financial Account Identifiers** during setup
-- A **Financial Account Identifier** is interpreted within one **Financial Account Identifier Scope**
-- **Financial Account Identifier Evidence** is matched against **Financial Account Identifiers**
-- **Account Attribution** may learn from **Financial Account Identifier Evidence**
-- New **Financial Account Identifiers** may reprocess past unresolved records only
-- A wrong learned **Financial Account Identifier** should be weakened or removed after user correction
-- Correcting a wrong learned identifier may re-evaluate past inferred records, but not confirmed ones
-- **Account Attribution** assigns a **Transaction** to one **Financial Account**
-- A **Transaction** has one **Account Attribution State**
-- A manually created **Transaction** always has one **Financial Account**, with a default account preselected but editable
-- An **inferred** account assignment counts in active balances until corrected
-- **Fallback Financial Account** is the user's **Default Financial Account**
-- When **Account Attribution** is unresolved, the **Transaction** is still created under one **Fallback Financial Account** until corrected
-- An unresolved fallback-assigned **Transaction** is provisional and does not count in account-specific balances
-- An unresolved **Transaction** still counts in overall spending or income analytics when its financial meaning is otherwise clear
-- An unresolved **Transaction** appears in the **Attribution Review Queue**
-- The **Attribution Review Queue** may create a missing **Financial Account** inline before assigning the record
-- Resolving an item in the **Attribution Review Queue** may save its captured evidence as new **Financial Account Identifiers**
-- Resolving an item in the **Attribution Review Queue** makes its **Account Attribution State** `confirmed`
-- The **Attribution Review Queue** may dismiss a capture as not trackable
-- A **Dismissed Capture** stays stored as capture evidence but does not become a **Transaction** or **Transfer**
-- A **Dismissed Capture** is hidden from normal user flows in v1
-- A **Dismissed Capture** syncs so it does not resurface on other devices
-- Dismissal is final in v1
-- An unresolved **Transaction** still syncs as unresolved and can be corrected later
-- When multiple **Financial Accounts** match the same evidence, **Account Attribution** remains unresolved until the user confirms the correct account
-- **Reclassification** may convert a captured **Transaction** into a **Transfer**
-- **Reclassification** preserves the original **Capture Source** evidence and relinks it to the corrected financial record
-- A captured **Transaction** replaced by **Reclassification** becomes a **Superseded Financial Record**
-- **Transfer** is not a **Transaction** category
+- The **Local Ledger** is the source of truth for transactions, transfers, financial accounts, budgets, goals, capture evidence, and financial derivations
+- **Remote Financial Sync** is legacy durability infrastructure and should be replaced by **Encrypted Backup**
+- **Private Backup** is the user-facing name for **Encrypted Backup** setup and restore
+- Fidy-controlled servers must not store **Plaintext Financial Data** as ordinary database rows for recovery
+- An **Encrypted Backup** may contain financial records before encryption, but remote storage only receives ciphertext and non-financial backup metadata
+- An **Encrypted Backup** exists to restore the **Local Ledger** after app deletion, reinstall, or device loss
+- A **Recovery Secret** decrypts an **Encrypted Backup**
+- Fidy should not be able to decrypt an **Encrypted Backup** without the user's **Recovery Secret**
+- The **Recovery Secret** should be handled through platform-native storage and recovery where possible, with manual recovery as a fallback
+- Fidy login can locate a user's **Encrypted Backup**, but it must not by itself decrypt the backup
+- A lost-phone restore requires either platform-backed recovery of the **Recovery Secret** or the user's manual recovery fallback
+- If the user loses both the device-held secret and the manual recovery fallback, Fidy must not imply that the old **Local Ledger** can be recovered
+- Fidy must not offer server-side recovery that lets Fidy decrypt an **Encrypted Backup**
+- Strong recovery means accepting that the old **Local Ledger** is unrecoverable when all user-held recovery material is lost
+- **Cloud AI Processing** may receive **Plaintext Financial Data** only for explicit ingestion or advisor tasks
+- **Cloud AI Processing** must not persist **Plaintext Financial Data** as Fidy financial records
+- A **Capture Interpreter** may use **Cloud AI Processing** to interpret fragile capture evidence
+- Deterministic ledger validation owns the final save decision after a **Capture Interpreter** produces a candidate
+- A **Financial Context Packet** is narrower than the **Local Ledger** and should be built per advisor request
+- AI advisor features should use **Financial Context Packets** instead of server-side queries over plaintext financial tables
+- Weekly digest-style insights should be generated from the **Local Ledger** on device unless the user explicitly opts into **Cloud AI Processing**
 
 ## Example dialogue
 
-> **Dev:** "When an email or notification creates a **Transaction**, do we store which **Financial Account** it belongs to?"
-> **Domain expert:** "Yes. The capture source may help identify it, but the **Financial Account** is the bookkeeping owner of the **Transaction**."
+> **Dev:** "If we stop syncing readable transactions to Supabase, how does the user recover after deleting the app?"
+> **Domain expert:** "The device creates an **Encrypted Backup** of the **Local Ledger**; Supabase stores only ciphertext, and restore requires the user's **Recovery Secret**."
 
 ## Flagged ambiguities
 
-- "account" was used to mean both a connected email account and the money-holding owner of a transaction. Resolved: use **Financial Account** for the money-holding concept.
-- "source" could be mistaken for the owner of a transaction. Resolved: a **Capture Source** is evidence, not identity.
-- "transfer" already exists in code as a category label, but the domain now uses **Transfer** as a distinct value movement. Resolved: they are not the same concept.
-- the built-in `"transfer"` category conflicts with first-class **Transfer** records. Resolved: remove `"transfer"` as a **Transaction** category.
-- credit-card statement dues were close to existing **Bill** language, but they do not behave like ordinary bills. Resolved: use **Card Statement Obligation** for the credit-card case.
-- "Activity" came up as a possible umbrella over transactions and transfers. Resolved: not a core domain concept for now; keep **Transaction** and **Transfer** separate and add combined UI projections only when needed.
-- credit-card **Card Billing Profile** data is worth storing now, but automatic **Card Statement Obligation** generation is deferred until transfer ingestion and account attribution are stable.
-- one-sided payment-like evidence without real-world samples is too broad to classify safely. Resolved: defer one-sided transfer inference in v1.
-- overall wealth came up while reasoning about transfers, but it is out of MVP scope and should not drive the current model.
+- "local-first" was used to mean both on-device source of truth and server-side plaintext recovery. Resolved: use **Local Ledger** for the source of truth and **Encrypted Backup** for recovery.
+- "sync" was used to mean both recovery and cross-device plaintext replication. Resolved: use **Encrypted Backup** for recovery and **Remote Financial Sync** for the legacy plaintext replication model.
+- "AI-first" could imply either cloud-only AI or private on-device-only AI. Resolved: MVP permits explicit **Cloud AI Processing** while avoiding stored plaintext financial rows on Fidy servers.

--- a/docs/adr/0002-local-ledger-encrypted-backup-and-cloud-ai.md
+++ b/docs/adr/0002-local-ledger-encrypted-backup-and-cloud-ai.md
@@ -1,0 +1,13 @@
+# Local ledger, encrypted recovery, and explicit cloud AI processing
+
+Fidy will stop treating plaintext Supabase financial tables as the durability mechanism for user financial data. The on-device **Local Ledger** remains the source of truth, recovery is provided by remotely stored **Encrypted Backups**, and AI-first ingestion/advisor features may use explicit **Cloud AI Processing** with task-scoped plaintext inputs that are not persisted as Fidy financial records.
+
+**Considered Options**
+
+- Keep plaintext **Remote Financial Sync** in Supabase: simplest for recovery and server-side features, but contradicts the privacy direction for sensitive financial data.
+- Require financial data to never leave the device: strongest privacy posture, but conflicts with AI-first ingestion and advisor quality for the MVP.
+- Use local ledger plus encrypted backup plus explicit cloud AI processing: preserves AI-first product quality while removing long-lived plaintext financial storage from Fidy-controlled servers.
+
+**Consequences**
+
+Cloud features must receive data through explicit task boundaries, such as capture interpretation or advisor context packets, instead of querying plaintext financial rows from Supabase. Backup restore depends on user-held recovery material; if Fidy cannot decrypt the backup, Fidy also cannot recover it when the user loses the recovery secret.

--- a/plans/local-ledger-encrypted-backup-and-cloud-ai.md
+++ b/plans/local-ledger-encrypted-backup-and-cloud-ai.md
@@ -1,0 +1,183 @@
+# Local Ledger, Encrypted Backup, and Cloud AI Migration
+
+## Problem
+
+Fidy was intended to feel local-first and on-device, but the current sync architecture stores readable financial rows in Supabase so users can recover data after deleting the app. That solves durability, but it turns Supabase into a plaintext financial ledger and lets server-side features query financial rows directly.
+
+The MVP still needs AI-first ingestion and an AI financial advisor. Regex-only parsing is too fragile for Colombian bank emails, notifications, Apple Pay, and Google Pay evidence, and on-device foundation models are not yet a dependable baseline across all MVP devices.
+
+## Target
+
+- The device-owned SQLite database is the **Local Ledger**.
+- Supabase no longer stores plaintext financial records for recovery.
+- Supabase stores auth, operational non-financial data, and encrypted backup blobs plus metadata.
+- AI ingestion and advisor features use explicit **Cloud AI Processing** boundaries.
+- Cloud AI inputs are task-scoped and not stored as Fidy financial records.
+- Server-side features do not query plaintext `transactions`, `budgets`, `goals`, `financial_accounts`, `transfers`, `opening_balances`, identifiers, or capture evidence.
+
+## Current Plaintext Server Surfaces
+
+- `apps/mobile/features/sync/services/syncEngine.ts` pushes financial rows to Supabase tables.
+- `supabase/functions/weekly-digest/index.ts` reads transactions, budgets, and goal contributions server-side.
+- `supabase/functions/ai-chat/index.ts` builds advisor context by querying plaintext financial rows server-side.
+- Capture parsing already sends sanitized text to cloud AI, but the result is later persisted through normal financial sync.
+
+## Architecture
+
+### Local Ledger
+
+SQLite owns all financial records and derivations:
+
+- transactions
+- transfers
+- financial accounts
+- opening balances
+- budgets
+- goals and contributions
+- capture evidence
+- account identifiers and suggestion dismissals
+- review queues and conflict/retry state
+
+### Encrypted Backup
+
+The app exports a canonical backup snapshot, encrypts it on device, and uploads only ciphertext plus non-financial metadata:
+
+- backup id
+- user id
+- created at
+- schema version
+- app version
+- device label
+- ciphertext size
+- hash/checksum
+
+The backup payload should be versioned so restore can run migrations before opening the Local Ledger.
+
+### Recovery Secret
+
+The recovery secret should be user-held, but the user-facing experience should be **Private Backup**, not "manage an encryption key." The default flow should feel like turning on a protected app backup, with the secret handled by platform-native storage where possible and manual recovery only as the fallback.
+
+UX target:
+
+- Non-technical mobile users should understand the promise in one sentence: Fidy can save an encrypted backup, but only they can unlock it.
+- Google, Microsoft, or Apple login should locate the user's backup account, not decrypt the backup by itself.
+- Same-device restore should be nearly invisible when platform secure storage still has the key.
+- New-device or lost-device restore should use the user's manual recovery phrase/passphrase or a platform-backed recovery mechanism.
+- Losing the recovery secret must be treated as a clear product state, not hidden in fine print.
+
+Security target:
+
+- Fidy must never store plaintext financial records remotely.
+- Fidy must never store a raw backup encryption key remotely.
+- Fidy must never store an unwrap-capable server secret that can decrypt a user's backup without user-held material.
+- Recovery key wrapping must happen on device.
+- Every remote backup should be encrypted with a random backup data key and authenticated encryption.
+- The backup data key may have multiple wrapped copies, but every wrap must require user-held or platform-held material.
+- If all user-held and platform-held recovery material is gone, the old Local Ledger is unrecoverable.
+
+Platform constraints:
+
+- `expo-secure-store` can store key material in iOS Keychain and Android secure storage, but it must not be the only source of truth for irreplaceable recovery.
+- On iOS, SecureStore-backed Keychain data may survive reinstall with the same bundle ID, but the app should not depend on that behavior as the sole recovery path.
+- On Android, SecureStore data does not survive uninstall because Android Keystore entries are removed; restored SecureStore shared preferences cannot be decrypted.
+- iOS Keychain access does not require Sign in with Apple. Sign in with Apple is an auth and App Store review concern, not a prerequisite for storing backup key material on iOS.
+
+Recommended recovery ladder:
+
+1. **Device unlock**: use stored local key material for normal app use and same-device reinstall when available.
+2. **Private Backup restore**: after login, locate the encrypted backup and try platform-backed recovery.
+3. **Manual recovery**: ask for a recovery phrase/passphrase only when platform recovery cannot unlock the backup.
+4. **No-secret state**: if the user cannot unlock the backup, let them start fresh without implying Fidy can recover the old ledger.
+
+Lost-phone UX:
+
+- Treat "I lost my phone" as a primary restore path on the sign-in/restoration screen.
+- First ask the user to sign in with Google, Microsoft, or Apple so Fidy can find backup metadata.
+- If platform-backed key recovery is available, unlock the backup without asking the user to understand encryption.
+- If platform recovery is not available, ask for the manual recovery phrase/passphrase with calm copy and clear examples of where they may have saved it.
+- If the user cannot provide the recovery fallback, explain that the backup is still private but cannot be unlocked, then offer "Start fresh" as the next step.
+- Do not frame this as an account problem: login identifies the backup; the recovery secret unlocks it.
+- In settings, show a backup health check that warns users before a lost-phone event if they have no manual recovery fallback saved.
+
+Strict security stance:
+
+- Do not add Fidy-managed escrow for MVP.
+- Do not add "forgot recovery secret" reset for encrypted backups.
+- Do not auto-restore from login alone.
+- Do not send the manual recovery phrase/passphrase to Supabase or AI providers.
+- Do not log recovery phrases, derived keys, wrapped keys, or backup plaintext.
+- Prefer a generated recovery phrase over a user-created password because non-technical users commonly choose weak passwords.
+- Require the user to confirm the recovery phrase before considering Private Backup healthy.
+- Let users rotate recovery material by decrypting locally, generating a new recovery phrase, rewrapping the backup key, and uploading new wrapped-key metadata.
+
+Recommended auth direction:
+
+- Add Sign in with Apple before iOS launch if Google/Microsoft remain primary sign-in options. It is not needed for Keychain, but it is the expected equivalent privacy-focused login path on iOS and reduces trust friction for users already in the Apple ecosystem.
+- Keep Google and Microsoft because they match current email-capture sources, but do not imply that those providers can decrypt Fidy backups.
+
+### Cloud AI Processing
+
+Cloud AI is allowed for explicit tasks:
+
+- interpret one capture into a transaction, transfer, or review candidate
+- classify a merchant/category when local rules are insufficient
+- answer advisor questions from a task-scoped financial context packet
+
+Cloud AI is not allowed to become remote storage:
+
+- no plaintext financial rows persisted for recovery
+- no long-lived server-side advisor profile built from financial records
+- no server-side weekly digest over plaintext financial tables
+
+## Implementation Slices
+
+1. Name the boundaries
+   - Add domain language and ADR.
+   - Add a feature flag or config value for legacy Remote Financial Sync.
+   - Add tests that make current plaintext sync surfaces visible.
+
+2. Build backup export/import
+   - Create a canonical `BackupSnapshot` schema for the Local Ledger.
+   - Export all financial tables from SQLite.
+   - Import into a clean local database and run existing migrations.
+   - Add round-trip tests for transactions, transfers, accounts, budgets, goals, and capture evidence.
+
+3. Add on-device encryption
+   - Generate backup encryption keys on device.
+   - Derive or wrap the key with the Recovery Secret.
+   - Encrypt/decrypt snapshots locally.
+   - Add corruption, wrong-secret, and schema-version tests.
+
+4. Add remote backup storage
+   - Add Supabase storage/table metadata for encrypted backup blobs.
+   - Upload, list, download, and delete backups.
+   - Ensure RLS never exposes backups across users.
+   - Keep metadata non-financial.
+
+5. Replace recovery sync
+   - Stop enqueueing financial rows to Remote Financial Sync for new users.
+   - Keep legacy migration support for existing users until their encrypted backup is created.
+   - Add a settings surface for backup status and restore.
+
+6. Move insights off server-side financial queries
+   - Replace weekly digest Edge Function financial queries with on-device local notification generation.
+   - Change AI chat to receive a Financial Context Packet from the app instead of querying Supabase financial tables.
+
+7. Harden cloud AI boundaries
+   - Create a Capture Interpreter API that returns structured candidates only.
+   - Persist only local ledger results and encrypted backups.
+   - Log request metadata without raw financial payloads.
+   - Add tests that cloud AI callers do not write plaintext financial records remotely.
+
+8. Retire plaintext financial tables
+   - After migration, prevent new writes to plaintext financial tables.
+   - Export/delete legacy plaintext financial rows for users who have migrated.
+   - Keep deletion/account-closure paths aligned with encrypted backup deletion.
+
+## Open Decisions
+
+- Should Private Backup be automatic after first successful onboarding, or should users explicitly enable it before their first captured data is saved?
+- Should manual recovery use a generated recovery phrase, a user-created passphrase, or both?
+- Should the generated recovery phrase be 12 words for lower friction or 24 words for a stricter security posture?
+- Are cloud AI ingestion and advisor enabled by default with disclosure, or opt-in before first use?
+- What exact retention promise applies to cloud AI request payloads and provider logs?


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Define the private backup boundary: keep a Local Ledger on device, replace plaintext server sync with Encrypted Backups, and allow explicit cloud processing for capture/advisor tasks only. Added ADR 0002 and a migration plan, rewrote CONTEXT.md to align terms and relationships, updated `.gitignore` to keep all ADRs, and trimmed AGENTS.md.

- **Migration**
  - Replace remote plaintext financial sync with encrypted backup storage in `Supabase`.
  - Restore requires a user-held Recovery Secret; servers cannot decrypt.
  - Server features must accept task-scoped context from the app instead of querying plaintext financial tables.

<sup>Written for commit ed797dac4296844700f34ce20532323ba8c865fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

