### PR TITLE
fix(mobile): close txn seam reviews

### DIFF
--- a/apps/mobile/__tests__/budget/monitoring.test.ts
+++ b/apps/mobile/__tests__/budget/monitoring.test.ts
@@ -388,7 +388,7 @@ describe("createBudgetMonitoringModule", () => {
       percentUsed: 85,
     });
 
-    vi.doUnmock("@/features/transactions/public");
+    vi.doUnmock("@/features/transactions/query.public");
     vi.doUnmock("@/features/transactions/lib/repository");
     vi.resetModules();
   });

--- a/apps/mobile/__tests__/calendar/bill-mutation-service.test.ts
+++ b/apps/mobile/__tests__/calendar/bill-mutation-service.test.ts
@@ -406,7 +406,7 @@ describe("calendar bill mutation service", () => {
       })
     );
 
-    vi.doUnmock("@/features/transactions/public");
+    vi.doUnmock("@/features/transactions/query.public");
     vi.doUnmock("@/features/transactions/lib/build-transaction");
     vi.resetModules();
   });

--- a/apps/mobile/__tests__/transactions/categories.test.ts
+++ b/apps/mobile/__tests__/transactions/categories.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { getBuiltInCategoryId } from "@/features/transactions";
+import { getBuiltInCategory } from "@/features/transactions/categories.public";
 import {
   CATEGORIES,
   CATEGORY_IDS,
@@ -83,5 +84,9 @@ describe("getBuiltInCategoryId", () => {
 
   it("throws for unknown built-in category keys", () => {
     expect(() => getBuiltInCategoryId("missing")).toThrow("Unknown built-in category: missing");
+  });
+
+  it("throws for inherited object keys", () => {
+    expect(() => getBuiltInCategory("toString")).toThrow("Unknown built-in category: toString");
   });
 });

--- a/apps/mobile/features/transactions/public.ts
+++ b/apps/mobile/features/transactions/public.ts
@@ -1,5 +1,3 @@
 export * from "./categories.public";
-export * from "./display.public";
 export * from "./query.public";
-export * from "./store.public";
 export { insertTransaction } from "./write.public";

--- a/apps/mobile/shared/categories/registry.ts
+++ b/apps/mobile/shared/categories/registry.ts
@@ -77,8 +77,9 @@ export const CATEGORIES: readonly Category[] = [
   },
 ] as const;
 
-export const CATEGORY_MAP: Record<string, Category | undefined> = Object.fromEntries(
-  CATEGORIES.map((category) => [category.id, category])
+export const CATEGORY_MAP: Record<string, Category | undefined> = Object.assign(
+  Object.create(null) as Record<string, Category | undefined>,
+  Object.fromEntries(CATEGORIES.map((category) => [category.id, category]))
 );
 
 export const getBuiltInCategory = (id: string): Category => {


### PR DESCRIPTION
- unmock query public in tests
- harden built-in category map
- narrow transaction public barrel

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents inherited keys from resolving as built-in categories and narrows the transactions public API surface. Tests now unmock `@/features/transactions/query.public`.

- **Bug Fixes**
  - Build `CATEGORY_MAP` with `Object.create(null)` to ignore prototype keys; `getBuiltInCategory("toString")` now throws.

- **Refactors**
  - Removed re-exports of `display.public` and `store.public` from `@/features/transactions/public`; keep `categories.public`, `query.public`, and `insertTransaction`.
  - Tests updated to `vi.doUnmock("@/features/transactions/query.public")` and added coverage for prototype-key access.

<sup>Written for commit bff4fd963664904d4bed95b6c31046fc046914c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

