### PR TITLE
feat(mobile): add private backup crypto

### DIFF
--- a/apps/mobile/__tests__/backup/encryption.test.ts
+++ b/apps/mobile/__tests__/backup/encryption.test.ts
@@ -183,24 +183,18 @@ describe("local ledger backup encryption", () => {
     });
 
     expect(() => assertLocalLedgerBackupSecretSafeForRemote(encrypted)).not.toThrow();
-    expect(() => assertLocalLedgerBackupSecretSafeForRemote(recoveryKey)).toThrow(
-      "Local ledger backup secret cannot be sent to remote services"
-    );
+    expectRemoteSecretRejection(recoveryKey);
     expect(() => assertLocalLedgerBackupSecretSafeForLog(recoveryKey)).toThrow(
       "Local ledger backup secret cannot be written to logs"
     );
-    expect(() => assertLocalLedgerBackupSecretSafeForRemote(SNAPSHOT)).toThrow(
-      "Local ledger backup secret cannot be sent to remote services"
-    );
-    expect(() =>
-      assertLocalLedgerBackupSecretSafeForRemote({ trustedDeviceSecret: "device-held-secret" })
-    ).toThrow("Local ledger backup secret cannot be sent to remote services");
-    expect(() =>
-      assertLocalLedgerBackupSecretSafeForRemote({ ...encrypted, plaintext: SNAPSHOT })
-    ).toThrow("Local ledger backup secret cannot be sent to remote services");
-    expect(() =>
-      assertLocalLedgerBackupSecretSafeForRemote({ ...encrypted, ciphertext: recoveryKey })
-    ).toThrow("Local ledger backup secret cannot be sent to remote services");
+    expectRemoteSecretRejection(SNAPSHOT);
+    expectRemoteSecretRejection({ trustedDeviceSecret: "device-held-secret" });
+    expectRemoteSecretRejection({ ...encrypted, plaintext: SNAPSHOT });
+    expectRemoteSecretRejection({ ...encrypted, ciphertext: recoveryKey });
+    expectRemoteSecretRejection({
+      ...encrypted,
+      wrappedDataKeys: [{ ...encrypted.wrappedDataKeys[0]!, rawKey: recoveryKey }],
+    });
   });
 
   it("handles cyclic payloads while checking for backup secrets", async () => {
@@ -215,3 +209,9 @@ describe("local ledger backup encryption", () => {
     );
   });
 });
+
+function expectRemoteSecretRejection(value: unknown) {
+  expect(() => assertLocalLedgerBackupSecretSafeForRemote(value)).toThrow(
+    "Local ledger backup secret cannot be sent to remote services"
+  );
+}

