### PR TITLE
feat(mobile): add ledger backup

### DIFF
--- a/apps/mobile/__tests__/backup/local-ledger-snapshot.test.ts
+++ b/apps/mobile/__tests__/backup/local-ledger-snapshot.test.ts
@@ -1,0 +1,422 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: integration test uses a real SQLite DB
+import { resolve } from "node:path";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  exportLocalLedgerBackupSnapshot,
+  importLocalLedgerBackupSnapshot,
+} from "@/features/backup/public";
+import {
+  accountSuggestionDismissals,
+  budgets,
+  captureEvidence,
+  financialAccountIdentifiers,
+  financialAccounts,
+  goalContributions,
+  goals,
+  openingBalances,
+  processedCaptures,
+  processedEmails,
+  syncConflicts,
+  transactions,
+  transfers,
+  userCategories,
+} from "@/shared/db/schema";
+
+let sourceSqlite: InstanceType<typeof Database>;
+let targetSqlite: InstanceType<typeof Database>;
+let sourceDb: ReturnType<typeof drizzle>;
+let targetDb: ReturnType<typeof drizzle>;
+
+const NOW = "2026-04-23T10:30:00.000Z";
+
+function migrateMemoryDb() {
+  const sqlite = new Database(":memory:");
+  const db = drizzle(sqlite);
+  migrate(db, { migrationsFolder: resolve(__dirname, "../../drizzle") });
+  return { sqlite, db };
+}
+
+beforeEach(() => {
+  const source = migrateMemoryDb();
+  const target = migrateMemoryDb();
+  sourceSqlite = source.sqlite;
+  targetSqlite = target.sqlite;
+  sourceDb = source.db;
+  targetDb = target.db;
+});
+
+afterEach(() => {
+  sourceSqlite.close();
+  targetSqlite.close();
+});
+
+function seedLocalLedgerFixture() {
+  seedAccounts();
+  seedActivity();
+  seedPlanningRows();
+  seedCaptureAndReviewState();
+}
+
+function seedAccounts() {
+  sourceSqlite.exec(`
+    insert into user_categories (
+      id, user_id, name, icon_name, color_hex, created_at, updated_at, deleted_at
+    ) values ('uc-food', 'user-1', 'Work lunches', 'utensils', '#2F80ED', '${NOW}', '${NOW}', null);
+
+    insert into financial_accounts (
+      id, user_id, name, kind, is_default, statement_closing_day, payment_due_day,
+      created_at, updated_at, deleted_at
+    ) values ('fa-bank', 'user-1', 'Bancolombia', 'checking', 1, null, null, '${NOW}', '${NOW}', null);
+
+    insert into financial_account_identifiers (
+      id, user_id, account_id, scope, value, created_at, updated_at, deleted_at
+    ) values ('fai-1', 'user-1', 'fa-bank', 'last4', '1234', '${NOW}', '${NOW}', null);
+
+    insert into opening_balances (
+      id, user_id, account_id, amount, effective_date, created_at, updated_at, deleted_at
+    ) values ('ob-1', 'user-1', 'fa-bank', 250000, '2026-04-01', '${NOW}', '${NOW}', null);
+  `);
+}
+
+function seedActivity() {
+  sourceSqlite.exec(`
+    insert into transactions (
+      id, user_id, type, amount, category_id, description, date, account_id,
+      account_attribution_state, superseded_at, created_at, updated_at, deleted_at, source
+    ) values (
+      'txn-1', 'user-1', 'expense', 42000, 'uc-food', 'Lunch', '2026-04-20', 'fa-bank',
+      'confirmed', null, '${NOW}', '${NOW}', null, 'email'
+    );
+
+    insert into transfers (
+      id, user_id, amount, from_account_id, to_account_id, from_external_label, to_external_label,
+      description, date, created_at, updated_at, deleted_at
+    ) values (
+      'trf-1', 'user-1', 100000, 'fa-bank', null, null, 'Broker',
+      'Investment', '2026-04-21', '${NOW}', '${NOW}', null
+    );
+  `);
+}
+
+function seedPlanningRows() {
+  sourceSqlite.exec(`
+    insert into budgets (
+      id, user_id, category_id, amount, month, created_at, updated_at, deleted_at
+    ) values ('budget-1', 'user-1', 'uc-food', 500000, '2026-04', '${NOW}', '${NOW}', null);
+
+    insert into goals (
+      id, user_id, name, type, target_amount, target_date, interest_rate_percent,
+      icon_name, color_hex, created_at, updated_at, deleted_at
+    ) values (
+      'goal-1', 'user-1', 'Emergency fund', 'savings', 5000000, '2026-12-31', null,
+      'piggy-bank', '#2F80ED', '${NOW}', '${NOW}', null
+    );
+
+    insert into goal_contributions (
+      id, goal_id, user_id, amount, note, date, created_at, updated_at, deleted_at
+    ) values ('gc-1', 'goal-1', 'user-1', 100000, 'April', '2026-04-22', '${NOW}', '${NOW}', null);
+  `);
+}
+
+function seedCaptureAndReviewState() {
+  seedProcessedCaptures();
+  seedCaptureEvidence();
+  seedDismissalsAndConflicts();
+}
+
+function seedProcessedCaptures() {
+  sourceSqlite.exec(`
+    insert into processed_emails (
+      id, external_id, provider, status, failure_reason, subject, raw_body_preview,
+      received_at, transaction_id, confidence, created_at, raw_body, retry_count, next_retry_at
+    ) values (
+      'email-1', 'provider-message-1', 'gmail', 'needs_review', 'ambiguous_account',
+      'Purchase alert', 'Paid with card ending 1234', '${NOW}', 'txn-1', 0.62,
+      '${NOW}', 'Paid with card ending 1234 at Store', 1, null
+    );
+
+    insert into processed_captures (
+      id, fingerprint_hash, source, status, raw_text, transaction_id, confidence, received_at, created_at
+    ) values ('capture-1', 'hash-1', 'notification', 'success', 'Transfer sent', null, 0.91, '${NOW}', '${NOW}');
+  `);
+}
+
+function seedCaptureEvidence() {
+  sourceSqlite.exec(`
+    insert into capture_evidence (
+      id, user_id, source_family, evidence_type, scope, value, transaction_id, transfer_id,
+      processed_email_id, processed_capture_id, created_at, updated_at, deleted_at
+    ) values
+      ('ce-email', 'user-1', 'gmail', 'last4', 'last4', '1234', 'txn-1', null, 'email-1', null, '${NOW}', '${NOW}', null),
+      ('ce-capture', 'user-1', 'push', 'alias_token', 'alias', 'Broker', null, 'trf-1', null, 'capture-1', '${NOW}', '${NOW}', null);
+  `);
+}
+
+function seedDismissalsAndConflicts() {
+  sourceSqlite.exec(`
+    insert into account_suggestion_dismissals (
+      id, user_id, scope, value, dismissed_score, created_at, updated_at, deleted_at
+    ) values ('dismissal-1', 'user-1', 'last4', '9999', 70, '${NOW}', '${NOW}', null);
+
+    insert into sync_conflicts (
+      id, transaction_id, local_data, server_data, detected_at, resolved_at, resolution
+    ) values ('conflict-1', 'txn-1', '{"amount":42000}', '{"amount":43000}', '${NOW}', null, null);
+  `);
+}
+
+function expectRestoredLedgerToMatchSource() {
+  expectRestoredAccountsAndActivity();
+  expectRestoredPlanningRows();
+  expectRestoredCaptureAndReviewState();
+}
+
+function expectRestoredAccountsAndActivity() {
+  expect(targetDb.select().from(userCategories).all()).toEqual(
+    sourceDb.select().from(userCategories).all()
+  );
+  expect(targetDb.select().from(financialAccounts).all()).toEqual(
+    sourceDb.select().from(financialAccounts).all()
+  );
+  expect(targetDb.select().from(financialAccountIdentifiers).all()).toEqual(
+    sourceDb.select().from(financialAccountIdentifiers).all()
+  );
+  expect(targetDb.select().from(openingBalances).all()).toEqual(
+    sourceDb.select().from(openingBalances).all()
+  );
+  expect(targetDb.select().from(transactions).all()).toEqual(
+    sourceDb.select().from(transactions).all()
+  );
+  expect(targetDb.select().from(transfers).all()).toEqual(sourceDb.select().from(transfers).all());
+}
+
+function expectRestoredPlanningRows() {
+  expect(targetDb.select().from(budgets).all()).toEqual(sourceDb.select().from(budgets).all());
+  expect(targetDb.select().from(goals).all()).toEqual(sourceDb.select().from(goals).all());
+  expect(targetDb.select().from(goalContributions).all()).toEqual(
+    sourceDb.select().from(goalContributions).all()
+  );
+}
+
+function expectRestoredCaptureAndReviewState() {
+  expect(targetDb.select().from(processedEmails).all()).toEqual(
+    sourceDb.select().from(processedEmails).all()
+  );
+  expect(targetDb.select().from(processedCaptures).all()).toEqual(
+    sourceDb.select().from(processedCaptures).all()
+  );
+  expect(targetDb.select().from(captureEvidence).all()).toEqual(
+    sourceDb.select().from(captureEvidence).all()
+  );
+  expect(targetDb.select().from(accountSuggestionDismissals).all()).toEqual(
+    sourceDb.select().from(accountSuggestionDismissals).all()
+  );
+  expect(targetDb.select().from(syncConflicts).all()).toEqual(
+    sourceDb.select().from(syncConflicts).all()
+  );
+}
+
+function snapshotWithDuplicateIdentifierRows() {
+  return {
+    version: 1,
+    exportedAt: NOW,
+    data: emptySnapshotData({
+      financialAccounts: [rollbackAccountRow()],
+      financialAccountIdentifiers: duplicateIdentifierRows(),
+    }),
+  };
+}
+
+function snapshotWithLargeAccountTable() {
+  return {
+    version: 1,
+    exportedAt: NOW,
+    data: emptySnapshotData({
+      financialAccounts: Array.from({ length: 51 }, (_, index) =>
+        rollbackAccountRow(`fa-${index}`)
+      ),
+    }),
+  };
+}
+
+function emptySnapshotData(overrides: Record<string, unknown> = {}) {
+  return {
+    transactions: [],
+    transfers: [],
+    userCategories: [],
+    financialAccounts: [],
+    openingBalances: [],
+    budgets: [],
+    goals: [],
+    goalContributions: [],
+    captureEvidence: [],
+    financialAccountIdentifiers: [],
+    accountSuggestionDismissals: [],
+    processedEmails: [],
+    processedCaptures: [],
+    syncConflicts: [],
+    ...overrides,
+  };
+}
+
+function rollbackAccountRow(id = "fa-rollback") {
+  return {
+    id,
+    userId: "user-1",
+    name: "Rollback wallet",
+    kind: "wallet",
+    isDefault: true,
+    statementClosingDay: null,
+    paymentDueDay: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+    deletedAt: null,
+  };
+}
+
+function duplicateIdentifierRows() {
+  return [rollbackIdentifierRow("1234"), rollbackIdentifierRow("5678")];
+}
+
+function rollbackIdentifierRow(value: string) {
+  return {
+    id: "fai-duplicate",
+    userId: "user-1",
+    accountId: "fa-rollback",
+    scope: "last4",
+    value,
+    createdAt: NOW,
+    updatedAt: NOW,
+    deletedAt: null,
+  };
+}
+
+function createCappedInsertDb(maxRowsPerInsert: number) {
+  let insertedRows = 0;
+  const tx = {
+    insert: () => ({
+      values: (rows: Record<string, unknown>[]) => {
+        if (rows.length > maxRowsPerInsert) {
+          throw new Error("too many SQL variables");
+        }
+        return { run: () => (insertedRows += rows.length) };
+      },
+    }),
+  };
+  return {
+    db: { transaction: (callback: (transaction: typeof tx) => unknown) => callback(tx) },
+    getInsertedRows: () => insertedRows,
+  };
+}
+
+describe("local ledger backup snapshots", () => {
+  it("round-trips financial accounts into a clean local database", () => {
+    sourceSqlite.exec(`
+      insert into financial_accounts (
+        id, user_id, name, kind, is_default, statement_closing_day, payment_due_day,
+        created_at, updated_at, deleted_at
+      ) values (
+        'fa-main', 'user-1', 'Main wallet', 'wallet', 1, null, null,
+        '${NOW}', '${NOW}', null
+      );
+    `);
+
+    const snapshot = exportLocalLedgerBackupSnapshot(sourceDb as any, { exportedAt: NOW });
+    importLocalLedgerBackupSnapshot(targetDb as any, snapshot);
+
+    expect(targetDb.select().from(financialAccounts).all()).toEqual([
+      expect.objectContaining({
+        id: "fa-main",
+        userId: "user-1",
+        name: "Main wallet",
+        kind: "wallet",
+        isDefault: true,
+      }),
+    ]);
+  });
+
+  it("round-trips the local ledger tables needed for backup restore", () => {
+    seedLocalLedgerFixture();
+
+    const snapshot = exportLocalLedgerBackupSnapshot(sourceDb as any, { exportedAt: NOW });
+    importLocalLedgerBackupSnapshot(targetDb as any, snapshot);
+
+    expect(snapshot).toMatchObject({
+      version: 1,
+      exportedAt: NOW,
+      data: {
+        transactions: expect.any(Array),
+        transfers: expect.any(Array),
+        userCategories: expect.any(Array),
+        financialAccounts: expect.any(Array),
+        openingBalances: expect.any(Array),
+        budgets: expect.any(Array),
+        goals: expect.any(Array),
+        goalContributions: expect.any(Array),
+        captureEvidence: expect.any(Array),
+        financialAccountIdentifiers: expect.any(Array),
+        accountSuggestionDismissals: expect.any(Array),
+        processedEmails: expect.any(Array),
+        processedCaptures: expect.any(Array),
+        syncConflicts: expect.any(Array),
+      },
+    });
+    expectRestoredLedgerToMatchSource();
+  });
+
+  it("rejects unsupported snapshot versions", () => {
+    expect(() =>
+      importLocalLedgerBackupSnapshot(
+        targetDb as any,
+        {
+          version: 999,
+          exportedAt: NOW,
+          data: {},
+        } as any
+      )
+    ).toThrow("Unsupported local ledger backup snapshot version: 999");
+  });
+
+  it("rejects malformed version 1 snapshots", () => {
+    expect(() =>
+      importLocalLedgerBackupSnapshot(
+        targetDb as any,
+        {
+          version: 1,
+          exportedAt: NOW,
+          data: {
+            financialAccounts: [],
+          },
+        } as any
+      )
+    ).toThrow("Malformed local ledger backup snapshot");
+  });
+
+  it("rejects non-record rows before import", () => {
+    expect(() =>
+      importLocalLedgerBackupSnapshot(targetDb as any, {
+        version: 1,
+        exportedAt: NOW,
+        data: emptySnapshotData({ financialAccounts: [null] }),
+      })
+    ).toThrow("Malformed local ledger backup snapshot");
+  });
+
+  it("rolls back a failed snapshot import", () => {
+    expect(() =>
+      importLocalLedgerBackupSnapshot(targetDb as any, snapshotWithDuplicateIdentifierRows())
+    ).toThrow();
+
+    expect(targetDb.select().from(financialAccounts).all()).toEqual([]);
+  });
+
+  it("imports table rows in bounded chunks", () => {
+    const { db, getInsertedRows } = createCappedInsertDb(50);
+
+    importLocalLedgerBackupSnapshot(db as any, snapshotWithLargeAccountTable());
+
+    expect(getInsertedRows()).toBe(51);
+  });
+});

