### PR TITLE
feat(mobile): store encrypted backups

### DIFF
--- a/apps/mobile/__tests__/backup/remote-schema.test.ts
+++ b/apps/mobile/__tests__/backup/remote-schema.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const MIGRATION = resolve(
+  __dirname,
+  "../../supabase/migrations/20260425100000_encrypted_backups.sql"
+);
+
+describe("remote encrypted backup schema", () => {
+  it("stores only encrypted backup metadata and scopes table and blob access to the owner", () => {
+    const sql = readFileSync(MIGRATION, "utf8").toLowerCase();
+
+    expect(sql).toContain("insert into storage.buckets");
+    expect(sql).toContain("'encrypted-backups'");
+    expect(sql).toContain("create table if not exists public.encrypted_backups");
+    expect(sql).toContain("id text not null");
+    expect(sql).toContain("user_id uuid not null references auth.users(id) on delete cascade");
+    expect(sql).toContain("created_at timestamptz not null");
+    expect(sql).toContain("schema_version integer not null");
+    expect(sql).toContain("app_version text not null");
+    expect(sql).toContain("device_label text not null");
+    expect(sql).toContain("ciphertext_size_bytes integer not null");
+    expect(sql).toContain("ciphertext_sha256 text not null");
+    expect(sql).toContain("alter table public.encrypted_backups enable row level security");
+    expect(sql).toContain("(select auth.uid()) = user_id");
+    expect(sql).toContain("storage.foldername(name)");
+    expect(sql).toContain("(storage.foldername(name))[1] = (select auth.uid())::text");
+    expect(sql).not.toMatch(/plaintext|raw_key|derived_key|recovery_key|recovery_phrase/u);
+  });
+});