--- a/apps/mobile/__tests__/backup/encryption.test.ts
+++ b/apps/mobile/__tests__/backup/encryption.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import type { BackupSnapshot } from "@/features/backup/public";
+import {
+  assertLocalLedgerBackupSecretSafeForLog,
+  assertLocalLedgerBackupSecretSafeForRemote,
+  type BackupDecryptError,
+  decryptLocalLedgerBackupSnapshot,
+  encryptLocalLedgerBackupSnapshot,
+  generateBackupRecoveryKey,
+  rotateLocalLedgerBackupRecoveryKey,
+} from "@/features/backup/public";
+
+const SNAPSHOT = {
+  version: 1,
+  exportedAt: "2026-04-23T10:30:00.000Z",
+  data: {
+    transactions: [{ id: "txn-1", description: "Lunch", amount: 42000 }],
+    transfers: [],
+    userCategories: [],
+    financialAccounts: [],
+    openingBalances: [],
+    budgets: [],
+    goals: [],
+    goalContributions: [],
+    captureEvidence: [],
+    financialAccountIdentifiers: [],
+    accountSuggestionDismissals: [],
+    processedEmails: [],
+    processedCaptures: [],
+    syncConflicts: [],
+  },
+} as unknown as BackupSnapshot;
+
+describe("local ledger backup encryption", () => {
+  it("creates an encrypted backup that a trusted device can unlock before a Recovery Key is saved", async () => {
+    const encrypted = await encryptLocalLedgerBackupSnapshot(SNAPSHOT, {
+      trustedDeviceSecret: "device-held-secret",
+    });
+
+    await expect(
+      decryptLocalLedgerBackupSnapshot(encrypted, { trustedDeviceSecret: "device-held-secret" })
+    ).resolves.toEqual(SNAPSHOT);
+    expect(encrypted.wrappedDataKeys.map((wrapped) => wrapped.kind)).toEqual(["trusted_device"]);
+    expect(JSON.stringify(encrypted)).not.toContain("Lunch");
+    expect(JSON.stringify(encrypted)).not.toContain("txn-1");
+  });
+
+  it("adds a confirmed Recovery Key so a new device can unlock the backup", async () => {
+    const recoveryKey = generateBackupRecoveryKey();
+
+    const encrypted = await encryptLocalLedgerBackupSnapshot(SNAPSHOT, {
+      trustedDeviceSecret: "device-held-secret",
+      recoveryKey,
+      confirmedRecoveryKey: recoveryKey,
+    });
+
+    await expect(decryptLocalLedgerBackupSnapshot(encrypted, { recoveryKey })).resolves.toEqual(
+      SNAPSHOT
+    );
+    expect(encrypted.wrappedDataKeys.map((wrapped) => wrapped.kind)).toEqual([
+      "trusted_device",
+      "recovery_key",
+    ]);
+  });
+
+  it("classifies a wrong Recovery Key without decrypting the snapshot", async () => {
+    const recoveryKey = generateBackupRecoveryKey();
+    const encrypted = await encryptLocalLedgerBackupSnapshot(SNAPSHOT, {
+      trustedDeviceSecret: "device-held-secret",
+      recoveryKey,
+      confirmedRecoveryKey: recoveryKey,
+    });
+
+    await expect(
+      decryptLocalLedgerBackupSnapshot(encrypted, { recoveryKey: "RK-wrong-key" })
+    ).rejects.toMatchObject({
+      failure: "wrong_recovery_key",
+    } satisfies Partial<BackupDecryptError>);
+  });
+
+  it("classifies tampered snapshot ciphertext after a key unwraps", async () => {
+    const encrypted = await encryptLocalLedgerBackupSnapshot(SNAPSHOT, {
+      trustedDeviceSecret: "device-held-secret",
+    });
+
+    await expect(
+      decryptLocalLedgerBackupSnapshot(
+        { ...encrypted, ciphertext: `${encrypted.ciphertext.slice(0, -1)}!` },
+        { trustedDeviceSecret: "device-held-secret" }
+      )
+    ).rejects.toMatchObject({
+      failure: "tampered_ciphertext",
+    } satisfies Partial<BackupDecryptError>);
+  });
+
+  it("requires Recovery Key confirmation before marking a backup fully recoverable", async () => {
+    await expect(
+      encryptLocalLedgerBackupSnapshot(SNAPSHOT, {
+        trustedDeviceSecret: "device-held-secret",
+        recoveryKey: "RK-current",
+        confirmedRecoveryKey: "RK-different",
+      })
+    ).rejects.toThrow("Recovery Key confirmation does not match");
+  });
+
+  it("classifies malformed wrapped key metadata before trying recovery material", async () => {
+    const encrypted = await encryptLocalLedgerBackupSnapshot(SNAPSHOT, {
+      trustedDeviceSecret: "device-held-secret",
+    });
+
+    await expect(
+      decryptLocalLedgerBackupSnapshot(
+        {
+          ...encrypted,
+          wrappedDataKeys: [
+            {
+              kind: "trusted_device",
+              algorithm: "PBKDF2-SHA256+A256GCM",
+              salt: "salt",
+              nonce: "nonce",
+              ciphertext: "ciphertext",
+              iterations: 1,
+            },
+          ],
+        },
+        { trustedDeviceSecret: "device-held-secret" }
+      )
+    ).rejects.toMatchObject({
+      failure: "malformed_wrapped_key_metadata",
+    } satisfies Partial<BackupDecryptError>);
+  });
+
+  it("classifies malformed wrapped key encoding before trying recovery material", async () => {
+    const encrypted = await encryptLocalLedgerBackupSnapshot(SNAPSHOT, {
+      trustedDeviceSecret: "device-held-secret",
+    });
+
+    await expect(
+      decryptLocalLedgerBackupSnapshot(
+        {
+          ...encrypted,
+          wrappedDataKeys: [{ ...encrypted.wrappedDataKeys[0]!, salt: "not base64" }],
+        },
+        { trustedDeviceSecret: "device-held-secret" }
+      )
+    ).rejects.toMatchObject({
+      failure: "malformed_wrapped_key_metadata",
+    } satisfies Partial<BackupDecryptError>);
+  });
+
+  it("rotates Recovery Key wrapping without changing encrypted snapshot ciphertext", async () => {
+    const oldRecoveryKey = generateBackupRecoveryKey();
+    const newRecoveryKey = generateBackupRecoveryKey();
+    const encrypted = await encryptLocalLedgerBackupSnapshot(SNAPSHOT, {
+      trustedDeviceSecret: "device-held-secret",
+      recoveryKey: oldRecoveryKey,
+      confirmedRecoveryKey: oldRecoveryKey,
+    });
+
+    const rotated = await rotateLocalLedgerBackupRecoveryKey(encrypted, {
+      currentRecoveryKey: oldRecoveryKey,
+      newRecoveryKey,
+      confirmedNewRecoveryKey: newRecoveryKey,
+    });
+
+    expect(rotated.ciphertext).toBe(encrypted.ciphertext);
+    await expect(
+      decryptLocalLedgerBackupSnapshot(rotated, { recoveryKey: newRecoveryKey })
+    ).resolves.toEqual(SNAPSHOT);
+    await expect(
+      decryptLocalLedgerBackupSnapshot(rotated, { recoveryKey: oldRecoveryKey })
+    ).rejects.toMatchObject({
+      failure: "wrong_recovery_key",
+    } satisfies Partial<BackupDecryptError>);
+  });
+
+  it("rejects backup secrets before remote transport or logging", async () => {
+    const recoveryKey = generateBackupRecoveryKey();
+    const encrypted = await encryptLocalLedgerBackupSnapshot(SNAPSHOT, {
+      trustedDeviceSecret: "device-held-secret",
+      recoveryKey,
+      confirmedRecoveryKey: recoveryKey,
+    });
+
+    expect(() => assertLocalLedgerBackupSecretSafeForRemote(encrypted)).not.toThrow();
+    expect(() => assertLocalLedgerBackupSecretSafeForRemote(recoveryKey)).toThrow(
+      "Local ledger backup secret cannot be sent to remote services"
+    );
+    expect(() => assertLocalLedgerBackupSecretSafeForLog(recoveryKey)).toThrow(
+      "Local ledger backup secret cannot be written to logs"
+    );
+    expect(() => assertLocalLedgerBackupSecretSafeForRemote(SNAPSHOT)).toThrow(
+      "Local ledger backup secret cannot be sent to remote services"
+    );
+    expect(() =>
+      assertLocalLedgerBackupSecretSafeForRemote({ trustedDeviceSecret: "device-held-secret" })
+    ).toThrow("Local ledger backup secret cannot be sent to remote services");
+    expect(() =>
+      assertLocalLedgerBackupSecretSafeForRemote({ ...encrypted, plaintext: SNAPSHOT })
+    ).toThrow("Local ledger backup secret cannot be sent to remote services");
+  });
+});