--- a/apps/mobile/features/backup/local-ledger-snapshot.ts
+++ b/apps/mobile/features/backup/local-ledger-snapshot.ts
@@ -1,0 +1,243 @@
+import {
+  accountSuggestionDismissals,
+  budgets,
+  captureEvidence,
+  financialAccountIdentifiers,
+  financialAccounts,
+  goalContributions,
+  goals,
+  openingBalances,
+  processedCaptures,
+  processedEmails,
+  syncConflicts,
+  transactions,
+  transfers,
+  userCategories,
+} from "@/shared/db/schema";
+
+export const LOCAL_LEDGER_BACKUP_SNAPSHOT_VERSION = 1;
+
+export type BackupSnapshot = {
+  readonly version: typeof LOCAL_LEDGER_BACKUP_SNAPSHOT_VERSION;
+  readonly exportedAt: string;
+  readonly data: LocalLedgerBackupSnapshotData;
+};
+
+export type ExportLocalLedgerBackupSnapshotOptions = {
+  readonly exportedAt: string;
+};
+
+const MAX_ROWS_PER_INSERT = 50;
+
+export function exportLocalLedgerBackupSnapshot(
+  db: BackupDb,
+  options: ExportLocalLedgerBackupSnapshotOptions
+): BackupSnapshot {
+  return {
+    version: LOCAL_LEDGER_BACKUP_SNAPSHOT_VERSION,
+    exportedAt: options.exportedAt,
+    data: {
+      transactions: selectRows(db, transactions) as readonly (typeof transactions.$inferSelect)[],
+      transfers: selectRows(db, transfers) as readonly (typeof transfers.$inferSelect)[],
+      userCategories: selectRows(
+        db,
+        userCategories
+      ) as readonly (typeof userCategories.$inferSelect)[],
+      financialAccounts: selectRows(
+        db,
+        financialAccounts
+      ) as readonly (typeof financialAccounts.$inferSelect)[],
+      openingBalances: selectRows(
+        db,
+        openingBalances
+      ) as readonly (typeof openingBalances.$inferSelect)[],
+      budgets: selectRows(db, budgets) as readonly (typeof budgets.$inferSelect)[],
+      goals: selectRows(db, goals) as readonly (typeof goals.$inferSelect)[],
+      goalContributions: selectRows(
+        db,
+        goalContributions
+      ) as readonly (typeof goalContributions.$inferSelect)[],
+      captureEvidence: selectRows(
+        db,
+        captureEvidence
+      ) as readonly (typeof captureEvidence.$inferSelect)[],
+      financialAccountIdentifiers: selectRows(
+        db,
+        financialAccountIdentifiers
+      ) as readonly (typeof financialAccountIdentifiers.$inferSelect)[],
+      accountSuggestionDismissals: selectRows(
+        db,
+        accountSuggestionDismissals
+      ) as readonly (typeof accountSuggestionDismissals.$inferSelect)[],
+      processedEmails: selectRows(
+        db,
+        processedEmails
+      ) as readonly (typeof processedEmails.$inferSelect)[],
+      processedCaptures: selectRows(
+        db,
+        processedCaptures
+      ) as readonly (typeof processedCaptures.$inferSelect)[],
+      syncConflicts: selectRows(
+        db,
+        syncConflicts
+      ) as readonly (typeof syncConflicts.$inferSelect)[],
+    },
+  };
+}
+
+export function importLocalLedgerBackupSnapshot(db: BackupDb, snapshot: unknown) {
+  const validatedSnapshot = parseBackupSnapshot(snapshot);
+
+  db.transaction((tx) => {
+    insertRows(tx, userCategories, validatedSnapshot.data.userCategories);
+    insertRows(tx, financialAccounts, validatedSnapshot.data.financialAccounts);
+    insertRows(tx, financialAccountIdentifiers, validatedSnapshot.data.financialAccountIdentifiers);
+    insertRows(tx, openingBalances, validatedSnapshot.data.openingBalances);
+    insertRows(tx, transactions, validatedSnapshot.data.transactions);
+    insertRows(tx, transfers, validatedSnapshot.data.transfers);
+    insertRows(tx, budgets, validatedSnapshot.data.budgets);
+    insertRows(tx, goals, validatedSnapshot.data.goals);
+    insertRows(tx, goalContributions, validatedSnapshot.data.goalContributions);
+    insertRows(tx, processedEmails, validatedSnapshot.data.processedEmails);
+    insertRows(tx, processedCaptures, validatedSnapshot.data.processedCaptures);
+    insertRows(tx, captureEvidence, validatedSnapshot.data.captureEvidence);
+    insertRows(tx, accountSuggestionDismissals, validatedSnapshot.data.accountSuggestionDismissals);
+    insertRows(tx, syncConflicts, validatedSnapshot.data.syncConflicts);
+  });
+}
+
+function insertRows(
+  db: BackupInsertDb,
+  table: BackupTable,
+  rows: readonly Record<string, unknown>[]
+) {
+  chunkRows(rows).forEach((chunk) => {
+    db.insert(table).values(chunk).run();
+  });
+}
+
+function chunkRows(rows: readonly Record<string, unknown>[]) {
+  return Array.from({ length: Math.ceil(rows.length / MAX_ROWS_PER_INSERT) }, (_, index) =>
+    rows.slice(index * MAX_ROWS_PER_INSERT, (index + 1) * MAX_ROWS_PER_INSERT)
+  );
+}
+
+function selectRows(db: BackupDb, table: BackupTable): readonly Record<string, unknown>[] {
+  return db.select().from(table).all();
+}
+
+function parseBackupSnapshot(snapshot: unknown): BackupSnapshot {
+  assertSnapshotRecord(snapshot);
+  assertSupportedSnapshotVersion(snapshot);
+  assertVersionOneSnapshotShape(snapshot);
+  return snapshot as BackupSnapshot;
+}
+
+function assertSnapshotRecord(snapshot: unknown): asserts snapshot is Record<string, unknown> {
+  if (!isRecord(snapshot)) {
+    throw new Error("Malformed local ledger backup snapshot");
+  }
+}
+
+function assertSupportedSnapshotVersion(snapshot: Record<string, unknown>) {
+  if (snapshot.version !== LOCAL_LEDGER_BACKUP_SNAPSHOT_VERSION) {
+    throw new Error(
+      `Unsupported local ledger backup snapshot version: ${String(snapshot.version)}`
+    );
+  }
+}
+
+function assertVersionOneSnapshotShape(snapshot: Record<string, unknown>) {
+  const data = snapshot.data;
+  if (typeof snapshot.exportedAt !== "string" || !isRecord(data)) {
+    throw new Error("Malformed local ledger backup snapshot");
+  }
+
+  if (!hasBackupTableArrays(data) || !hasBackupTableRows(data)) {
+    throw new Error("Malformed local ledger backup snapshot");
+  }
+}
+
+function hasBackupTableArrays(data: Record<string, unknown>) {
+  return BACKUP_DATA_KEYS.every((key) => Array.isArray(data[key]));
+}
+
+function hasBackupTableRows(data: Record<string, unknown>) {
+  return BACKUP_DATA_KEYS.every((key) => {
+    const rows = data[key];
+    return Array.isArray(rows) && rows.every(isRecord);
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+const BACKUP_DATA_KEYS = [
+  "transactions",
+  "transfers",
+  "userCategories",
+  "financialAccounts",
+  "openingBalances",
+  "budgets",
+  "goals",
+  "goalContributions",
+  "captureEvidence",
+  "financialAccountIdentifiers",
+  "accountSuggestionDismissals",
+  "processedEmails",
+  "processedCaptures",
+  "syncConflicts",
+] as const;
+
+type LocalLedgerBackupSnapshotData = {
+  readonly transactions: readonly (typeof transactions.$inferSelect)[];
+  readonly transfers: readonly (typeof transfers.$inferSelect)[];
+  readonly userCategories: readonly (typeof userCategories.$inferSelect)[];
+  readonly financialAccounts: readonly (typeof financialAccounts.$inferSelect)[];
+  readonly openingBalances: readonly (typeof openingBalances.$inferSelect)[];
+  readonly budgets: readonly (typeof budgets.$inferSelect)[];
+  readonly goals: readonly (typeof goals.$inferSelect)[];
+  readonly goalContributions: readonly (typeof goalContributions.$inferSelect)[];
+  readonly captureEvidence: readonly (typeof captureEvidence.$inferSelect)[];
+  readonly financialAccountIdentifiers: readonly (typeof financialAccountIdentifiers.$inferSelect)[];
+  readonly accountSuggestionDismissals: readonly (typeof accountSuggestionDismissals.$inferSelect)[];
+  readonly processedEmails: readonly (typeof processedEmails.$inferSelect)[];
+  readonly processedCaptures: readonly (typeof processedCaptures.$inferSelect)[];
+  readonly syncConflicts: readonly (typeof syncConflicts.$inferSelect)[];
+};
+
+type BackupTable =
+  | typeof accountSuggestionDismissals
+  | typeof budgets
+  | typeof captureEvidence
+  | typeof financialAccountIdentifiers
+  | typeof financialAccounts
+  | typeof goalContributions
+  | typeof goals
+  | typeof openingBalances
+  | typeof processedCaptures
+  | typeof processedEmails
+  | typeof syncConflicts
+  | typeof transactions
+  | typeof transfers
+  | typeof userCategories;
+
+type BackupSelectDb = {
+  readonly select: () => {
+    readonly from: (table: BackupTable) => {
+      readonly all: () => Record<string, unknown>[];
+    };
+  };
+};
+
+type BackupInsertDb = {
+  readonly insert: (table: BackupTable) => {
+    readonly values: (rows: Record<string, unknown>[]) => { readonly run: () => unknown };
+  };
+};
+
+type BackupDb = BackupSelectDb &
+  BackupInsertDb & {
+    readonly transaction: (callback: (tx: BackupInsertDb) => unknown) => unknown;
+  };

--- a/apps/mobile/features/backup/public.ts
+++ b/apps/mobile/features/backup/public.ts
@@ -1,0 +1,9 @@
+export type {
+  BackupSnapshot,
+  ExportLocalLedgerBackupSnapshotOptions,
+} from "./local-ledger-snapshot";
+export {
+  exportLocalLedgerBackupSnapshot,
+  importLocalLedgerBackupSnapshot,
+  LOCAL_LEDGER_BACKUP_SNAPSHOT_VERSION,
+} from "./local-ledger-snapshot";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds versioned local ledger backup snapshots to export and import user data on mobile. Uses chunked inserts and a transaction to safely restore into a clean DB.

- **New Features**
  - Export/import via `exportLocalLedgerBackupSnapshot` and `importLocalLedgerBackupSnapshot` with `LOCAL_LEDGER_BACKUP_SNAPSHOT_VERSION = 1`, strict validation, transactional import with rollback, and bounded inserts (50 rows/chunk) to avoid SQLite limits.
  - Backs up and restores: accounts/identifiers, opening balances, transactions/transfers, budgets/goals (+contributions), capture evidence & processed items, suggestion dismissals, sync conflicts.
  - Public API re-exported from `apps/mobile/features/backup/public.ts`.
  - Integration tests cover round-trip, unsupported version, malformed snapshot and non-record rows, rollback behavior, and chunked imports.

- **Migration**
  - Backup: `exportLocalLedgerBackupSnapshot(db, { exportedAt: <ISO string> })`.
  - Restore: start with an empty target DB, then `importLocalLedgerBackupSnapshot(db, snapshot)`.

<sup>Written for commit 342c0bee661cb33bc6063dd3708202eaf3ccdfb9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

