### PR TITLE
ci(hooks): inline pre-push checks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -34,25 +34,25 @@ pre-push:
   commands:
     root-biome:
       files: git ls-files
-      run: ./scripts/run-pre-push-check.sh root-biome {files}
+      run: bun run lint
       skip_output: false
     branded-boundaries:
       files: git ls-files
-      run: ./scripts/run-pre-push-check.sh branded-boundaries {files}
+      run: bun run lint:brands
       skip_output: false
     mobile-eslint:
       files: git ls-files
-      run: ./scripts/run-pre-push-check.sh mobile-eslint {files}
+      run: bun run lint:mobile
       skip_output: false
     mobile-typecheck:
       files: git ls-files
-      run: ./scripts/run-pre-push-check.sh mobile-typecheck {files}
+      run: bun run typecheck
       skip_output: false
     complexity:
       files: git ls-files
-      run: ./scripts/run-pre-push-check.sh complexity {files}
+      run: bun run lint:complexity
       skip_output: false
     tests:
       files: git ls-files
-      run: ./scripts/run-pre-push-check.sh tests {files}
+      run: bun run test
       skip_output: false


### PR DESCRIPTION
- Inline pre-push package scripts

- Verification: lint, mobile lint, tests passed

- Blocked: branded boundaries, complexity, typecheck



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inline pre-push checks in `lefthook.yml` now run package scripts with `bun run` instead of the wrapper script. This reduces indirection and makes failures easier to read.

- **Refactors**
  - Replaced `./scripts/run-pre-push-check.sh` with direct calls: `lint`, `lint:brands`, `lint:mobile`, `typecheck`, `lint:complexity`, `test`.
  - Kept `git ls-files` inputs and `skip_output: false` as-is.

<sup>Written for commit 295839fe5c25ffb4816cbfedb0a70744f45b497f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