--- a/apps/mobile/__tests__/backup/remote-storage.test.ts
+++ b/apps/mobile/__tests__/backup/remote-storage.test.ts
@@ -1,0 +1,288 @@
+// biome-ignore-all lint/style/useNamingConvention: Supabase API payloads use snake_case fields
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { describe, expect, it, vi } from "vitest";
+import type { EncryptedLocalLedgerBackupSnapshot } from "@/features/backup/public";
+import {
+  deleteEncryptedRemoteBackup,
+  downloadEncryptedRemoteBackup,
+  listEncryptedRemoteBackups,
+  uploadEncryptedRemoteBackup,
+} from "@/features/backup/public";
+import { requireBackupId, requireIsoDateTime, requireUserId } from "@/shared/types/assertions";
+
+const USER_ID = requireUserId("00000000-0000-4000-8000-000000000001");
+const BACKUP_ID = requireBackupId("backup-1");
+const CREATED_AT = requireIsoDateTime("2026-04-24T10:30:00.000Z");
+
+const ENCRYPTED_BACKUP = {
+  version: 1,
+  algorithm: "AES-GCM",
+  ciphertext: "Y2lwaGVydGV4dA==",
+  nonce: "bm9uY2U=",
+  wrappedDataKeys: [
+    {
+      kind: "recovery_key",
+      algorithm: "PBKDF2-SHA256+A256GCM",
+      salt: "c2FsdA==",
+      nonce: "d3JhcC1ub25jZQ==",
+      ciphertext: "d3JhcHBlZC1kYXRhLWtleQ==",
+      iterations: 210_000,
+    },
+  ],
+} satisfies EncryptedLocalLedgerBackupSnapshot;
+
+const FORBIDDEN_REMOTE_VALUES = [
+  "Lunch",
+  "txn-1",
+  "raw-key-material",
+  "RK-AAAA-BBBB-CCCC-DDDD-EEEE-FFFF",
+  "trusted-device-secret",
+] as const;
+
+type RemoteMetadataRow = {
+  readonly id: string;
+  readonly user_id: string;
+  readonly created_at: string;
+  readonly schema_version: number;
+  readonly app_version: string;
+  readonly device_label: string;
+  readonly ciphertext_size_bytes: number;
+  readonly ciphertext_sha256: string;
+};
+
+describe("remote encrypted backup storage", () => {
+  it("uploads encrypted backup blobs with metadata that excludes plaintext and secrets", async () => {
+    const supabase = createRemoteBackupSupabase();
+
+    const metadata = await uploadEncryptedRemoteBackup(supabase.client, remoteBackupUploadInput());
+
+    expectUploadCalls(supabase);
+    expect(metadata).toMatchObject(expectedRemoteMetadata());
+    expectRemotePayloadsToExclude(FORBIDDEN_REMOTE_VALUES, supabase.remotePayloads());
+  });
+
+  it("removes an uploaded blob when metadata persistence fails", async () => {
+    const supabase = createRemoteBackupSupabase({
+      metadataUpsertError: { message: "metadata write failed" },
+    });
+
+    await expect(
+      uploadEncryptedRemoteBackup(supabase.client, remoteBackupUploadInput())
+    ).rejects.toThrow("Unable to save encrypted backup metadata: metadata write failed");
+    expect(supabase.storageUpload).toHaveBeenCalledWith(
+      `${USER_ID}/${BACKUP_ID}.json`,
+      JSON.stringify(ENCRYPTED_BACKUP),
+      { contentType: "application/json", upsert: true }
+    );
+    expect(supabase.storageRemove).toHaveBeenCalledWith([`${USER_ID}/${BACKUP_ID}.json`]);
+  });
+
+  it("lists only encrypted backup metadata for the current user", async () => {
+    const supabase = createRemoteBackupSupabase({ metadataRows: [remoteMetadataRow()] });
+
+    await expect(listEncryptedRemoteBackups(supabase.client, USER_ID)).resolves.toEqual([
+      expectedRemoteMetadata(),
+    ]);
+    expect(supabase.metadataEq).toHaveBeenCalledWith("user_id", USER_ID);
+    expect(supabase.metadataOrder).toHaveBeenCalledWith("created_at", { ascending: false });
+    expect(supabase.storageUpload).not.toHaveBeenCalled();
+  });
+
+  it("downloads an encrypted backup blob through user-scoped metadata", async () => {
+    const supabase = createRemoteBackupSupabase({
+      metadataRows: [remoteMetadataRow()],
+      storageBody: JSON.stringify(ENCRYPTED_BACKUP),
+    });
+
+    await expect(
+      downloadEncryptedRemoteBackup(supabase.client, {
+        userId: USER_ID,
+        backupId: BACKUP_ID,
+      })
+    ).resolves.toEqual(ENCRYPTED_BACKUP);
+    expect(supabase.metadataEq).toHaveBeenCalledWith("user_id", USER_ID);
+    expect(supabase.metadataEq).toHaveBeenCalledWith("id", BACKUP_ID);
+    expect(supabase.storageDownload).toHaveBeenCalledWith(`${USER_ID}/${BACKUP_ID}.json`);
+    expectRemotePayloadsToExclude(FORBIDDEN_REMOTE_VALUES, supabase.remotePayloads());
+  });
+
+  it("rejects a downloaded blob that does not match its metadata", async () => {
+    const supabase = createRemoteBackupSupabase({
+      metadataRows: [remoteMetadataRow()],
+      storageBody: JSON.stringify({ ...ENCRYPTED_BACKUP, ciphertext: "c3RhbGU=" }),
+    });
+
+    await expect(
+      downloadEncryptedRemoteBackup(supabase.client, {
+        userId: USER_ID,
+        backupId: BACKUP_ID,
+      })
+    ).rejects.toThrow("Downloaded encrypted backup does not match metadata");
+  });
+
+  it("deletes the encrypted backup blob and user-scoped metadata row", async () => {
+    const supabase = createRemoteBackupSupabase();
+
+    await expect(
+      deleteEncryptedRemoteBackup(supabase.client, {
+        userId: USER_ID,
+        backupId: BACKUP_ID,
+      })
+    ).resolves.toBeUndefined();
+    expect(supabase.storageRemove).toHaveBeenCalledWith([`${USER_ID}/${BACKUP_ID}.json`]);
+    expect(supabase.metadataDelete).toHaveBeenCalled();
+    expect(supabase.metadataDeleteEq).toHaveBeenCalledWith("user_id", USER_ID);
+    expect(supabase.metadataDeleteEq).toHaveBeenCalledWith("id", BACKUP_ID);
+  });
+
+  it("keeps the blob when metadata deletion fails", async () => {
+    const supabase = createRemoteBackupSupabase({
+      metadataDeleteError: { message: "metadata delete failed" },
+    });
+
+    await expect(
+      deleteEncryptedRemoteBackup(supabase.client, {
+        userId: USER_ID,
+        backupId: BACKUP_ID,
+      })
+    ).rejects.toThrow("Unable to delete encrypted backup metadata: metadata delete failed");
+    expect(supabase.metadataDelete).toHaveBeenCalled();
+    expect(supabase.storageRemove).not.toHaveBeenCalled();
+  });
+});
+
+function remoteBackupUploadInput() {
+  return {
+    userId: USER_ID,
+    backupId: BACKUP_ID,
+    createdAt: CREATED_AT,
+    schemaVersion: 1,
+    appVersion: "1.2.3",
+    deviceLabel: "iPhone 17",
+    encryptedBackup: ENCRYPTED_BACKUP,
+  };
+}
+
+function expectedRemoteMetadata() {
+  return {
+    backupId: BACKUP_ID,
+    userId: USER_ID,
+    createdAt: CREATED_AT,
+    schemaVersion: 1,
+    appVersion: "1.2.3",
+    deviceLabel: "iPhone 17",
+    ciphertextSizeBytes: 10,
+    ciphertextSha256: "305531dcc50ebca31cf1d5b31e9fc76ed51f66b3b6dd5a030c6539ae6532f979",
+  };
+}
+
+function expectUploadCalls(supabase: ReturnType<typeof createRemoteBackupSupabase>) {
+  expect(supabase.storageUpload).toHaveBeenCalledWith(
+    `${USER_ID}/${BACKUP_ID}.json`,
+    JSON.stringify(ENCRYPTED_BACKUP),
+    { contentType: "application/json", upsert: true }
+  );
+  expect(supabase.metadataUpsert).toHaveBeenCalledWith(remoteMetadataRow(), {
+    onConflict: "user_id,id",
+  });
+}
+
+function remoteMetadataRow(): RemoteMetadataRow {
+  return {
+    id: BACKUP_ID,
+    user_id: USER_ID,
+    created_at: CREATED_AT,
+    schema_version: 1,
+    app_version: "1.2.3",
+    device_label: "iPhone 17",
+    ciphertext_size_bytes: 10,
+    ciphertext_sha256: "305531dcc50ebca31cf1d5b31e9fc76ed51f66b3b6dd5a030c6539ae6532f979",
+  };
+}
+
+function createRemoteBackupSupabase(
+  options: {
+    readonly metadataRows?: readonly RemoteMetadataRow[];
+    readonly metadataDeleteError?: { readonly message: string };
+    readonly metadataUpsertError?: { readonly message: string };
+    readonly storageBody?: string;
+  } = {}
+) {
+  const metadataOrder = vi.fn(() =>
+    Promise.resolve({ data: options.metadataRows ?? [], error: null })
+  );
+  const metadataSingle = vi.fn(() =>
+    Promise.resolve({ data: options.metadataRows?.[0] ?? null, error: null })
+  );
+  const metadataEq = vi.fn(() => ({
+    eq: metadataEq,
+    error: null,
+    order: metadataOrder,
+    single: metadataSingle,
+  }));
+  const metadataDeleteEq = vi.fn(() => ({
+    eq: metadataDeleteEq,
+    error: options.metadataDeleteError ?? null,
+  }));
+  const metadataSelect = vi.fn(() => ({ eq: metadataEq }));
+  const metadataDelete = vi.fn(() => ({
+    eq: metadataDeleteEq,
+    error: options.metadataDeleteError ?? null,
+  }));
+  const metadataUpsert = vi.fn(() =>
+    Promise.resolve({ error: options.metadataUpsertError ?? null })
+  );
+  const storageUpload = vi.fn(() => Promise.resolve({ error: null }));
+  const storageDownload = vi.fn(() =>
+    Promise.resolve({
+      data: { text: () => Promise.resolve(options.storageBody ?? "") },
+      error: null,
+    })
+  );
+  const storageRemove = vi.fn(() => Promise.resolve({ error: null }));
+  const table = { delete: metadataDelete, select: metadataSelect, upsert: metadataUpsert };
+  const bucket = { download: storageDownload, remove: storageRemove, upload: storageUpload };
+  const client = {
+    from: vi.fn((tableName: string) => {
+      expect(tableName).toBe("encrypted_backups");
+      return table;
+    }),
+    storage: {
+      from: vi.fn((bucketName: string) => {
+        expect(bucketName).toBe("encrypted-backups");
+        return bucket;
+      }),
+    },
+  };
+
+  return {
+    client: client as unknown as SupabaseClient,
+    metadataEq,
+    metadataOrder,
+    metadataSelect,
+    metadataSingle,
+    metadataDelete,
+    metadataDeleteEq,
+    metadataUpsert,
+    storageDownload,
+    storageRemove,
+    storageUpload,
+    remotePayloads: () => [
+      metadataEq.mock.calls,
+      metadataUpsert.mock.calls,
+      storageDownload.mock.calls,
+      storageUpload.mock.calls,
+    ],
+  };
+}
+
+function expectRemotePayloadsToExclude(
+  forbiddenValues: readonly string[],
+  remotePayloads: readonly unknown[]
+) {
+  const serialized = JSON.stringify(remotePayloads);
+  forbiddenValues.forEach((value) => {
+    expect(serialized).not.toContain(value);
+  });
+}