--- a/apps/mobile/__tests__/backup/encryption.test.ts
+++ b/apps/mobile/__tests__/backup/encryption.test.ts
@@ -198,5 +198,20 @@ describe("local ledger backup encryption", () => {
     expect(() =>
       assertLocalLedgerBackupSecretSafeForRemote({ ...encrypted, plaintext: SNAPSHOT })
     ).toThrow("Local ledger backup secret cannot be sent to remote services");
+    expect(() =>
+      assertLocalLedgerBackupSecretSafeForRemote({ ...encrypted, ciphertext: recoveryKey })
+    ).toThrow("Local ledger backup secret cannot be sent to remote services");
+  });
+
+  it("handles cyclic payloads while checking for backup secrets", async () => {
+    const recoveryKey = generateBackupRecoveryKey();
+    const cyclicPayload: Record<string, unknown> = {};
+    cyclicPayload.self = cyclicPayload;
+
+    expect(() => assertLocalLedgerBackupSecretSafeForRemote(cyclicPayload)).not.toThrow();
+    cyclicPayload.recoveryKey = recoveryKey;
+    expect(() => assertLocalLedgerBackupSecretSafeForRemote(cyclicPayload)).toThrow(
+      "Local ledger backup secret cannot be sent to remote services"
+    );
   });
 });

--- a/apps/mobile/features/backup/local-ledger-crypto.ts
+++ b/apps/mobile/features/backup/local-ledger-crypto.ts
@@ -1,0 +1,104 @@
+export async function deriveWrappingKey(
+  secret: string,
+  salt: Uint8Array,
+  options: { readonly keyBytes: number; readonly iterations: number }
+): Promise<Uint8Array> {
+  const keyMaterial = await crypto.subtle.importKey(
+    "raw",
+    toPlainBufferSource(encodeUtf8(secret)),
+    "PBKDF2",
+    false,
+    ["deriveBits"]
+  );
+  const bits = await crypto.subtle.deriveBits(
+    {
+      name: "PBKDF2",
+      hash: "SHA-256",
+      salt: toPlainBufferSource(salt),
+      iterations: options.iterations,
+    },
+    keyMaterial,
+    options.keyBytes * 8
+  );
+  return new Uint8Array(bits);
+}
+
+export async function encryptAesGcm(
+  rawKey: Uint8Array,
+  nonce: Uint8Array,
+  plaintext: Uint8Array
+): Promise<Uint8Array> {
+  const key = await importAesGcmKey(rawKey, ["encrypt"]);
+  const encrypted = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv: toPlainBufferSource(nonce) },
+    key,
+    toPlainBufferSource(plaintext)
+  );
+  return new Uint8Array(encrypted);
+}
+
+export async function decryptAesGcm(
+  rawKey: Uint8Array,
+  nonce: Uint8Array,
+  ciphertext: Uint8Array
+): Promise<Uint8Array> {
+  const key = await importAesGcmKey(rawKey, ["decrypt"]);
+  const decrypted = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: toPlainBufferSource(nonce) },
+    key,
+    toPlainBufferSource(ciphertext)
+  );
+  return new Uint8Array(decrypted);
+}
+
+export const getRandomBytes = (length: number): Uint8Array => {
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+  return bytes;
+};
+
+export const encodeJson = (value: unknown): Uint8Array => {
+  return encodeUtf8(JSON.stringify(value));
+};
+
+export const decodeUtf8 = (value: Uint8Array): string => {
+  return new TextDecoder().decode(value);
+};
+
+export const toBase64 = (value: Uint8Array): string => {
+  return btoa(Array.from(value, (byte) => String.fromCodePoint(byte)).join(""));
+};
+
+export const fromBase64 = (value: string): Uint8Array => {
+  return Uint8Array.from(atob(value), (char) => char.codePointAt(0) ?? 0);
+};
+
+export const isBase64String = (value: unknown): boolean => {
+  if (typeof value !== "string" || value.length === 0) {
+    return false;
+  }
+
+  try {
+    return toBase64(fromBase64(value)) === value;
+  } catch (_error) {
+    return false;
+  }
+};
+
+export const toHex = (value: Uint8Array): string => {
+  return Array.from(value, (byte) => byte.toString(16).padStart(2, "0").toUpperCase()).join("");
+};
+
+function importAesGcmKey(rawKey: Uint8Array, usages: readonly KeyUsage[]): Promise<CryptoKey> {
+  return crypto.subtle.importKey("raw", toPlainBufferSource(rawKey), "AES-GCM", false, [...usages]);
+}
+
+function encodeUtf8(value: string): Uint8Array {
+  return new TextEncoder().encode(value);
+}
+
+function toPlainBufferSource(value: Uint8Array): BufferSource {
+  const copy = new Uint8Array(new ArrayBuffer(value.byteLength));
+  copy.set(value);
+  return copy;
+}

