### PR TITLE
chore(mobile): apply bootstrap followups

### DIFF
--- a/apps/mobile/__tests__/navigation/root-layout-local-qa.test.ts
+++ b/apps/mobile/__tests__/navigation/root-layout-local-qa.test.ts
@@ -6,7 +6,9 @@ describe("Root layout local QA gating", () => {
   const source = readFileSync(resolve(__dirname, "../../app/_layout.tsx"), "utf-8");
 
   test("disables sync and capture hooks when remote effects are off", () => {
-    expect(source).toContain("useSyncBootstrap({ db, enableRemoteEffects, migrationsReady, userId })");
+    expect(source).toContain(
+      "useSyncBootstrap({ db, enableRemoteEffects, migrationsReady, userId })"
+    );
     expect(source).toContain("enableRemoteEffects ? userId : null");
   });
 

--- a/apps/mobile/bootstrap/authenticated-shell.ts
+++ b/apps/mobile/bootstrap/authenticated-shell.ts
@@ -18,10 +18,7 @@ import {
   emailCaptureBootstrapTask,
   useEmailCaptureBootstrap,
 } from "@/features/email-capture/bootstrap";
-import {
-  goalsBootstrapTask,
-  goalsTransactionSubscriptionTask,
-} from "@/features/goals/bootstrap";
+import { goalsBootstrapTask, goalsTransactionSubscriptionTask } from "@/features/goals/bootstrap";
 import {
   notificationsBootstrapTask,
   useNotificationBootstrap,

--- a/apps/mobile/features/analytics/bootstrap.ts
+++ b/apps/mobile/features/analytics/bootstrap.ts
@@ -1,17 +1,15 @@
 import type { BootstrapTask, SubscriptionTask } from "@/shared/bootstrap/registry";
 import type { AuthenticatedBootstrapContext } from "@/shared/bootstrap/types";
 import { handleRecoverableError } from "@/shared/lib";
-import { subscribeAnalyticsToTransactions } from "./services/subscribe-analytics-to-transactions";
-import { initializeAnalyticsSession, loadAnalyticsForUser, useAnalyticsStore } from "./public";
 import { useTransactionStore } from "../transactions/store.public";
+import { initializeAnalyticsSession, loadAnalyticsForUser, useAnalyticsStore } from "./public";
+import { subscribeAnalyticsToTransactions } from "./services/subscribe-analytics-to-transactions";
 
 export const analyticsBootstrapTask: BootstrapTask<AuthenticatedBootstrapContext> = {
   id: "analytics",
   run: ({ db, userId }) => {
     initializeAnalyticsSession(userId);
-    void loadAnalyticsForUser(db, userId).catch(
-      handleRecoverableError("Failed to load analytics")
-    );
+    void loadAnalyticsForUser(db, userId).catch(handleRecoverableError("Failed to load analytics"));
   },
 };
 

--- a/apps/mobile/features/budget/bootstrap.ts
+++ b/apps/mobile/features/budget/bootstrap.ts
@@ -1,9 +1,9 @@
 import type { BootstrapTask, SubscriptionTask } from "@/shared/bootstrap/registry";
 import type { AuthenticatedBootstrapContext } from "@/shared/bootstrap/types";
 import { handleRecoverableError } from "@/shared/lib";
-import { subscribeBudgetToTransactions } from "./services/subscribe-budget-to-transactions";
-import { initializeBudgetSession, loadBudgetsForUser, useBudgetStore } from "./public";
 import { useTransactionStore } from "../transactions/store.public";
+import { initializeBudgetSession, loadBudgetsForUser, useBudgetStore } from "./public";
+import { subscribeBudgetToTransactions } from "./services/subscribe-budget-to-transactions";
 
 export const budgetBootstrapTask: BootstrapTask<AuthenticatedBootstrapContext> = {
   id: "budget",

--- a/apps/mobile/features/capture-sources/bootstrap.ts
+++ b/apps/mobile/features/capture-sources/bootstrap.ts
@@ -1,5 +1,8 @@
 import type { BootstrapTask } from "@/shared/bootstrap/registry";
-import type { AuthenticatedBootstrapContext, CapturePipelineContext } from "@/shared/bootstrap/types";
+import type {
+  AuthenticatedBootstrapContext,
+  CapturePipelineContext,
+} from "@/shared/bootstrap/types";
 import { handleRecoverableError } from "@/shared/lib";
 import { useApplePayCapture } from "./hooks/useApplePayCapture";
 import { useNotificationCapture } from "./hooks/useNotificationCapture";

--- a/apps/mobile/features/email-capture/bootstrap.ts
+++ b/apps/mobile/features/email-capture/bootstrap.ts
@@ -1,5 +1,8 @@
 import type { BootstrapTask } from "@/shared/bootstrap/registry";
-import type { AuthenticatedBootstrapContext, CapturePipelineContext } from "@/shared/bootstrap/types";
+import type {
+  AuthenticatedBootstrapContext,
+  CapturePipelineContext,
+} from "@/shared/bootstrap/types";
 import { handleRecoverableError } from "@/shared/lib";
 import { useEmailCapture } from "./hooks/useEmailCapture";
 import { initializeEmailCaptureSession, loadEmailAccounts } from "./public";

--- a/apps/mobile/features/goals/bootstrap.ts
+++ b/apps/mobile/features/goals/bootstrap.ts
@@ -1,9 +1,9 @@
 import type { BootstrapTask, SubscriptionTask } from "@/shared/bootstrap/registry";
 import type { AuthenticatedBootstrapContext } from "@/shared/bootstrap/types";
 import { handleRecoverableError } from "@/shared/lib";
-import { subscribeGoalsToTransactions } from "./services/subscribe-goals-to-transactions";
-import { initializeGoalSession, loadGoalsForUser, useGoalStore } from "./public";
 import { useTransactionStore } from "../transactions/store.public";
+import { initializeGoalSession, loadGoalsForUser, useGoalStore } from "./public";
+import { subscribeGoalsToTransactions } from "./services/subscribe-goals-to-transactions";
 
 export const goalsBootstrapTask: BootstrapTask<AuthenticatedBootstrapContext> = {
   id: "goals",

--- a/apps/mobile/features/notifications/bootstrap.ts
+++ b/apps/mobile/features/notifications/bootstrap.ts
@@ -8,6 +8,34 @@ import { useSubscription } from "@/shared/hooks";
 import { captureError } from "@/shared/lib";
 import { initializeNotificationStore, registerPushToken } from "./public";
 
+const notificationBehavior = {
+  shouldShowBanner: true,
+  shouldShowList: true,
+  shouldPlaySound: false,
+  shouldSetBadge: false,
+} as const;
+
+const registerCurrentPushToken = (userId: NotificationBootstrapContext["userId"]): void => {
+  void registerPushToken(userId).catch(captureError);
+};
+
+const configureNotificationHandler = (): void => {
+  Notifications.setNotificationHandler({
+    handleNotification: async () => notificationBehavior,
+  });
+};
+
+const subscribeNotificationNavigation = ({
+  navigateToRoute,
+}: Pick<NotificationBootstrapContext, "navigateToRoute">) =>
+  Notifications.addNotificationResponseReceivedListener((response) => {
+    const data = response.notification.request.content.data;
+    const route = data?.route;
+    if (typeof route === "string" && route.startsWith("/")) {
+      navigateToRoute(route);
+    }
+  });
+
 export const notificationsBootstrapTask: BootstrapTask<AuthenticatedBootstrapContext> = {
   id: "notifications",
   run: ({ db, userId }) => {
@@ -23,28 +51,12 @@ export const useNotificationBootstrap = ({
   useSubscription(() => {
     if (!enableRemoteEffects) return;
 
-    Notifications.setNotificationHandler({
-      handleNotification: async () => ({
-        shouldShowBanner: true,
-        shouldShowList: true,
-        shouldPlaySound: false,
-        shouldSetBadge: false,
-      }),
-    });
-
-    void registerPushToken(userId).catch(captureError);
-
+    configureNotificationHandler();
+    registerCurrentPushToken(userId);
     const tokenSub = Notifications.addPushTokenListener(() => {
-      void registerPushToken(userId).catch(captureError);
+      registerCurrentPushToken(userId);
     });
-
-    const responseSub = Notifications.addNotificationResponseReceivedListener((response) => {
-      const data = response.notification.request.content.data;
-      const route = data?.route;
-      if (typeof route === "string" && route.startsWith("/")) {
-        navigateToRoute(route);
-      }
-    });
+    const responseSub = subscribeNotificationNavigation({ navigateToRoute });
 
     return () => {
       tokenSub.remove();

--- a/apps/mobile/features/settings/bootstrap.ts
+++ b/apps/mobile/features/settings/bootstrap.ts
@@ -6,8 +6,9 @@ import { useSettingsStore } from "./public";
 export const settingsBootstrapTask: BootstrapTask<AuthenticatedBootstrapContext> = {
   id: "settings",
   run: () => {
-    void useSettingsStore.getState().hydrate().catch(
-      handleRecoverableError("Failed to hydrate settings")
-    );
+    void useSettingsStore
+      .getState()
+      .hydrate()
+      .catch(handleRecoverableError("Failed to hydrate settings"));
   },
 };

--- a/apps/mobile/features/transactions/bootstrap.ts
+++ b/apps/mobile/features/transactions/bootstrap.ts
@@ -2,7 +2,11 @@ import { tryEnsureDefaultFinancialAccount } from "@/features/financial-accounts/
 import type { BootstrapTask } from "@/shared/bootstrap/registry";
 import type { AuthenticatedBootstrapContext } from "@/shared/bootstrap/types";
 import { handleRecoverableError } from "@/shared/lib";
-import { initializeTransactionSession, loadInitialTransactions, useTransactionStore } from "./store.public";
+import {
+  initializeTransactionSession,
+  loadInitialTransactions,
+  useTransactionStore,
+} from "./store.public";
 
 export const transactionBootstrapTask: BootstrapTask<AuthenticatedBootstrapContext> = {
   id: "transactions",

--- a/apps/mobile/features/transfers/components/transfer-form/TransferForm.helpers.ts
+++ b/apps/mobile/features/transfers/components/transfer-form/TransferForm.helpers.ts
@@ -1,5 +1,5 @@
-import type { FinancialAccountRow } from "@/features/financial-accounts/public";
 import { readFinancialAccountKind } from "@/features/financial-accounts/lib/kind";
+import type { FinancialAccountRow } from "@/features/financial-accounts/public";
 import type { TransferSide } from "@/features/transfers/lib/build-transfer";
 import type { TransferMutationError } from "@/features/transfers/lib/mutation-service";
 import type { ReclassifyTransactionAsTransferError } from "@/features/transfers/lib/reclassify-transaction-as-transfer";

--- a/apps/mobile/features/transfers/components/transfer-form/TransferSideCard.tsx
+++ b/apps/mobile/features/transfers/components/transfer-form/TransferSideCard.tsx
@@ -1,5 +1,5 @@
-import type { FinancialAccountRow } from "@/features/financial-accounts/public";
 import { readFinancialAccountKind } from "@/features/financial-accounts/lib/kind";
+import type { FinancialAccountRow } from "@/features/financial-accounts/public";
 import type { TransferSide } from "@/features/transfers/lib/build-transfer";
 import { ChevronRight, ExternalLink, Landmark } from "@/shared/components/icons";
 import { Pressable, Text, View } from "@/shared/components/rn";

--- a/apps/mobile/features/transfers/components/transfer-form/TransferSidePicker.tsx
+++ b/apps/mobile/features/transfers/components/transfer-form/TransferSidePicker.tsx
@@ -1,5 +1,5 @@
-import type { FinancialAccountRow } from "@/features/financial-accounts/public";
 import { readFinancialAccountKind } from "@/features/financial-accounts/lib/kind";
+import type { FinancialAccountRow } from "@/features/financial-accounts/public";
 import type { TransferSide } from "@/features/transfers/lib/build-transfer";
 import { OUTSIDE_FIDY_LABEL } from "@/features/transfers/lib/build-transfer";
 import { isTransferSideSelected } from "@/features/transfers/lib/presentation";

--- a/scripts/bootstrap-registry.test.ts
+++ b/scripts/bootstrap-registry.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "bun:test";
 import {
-  runBootstrapTasks,
-  subscribeBootstrapTasks,
   type BootstrapTask,
+  runBootstrapTasks,
   type SubscriptionTask,
+  subscribeBootstrapTasks,
 } from "../apps/mobile/shared/bootstrap/registry";
 
 type TestContext = {

--- a/scripts/scaffold-syncable-feature.test.ts
+++ b/scripts/scaffold-syncable-feature.test.ts
@@ -70,7 +70,9 @@ test("writes the checklist to the requested output path", () => {
   expect(result.stdout.toString()).toContain(outputPath);
   expect(existsSync(outputPath)).toBe(true);
   expect(readFileSync(outputPath, "utf8")).toContain("apps/mobile/features/demo/public.ts");
-  expect(readFileSync(outputPath, "utf8")).toContain('enqueueSync(db, "demo_rows", rowId, operation)');
+  expect(readFileSync(outputPath, "utf8")).toContain(
+    'enqueueSync(db, "demo_rows", rowId, operation)'
+  );
 });
 
 test("fails when required arguments are missing", () => {


### PR DESCRIPTION
- keep hook rewrites explicit
- align bootstrap helper formatting
- preserve green verification


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns mobile bootstrap helpers and hooks and refactors notifications bootstrap for clarity while preserving behavior. No functional changes.

- **Refactors**
  - Standardized import order and formatting across `analytics`, `budget`, `goals`, `transactions`, `settings`, `email-capture`, and `capture-sources` bootstraps.
  - Notifications bootstrap: extracted small helpers (handler config, push token registration, navigation subscription) and a shared behavior object; kept effect wiring explicit.
  - Updated tests to account for multiline assertions and export ordering; kept hook rewrites explicit in `root-layout` QA gating.

<sup>Written for commit 3c9a6d522ec9e34f69efc7b4d6292e146f8f7f7d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

