### PR TITLE
refactor(mobile): narrow budget goal api

### DIFF
--- a/apps/mobile/__tests__/budget/create-budget-screen-helpers.test.ts
+++ b/apps/mobile/__tests__/budget/create-budget-screen-helpers.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "vitest";
-import type { Budget } from "@/features/budget";
 import {
   resolveBudgetIdParam,
   resolveExistingBudget,
   resolveExistingCategoryIds,
 } from "@/features/budget/components/create-budget/CreateBudgetScreen.helpers";
+import type { Budget } from "@/features/budget/public";
 
 const internetBudget = {
   amount: 100000,

--- a/apps/mobile/__tests__/goals/repository.test.ts
+++ b/apps/mobile/__tests__/goals/repository.test.ts
@@ -16,7 +16,7 @@ import {
   softDeleteContribution,
   softDeleteGoal,
   updateGoal,
-} from "@/features/goals";
+} from "@/features/goals/public";
 
 let sqlite: InstanceType<typeof Database>;
 let db: ReturnType<typeof drizzle>;

--- a/apps/mobile/app/(auth)/onboarding.tsx
+++ b/apps/mobile/app/(auth)/onboarding.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { OnboardingAccountReviewStep } from "@/features/account-suggestions/routes.public";
 import { useOptionalUserId } from "@/features/auth/hooks.public";