--- a/apps/mobile/features/backup/local-ledger-encryption-metadata.ts
+++ b/apps/mobile/features/backup/local-ledger-encryption-metadata.ts
@@ -1,0 +1,64 @@
+import { isBase64String } from "./local-ledger-crypto";
+import type {
+  BackupWrappedDataKey,
+  EncryptedLocalLedgerBackupSnapshot,
+} from "./local-ledger-encryption";
+
+export function isEncryptedBackupMetadataValid(
+  encrypted: EncryptedLocalLedgerBackupSnapshot,
+  options: {
+    readonly encryptedBackupVersion: number;
+    readonly wrapIterations: number;
+  }
+) {
+  return (
+    metadataScalarsAreValid(encrypted, options.encryptedBackupVersion) &&
+    wrappedDataKeysAreValid(encrypted.wrappedDataKeys, options.wrapIterations)
+  );
+}
+
+function isValidWrappedDataKey(
+  wrappedDataKey: unknown,
+  wrapIterations: number
+): wrappedDataKey is BackupWrappedDataKey {
+  const record = toRecord(wrappedDataKey);
+  return record !== null && wrappedDataKeyRecordIsValid(record, wrapIterations);
+}
+
+function metadataScalarsAreValid(
+  encrypted: EncryptedLocalLedgerBackupSnapshot,
+  encryptedBackupVersion: number
+) {
+  return [
+    encrypted.version === encryptedBackupVersion,
+    encrypted.algorithm === "AES-GCM",
+    typeof encrypted.ciphertext === "string",
+    typeof encrypted.nonce === "string",
+  ].every(Boolean);
+}
+
+function wrappedDataKeysAreValid(wrappedDataKeys: unknown, wrapIterations: number) {
+  return (
+    Array.isArray(wrappedDataKeys) &&
+    wrappedDataKeys.length > 0 &&
+    wrappedDataKeys.every((wrappedDataKey) => isValidWrappedDataKey(wrappedDataKey, wrapIterations))
+  );
+}
+
+function wrappedDataKeyRecordIsValid(record: Record<string, unknown>, wrapIterations: number) {
+  return [
+    record.kind === "trusted_device" || record.kind === "recovery_key",
+    record.algorithm === "PBKDF2-SHA256+A256GCM",
+    isBase64String(record.salt),
+    isBase64String(record.nonce),
+    isBase64String(record.ciphertext),
+    record.iterations === wrapIterations,
+  ].every(Boolean);
+}
+
+function toRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}

