### PR TITLE
refactor(mobile): migrate feature surfaces

### DIFF
--- a/apps/mobile/__tests__/auth/store.test.ts
+++ b/apps/mobile/__tests__/auth/store.test.ts
@@ -77,7 +77,7 @@ const { mockSetSession, mockSignInWithOAuth, mockSignOut, mockGetSession, supaba
     };
   });
 
-vi.mock("@/shared/db", () => ({
+vi.mock("@/shared/db/supabase", () => ({
   getSupabase: () => ({ auth: supabaseAuthMock }),
 }));
 

--- a/apps/mobile/features/account-suggestions/components/AccountSuggestionReviewScreen.tsx
+++ b/apps/mobile/features/account-suggestions/components/AccountSuggestionReviewScreen.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "expo-router";
 import { useMemo } from "react";
-import { useOptionalUserId } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth/public";
 import { ScreenLayout } from "@/shared/components";
 import { ScrollView, StyleSheet, Text, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";

--- a/apps/mobile/features/account-suggestions/components/CreateSuggestedAccountScreen.tsx
+++ b/apps/mobile/features/account-suggestions/components/CreateSuggestedAccountScreen.tsx
@@ -1,7 +1,7 @@
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useMemo, useState } from "react";
-import { useOptionalUserId } from "@/features/auth";
-import type { FinancialAccountKind } from "@/features/financial-accounts";
+import { useOptionalUserId } from "@/features/auth/public";
+import type { FinancialAccountKind } from "@/features/financial-accounts/public";
 import { ScreenLayout } from "@/shared/components";
 import { Pressable, ScrollView, StyleSheet, Text, TextInput, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";

--- a/apps/mobile/features/account-suggestions/components/LinkSuggestedAccountScreen.tsx
+++ b/apps/mobile/features/account-suggestions/components/LinkSuggestedAccountScreen.tsx
@@ -1,7 +1,7 @@
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useMemo } from "react";
-import { useOptionalUserId } from "@/features/auth";
-import { getFinancialAccountsForUser } from "@/features/financial-accounts";
+import { useOptionalUserId } from "@/features/auth/public";
+import { getFinancialAccountsForUser } from "@/features/financial-accounts/public";
 import { ScreenLayout } from "@/shared/components";
 import { Pressable, ScrollView, StyleSheet, Text, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";

--- a/apps/mobile/features/account-suggestions/components/OnboardingAccountReviewStep.tsx
+++ b/apps/mobile/features/account-suggestions/components/OnboardingAccountReviewStep.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "expo-router";
 import { useState } from "react";
-import { useOptionalUserId } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth/public";
 import { useOnboardingStore } from "@/features/onboarding/store";
 import { Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";

--- a/apps/mobile/features/account-suggestions/lib/derive-account-suggestions.ts
+++ b/apps/mobile/features/account-suggestions/lib/derive-account-suggestions.ts
@@ -1,4 +1,4 @@
-import type { CaptureEvidenceType } from "@/features/capture-evidence";
+import type { CaptureEvidenceType } from "@/features/capture-evidence/public";
 
 type RepeatedCaptureEvidence = {
   readonly scope: string;

--- a/apps/mobile/features/account-suggestions/lib/match-financial-account.ts
+++ b/apps/mobile/features/account-suggestions/lib/match-financial-account.ts
@@ -1,10 +1,10 @@
-import type { CaptureEvidenceSeed } from "@/features/capture-evidence";
+import type { CaptureEvidenceSeed } from "@/features/capture-evidence/public";
 import {
   type FinancialAccountIdentifierRow,
   type FinancialAccountRow,
   getFinancialAccountIdentifiersForUser,
   getFinancialAccountsForUser,
-} from "@/features/financial-accounts";
+} from "@/features/financial-accounts/public";
 import type { AnyDb } from "@/shared/db";
 import type { FinancialAccountId, UserId } from "@/shared/types/branded";
 

--- a/apps/mobile/features/account-suggestions/lib/presentation.ts
+++ b/apps/mobile/features/account-suggestions/lib/presentation.ts
@@ -1,4 +1,4 @@
-import type { FinancialAccountKind, FinancialAccountRow } from "@/features/financial-accounts";
+import type { FinancialAccountKind, FinancialAccountRow } from "@/features/financial-accounts/public";
 import type { AccountCreationSuggestion } from "./derive-account-suggestions";
 
 type SuggestedFinancialAccountDraft = {

--- a/apps/mobile/features/ai-chat/components/ConversationList.tsx
+++ b/apps/mobile/features/ai-chat/components/ConversationList.tsx
@@ -2,7 +2,7 @@ import { FlashList } from "@shopify/flash-list";
 import { format } from "date-fns";
 import { Stack } from "expo-router";
 import { memo, useCallback } from "react";
-import { useOptionalUserId } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth/public";
 import { ScreenLayout, TAB_BAR_CLEARANCE } from "@/shared/components";
 import { MessageSquare, Plus, Trash2, X } from "@/shared/components/icons";
 import { Platform, Pressable, Text, View } from "@/shared/components/rn";

--- a/apps/mobile/features/ai-chat/hooks/use-session-cleanup.ts
+++ b/apps/mobile/features/ai-chat/hooks/use-session-cleanup.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react";
-import { useOptionalUserId } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth/public";
 import { tryGetDb } from "@/shared/db";
 import { useSubscription } from "@/shared/hooks";
 import { useLocaleStore } from "@/shared/i18n/store";

--- a/apps/mobile/features/ai-chat/hooks/use-user-memories.ts
+++ b/apps/mobile/features/ai-chat/hooks/use-user-memories.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useOptionalUserId } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth/public";
 import type { UserId, UserMemoryId } from "@/shared/types/branded";
 import {
   extractMemoriesFromConversation,

--- a/apps/mobile/features/ai-chat/public.ts
+++ b/apps/mobile/features/ai-chat/public.ts
@@ -1,0 +1,1 @@
+export * from "./index";

--- a/apps/mobile/features/analytics/components/AnalyticsScreen.tsx
+++ b/apps/mobile/features/analytics/components/AnalyticsScreen.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback } from "react";
-import { useOptionalUserId } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth/public";
 import type { ViewStyle } from "@/shared/components/rn";
 import { Pressable, ScrollView, StyleSheet, Text, View } from "@/shared/components/rn";
 import { getDb } from "@/shared/db";

--- a/apps/mobile/features/analytics/public.ts
+++ b/apps/mobile/features/analytics/public.ts
@@ -1,0 +1,1 @@
+export * from "./index";

--- a/apps/mobile/features/auth/lib/effective-auth.ts
+++ b/apps/mobile/features/auth/lib/effective-auth.ts
@@ -1,5 +1,5 @@
 import type { Session } from "@supabase/supabase-js";
-import type { LocalQaSession } from "@/features/qa";
+import type { LocalQaSession } from "@/features/qa/public";
 import { requireUserId } from "@/shared/types/assertions";
 import type { UserId } from "@/shared/types/branded";
 

--- a/apps/mobile/features/auth/store.ts
+++ b/apps/mobile/features/auth/store.ts
@@ -9,7 +9,7 @@ import {
   type LocalQaSession,
   loadLocalQaSession,
 } from "@/features/qa/local-session";
-import { getSupabase } from "@/shared/db";
+import { getSupabase } from "@/shared/db/supabase";
 import { captureWarning, identifyUser, resetAnalyticsUser } from "@/shared/lib";
 
 // biome-ignore lint/style/useNamingConvention: OAuth is a proper noun

--- a/apps/mobile/features/background-fetch/public.ts
+++ b/apps/mobile/features/background-fetch/public.ts
@@ -1,0 +1,1 @@
+export * from "./index";

--- a/apps/mobile/features/background-fetch/task.ts
+++ b/apps/mobile/features/background-fetch/task.ts
@@ -6,7 +6,7 @@ import {
   getOutlookClientId,
   initializeEmailCaptureSession,
   loadEmailAccounts,
-} from "@/features/email-capture";
+} from "@/features/email-capture/public";
 import { getDb, getSupabase } from "@/shared/db";
 import { captureError } from "@/shared/lib";
 import { requireUserId } from "@/shared/types/assertions";

--- a/apps/mobile/features/budget/components/create-budget/CreateBudgetFormContent.tsx
+++ b/apps/mobile/features/budget/components/create-budget/CreateBudgetFormContent.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import Animated from "react-native-reanimated";
-import { type CategoryId, CATEGORIES } from "@/shared/categories";
 import { CategoryPill } from "@/features/transactions/display.public";
+import { CATEGORIES, type CategoryId } from "@/shared/categories";
 import { FidyNumpad } from "@/shared/components";
 import { Pressable, ScrollView, Text, View } from "@/shared/components/rn";
 import { useBlinkingCursor, useThemeColor, useTranslation } from "@/shared/hooks";

--- a/apps/mobile/features/capture-sources/components/NotificationSetupCard.tsx
+++ b/apps/mobile/features/capture-sources/components/NotificationSetupCard.tsx
@@ -1,4 +1,4 @@
-import { useOptionalUserId } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth/public";
 import { Bell, ExternalLink } from "@/shared/components/icons";
 import { Linking, Platform, Pressable, Switch, Text, View } from "@/shared/components/rn";
 import { getDb } from "@/shared/db";

--- a/apps/mobile/features/capture-sources/public.ts
+++ b/apps/mobile/features/capture-sources/public.ts
@@ -1,0 +1,1 @@
+export * from "./index";

--- a/apps/mobile/features/capture-sources/services/notification-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/notification-pipeline.ts
@@ -1,6 +1,6 @@
-import { findMatchingFinancialAccountId } from "@/features/account-suggestions";
+import { findMatchingFinancialAccountId } from "@/features/account-suggestions/public";
 import { lookupMerchantRule } from "@/features/email-capture/merchant-rules.public";
-import { ensureDefaultFinancialAccount } from "@/features/financial-accounts";
+import { ensureDefaultFinancialAccount } from "@/features/financial-accounts/public";
 import type { AnyDb } from "@/shared/db";
 import { normalizeMerchant, toIsoDateTime } from "@/shared/lib";
 import { assertUserId } from "@/shared/types/assertions";

--- a/apps/mobile/features/capture-sources/services/notification-pipeline/types.ts
+++ b/apps/mobile/features/capture-sources/services/notification-pipeline/types.ts
@@ -1,4 +1,4 @@
-import type { CaptureEvidenceSeed } from "@/features/capture-evidence";
+import type { CaptureEvidenceSeed } from "@/features/capture-evidence/public";
 import type { AnyDb } from "@/shared/db";
 import type {
   CategoryId,

--- a/apps/mobile/features/categories/components/category-sheet/useCreateCategorySheet.ts
+++ b/apps/mobile/features/categories/components/category-sheet/useCreateCategorySheet.ts
@@ -1,5 +1,5 @@
 import { useRouter } from "expo-router";
-import { useOptionalUserId } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth/public";
 import { Ellipsis } from "@/shared/components/icons";
 import { useAsyncGuard } from "@/shared/hooks";
 import { ICON_MAP } from "../../lib/icon-map";

--- a/apps/mobile/features/categories/public.ts
+++ b/apps/mobile/features/categories/public.ts
@@ -1,0 +1,1 @@
+export * from "./index";

--- a/apps/mobile/features/dashboard/components/AttributionReviewBanner.tsx
+++ b/apps/mobile/features/dashboard/components/AttributionReviewBanner.tsx
@@ -1,4 +1,4 @@
-import { useOptionalUserId } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth/public";
 import { useAttributionReviewQueue } from "@/features/review-queues/hooks/use-attribution-review-queue";
 import { ChevronRight, Landmark } from "@/shared/components/icons";
 import { Pressable, Text, View } from "@/shared/components/rn";

--- a/apps/mobile/features/dashboard/components/NeedsReviewBanner.tsx
+++ b/apps/mobile/features/dashboard/components/NeedsReviewBanner.tsx
@@ -1,4 +1,4 @@
-import { useEmailCaptureStore } from "@/features/email-capture";
+import { useEmailCaptureStore } from "@/features/email-capture/public";
 import { ChevronRight, TriangleAlert } from "@/shared/components/icons";
 import { Pressable, Text, View } from "@/shared/components/rn";
 import { useTranslation } from "@/shared/hooks";

--- a/apps/mobile/features/dashboard/components/home-screen/ActivityFeedItem.tsx
+++ b/apps/mobile/features/dashboard/components/home-screen/ActivityFeedItem.tsx
@@ -1,9 +1,9 @@
 import { memo, useCallback } from "react";
 import type { StoredActivityItem } from "@/features/activity/services/create-activity-query-service";
+import { CATEGORY_MAP } from "@/shared/categories";
 import { makeDateLabel } from "@/features/transactions/display.public";
 import type { StoredTransaction } from "@/features/transactions/query.public";
 import { getTransferActivityCopy } from "@/features/transfers/lib/presentation";
-import { CATEGORY_MAP } from "@/shared/categories";
 import { TransactionRow } from "@/shared/components";
 import { ArrowLeftRight, Ellipsis } from "@/shared/components/icons";
 import { View } from "@/shared/components/rn";

--- a/apps/mobile/features/dashboard/components/home-screen/HomeScreenHeader.tsx
+++ b/apps/mobile/features/dashboard/components/home-screen/HomeScreenHeader.tsx
@@ -3,16 +3,16 @@ import {
   AccountSuggestionsPromptBanner,
   useAccountSuggestions,
 } from "@/features/account-suggestions/routes.public";
-import { useOptionalUserId } from "@/features/auth";
-import { DetectedTransactionsBanner } from "@/features/capture-sources";
+import { useOptionalUserId } from "@/features/auth/public";
+import { DetectedTransactionsBanner } from "@/features/capture-sources/public";
 import {
   connectEmailAccount,
   EmailConnectBanner,
   FailedEmailsBanner,
   getGmailClientId,
   getOutlookClientId,
-} from "@/features/email-capture";
-import { SyncConflictBanner } from "@/features/sync";
+} from "@/features/email-capture/public";
+import { SyncConflictBanner } from "@/features/sync/public";
 import { Platform, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
 import { AttributionReviewBanner } from "../AttributionReviewBanner";

--- a/apps/mobile/features/dashboard/lib/get-activity-account-names.ts
+++ b/apps/mobile/features/dashboard/lib/get-activity-account-names.ts
@@ -1,4 +1,4 @@
-import { getFinancialAccountsForUser } from "@/features/financial-accounts";
+import { getFinancialAccountsForUser } from "@/features/financial-accounts/public";
 import type { AnyDb } from "@/shared/db";
 import { isMissingSqliteTableError } from "@/shared/lib/sqlite-errors";
 import type { UserId } from "@/shared/types/branded";

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/internal-types.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/internal-types.ts
@@ -1,6 +1,6 @@
 import type { Effect } from "effect";
-import type { CaptureEvidenceSeed } from "@/features/capture-evidence";
-import type { FinancialAccountRow } from "@/features/financial-accounts";
+import type { CaptureEvidenceSeed } from "@/features/capture-evidence/public";
+import type { FinancialAccountRow } from "@/features/financial-accounts/public";
 import type { AnyDb } from "@/shared/db";
 import type { AppClock } from "@/shared/effect/clock";
 import type { AppTelemetry } from "@/shared/effect/telemetry";

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/runtime.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/runtime.ts
@@ -2,7 +2,7 @@ import { Effect } from "effect";
 import {
   type CaptureEvidenceRow,
   materializeCaptureEvidenceRows,
-} from "@/features/capture-evidence";
+} from "@/features/capture-evidence/public";
 import type { AnyDb } from "@/shared/db";
 import { type AppClock, bindAppClock, currentDateEffect } from "@/shared/effect/clock";
 import { fromPromise, fromThunk, makeAppService } from "@/shared/effect/runtime";

--- a/apps/mobile/features/financial-accounts/components/FinancialAccountFormScreen.tsx
+++ b/apps/mobile/features/financial-accounts/components/FinancialAccountFormScreen.tsx
@@ -1,7 +1,7 @@
 import { useFocusEffect } from "@react-navigation/native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useCallback, useState } from "react";
-import { useOptionalUserId } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth/public";
 import {
   type FinancialAccountFormLookupStatus,
   getFinancialAccountFormScreenState,

--- a/apps/mobile/features/financial-accounts/components/FinancialAccountIdentifierSheet.tsx
+++ b/apps/mobile/features/financial-accounts/components/FinancialAccountIdentifierSheet.tsx
@@ -1,6 +1,6 @@
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useState } from "react";
-import { useOptionalUserId } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth/public";
 import { createFinancialAccountManagementService } from "@/features/financial-accounts/lib/management-service";
 import { parseFinancialAccountRouteParam } from "@/features/financial-accounts/lib/route-params";
 import { ScreenLayout } from "@/shared/components";

--- a/apps/mobile/features/financial-accounts/components/financial-account-details-screen/useFinancialAccountDetailsScreen.ts
+++ b/apps/mobile/features/financial-accounts/components/financial-account-details-screen/useFinancialAccountDetailsScreen.ts
@@ -1,7 +1,7 @@
 import { useFocusEffect } from "@react-navigation/native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useCallback, useState } from "react";
-import { useOptionalUserId } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth/public";
 import { readFinancialAccountKind } from "@/features/financial-accounts/lib/kind";
 import { createFinancialAccountManagementService } from "@/features/financial-accounts/lib/management-service";
 import type { FinancialAccountDetails } from "@/features/financial-accounts/lib/management-service/types";

--- a/apps/mobile/features/financial-accounts/components/financial-account-form/FinancialAccountFormFields.tsx
+++ b/apps/mobile/features/financial-accounts/components/financial-account-form/FinancialAccountFormFields.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import {
   type FinancialAccountKind,
   financialAccountKindSchema,
-} from "@/features/financial-accounts";
+} from "@/features/financial-accounts/public";
 import { ChevronRight } from "@/shared/components/icons";
 import { Pressable, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";

--- a/apps/mobile/features/financial-accounts/components/financial-account-form/useFinancialAccountForm.ts
+++ b/apps/mobile/features/financial-accounts/components/financial-account-form/useFinancialAccountForm.ts
@@ -1,7 +1,7 @@
 import { useRouter } from "expo-router";
 import { useState } from "react";
-import { useOptionalUserId } from "@/features/auth";
-import type { FinancialAccountKind } from "@/features/financial-accounts";
+import { useOptionalUserId } from "@/features/auth/public";
+import type { FinancialAccountKind } from "@/features/financial-accounts/public";
 import { hasInvalidBillingDayInput } from "@/features/financial-accounts/lib/form-screen";
 import { readFinancialAccountKind } from "@/features/financial-accounts/lib/kind";
 import { createFinancialAccountManagementService } from "@/features/financial-accounts/lib/management-service";

--- a/apps/mobile/features/financial-accounts/components/financial-accounts-screen/FinancialAccountsScreen.types.ts
+++ b/apps/mobile/features/financial-accounts/components/financial-accounts-screen/FinancialAccountsScreen.types.ts
@@ -1,4 +1,4 @@
-import type { FinancialAccountRow } from "@/features/financial-accounts";
+import type { FinancialAccountRow } from "@/features/financial-accounts/public";
 
 export type FinancialAccountListItem = {
   readonly account: FinancialAccountRow;

--- a/apps/mobile/features/financial-accounts/components/financial-accounts-screen/useFinancialAccountsScreen.ts
+++ b/apps/mobile/features/financial-accounts/components/financial-accounts-screen/useFinancialAccountsScreen.ts
@@ -1,8 +1,8 @@
 import { useFocusEffect } from "@react-navigation/native";
 import { useRouter } from "expo-router";
 import { useCallback, useState } from "react";
-import { useOptionalUserId } from "@/features/auth";
-import { getFinancialAccountsForUser } from "@/features/financial-accounts";
+import { useOptionalUserId } from "@/features/auth/public";
+import { getFinancialAccountsForUser } from "@/features/financial-accounts/public";
 import { readFinancialAccountKind } from "@/features/financial-accounts/lib/kind";
 import { createFinancialAccountManagementService } from "@/features/financial-accounts/lib/management-service";
 import { tryGetDb } from "@/shared/db";

--- a/apps/mobile/features/notifications/components/NotificationsScreen.tsx
+++ b/apps/mobile/features/notifications/components/NotificationsScreen.tsx
@@ -1,7 +1,7 @@
 import { Stack, useRouter } from "expo-router";
 import { useCallback, useMemo } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { useAccountCreatedAt, useOptionalUserId } from "@/features/auth";
+import { useAccountCreatedAt, useOptionalUserId } from "@/features/auth/public";
 import { ScreenLayout } from "@/shared/components";
 import { Platform, Pressable, SectionList, StyleSheet, Text, View } from "@/shared/components/rn";
 import { getDb } from "@/shared/db";

--- a/apps/mobile/features/onboarding/components/ConnectEmailStep.tsx
+++ b/apps/mobile/features/onboarding/components/ConnectEmailStep.tsx
@@ -1,11 +1,12 @@
 import Ionicons from "@expo/vector-icons/Ionicons";
-import { GoogleIcon, MicrosoftIcon, OAuthButton, useOptionalUserId } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth/public";
+import { GoogleIcon, MicrosoftIcon, OAuthButton } from "@/features/auth/ui.public";
 import {
   connectEmailAccount,
   getGmailClientId,
   getOutlookClientId,
   useEmailCaptureStore,
-} from "@/features/email-capture";
+} from "@/features/email-capture/public";
 import { Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
 import { useAsyncGuard, useThemeColor, useTranslation } from "@/shared/hooks";

--- a/apps/mobile/features/qa/components/LocalQaLoginButton.tsx
+++ b/apps/mobile/features/qa/components/LocalQaLoginButton.tsx
@@ -1,4 +1,5 @@
-import { OAuthButton, useAuthStore } from "@/features/auth";
+import { useAuthStore } from "@/features/auth/public";
+import { OAuthButton } from "@/features/auth/ui.public";
 import { useTranslation } from "@/shared/hooks";
 import { isLocalQaAvailable } from "../local-session";
 

--- a/apps/mobile/features/qa/components/LocalQaProfileTools.tsx
+++ b/apps/mobile/features/qa/components/LocalQaProfileTools.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "expo-router";
-import { useAuthMode, useAuthStore } from "@/features/auth";
+import { useAuthMode, useAuthStore } from "@/features/auth/public";
 import { Pressable, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 

--- a/apps/mobile/features/qa/components/QaLauncherScreen.tsx
+++ b/apps/mobile/features/qa/components/QaLauncherScreen.tsx
@@ -1,6 +1,6 @@
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useEffect, useRef, useState } from "react";
-import { useAuthStore } from "@/features/auth";
+import { useAuthStore } from "@/features/auth/public";
 import { ScreenLayout } from "@/shared/components";
 import { ActivityIndicator, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";

--- a/apps/mobile/features/qa/components/QaStatusBanner.tsx
+++ b/apps/mobile/features/qa/components/QaStatusBanner.tsx
@@ -1,4 +1,4 @@
-import { useAuthStore } from "@/features/auth";
+import { useAuthStore } from "@/features/auth/public";
 import { Text, View } from "@/shared/components/rn";
 import { useTranslation } from "@/shared/hooks";
 import { useQaDevtoolsStore } from "../devtools-store";

--- a/apps/mobile/features/qa/components/qa-tools/useQaScenarioRunner.ts
+++ b/apps/mobile/features/qa/components/qa-tools/useQaScenarioRunner.ts
@@ -1,6 +1,6 @@
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useAuthStore } from "@/features/auth";
+import { useAuthStore } from "@/features/auth/public";
 import {
   getDefaultQaTarget,
   isLocalQaAvailable,

--- a/apps/mobile/features/qa/components/qa-tools/useQaToolsScreen.ts
+++ b/apps/mobile/features/qa/components/qa-tools/useQaToolsScreen.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { useAuthStore } from "@/features/auth";
+import { useAuthStore } from "@/features/auth/public";
 import {
   type QaFeatureFlagName,
   type QaNetworkEvent,

--- a/apps/mobile/features/qa/lib/build-local-qa-seed.ts
+++ b/apps/mobile/features/qa/lib/build-local-qa-seed.ts
@@ -1,8 +1,8 @@
 import { buildDefaultFinancialAccountId } from "@/features/financial-accounts/lib/default-account";
 import type { FinancialAccountRow } from "@/features/financial-accounts/lib/repository";
+import { getBuiltInCategoryId } from "@/shared/categories";
 import type { TransactionRow } from "@/features/transactions/lib/repository";
 import type { TransferRow } from "@/features/transfers/lib/repository";
-import { getBuiltInCategoryId } from "@/shared/categories";
 import {
   generateFinancialAccountId,
   generateTransactionId,

--- a/apps/mobile/features/qa/public.ts
+++ b/apps/mobile/features/qa/public.ts
@@ -1,0 +1,1 @@
+export * from "./index";

--- a/apps/mobile/features/review-queues/components/FinancialMeaningQueueScreen.tsx
+++ b/apps/mobile/features/review-queues/components/FinancialMeaningQueueScreen.tsx
@@ -3,10 +3,7 @@ import { format } from "date-fns";
 import { useRouter } from "expo-router";
 import { useState } from "react";
 import { useOptionalUserId } from "@/features/auth/public";
-import {
-  dismissFinancialMeaningReview,
-  loadNeedsReviewEmails,
-} from "@/features/email-capture/public";
+import { dismissFinancialMeaningReview, loadNeedsReviewEmails } from "@/features/email-capture/public";
 import { refreshTransactions } from "@/features/transactions/store.public";
 import { ScreenLayout } from "@/shared/components";
 import { ChevronRight, TriangleAlert } from "@/shared/components/icons";

--- a/apps/mobile/features/review-queues/hooks/use-financial-meaning-review-queue.ts
+++ b/apps/mobile/features/review-queues/hooks/use-financial-meaning-review-queue.ts
@@ -1,6 +1,6 @@
 import { useFocusEffect } from "@react-navigation/native";
 import { useCallback, useState } from "react";
-import { getFinancialMeaningReviewItems, loadNeedsReviewEmails } from "@/features/email-capture";
+import { getFinancialMeaningReviewItems, loadNeedsReviewEmails } from "@/features/email-capture/public";
 import type { AnyDb } from "@/shared/db";
 import { isMissingSqliteTableError } from "@/shared/lib/sqlite-errors";
 import type { UserId } from "@/shared/types/branded";

--- a/apps/mobile/features/review-queues/public.ts
+++ b/apps/mobile/features/review-queues/public.ts
@@ -1,0 +1,1 @@
+export * from "./index";

--- a/apps/mobile/features/search/components/search-screen/SearchTransactionItem.tsx
+++ b/apps/mobile/features/search/components/search-screen/SearchTransactionItem.tsx
@@ -1,7 +1,7 @@
 import { memo } from "react";
+import { CATEGORY_MAP } from "@/shared/categories";
 import { makeDateLabel } from "@/features/transactions/display.public";
 import type { StoredTransaction } from "@/features/transactions/query.public";
-import { CATEGORY_MAP } from "@/shared/categories";
 import { TransactionRow } from "@/shared/components";
 import { Ellipsis } from "@/shared/components/icons";
 import { Text, View } from "@/shared/components/rn";

--- a/apps/mobile/features/search/components/search-screen/useSearchScreenBase.ts
+++ b/apps/mobile/features/search/components/search-screen/useSearchScreenBase.ts
@@ -1,5 +1,5 @@
 import { useLocalSearchParams } from "expo-router";
-import { useOptionalUserId } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth/public";
 import { getDb } from "@/shared/db";
 import { useThemeColor } from "@/shared/hooks";
 import { resolveSearchRouteFilters } from "../../lib/route-params";

--- a/apps/mobile/features/settings/components/ProfileScreen.tsx
+++ b/apps/mobile/features/settings/components/ProfileScreen.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "expo-router";
-import { useAuthIdentity, useAuthMode, useAuthStore } from "@/features/auth";
+import { useAuthIdentity, useAuthMode, useAuthStore } from "@/features/auth/public";
 import { LocalQaProfileTools } from "@/features/qa/routes.public";
 import { ScreenLayout } from "@/shared/components";
 import { Brain, LogOut } from "@/shared/components/icons";

--- a/apps/mobile/features/settings/components/SettingsScreen.tsx
+++ b/apps/mobile/features/settings/components/SettingsScreen.tsx
@@ -1,8 +1,8 @@
 import Constants from "expo-constants";
 import { Stack, useRouter } from "expo-router";
 import { openBrowserAsync } from "expo-web-browser";
-import { useAuthIdentity } from "@/features/auth";
-import { useEmailCaptureStore } from "@/features/email-capture";
+import { useAuthIdentity } from "@/features/auth/public";
+import { useEmailCaptureStore } from "@/features/email-capture/public";
 import { ScreenLayout, SettingsSection, TAB_BAR_CLEARANCE } from "@/shared/components";
 import {
   Bell,

--- a/apps/mobile/features/settings/hooks/use-delete-account.ts
+++ b/apps/mobile/features/settings/hooks/use-delete-account.ts
@@ -1,5 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
-import { useAuthStore } from "@/features/auth";
+import { useAuthStore } from "@/features/auth/public";
 import { deleteAccountRequest } from "../data/notification-preferences";
 
 type DeleteAccountInput = {

--- a/apps/mobile/features/settings/hooks/use-notification-preferences.ts
+++ b/apps/mobile/features/settings/hooks/use-notification-preferences.ts
@@ -1,5 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
-import { useOptionalUserId } from "@/features/auth";
+import { useOptionalUserId } from "@/features/auth/public";
 import { saveNotificationPreferences } from "../data/notification-preferences";
 import type { NotificationPreferences } from "../store";
 

--- a/apps/mobile/features/settings/public.ts
+++ b/apps/mobile/features/settings/public.ts
@@ -1,5 +1,6 @@
 import type { NotificationPreferences } from "./store";
 import { useSettingsStore } from "./store";
+
 export { getUnsyncedCount } from "./lib/check-unsynced";
 export {
   buildPrivacyUrl,

--- a/apps/mobile/features/sync/components/ConflictResolutionScreen.tsx
+++ b/apps/mobile/features/sync/components/ConflictResolutionScreen.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "expo-router";
 import { useCallback } from "react";
-import { useAuthStore } from "@/features/auth";
+import { useAuthStore } from "@/features/auth/public";
 import { ScreenLayout } from "@/shared/components";
 import { FlatList, Text, View } from "@/shared/components/rn";
 import { getDb } from "@/shared/db";

--- a/apps/mobile/features/sync/public.ts
+++ b/apps/mobile/features/sync/public.ts
@@ -1,0 +1,1 @@
+export * from "./index";


### PR DESCRIPTION
- move feature callers to public surfaces
- align auth and db import boundaries
- keep feature exports explicit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated mobile features to explicit public surfaces and aligned auth/db import boundaries to keep callers on stable APIs. No runtime behavior changes.

- **Refactors**
  - Added `public.ts` entrypoints across more features (e.g., `ai-chat`, `analytics`, `background-fetch`, `capture-sources`, `categories`, `qa`, `review-queues`, `sync`) and re-exported from `index`.
  - Switched imports to `.../public`, `routes.public`, and `auth/ui.public` instead of private modules; updated callers in email-capture, financial-accounts, capture-evidence, account-suggestions, and others.
  - Moved Supabase access to `@/shared/db/supabase`; updated tests to mock `@/shared/db/supabase`.
  - Kept feature exports explicit to prevent private coupling.

<sup>Written for commit c700bcbb9dbbe94e1b0b9118140743fea9fa2779. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