-import { initializeBudgetSession } from "@/features/budget/public";
+import { initializeBudgetSession } from "@/features/budget/hooks.public";
 import { initializeEmailCaptureSession, loadEmailAccounts } from "@/features/email-capture";
 import { tryEnsureDefaultFinancialAccount } from "@/features/financial-accounts";
 import {

--- a/apps/mobile/app/(tabs)/(finance)/index.tsx
+++ b/apps/mobile/app/(tabs)/(finance)/index.tsx
@@ -1,8 +1,9 @@
 import { Stack, useRouter } from "expo-router";
 import { useMemo, useState } from "react";
 import { AnalyticsScreen } from "@/features/analytics";
-import { BudgetListScreen } from "@/features/budget";
-import { GoalsListScreen, useGoalStore } from "@/features/goals";
+import { BudgetListScreen } from "@/features/budget/ui.public";
+import { useGoalStore } from "@/features/goals/hooks.public";
+import { GoalsListScreen } from "@/features/goals/ui.public";
 import { Plus } from "@/shared/components/icons";
 import { Platform, Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";

--- a/apps/mobile/app/add-payment.tsx
+++ b/apps/mobile/app/add-payment.tsx
@@ -1,4 +1,4 @@
-import { AddPaymentSheet } from "@/features/goals";
+import { AddPaymentSheet } from "@/features/goals/ui.public";
 
 export default function AddPaymentRoute() {
   return <AddPaymentSheet />;

--- a/apps/mobile/app/auto-suggest-budgets.tsx
+++ b/apps/mobile/app/auto-suggest-budgets.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "expo-router";
 import { useOptionalUserId } from "@/features/auth/hooks.public";
-import { acceptBudgetSuggestions, useBudgetStore } from "@/features/budget/public";
+import { acceptBudgetSuggestions, useBudgetStore } from "@/features/budget/hooks.public";
 import { useSuggestionSelection } from "@/features/budget/ui.public";
 import { CATEGORY_MAP } from "@/features/transactions";
 import {

--- a/apps/mobile/app/create-goal.tsx
+++ b/apps/mobile/app/create-goal.tsx
@@ -1,4 +1,4 @@
-import { GoalCreateSheet } from "@/features/goals";
+import { GoalCreateSheet } from "@/features/goals/ui.public";
 
 export default function CreateGoalRoute() {
   return <GoalCreateSheet />;

--- a/apps/mobile/app/edit-goal.tsx
+++ b/apps/mobile/app/edit-goal.tsx
@@ -1,4 +1,4 @@
-import { GoalEditSheet } from "@/features/goals";
+import { GoalEditSheet } from "@/features/goals/ui.public";
 
 export default function EditGoalRoute() {
   return <GoalEditSheet />;

--- a/apps/mobile/app/goal-detail.tsx
+++ b/apps/mobile/app/goal-detail.tsx
@@ -1,4 +1,4 @@
-import { GoalDetailScreen } from "@/features/goals";
+import { GoalDetailScreen } from "@/features/goals/ui.public";
 
 export default function GoalDetailRoute() {
   return <GoalDetailScreen />;

--- a/apps/mobile/features/budget/components/BudgetAlertBanner.tsx
+++ b/apps/mobile/features/budget/components/BudgetAlertBanner.tsx
@@ -1,4 +1,4 @@
-import { CATEGORY_MAP } from "@/features/transactions";
+import { CATEGORY_MAP } from "@/shared/categories";
 import { X } from "@/shared/components/icons";
 import { Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
 import { useMountEffect, useThemeColor, useTranslation } from "@/shared/hooks";

--- a/apps/mobile/features/budget/components/BudgetCard.tsx
+++ b/apps/mobile/features/budget/components/BudgetCard.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { CATEGORY_MAP } from "@/features/transactions";
+import { CATEGORY_MAP } from "@/shared/categories";
 import { ProgressBar } from "@/shared/components";
 import { Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";

--- a/apps/mobile/features/budget/components/BudgetListScreen.tsx
+++ b/apps/mobile/features/budget/components/BudgetListScreen.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from "expo-router";
 import { useCallback } from "react";
-import { useOptionalUserId } from "@/features/auth";
-import { MonthNavigator } from "@/features/calendar";
+import { useOptionalUserId } from "@/features/auth/public";
+import { MonthNavigator } from "@/features/calendar/public";
 import { ScreenLayout, TAB_BAR_CLEARANCE } from "@/shared/components";
 import { Plus, Wallet } from "@/shared/components/icons";
 import { Platform, Pressable, ScrollView, StyleSheet, Text, View } from "@/shared/components/rn";

--- a/apps/mobile/features/budget/components/UpcomingBillsSection.tsx
+++ b/apps/mobile/features/budget/components/UpcomingBillsSection.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from "expo-router";
 import { useMemo } from "react";
-import { getNextOccurrence, useCalendarStore } from "@/features/calendar";
-import { CATEGORY_MAP } from "@/features/transactions";
+import { getNextOccurrence, useCalendarStore } from "@/features/calendar/public";
+import { CATEGORY_MAP } from "@/shared/categories";
 import { Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { getCategoryLabel } from "@/shared/i18n";

--- a/apps/mobile/features/budget/components/create-budget/CreateBudget.types.ts
+++ b/apps/mobile/features/budget/components/create-budget/CreateBudget.types.ts
@@ -1,5 +1,5 @@
 import type { SetStateAction } from "react";
-import type { CategoryId } from "@/features/transactions";
+import type { CategoryId } from "@/shared/categories";
 import type { BudgetId, CopAmount, UserId } from "@/shared/types/branded";
 import type { BudgetSuggestion } from "../../lib/derive";
 import type { Budget } from "../../schema";

--- a/apps/mobile/features/budget/components/create-budget/CreateBudgetForm.tsx
+++ b/apps/mobile/features/budget/components/create-budget/CreateBudgetForm.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { handleNumpadPress } from "@/features/transactions";
+import { handleNumpadPress } from "@/features/transactions/display.public";
 import type { CreateBudgetFormProps } from "./CreateBudget.types";
 import { CreateBudgetFormContent } from "./CreateBudgetFormContent";
 import { useCreateBudgetDraft } from "./useCreateBudgetDraft";

--- a/apps/mobile/features/budget/components/create-budget/CreateBudgetFormContent.tsx
+++ b/apps/mobile/features/budget/components/create-budget/CreateBudgetFormContent.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import Animated from "react-native-reanimated";
-import { CATEGORIES, type CategoryId, CategoryPill } from "@/features/transactions";
+import { type CategoryId, CATEGORIES } from "@/shared/categories";
+import { CategoryPill } from "@/features/transactions/display.public";
 import { FidyNumpad } from "@/shared/components";
 import { Pressable, ScrollView, Text, View } from "@/shared/components/rn";
 import { useBlinkingCursor, useThemeColor, useTranslation } from "@/shared/hooks";

--- a/apps/mobile/features/budget/components/create-budget/CreateBudgetScreen.tsx
+++ b/apps/mobile/features/budget/components/create-budget/CreateBudgetScreen.tsx
@@ -1,6 +1,6 @@
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useMemo } from "react";
-import { useOptionalUserId } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth/public";
 import { useBudgetStore } from "../../store";
 import { AuthenticatedCreateBudgetForm } from "./AuthenticatedCreateBudgetForm";
 import { CreateBudgetForm } from "./CreateBudgetForm";

--- a/apps/mobile/features/budget/components/create-budget/useCreateBudgetDraft.ts
+++ b/apps/mobile/features/budget/components/create-budget/useCreateBudgetDraft.ts
@@ -1,6 +1,6 @@
 import type { SetStateAction } from "react";
 import { useCallback, useState } from "react";
-import { isValidCategoryId } from "@/features/transactions";
+import { isValidCategoryId } from "@/shared/categories";
 import type { Budget } from "../../schema";
 import type { CreateBudgetDraftController, CreateBudgetDraftState } from "./CreateBudget.types";
 

--- a/apps/mobile/features/budget/hooks.public.ts
+++ b/apps/mobile/features/budget/hooks.public.ts
@@ -1,0 +1,1 @@
+export { acceptBudgetSuggestions, initializeBudgetSession, useBudgetStore } from "./public";

--- a/apps/mobile/features/budget/lib/monitoring.ts
+++ b/apps/mobile/features/budget/lib/monitoring.ts
@@ -1,6 +1,6 @@
 import { subMonths } from "date-fns";
-import { getSpendingByCategoryAggregate } from "@/features/transactions/public";
-import type { AnyDb } from "@/shared/db";
+import { getSpendingByCategoryAggregate } from "@/features/transactions/query.public";
+import type { AnyDb } from "@/shared/db/client";
 import { formatMoney, toMonth } from "@/shared/lib";
 import { assertCopAmount } from "@/shared/types/assertions";
 import type { BudgetId, CategoryId, Month, UserId } from "@/shared/types/branded";

--- a/apps/mobile/features/budget/lib/notifications.ts
+++ b/apps/mobile/features/budget/lib/notifications.ts
@@ -1,6 +1,6 @@
 import * as Notifications from "expo-notifications";
 import * as SecureStore from "expo-secure-store";
-import { determineAlertAction, PRE_PERMISSION_KEY } from "@/features/notifications";
+import { determineAlertAction, PRE_PERMISSION_KEY } from "@/features/notifications/public";
 import i18n from "../../../shared/i18n/i18n";
 import type { BudgetAlert } from "./derive";
 

--- a/apps/mobile/features/budget/lib/repository.ts
+++ b/apps/mobile/features/budget/lib/repository.ts
@@ -1,6 +1,6 @@
 import { and, eq, isNull } from "drizzle-orm";
-import type { AnyDb } from "@/shared/db";
-import { budgets } from "@/shared/db";
+import type { AnyDb } from "@/shared/db/client";
+import { budgets } from "@/shared/db/schema";
 import type { BudgetId, CopAmount, IsoDateTime, Month, UserId } from "@/shared/types/branded";
 
 export type BudgetRow = typeof budgets.$inferInsert;

--- a/apps/mobile/features/budget/public.ts
+++ b/apps/mobile/features/budget/public.ts
@@ -1,0 +1,44 @@
+export type { BudgetAlert, BudgetProgress, BudgetSuggestion } from "./lib/derive";
+export {
+  deriveAutoSuggestBudgets,
+  deriveBudgetAlerts,
+  deriveBudgetProgress,
+  deriveBudgetSummary,
+} from "./lib/derive";
+export type {
+  AcknowledgeBudgetAlertInput,
+  BudgetAlertState,
+  BudgetMonitoringModule,
+  BudgetMonitoringPorts,
+  BudgetMonthSnapshot,
+  BudgetNotificationInput,
+  RefreshBudgetMonthInput,
+} from "./lib/monitoring";
+export { createBudgetMonitoringModule } from "./lib/monitoring";
+export type { ScheduleResult } from "./lib/notifications";
+export { scheduleBudgetAlert } from "./lib/notifications";
+export type { BudgetRow } from "./lib/repository";
+export {
+  copyBudgetsToMonth,
+  getBudgetById,
+  getBudgetsForMonth,
+  insertBudget,
+  softDeleteBudget,
+  updateBudgetAmount,
+} from "./lib/repository";
+export type { Budget, CreateBudgetInput } from "./schema";
+export { createBudgetSchema } from "./schema";
+export { subscribeBudgetToTransactions } from "./services/subscribe-budget-to-transactions";
+export {
+  acceptBudgetSuggestions,
+  copyBudgetsForward,
+  createBudget,
+  deleteBudget,
+  initializeBudgetSession,
+  loadBudgetAutoSuggestions,
+  loadBudgetsForUser,
+  nextBudgetMonth,
+  prevBudgetMonth,
+  updateBudget,
+  useBudgetStore,
+} from "./store";

--- a/apps/mobile/features/budget/schema.ts
+++ b/apps/mobile/features/budget/schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { categoryIdSchema } from "@/features/transactions";
+import { categoryIdSchema } from "@/shared/categories";
 import { requireMonth } from "@/shared/types/assertions";
 import type {
   BudgetId,

--- a/apps/mobile/features/budget/store.ts
+++ b/apps/mobile/features/budget/store.ts
@@ -1,9 +1,9 @@
 import { create } from "zustand";
-import { insertNotificationRecord } from "@/features/notifications";
-import { useSettingsStore } from "@/features/settings";
-import { CATEGORY_MAP } from "@/features/transactions";
+import { insertNotificationRecord } from "@/features/notifications/public";
+import { useSettingsStore } from "@/features/settings/public";
 import { createWriteThroughMutationModule } from "@/mutations";
-import type { AnyDb } from "@/shared/db";
+import { CATEGORY_MAP } from "@/shared/categories";
+import type { AnyDb } from "@/shared/db/client";
 import { getCategoryLabel, useLocaleStore } from "@/shared/i18n";
 import { generateBudgetId, toIsoDateTime, trackBudgetCreated } from "@/shared/lib";
 import type { BudgetId, CategoryId, CopAmount, Month, UserId } from "@/shared/types/branded";

--- a/apps/mobile/features/budget/ui.public.ts
+++ b/apps/mobile/features/budget/ui.public.ts
@@ -1,0 +1,2 @@
+export { BudgetListScreen } from "./components/BudgetListScreen";
+export { useSuggestionSelection } from "./hooks/use-suggestion-selection";

--- a/apps/mobile/features/calendar/public.ts
+++ b/apps/mobile/features/calendar/public.ts
@@ -1,0 +1,1 @@
+export * from "./index";

--- a/apps/mobile/features/goals/components/AddPaymentSheet.tsx
+++ b/apps/mobile/features/goals/components/AddPaymentSheet.tsx
@@ -1,8 +1,8 @@
 import { useRouter } from "expo-router";
 import { useCallback, useRef, useState } from "react";
 import Animated from "react-native-reanimated";
-import { useOptionalUserId } from "@/features/auth";
-import { handleNumpadPress } from "@/features/transactions";
+import { useOptionalUserId } from "@/features/auth/public";
+import { handleNumpadPress } from "@/features/transactions/display.public";
 import { FidyNumpad } from "@/shared/components";
 import {
   Keyboard,

--- a/apps/mobile/features/goals/components/GoalSmartCard.tsx
+++ b/apps/mobile/features/goals/components/GoalSmartCard.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "expo-router";
 import { memo, useCallback, useMemo } from "react";
-import { useOptionalUserId } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth/public";
 import { Pressable, Text, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
 import { useThemeColor, useTranslation } from "@/shared/hooks";

--- a/apps/mobile/features/goals/components/GoalsListScreen.tsx
+++ b/apps/mobile/features/goals/components/GoalsListScreen.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "expo-router";
 import { useCallback } from "react";
-import { useOptionalUserId } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth/public";
 import { ScreenLayout, TAB_BAR_CLEARANCE } from "@/shared/components";
 import { Plus, Target } from "@/shared/components/icons";
 import { FlatList, Platform, Pressable, StyleSheet, Text, View } from "@/shared/components/rn";

--- a/apps/mobile/features/goals/components/goal-detail/useGoalDetail.ts
+++ b/apps/mobile/features/goals/components/goal-detail/useGoalDetail.ts
@@ -1,6 +1,6 @@
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useCallback, useRef, useState } from "react";
-import { useOptionalUserId } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth/public";
 import { tryGetDb } from "@/shared/db";
 import { useSubscription, useTranslation } from "@/shared/hooks";
 import { resolveGoalDetailGoalId } from "../../lib/route-params";

--- a/apps/mobile/features/goals/components/goal-sheet/useGoalCreateActions.ts
+++ b/apps/mobile/features/goals/components/goal-sheet/useGoalCreateActions.ts
@@ -1,7 +1,8 @@
 import { useRouter } from "expo-router";
 import { useCallback } from "react";
-import { useOptionalUserId } from "@/features/auth";
-import { type AnyDb, tryGetDb } from "@/shared/db";
+import { useOptionalUserId } from "@/features/auth/public";
+import type { AnyDb } from "@/shared/db/client";
+import { tryGetDb } from "@/shared/db/client";
 import { useAsyncGuard } from "@/shared/hooks";
 import { toIsoDate } from "@/shared/lib";
 import type { UserId } from "@/shared/types/branded";

--- a/apps/mobile/features/goals/components/goal-sheet/useGoalEditActions.ts
+++ b/apps/mobile/features/goals/components/goal-sheet/useGoalEditActions.ts
@@ -1,8 +1,9 @@
 import { useRouter } from "expo-router";
 import { useCallback } from "react";
-import { useOptionalUserId } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth/public";
 import { Alert } from "@/shared/components/rn";
-import { type AnyDb, tryGetDb } from "@/shared/db";
+import type { AnyDb } from "@/shared/db/client";
+import { tryGetDb } from "@/shared/db/client";
 import { useAsyncGuard, useTranslation } from "@/shared/hooks";
 import { toIsoDate } from "@/shared/lib";
 import type { UserId } from "@/shared/types/branded";

--- a/apps/mobile/features/goals/components/goal-sheet/useGoalSheetForm.ts
+++ b/apps/mobile/features/goals/components/goal-sheet/useGoalSheetForm.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState } from "react";
-import { handleNumpadPress } from "@/features/transactions";
+import { handleNumpadPress } from "@/features/transactions/display.public";
 import { Keyboard, Platform } from "@/shared/components/rn";
 import { useBlinkingCursor } from "@/shared/hooks";
 import { formatInputDisplay, parseDigitsToAmount } from "@/shared/lib";

--- a/apps/mobile/features/goals/hooks.public.ts
+++ b/apps/mobile/features/goals/hooks.public.ts
@@ -1,0 +1,1 @@
+export { useGoalStore } from "./public";

--- a/apps/mobile/features/goals/lib/repository.ts
+++ b/apps/mobile/features/goals/lib/repository.ts
@@ -1,6 +1,6 @@
 import { and, desc, eq, isNull, sql, sum } from "drizzle-orm";
-import type { AnyDb } from "@/shared/db";
-import { goalContributions, goals } from "@/shared/db";
+import type { AnyDb } from "@/shared/db/client";
+import { goalContributions, goals } from "@/shared/db/schema";
 
 export type GoalRow = typeof goals.$inferInsert;
 export type GoalContributionRow = typeof goalContributions.$inferInsert;

--- a/apps/mobile/features/goals/public.ts
+++ b/apps/mobile/features/goals/public.ts
@@ -1,0 +1,53 @@
+export type {
+  BudgetNudge,
+  ConfidenceTier,
+  GoalAlert,
+  GoalPaceGuidance,
+  GoalProgress,
+  GoalProjection,
+  InstallmentProgress,
+  Milestone,
+  MonthlyTotal,
+} from "./lib/derive";
+export {
+  computeMedian,
+  deriveBudgetNudges,
+  deriveDebtProjection,
+  deriveGoalAlerts,
+  deriveGoalPaceGuidance,
+  deriveGoalProgress,
+  deriveGoalProjection,
+  deriveInstallmentProgress,
+  deriveMonthlyMilestones,
+} from "./lib/derive";
+export type { GoalContributionRow, GoalRow } from "./lib/repository";
+export {
+  getContributionById,
+  getContributionMonthCount,
+  getContributionsForGoal,
+  getGoalById,
+  getGoalCurrentAmount,
+  getGoalsForUser,
+  insertContribution,
+  insertGoal,
+  softDeleteContribution,
+  softDeleteGoal,
+  updateGoal,
+} from "./lib/repository";
+export type {
+  AddContributionInput,
+  CreateGoalInput,
+  Goal,
+  GoalContribution,
+  GoalType,
+} from "./schema";
+export { addContributionSchema, createGoalSchema } from "./schema";
+export { createGoalQueryService } from "./services/create-goal-query-service";
+export { subscribeGoalsToTransactions } from "./services/subscribe-goals-to-transactions";
+export {
+  initializeGoalSession,
+  loadGoalsForUser,
+  selectGoal,
+  useGoalStore,
+} from "./store";
+export type { GoalWithProgress } from "./types";

--- a/apps/mobile/features/goals/services/create-goal-mutation-service.ts
+++ b/apps/mobile/features/goals/services/create-goal-mutation-service.ts
@@ -1,6 +1,6 @@
-import { insertNotificationRecord, scheduleLocalPush } from "@/features/notifications";
+import { insertNotificationRecord, scheduleLocalPush } from "@/features/notifications/public";
 import { createWriteThroughMutationModule } from "@/mutations";
-import type { AnyDb } from "@/shared/db";
+import type { AnyDb } from "@/shared/db/client";
 import { i18n } from "@/shared/i18n";
 import {
   captureWarning,

--- a/apps/mobile/features/goals/services/create-goal-query-service.ts
+++ b/apps/mobile/features/goals/services/create-goal-query-service.ts
@@ -1,5 +1,5 @@
-import { getMonthlyTotalsByType } from "@/features/transactions";
-import type { AnyDb } from "@/shared/db";
+import { getMonthlyTotalsByType } from "@/features/transactions/query.public";
+import type { AnyDb } from "@/shared/db/client";
 import type { UserId } from "@/shared/types/branded";
 import {
   deriveDebtProjection,

--- a/apps/mobile/features/goals/store.ts
+++ b/apps/mobile/features/goals/store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import type { AnyDb } from "@/shared/db";
+import type { AnyDb } from "@/shared/db/client";
 import type { UserId } from "@/shared/types/branded";
 import type { AddContributionInput, CreateGoalInput, GoalContribution } from "./schema";
 import {

--- a/apps/mobile/features/goals/ui.public.ts
+++ b/apps/mobile/features/goals/ui.public.ts
@@ -1,0 +1,9 @@
+export { AddPaymentSheet } from "./components/AddPaymentSheet";
+export type { CelebrationMilestone } from "./components/CelebrationModal";
+export { CelebrationModal } from "./components/CelebrationModal";
+export { GoalCard } from "./components/GoalCard";
+export { GoalCreateSheet } from "./components/GoalCreateSheet";
+export { GoalDetailScreen } from "./components/GoalDetail";
+export { GoalEditSheet } from "./components/GoalEditSheet";
+export { GoalSmartCard } from "./components/GoalSmartCard";
+export { GoalsListScreen } from "./components/GoalsListScreen";

--- a/apps/mobile/features/notifications/lib/derive.ts
+++ b/apps/mobile/features/notifications/lib/derive.ts
@@ -1,7 +1,7 @@
 import { addDays, differenceInDays, endOfDay, getDate, getDaysInMonth, startOfDay } from "date-fns";
-import type { BudgetProgress } from "@/features/budget";
-import { computeMedian } from "@/features/goals";
-import type { StoredTransaction } from "@/features/transactions";
+import type { BudgetProgress } from "@/features/budget/public";
+import { computeMedian } from "@/features/goals/public";
+import type { StoredTransaction } from "@/features/transactions/query.public";
 import type { BudgetId, CategoryId, CopAmount } from "@/shared/types/branded";
 
 // ---------------------------------------------------------------------------

--- a/apps/mobile/features/onboarding/components/BudgetSetupStep.tsx
+++ b/apps/mobile/features/onboarding/components/BudgetSetupStep.tsx
@@ -1,11 +1,11 @@
-import { useOptionalUserId } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth/public";
 import {
   acceptBudgetSuggestions,
   loadBudgetAutoSuggestions,
   useBudgetStore,
-  useSuggestionSelection,
-} from "@/features/budget";
-import { CATEGORY_MAP } from "@/features/transactions";
+} from "@/features/budget/public";
+import { useSuggestionSelection } from "@/features/budget/ui.public";
+import { CATEGORY_MAP } from "@/shared/categories";
 import {
   Pressable,
   ScrollView,

--- a/apps/mobile/features/onboarding/components/CompleteStep.tsx
+++ b/apps/mobile/features/onboarding/components/CompleteStep.tsx
@@ -1,6 +1,6 @@
 import Ionicons from "@expo/vector-icons/Ionicons";
-import { useBudgetStore } from "@/features/budget";
-import { useTransactionStore } from "@/features/transactions";
+import { useBudgetStore } from "@/features/budget/public";
+import { useTransactionStore } from "@/features/transactions/store.public";
 import { Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
 import { useAsyncGuard, useThemeColor, useTranslation } from "@/shared/hooks";
 import { useOnboardingStore } from "../store";

--- a/apps/mobile/features/onboarding/components/SyncProgressStep.tsx
+++ b/apps/mobile/features/onboarding/components/SyncProgressStep.tsx
@@ -1,14 +1,14 @@
 import { useMemo, useRef } from "react";
 import { useShallow } from "zustand/react/shallow";
-import { createAccountSuggestionService } from "@/features/account-suggestions";
-import { useOptionalUserId } from "@/features/auth";
+import { createAccountSuggestionService } from "@/features/account-suggestions/public";
+import { useOptionalUserId } from "@/features/auth/public";
 import {
   fetchAndProcessEmails,
   getGmailClientId,
   getOutlookClientId,
   useEmailCaptureStore,
-} from "@/features/email-capture";
-import { refreshTransactions, useTransactionStore } from "@/features/transactions";
+} from "@/features/email-capture/public";
+import { refreshTransactions, useTransactionStore } from "@/features/transactions/store.public";
 import { ProgressBar } from "@/shared/components";
 import { Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";


### PR DESCRIPTION
- split budget and goal ui surfaces
- migrate budget and goal callers
- keep derivations on narrow exports


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrowed the mobile budget and goals API by splitting UI and hooks into dedicated public entry points. Callers now use `.../ui.public`, `.../hooks.public`, and slimmer `.../public` modules to reduce coupling and clarify boundaries.

- **Refactors**
  - Added `features/budget/public`, `features/budget/hooks.public`, `features/budget/ui.public`; same for goals.
  - Migrated screens, sheets, and tests to the new public imports.
  - Moved category types/constants to `@/shared/categories`; split transaction helpers into `transactions/display.public`, queries into `transactions/query.public`, and store into `transactions/store.public`.
  - Introduced `calendar/public` and switched auth, settings, notifications, email-capture to `*.public`.
  - Standardized DB imports to `@/shared/db/client` and `@/shared/db/schema`; kept derivation exports available via the narrow `public` modules.

- **Migration**
  - Import UI from `.../ui.public` and stores/init hooks from `.../hooks.public`.
  - Import domain types and core functions from `.../public`.
  - Replace category imports with `@/shared/categories`.
  - Use `transactions/display.public` for UI helpers, `transactions/query.public` for reads, and `transactions/store.public` for store actions.
  - Update DB imports to `@/shared/db/client` (types/access) and `@/shared/db/schema` (tables), and switch `calendar`, `auth`, `settings`, `notifications`, `email-capture` to their `*.public` entry points.

<sup>Written for commit a93ff1ddd86e7d67df5f914099cc5d03f29d5a88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