--- a/apps/mobile/features/backup/local-ledger-encryption.ts
+++ b/apps/mobile/features/backup/local-ledger-encryption.ts
@@ -1,0 +1,284 @@
+import {
+  decodeUtf8,
+  decryptAesGcm,
+  deriveWrappingKey,
+  encodeJson,
+  encryptAesGcm,
+  fromBase64,
+  getRandomBytes,
+  toBase64,
+  toHex,
+} from "./local-ledger-crypto";
+import { isEncryptedBackupMetadataValid } from "./local-ledger-encryption-metadata";
+import { containsLocalLedgerBackupSecret } from "./local-ledger-secret-guard";
+import type { BackupSnapshot } from "./local-ledger-snapshot";
+
+export const LOCAL_LEDGER_ENCRYPTED_BACKUP_VERSION = 1;
+
+export type BackupDecryptFailure =
+  | "wrong_recovery_key"
+  | "wrong_trusted_device_secret"
+  | "missing_key_material"
+  | "tampered_ciphertext"
+  | "malformed_wrapped_key_metadata";
+
+export class BackupDecryptError extends Error {
+  constructor(readonly failure: BackupDecryptFailure) {
+    super(`Unable to decrypt local ledger backup: ${failure}`);
+    this.name = "BackupDecryptError";
+  }
+}
+
+export type BackupWrappedDataKeyKind = "trusted_device" | "recovery_key";
+
+export type EncryptedLocalLedgerBackupSnapshot = {
+  readonly version: typeof LOCAL_LEDGER_ENCRYPTED_BACKUP_VERSION;
+  readonly algorithm: "AES-GCM";
+  readonly ciphertext: string;
+  readonly nonce: string;
+  readonly wrappedDataKeys: readonly BackupWrappedDataKey[];
+};
+
+export type BackupWrappedDataKey = {
+  readonly kind: BackupWrappedDataKeyKind;
+  readonly algorithm: "PBKDF2-SHA256+A256GCM";
+  readonly salt: string;
+  readonly nonce: string;
+  readonly ciphertext: string;
+  readonly iterations: number;
+};
+
+export type EncryptLocalLedgerBackupSnapshotOptions = {
+  readonly trustedDeviceSecret: string;
+  readonly recoveryKey?: string;
+  readonly confirmedRecoveryKey?: string;
+};
+
+export type DecryptLocalLedgerBackupSnapshotOptions = {
+  readonly trustedDeviceSecret?: string;
+  readonly recoveryKey?: string;
+};
+
+export type RotateLocalLedgerBackupRecoveryKeyOptions = {
+  readonly currentRecoveryKey: string;
+  readonly newRecoveryKey: string;
+  readonly confirmedNewRecoveryKey: string;
+};
+
+const DATA_KEY_BYTES = 32;
+const GCM_NONCE_BYTES = 12;
+const RECOVERY_KEY_PARTS = 6;
+const RECOVERY_KEY_PART_BYTES = 2;
+const WRAP_SALT_BYTES = 16;
+const WRAP_ITERATIONS = 210_000;
+
+export function generateBackupRecoveryKey(): string {
+  return `RK-${Array.from({ length: RECOVERY_KEY_PARTS }, () =>
+    toHex(getRandomBytes(RECOVERY_KEY_PART_BYTES))
+  ).join("-")}`;
+}
+
+export async function encryptLocalLedgerBackupSnapshot(
+  snapshot: BackupSnapshot,
+  options: EncryptLocalLedgerBackupSnapshotOptions
+): Promise<EncryptedLocalLedgerBackupSnapshot> {
+  assertRecoveryKeyConfirmation(options);
+  const dataKey = getRandomBytes(DATA_KEY_BYTES);
+  const nonce = getRandomBytes(GCM_NONCE_BYTES);
+  const wrappedDataKeys = await wrapDataKeyForBackup(dataKey, options);
+  const ciphertext = await encryptAesGcm(dataKey, nonce, encodeJson(snapshot));
+
+  return {
+    version: LOCAL_LEDGER_ENCRYPTED_BACKUP_VERSION,
+    algorithm: "AES-GCM",
+    nonce: toBase64(nonce),
+    ciphertext: toBase64(ciphertext),
+    wrappedDataKeys,
+  };
+}
+
+export async function decryptLocalLedgerBackupSnapshot(
+  encrypted: EncryptedLocalLedgerBackupSnapshot,
+  options: DecryptLocalLedgerBackupSnapshotOptions
+): Promise<BackupSnapshot> {
+  assertEncryptedBackupMetadata(encrypted);
+  const dataKey = await unwrapDataKey(encrypted.wrappedDataKeys, options);
+  const plaintext = await decryptSnapshotCiphertext(encrypted, dataKey);
+  return JSON.parse(decodeUtf8(plaintext)) as BackupSnapshot;
+}
+
+export async function rotateLocalLedgerBackupRecoveryKey(
+  encrypted: EncryptedLocalLedgerBackupSnapshot,
+  options: RotateLocalLedgerBackupRecoveryKeyOptions
+): Promise<EncryptedLocalLedgerBackupSnapshot> {
+  assertRecoveryKeyConfirmation({
+    trustedDeviceSecret: "already-wrapped",
+    recoveryKey: options.newRecoveryKey,
+    confirmedRecoveryKey: options.confirmedNewRecoveryKey,
+  });
+  assertEncryptedBackupMetadata(encrypted);
+  const dataKey = await unwrapDataKey(encrypted.wrappedDataKeys, {
+    recoveryKey: options.currentRecoveryKey,
+  });
+  const nonRecoveryKeyWraps = encrypted.wrappedDataKeys.filter(
+    (wrapped) => wrapped.kind !== "recovery_key"
+  );
+  return {
+    ...encrypted,
+    wrappedDataKeys: [
+      ...nonRecoveryKeyWraps,
+      await wrapDataKey(dataKey, "recovery_key", options.newRecoveryKey),
+    ],
+  };
+}
+
+export function assertLocalLedgerBackupSecretSafeForRemote(value: unknown) {
+  if (
+    containsLocalLedgerBackupSecret(value, {
+      encryptedBackupVersion: LOCAL_LEDGER_ENCRYPTED_BACKUP_VERSION,
+    })
+  ) {
+    throw new Error("Local ledger backup secret cannot be sent to remote services");
+  }
+}
+
+export function assertLocalLedgerBackupSecretSafeForLog(value: unknown) {
+  if (
+    containsLocalLedgerBackupSecret(value, {
+      encryptedBackupVersion: LOCAL_LEDGER_ENCRYPTED_BACKUP_VERSION,
+    })
+  ) {
+    throw new Error("Local ledger backup secret cannot be written to logs");
+  }
+}
+
+function assertRecoveryKeyConfirmation(options: EncryptLocalLedgerBackupSnapshotOptions) {
+  if (options.recoveryKey !== undefined && options.recoveryKey !== options.confirmedRecoveryKey) {
+    throw new Error("Recovery Key confirmation does not match");
+  }
+}
+
+async function wrapDataKeyForBackup(
+  dataKey: Uint8Array,
+  options: EncryptLocalLedgerBackupSnapshotOptions
+): Promise<readonly BackupWrappedDataKey[]> {
+  const trustedDeviceWrap = await wrapDataKey(
+    dataKey,
+    "trusted_device",
+    options.trustedDeviceSecret
+  );
+  if (options.recoveryKey === undefined) {
+    return [trustedDeviceWrap];
+  }
+  return [trustedDeviceWrap, await wrapDataKey(dataKey, "recovery_key", options.recoveryKey)];
+}
+
+async function wrapDataKey(
+  dataKey: Uint8Array,
+  kind: BackupWrappedDataKeyKind,
+  secret: string
+): Promise<BackupWrappedDataKey> {
+  const salt = getRandomBytes(WRAP_SALT_BYTES);
+  const nonce = getRandomBytes(GCM_NONCE_BYTES);
+  const wrappingKey = await deriveWrappingKey(secret, salt, {
+    keyBytes: DATA_KEY_BYTES,
+    iterations: WRAP_ITERATIONS,
+  });
+  const ciphertext = await encryptAesGcm(wrappingKey, nonce, dataKey);
+  return {
+    kind,
+    algorithm: "PBKDF2-SHA256+A256GCM",
+    salt: toBase64(salt),
+    nonce: toBase64(nonce),
+    ciphertext: toBase64(ciphertext),
+    iterations: WRAP_ITERATIONS,
+  };
+}
+
+async function unwrapDataKey(
+  wrappedDataKeys: readonly BackupWrappedDataKey[],
+  options: DecryptLocalLedgerBackupSnapshotOptions
+): Promise<Uint8Array> {
+  const candidates = getUnwrapCandidates(wrappedDataKeys, options);
+  if (candidates.length === 0) {
+    throw new BackupDecryptError("missing_key_material");
+  }
+  return unwrapFirstCandidate(candidates);
+}
+
+async function unwrapFirstCandidate(
+  candidates: readonly { readonly wrappedDataKey: BackupWrappedDataKey; readonly secret: string }[]
+): Promise<Uint8Array> {
+  const [candidate, ...rest] = candidates;
+  if (candidate === undefined) {
+    throw new BackupDecryptError("missing_key_material");
+  }
+
+  try {
+    const wrappingKey = await deriveWrappingKey(
+      candidate.secret,
+      fromBase64(candidate.wrappedDataKey.salt),
+      {
+        keyBytes: DATA_KEY_BYTES,
+        iterations: WRAP_ITERATIONS,
+      }
+    );
+    return await decryptAesGcm(
+      wrappingKey,
+      fromBase64(candidate.wrappedDataKey.nonce),
+      fromBase64(candidate.wrappedDataKey.ciphertext)
+    );
+  } catch (_error) {
+    if (rest.length > 0) {
+      return unwrapFirstCandidate(rest);
+    }
+    throw new BackupDecryptError(failureForWrappedKeyKind(candidate.wrappedDataKey.kind));
+  }
+}
+
+function getUnwrapCandidates(
+  wrappedDataKeys: readonly BackupWrappedDataKey[],
+  options: DecryptLocalLedgerBackupSnapshotOptions
+) {
+  return wrappedDataKeys.flatMap((wrappedDataKey) => {
+    if (wrappedDataKey.kind === "trusted_device" && options.trustedDeviceSecret !== undefined) {
+      return [{ wrappedDataKey, secret: options.trustedDeviceSecret }];
+    }
+    if (wrappedDataKey.kind === "recovery_key" && options.recoveryKey !== undefined) {
+      return [{ wrappedDataKey, secret: options.recoveryKey }];
+    }
+    return [];
+  });
+}
+
+function failureForWrappedKeyKind(kind: BackupWrappedDataKeyKind): BackupDecryptFailure {
+  return kind === "recovery_key" ? "wrong_recovery_key" : "wrong_trusted_device_secret";
+}
+
+async function decryptSnapshotCiphertext(
+  encrypted: EncryptedLocalLedgerBackupSnapshot,
+  dataKey: Uint8Array
+): Promise<Uint8Array> {
+  try {
+    return await decryptAesGcm(
+      dataKey,
+      fromBase64(encrypted.nonce),
+      fromBase64(encrypted.ciphertext)
+    );
+  } catch (_error) {
+    throw new BackupDecryptError("tampered_ciphertext");
+  }
+}
+
+function assertEncryptedBackupMetadata(
+  encrypted: EncryptedLocalLedgerBackupSnapshot
+): asserts encrypted is EncryptedLocalLedgerBackupSnapshot {
+  if (!isEncryptedBackupMetadataValid(encrypted, metadataValidationOptions)) {
+    throw new BackupDecryptError("malformed_wrapped_key_metadata");
+  }
+}
+
+const metadataValidationOptions = {
+  encryptedBackupVersion: LOCAL_LEDGER_ENCRYPTED_BACKUP_VERSION,
+  wrapIterations: WRAP_ITERATIONS,
+};