--- a/apps/mobile/features/backup/public.ts
+++ b/apps/mobile/features/backup/public.ts
@@ -26,3 +26,17 @@ export {
   importLocalLedgerBackupSnapshot,
   LOCAL_LEDGER_BACKUP_SNAPSHOT_VERSION,
 } from "./local-ledger-snapshot";
+export type {
+  DeleteEncryptedRemoteBackupInput,
+  DownloadEncryptedRemoteBackupInput,
+  RemoteBackupMetadata,
+  UploadEncryptedRemoteBackupInput,
+} from "./remote-storage";
+export {
+  deleteEncryptedRemoteBackup,
+  downloadEncryptedRemoteBackup,
+  listEncryptedRemoteBackups,
+  REMOTE_BACKUP_BUCKET,
+  REMOTE_BACKUP_METADATA_TABLE,
+  uploadEncryptedRemoteBackup,
+} from "./remote-storage";

--- a/apps/mobile/features/backup/remote-storage.ts
+++ b/apps/mobile/features/backup/remote-storage.ts
@@ -1,0 +1,245 @@
+// biome-ignore-all lint/style/useNamingConvention: Supabase tables use snake_case fields
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { requireBackupId, requireIsoDateTime, requireUserId } from "@/shared/types/assertions";
+import type { BackupId, IsoDateTime, UserId } from "@/shared/types/branded";
+import { fromBase64 } from "./local-ledger-crypto";
+import type { EncryptedLocalLedgerBackupSnapshot } from "./local-ledger-encryption";
+import { assertLocalLedgerBackupSecretSafeForRemote } from "./local-ledger-encryption";
+
+export const REMOTE_BACKUP_BUCKET = "encrypted-backups";
+export const REMOTE_BACKUP_METADATA_TABLE = "encrypted_backups";
+const REMOTE_BACKUP_METADATA_COLUMNS =
+  "id,user_id,created_at,schema_version,app_version,device_label,ciphertext_size_bytes,ciphertext_sha256";
+
+export type RemoteBackupMetadata = {
+  readonly userId: UserId;
+  readonly backupId: BackupId;
+  readonly createdAt: IsoDateTime;
+  readonly schemaVersion: number;
+  readonly appVersion: string;
+  readonly deviceLabel: string;
+  readonly ciphertextSizeBytes: number;
+  readonly ciphertextSha256: string;
+};
+
+export type UploadEncryptedRemoteBackupInput = {
+  readonly userId: UserId;
+  readonly backupId: BackupId;
+  readonly createdAt: IsoDateTime;
+  readonly schemaVersion: number;
+  readonly appVersion: string;
+  readonly deviceLabel: string;
+  readonly encryptedBackup: EncryptedLocalLedgerBackupSnapshot;
+};
+
+export type DownloadEncryptedRemoteBackupInput = {
+  readonly userId: UserId;
+  readonly backupId: BackupId;
+};
+
+export type DeleteEncryptedRemoteBackupInput = DownloadEncryptedRemoteBackupInput;
+
+type RemoteBackupMetadataRow = {
+  readonly id: string;
+  readonly user_id: string;
+  readonly created_at: string;
+  readonly schema_version: number;
+  readonly app_version: string;
+  readonly device_label: string;
+  readonly ciphertext_size_bytes: number;
+  readonly ciphertext_sha256: string;
+};
+
+type RemoteBackupErrorLike = {
+  readonly message?: string;
+};
+
+export async function uploadEncryptedRemoteBackup(
+  supabase: SupabaseClient,
+  input: UploadEncryptedRemoteBackupInput
+): Promise<RemoteBackupMetadata> {
+  assertLocalLedgerBackupSecretSafeForRemote(input.encryptedBackup);
+  const storagePath = buildRemoteBackupStoragePath(input.userId, input.backupId);
+  const metadata = await buildRemoteBackupMetadata(input);
+  const metadataRow = toRemoteBackupMetadataRow(metadata);
+  assertLocalLedgerBackupSecretSafeForRemote(metadataRow);
+
+  const uploadResponse = await supabase.storage
+    .from(REMOTE_BACKUP_BUCKET)
+    .upload(storagePath, JSON.stringify(input.encryptedBackup), {
+      contentType: "application/json",
+      upsert: true,
+    });
+  throwIfRemoteBackupError(uploadResponse.error, "upload encrypted backup");
+
+  const metadataResponse = await supabase
+    .from(REMOTE_BACKUP_METADATA_TABLE)
+    .upsert(metadataRow, { onConflict: "user_id,id" });
+  if (metadataResponse.error !== null) {
+    await deleteRemoteBackupObject(supabase, storagePath, "roll back encrypted backup object");
+  }
+  throwIfRemoteBackupError(metadataResponse.error, "save encrypted backup metadata");
+
+  return metadata;
+}
+
+export async function listEncryptedRemoteBackups(
+  supabase: SupabaseClient,
+  userId: UserId
+): Promise<readonly RemoteBackupMetadata[]> {
+  const response = await supabase
+    .from(REMOTE_BACKUP_METADATA_TABLE)
+    .select(REMOTE_BACKUP_METADATA_COLUMNS)
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false });
+  throwIfRemoteBackupError(response.error, "list encrypted backup metadata");
+
+  return ((response.data ?? []) as RemoteBackupMetadataRow[]).map(fromRemoteBackupMetadataRow);
+}
+
+export async function downloadEncryptedRemoteBackup(
+  supabase: SupabaseClient,
+  input: DownloadEncryptedRemoteBackupInput
+): Promise<EncryptedLocalLedgerBackupSnapshot> {
+  const metadata = await getRemoteBackupMetadata(supabase, input);
+  const response = await supabase.storage
+    .from(REMOTE_BACKUP_BUCKET)
+    .download(buildRemoteBackupStoragePath(input.userId, input.backupId));
+  throwIfRemoteBackupError(response.error, "download encrypted backup");
+  if (response.data === null) {
+    throw new Error("Unable to download encrypted backup: missing storage object");
+  }
+
+  const encryptedBackup = JSON.parse(
+    await response.data.text()
+  ) as EncryptedLocalLedgerBackupSnapshot;
+  assertLocalLedgerBackupSecretSafeForRemote(encryptedBackup);
+  await assertEncryptedBackupMatchesMetadata(encryptedBackup, metadata);
+  return encryptedBackup;
+}
+
+export async function deleteEncryptedRemoteBackup(
+  supabase: SupabaseClient,
+  input: DeleteEncryptedRemoteBackupInput
+): Promise<void> {
+  const metadataResponse = await supabase
+    .from(REMOTE_BACKUP_METADATA_TABLE)
+    .delete()
+    .eq("user_id", input.userId)
+    .eq("id", input.backupId);
+  throwIfRemoteBackupError(metadataResponse.error, "delete encrypted backup metadata");
+
+  await deleteRemoteBackupObject(
+    supabase,
+    buildRemoteBackupStoragePath(input.userId, input.backupId),
+    "delete encrypted backup object"
+  );
+}
+
+async function getRemoteBackupMetadata(
+  supabase: SupabaseClient,
+  input: DownloadEncryptedRemoteBackupInput
+): Promise<RemoteBackupMetadata> {
+  const response = await supabase
+    .from(REMOTE_BACKUP_METADATA_TABLE)
+    .select(REMOTE_BACKUP_METADATA_COLUMNS)
+    .eq("user_id", input.userId)
+    .eq("id", input.backupId)
+    .single();
+  throwIfRemoteBackupError(response.error, "load encrypted backup metadata");
+  if (response.data === null) {
+    throw new Error("Unable to load encrypted backup metadata: backup not found");
+  }
+  return fromRemoteBackupMetadataRow(response.data as RemoteBackupMetadataRow);
+}
+
+function buildRemoteBackupStoragePath(userId: UserId, backupId: BackupId) {
+  return `${userId}/${backupId}.json`;
+}
+
+async function deleteRemoteBackupObject(
+  supabase: SupabaseClient,
+  storagePath: string,
+  operation: string
+) {
+  const storageResponse = await supabase.storage.from(REMOTE_BACKUP_BUCKET).remove([storagePath]);
+  throwIfRemoteBackupError(storageResponse.error, operation);
+}
+
+async function buildRemoteBackupMetadata(
+  input: UploadEncryptedRemoteBackupInput
+): Promise<RemoteBackupMetadata> {
+  const ciphertextMetadata = await readCiphertextMetadata(input.encryptedBackup);
+  return {
+    userId: input.userId,
+    backupId: input.backupId,
+    createdAt: input.createdAt,
+    schemaVersion: input.schemaVersion,
+    appVersion: input.appVersion,
+    deviceLabel: input.deviceLabel,
+    ...ciphertextMetadata,
+  };
+}
+
+function toRemoteBackupMetadataRow(metadata: RemoteBackupMetadata): RemoteBackupMetadataRow {
+  return {
+    id: metadata.backupId,
+    user_id: metadata.userId,
+    created_at: metadata.createdAt,
+    schema_version: metadata.schemaVersion,
+    app_version: metadata.appVersion,
+    device_label: metadata.deviceLabel,
+    ciphertext_size_bytes: metadata.ciphertextSizeBytes,
+    ciphertext_sha256: metadata.ciphertextSha256,
+  };
+}
+
+function fromRemoteBackupMetadataRow(row: RemoteBackupMetadataRow): RemoteBackupMetadata {
+  return {
+    userId: requireUserId(row.user_id),
+    backupId: requireBackupId(row.id),
+    createdAt: requireIsoDateTime(row.created_at),
+    schemaVersion: row.schema_version,
+    appVersion: row.app_version,
+    deviceLabel: row.device_label,
+    ciphertextSizeBytes: row.ciphertext_size_bytes,
+    ciphertextSha256: row.ciphertext_sha256,
+  };
+}
+
+async function sha256Hex(value: Uint8Array): Promise<string> {
+  const copy = new Uint8Array(new ArrayBuffer(value.byteLength));
+  copy.set(value);
+  const digest = await crypto.subtle.digest("SHA-256", copy);
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function readCiphertextMetadata(
+  encryptedBackup: EncryptedLocalLedgerBackupSnapshot
+): Promise<Pick<RemoteBackupMetadata, "ciphertextSizeBytes" | "ciphertextSha256">> {
+  const ciphertext = fromBase64(encryptedBackup.ciphertext);
+  return {
+    ciphertextSizeBytes: ciphertext.byteLength,
+    ciphertextSha256: await sha256Hex(ciphertext),
+  };
+}
+
+async function assertEncryptedBackupMatchesMetadata(
+  encryptedBackup: EncryptedLocalLedgerBackupSnapshot,
+  metadata: RemoteBackupMetadata
+) {
+  const ciphertextMetadata = await readCiphertextMetadata(encryptedBackup);
+  if (
+    ciphertextMetadata.ciphertextSizeBytes !== metadata.ciphertextSizeBytes ||
+    ciphertextMetadata.ciphertextSha256 !== metadata.ciphertextSha256
+  ) {
+    throw new Error("Downloaded encrypted backup does not match metadata");
+  }
+}
+
+function throwIfRemoteBackupError(error: RemoteBackupErrorLike | null, operation: string) {
+  if (error !== null) {
+    throw new Error(`Unable to ${operation}: ${error.message ?? "unknown error"}`);
+  }
+}

--- a/apps/mobile/shared/lib/generate-id.ts
+++ b/apps/mobile/shared/lib/generate-id.ts
@@ -1,5 +1,6 @@
 import type {
   AccountSuggestionDismissalId,
+  BackupId,
   BillId,
   BillPaymentId,
   BudgetId,
@@ -58,6 +59,10 @@ export function generateBillId(): BillId {
 
 export function generateBillPaymentId(): BillPaymentId {
   return generateId("bp") as BillPaymentId;
+}
+
+export function generateBackupId(): BackupId {
+  return generateId("backup") as BackupId;
 }
 
 export function generateSyncQueueId(): SyncQueueId {

--- a/apps/mobile/shared/lib/index.ts
+++ b/apps/mobile/shared/lib/index.ts
@@ -39,6 +39,7 @@ export {
 } from "./format-money";
 export {
   generateAccountSuggestionDismissalId,
+  generateBackupId,
   generateBillId,
   generateBillPaymentId,
   generateBudgetId,

--- a/apps/mobile/shared/types/assertions.ts
+++ b/apps/mobile/shared/types/assertions.ts
@@ -1,4 +1,5 @@
 import type {
+  BackupId,
   BillId,
   BudgetId,
   CategoryId,
@@ -151,6 +152,10 @@ export function assertBillId(value: string): asserts value is BillId {
   assertNonEmptyString(value, "billId");
 }
 
+export function assertBackupId(value: string): asserts value is BackupId {
+  assertNonEmptyString(value, "backupId");
+}
+
 export function assertBudgetId(value: string): asserts value is BudgetId {
   assertNonEmptyString(value, "budgetId");
 }
@@ -233,6 +238,10 @@ export function requireCopAmount(value: number): CopAmount {
 
 export function requireBillId(value: string): BillId {
   return requireValue(value, assertBillId);
+}
+
+export function requireBackupId(value: string): BackupId {
+  return requireValue(value, assertBackupId);
 }
 
 export function requireBudgetId(value: string): BudgetId {

--- a/apps/mobile/shared/types/branded.ts
+++ b/apps/mobile/shared/types/branded.ts
@@ -26,6 +26,7 @@ export type ProcessedEmailId = Brand<string, "ProcessedEmailId">;
 export type DetectedSmsEventId = Brand<string, "DetectedSmsEventId">;
 export type UserCategoryId = Brand<string, "UserCategoryId">;
 export type NotificationId = Brand<string, "NotificationId">;
+export type BackupId = Brand<string, "BackupId">;
 // Server-generated (Supabase gen_random_uuid()) — no client-side generator needed
 export type PushDeviceId = Brand<string, "PushDeviceId">;
 

--- a/apps/mobile/supabase/migrations/20260425100000_encrypted_backups.sql
+++ b/apps/mobile/supabase/migrations/20260425100000_encrypted_backups.sql
@@ -1,0 +1,87 @@
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'encrypted-backups',
+  'encrypted-backups',
+  false,
+  52428800,
+  array['application/json']
+)
+on conflict (id) do update
+set
+  public = excluded.public,
+  file_size_limit = excluded.file_size_limit,
+  allowed_mime_types = excluded.allowed_mime_types;
+
+create table if not exists public.encrypted_backups (
+  id text not null,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  created_at timestamptz not null,
+  schema_version integer not null check (schema_version > 0),
+  app_version text not null check (length(trim(app_version)) > 0),
+  device_label text not null check (length(trim(device_label)) > 0),
+  ciphertext_size_bytes integer not null check (ciphertext_size_bytes > 0),
+  ciphertext_sha256 text not null check (ciphertext_sha256 ~ '^[0-9a-f]{64}$'),
+  primary key (user_id, id)
+);
+
+create index if not exists idx_encrypted_backups_user_created
+  on public.encrypted_backups (user_id, created_at desc);
+
+alter table public.encrypted_backups enable row level security;
+
+drop policy if exists "Users can read own encrypted backups" on public.encrypted_backups;
+create policy "Users can read own encrypted backups"
+  on public.encrypted_backups for select to authenticated
+  using ((select auth.uid()) = user_id);
+
+drop policy if exists "Users can insert own encrypted backups" on public.encrypted_backups;
+create policy "Users can insert own encrypted backups"
+  on public.encrypted_backups for insert to authenticated
+  with check ((select auth.uid()) = user_id);
+
+drop policy if exists "Users can update own encrypted backups" on public.encrypted_backups;
+create policy "Users can update own encrypted backups"
+  on public.encrypted_backups for update to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+drop policy if exists "Users can delete own encrypted backups" on public.encrypted_backups;
+create policy "Users can delete own encrypted backups"
+  on public.encrypted_backups for delete to authenticated
+  using ((select auth.uid()) = user_id);
+
+drop policy if exists "Users can read own encrypted backup objects" on storage.objects;
+create policy "Users can read own encrypted backup objects"
+  on storage.objects for select to authenticated
+  using (
+    bucket_id = 'encrypted-backups'
+    and (storage.foldername(name))[1] = (select auth.uid())::text
+  );
+
+drop policy if exists "Users can insert own encrypted backup objects" on storage.objects;
+create policy "Users can insert own encrypted backup objects"
+  on storage.objects for insert to authenticated
+  with check (
+    bucket_id = 'encrypted-backups'
+    and (storage.foldername(name))[1] = (select auth.uid())::text
+  );
+
+drop policy if exists "Users can update own encrypted backup objects" on storage.objects;
+create policy "Users can update own encrypted backup objects"
+  on storage.objects for update to authenticated
+  using (
+    bucket_id = 'encrypted-backups'
+    and (storage.foldername(name))[1] = (select auth.uid())::text
+  )
+  with check (
+    bucket_id = 'encrypted-backups'
+    and (storage.foldername(name))[1] = (select auth.uid())::text
+  );
+
+drop policy if exists "Users can delete own encrypted backup objects" on storage.objects;
+create policy "Users can delete own encrypted backup objects"
+  on storage.objects for delete to authenticated
+  using (
+    bucket_id = 'encrypted-backups'
+    and (storage.foldername(name))[1] = (select auth.uid())::text
+  );


### PR DESCRIPTION
- Supabase blob storage

- Owner-scoped metadata

- Remote backup API

- Full verify passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds encrypted mobile backups in Supabase with owner-scoped access and a small API to upload, list, download, and delete. Verifies downloads against metadata and ensures no plaintext or secrets leave the device.

- New Features
  - Supabase bucket `encrypted-backups` and table `encrypted_backups` with RLS on table and storage objects; JSON-only, 50MB limit; metadata only (size, SHA-256, versions, device, timestamps).
  - Remote backup API: `uploadEncryptedRemoteBackup`, `listEncryptedRemoteBackups`, `downloadEncryptedRemoteBackup`, `deleteEncryptedRemoteBackup` (exported via `features/backup/public.ts`), plus `REMOTE_BACKUP_BUCKET` and `REMOTE_BACKUP_METADATA_TABLE` and input/output types.
  - Validation: secret-safe assertions on payloads and metadata; verify downloaded blobs match size and SHA-256; upload rollback on metadata write failure and safe deletion flow.

- Migration
  - Run Supabase migration `apps/mobile/supabase/migrations/20260425100000_encrypted_backups.sql`.

<sup>Written for commit e7ff6e1b804d6cd60de0c22363141f1a92a93c30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