--- a/apps/mobile/features/backup/local-ledger-secret-guard.ts
+++ b/apps/mobile/features/backup/local-ledger-secret-guard.ts
@@ -119,7 +119,10 @@ function wrappedDataKeyIsWellFormed(entry: unknown) {
 }
 
 function wrappedDataKeyFieldsAreWellFormed(record: Record<string, unknown>) {
-  return WRAPPED_DATA_KEY_FIELD_CHECKS.every((check) => check(record));
+  return (
+    Object.keys(record).every((key) => WRAPPED_DATA_KEY_FIELDS.includes(key)) &&
+    WRAPPED_DATA_KEY_FIELD_CHECKS.every((check) => check(record))
+  );
 }
 
 function unseenObjectContainsSecret(
@@ -173,6 +176,15 @@ const WRAPPED_DATA_KEY_FIELD_CHECKS = [
   (record: Record<string, unknown>) => isBase64String(record.ciphertext),
   (record: Record<string, unknown>) => typeof record.iterations === "number",
 ] as const;
+
+const WRAPPED_DATA_KEY_FIELDS: readonly string[] = [
+  "kind",
+  "algorithm",
+  "salt",
+  "nonce",
+  "ciphertext",
+  "iterations",
+];
 
 type SecretScanContext = {
   readonly encryptedBackupVersion: number;

--- a/apps/mobile/features/backup/local-ledger-secret-guard.ts
+++ b/apps/mobile/features/backup/local-ledger-secret-guard.ts
@@ -1,0 +1,133 @@
+export function containsLocalLedgerBackupSecret(
+  value: unknown,
+  options: { readonly encryptedBackupVersion: number }
+): boolean {
+  return (
+    isStringSecret(value) ||
+    isBinarySecret(value) ||
+    isContainerSecret(value, options.encryptedBackupVersion)
+  );
+}
+
+function isStringSecret(value: unknown) {
+  return typeof value === "string" && looksLikeRecoveryKey(value);
+}
+
+function isBinarySecret(value: unknown) {
+  return ArrayBuffer.isView(value);
+}
+
+function isContainerSecret(value: unknown, encryptedBackupVersion: number) {
+  if (Array.isArray(value)) {
+    return value.some((entry) =>
+      containsLocalLedgerBackupSecret(entry, { encryptedBackupVersion })
+    );
+  }
+
+  const record = toRecord(value);
+  if (record === null) {
+    return false;
+  }
+
+  return isRecordSecret(record, encryptedBackupVersion);
+}
+
+function isRecordSecret(value: Record<string, unknown>, encryptedBackupVersion: number) {
+  if (isPlaintextBackupSnapshot(value)) {
+    return true;
+  }
+
+  return entriesContainSecret(
+    value,
+    isEncryptedBackupSnapshot(value, encryptedBackupVersion),
+    encryptedBackupVersion
+  );
+}
+
+function entriesContainSecret(
+  value: Record<string, unknown>,
+  encryptedBackupShape: boolean,
+  encryptedBackupVersion: number
+) {
+  const context = { encryptedBackupShape, encryptedBackupVersion };
+  return Object.entries(value).some(([key, entry]) => entryContainsSecret(key, entry, context));
+}
+
+function entryContainsSecret(
+  key: string,
+  entry: unknown,
+  context: { readonly encryptedBackupShape: boolean; readonly encryptedBackupVersion: number }
+) {
+  if (isSafeEncryptedBackupEntry(key, context.encryptedBackupShape)) {
+    return false;
+  }
+
+  return (
+    isSecretKeyName(key) ||
+    containsLocalLedgerBackupSecret(entry, {
+      encryptedBackupVersion: context.encryptedBackupVersion,
+    })
+  );
+}
+
+function isSafeEncryptedBackupEntry(key: string, encryptedBackupShape: boolean) {
+  return encryptedBackupShape && isEncryptedBackupField(key);
+}
+
+function looksLikeRecoveryKey(value: string) {
+  return /^RK-([0-9A-F]{4}-){5}[0-9A-F]{4}$/u.test(value);
+}
+
+function isSecretKeyName(key: string) {
+  const normalizedKey = key.toLowerCase();
+  return (
+    normalizedKey === "plaintext" ||
+    SECRET_KEY_NAME_FRAGMENTS.some((fragment) => normalizedKey.includes(fragment))
+  );
+}
+
+function isPlaintextBackupSnapshot(value: Record<string, unknown>) {
+  return (
+    value.version === 1 && typeof value.exportedAt === "string" && toRecord(value.data) !== null
+  );
+}
+
+function isEncryptedBackupSnapshot(value: Record<string, unknown>, encryptedBackupVersion: number) {
+  return (
+    value.version === encryptedBackupVersion &&
+    value.algorithm === "AES-GCM" &&
+    typeof value.ciphertext === "string" &&
+    typeof value.nonce === "string" &&
+    Array.isArray(value.wrappedDataKeys)
+  );
+}
+
+function isEncryptedBackupField(key: string) {
+  return ENCRYPTED_BACKUP_FIELDS.includes(key);
+}
+
+function toRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+const SECRET_KEY_NAME_FRAGMENTS = [
+  "recoverykey",
+  "recovery_key",
+  "trusteddevicesecret",
+  "trusted_device_secret",
+  "rawkey",
+  "raw_key",
+  "derivedkey",
+  "derived_key",
+] as const;
+
+const ENCRYPTED_BACKUP_FIELDS: readonly string[] = [
+  "version",
+  "algorithm",
+  "ciphertext",
+  "nonce",
+  "wrappedDataKeys",
+];

--- a/apps/mobile/features/backup/local-ledger-secret-guard.ts
+++ b/apps/mobile/features/backup/local-ledger-secret-guard.ts
@@ -1,12 +1,18 @@
+import { isBase64String } from "./local-ledger-crypto";
+
 export function containsLocalLedgerBackupSecret(
   value: unknown,
   options: { readonly encryptedBackupVersion: number }
 ): boolean {
-  return (
-    isStringSecret(value) ||
-    isBinarySecret(value) ||
-    isContainerSecret(value, options.encryptedBackupVersion)
-  );
+  const context = {
+    encryptedBackupVersion: options.encryptedBackupVersion,
+    seen: new WeakSet<object>(),
+  };
+  return containsSecret(value, context);
+}
+
+function containsSecret(value: unknown, context: SecretScanContext): boolean {
+  return isStringSecret(value) || isBinarySecret(value) || isContainerSecret(value, context);
 }
 
 function isStringSecret(value: unknown) {
@@ -17,10 +23,10 @@ function isBinarySecret(value: unknown) {
   return ArrayBuffer.isView(value);
 }
 
-function isContainerSecret(value: unknown, encryptedBackupVersion: number) {
+function isContainerSecret(value: unknown, context: SecretScanContext) {
   if (Array.isArray(value)) {
-    return value.some((entry) =>
-      containsLocalLedgerBackupSecret(entry, { encryptedBackupVersion })
+    return unseenObjectContainsSecret(value, context, () =>
+      value.some((entry) => containsSecret(entry, context))
     );
   }
 
@@ -29,49 +35,42 @@ function isContainerSecret(value: unknown, encryptedBackupVersion: number) {
     return false;
   }
 
-  return isRecordSecret(record, encryptedBackupVersion);
+  return unseenObjectContainsSecret(record, context, () => isRecordSecret(record, context));
 }
 
-function isRecordSecret(value: Record<string, unknown>, encryptedBackupVersion: number) {
+function isRecordSecret(value: Record<string, unknown>, context: SecretScanContext) {
   if (isPlaintextBackupSnapshot(value)) {
     return true;
   }
 
-  return entriesContainSecret(
-    value,
-    isEncryptedBackupSnapshot(value, encryptedBackupVersion),
-    encryptedBackupVersion
-  );
+  return entriesContainSecret(value, isEncryptedBackupSnapshot(value, context), context);
 }
 
 function entriesContainSecret(
   value: Record<string, unknown>,
   encryptedBackupShape: boolean,
-  encryptedBackupVersion: number
+  context: SecretScanContext
 ) {
-  const context = { encryptedBackupShape, encryptedBackupVersion };
-  return Object.entries(value).some(([key, entry]) => entryContainsSecret(key, entry, context));
+  return Object.entries(value).some(([key, entry]) => {
+    const entryContext = { ...context, encryptedBackupShape };
+    return entryContainsSecret(key, entry, entryContext);
+  });
 }
 
 function entryContainsSecret(
   key: string,
   entry: unknown,
-  context: { readonly encryptedBackupShape: boolean; readonly encryptedBackupVersion: number }
+  context: SecretScanContext & { readonly encryptedBackupShape: boolean }
 ) {
-  if (isSafeEncryptedBackupEntry(key, context.encryptedBackupShape)) {
+  if (isSafeEncryptedBackupEntry(key, entry, context.encryptedBackupShape)) {
     return false;
   }
 
-  return (
-    isSecretKeyName(key) ||
-    containsLocalLedgerBackupSecret(entry, {
-      encryptedBackupVersion: context.encryptedBackupVersion,
-    })
-  );
+  return isSecretKeyName(key) || containsSecret(entry, context);
 }
 
-function isSafeEncryptedBackupEntry(key: string, encryptedBackupShape: boolean) {
-  return encryptedBackupShape && isEncryptedBackupField(key);
+function isSafeEncryptedBackupEntry(key: string, entry: unknown, encryptedBackupShape: boolean) {
+  return encryptedBackupShape && encryptedBackupEntryIsWellFormed(key, entry);
 }
 
 function looksLikeRecoveryKey(value: string) {
@@ -92,9 +91,9 @@ function isPlaintextBackupSnapshot(value: Record<string, unknown>) {
   );
 }
 
-function isEncryptedBackupSnapshot(value: Record<string, unknown>, encryptedBackupVersion: number) {
+function isEncryptedBackupSnapshot(value: Record<string, unknown>, context: SecretScanContext) {
   return (
-    value.version === encryptedBackupVersion &&
+    value.version === context.encryptedBackupVersion &&
     value.algorithm === "AES-GCM" &&
     typeof value.ciphertext === "string" &&
     typeof value.nonce === "string" &&
@@ -102,8 +101,38 @@ function isEncryptedBackupSnapshot(value: Record<string, unknown>, encryptedBack
   );
 }
 
-function isEncryptedBackupField(key: string) {
-  return ENCRYPTED_BACKUP_FIELDS.includes(key);
+function encryptedBackupEntryIsWellFormed(key: string, entry: unknown) {
+  return encryptedBackupFieldValidator(key)(entry);
+}
+
+function encryptedBackupFieldValidator(key: string): (entry: unknown) => boolean {
+  return ENCRYPTED_BACKUP_FIELD_VALIDATORS[key] ?? alwaysUnsafe;
+}
+
+function wrappedDataKeysAreWellFormed(entry: unknown) {
+  return Array.isArray(entry) && entry.every(wrappedDataKeyIsWellFormed);
+}
+
+function wrappedDataKeyIsWellFormed(entry: unknown) {
+  const record = toRecord(entry);
+  return record !== null && wrappedDataKeyFieldsAreWellFormed(record);
+}
+
+function wrappedDataKeyFieldsAreWellFormed(record: Record<string, unknown>) {
+  return WRAPPED_DATA_KEY_FIELD_CHECKS.every((check) => check(record));
+}
+
+function unseenObjectContainsSecret(
+  value: object,
+  context: SecretScanContext,
+  scan: () => boolean
+) {
+  if (context.seen.has(value)) {
+    return false;
+  }
+
+  context.seen.add(value);
+  return scan();
 }
 
 function toRecord(value: unknown): Record<string, unknown> | null {
@@ -124,10 +153,28 @@ const SECRET_KEY_NAME_FRAGMENTS = [
   "derived_key",
 ] as const;
 
-const ENCRYPTED_BACKUP_FIELDS: readonly string[] = [
-  "version",
-  "algorithm",
-  "ciphertext",
-  "nonce",
-  "wrappedDataKeys",
-];
+const alwaysSafe = () => true;
+const alwaysUnsafe = () => false;
+
+const ENCRYPTED_BACKUP_FIELD_VALIDATORS: Record<string, (entry: unknown) => boolean> = {
+  algorithm: alwaysSafe,
+  ciphertext: isBase64String,
+  nonce: isBase64String,
+  version: alwaysSafe,
+  wrappedDataKeys: wrappedDataKeysAreWellFormed,
+};
+
+const WRAPPED_DATA_KEY_FIELD_CHECKS = [
+  (record: Record<string, unknown>) =>
+    record.kind === "trusted_device" || record.kind === "recovery_key",
+  (record: Record<string, unknown>) => record.algorithm === "PBKDF2-SHA256+A256GCM",
+  (record: Record<string, unknown>) => isBase64String(record.salt),
+  (record: Record<string, unknown>) => isBase64String(record.nonce),
+  (record: Record<string, unknown>) => isBase64String(record.ciphertext),
+  (record: Record<string, unknown>) => typeof record.iterations === "number",
+] as const;
+
+type SecretScanContext = {
+  readonly encryptedBackupVersion: number;
+  readonly seen: WeakSet<object>;
+};

--- a/apps/mobile/features/backup/public.ts
+++ b/apps/mobile/features/backup/public.ts
@@ -1,4 +1,23 @@
 export type {
+  BackupDecryptFailure,
+  BackupWrappedDataKey,
+  BackupWrappedDataKeyKind,
+  DecryptLocalLedgerBackupSnapshotOptions,
+  EncryptedLocalLedgerBackupSnapshot,
+  EncryptLocalLedgerBackupSnapshotOptions,
+  RotateLocalLedgerBackupRecoveryKeyOptions,
+} from "./local-ledger-encryption";
+export {
+  assertLocalLedgerBackupSecretSafeForLog,
+  assertLocalLedgerBackupSecretSafeForRemote,
+  BackupDecryptError,
+  decryptLocalLedgerBackupSnapshot,
+  encryptLocalLedgerBackupSnapshot,
+  generateBackupRecoveryKey,
+  LOCAL_LEDGER_ENCRYPTED_BACKUP_VERSION,
+  rotateLocalLedgerBackupRecoveryKey,
+} from "./local-ledger-encryption";
+export type {
   BackupSnapshot,
   ExportLocalLedgerBackupSnapshotOptions,
 } from "./local-ledger-snapshot";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds end-to-end encryption for mobile local ledger backups. Supports trusted device unlock and an optional Recovery Key, with stricter secret guards and full test coverage.

- **New Features**
  - Encrypt/decrypt backups with per-backup AES-GCM data keys.
  - Wrap data keys with PBKDF2-SHA256 using a trusted device secret and optional Recovery Key.
  - Generate `RK-` Recovery Keys; rotate without re-encrypting snapshot ciphertext.
  - Validate metadata; classify errors (wrong keys, tampered ciphertext, malformed metadata).
  - Harden secret scanning to block remote/log transport; handles cyclic payloads and malformed fields.
  - Expose APIs and types in `public.ts` (`encryptLocalLedgerBackupSnapshot`, `decryptLocalLedgerBackupSnapshot`, `generateBackupRecoveryKey`, `rotateLocalLedgerBackupRecoveryKey`, guards, `BackupDecryptError`, `LOCAL_LEDGER_ENCRYPTED_BACKUP_VERSION`).
  - Add unit tests for happy paths and failure cases.

- **Bug Fixes**
  - Reject extra fields in wrapped data keys during secret scanning, so mutated backups aren’t treated as safe for remote/log transport.

<sup>Written for commit b9b46470209f2f4b2377adfb636cae1d6b430fe2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

