### PR TITLE
[codex] fix Supabase migration deploy workflow and add smoke test migration

### DIFF
--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -28,3 +28,4 @@ jobs:
         run: supabase db push --include-all --workdir apps/mobile
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}

--- a/apps/mobile/supabase/migrations/20260425123000_smoke_test_deploy_migrations.sql
+++ b/apps/mobile/supabase/migrations/20260425123000_smoke_test_deploy_migrations.sql
@@ -1,0 +1,2 @@
+-- Smoke test migration to trigger the Deploy Migrations workflow.
+select 1;


### PR DESCRIPTION
## What changed
- Pass `SUPABASE_DB_PASSWORD` into the Deploy Migrations workflow so `supabase db push` can authenticate correctly.
- Add a harmless migration file under `apps/mobile/supabase/migrations/` to trigger the deployment workflow path.

## Why
The failing GitHub Actions job was dying in `supabase db push` with a `permission denied to alter role` error because the runner did not receive the database password Supabase CLI expects for migration pushes.

## Impact
- The workflow should now be able to complete once the repo secret is configured.
- The added migration is a no-op smoke test (`select 1;`) so it should not change schema state, but it does exercise the deployment trigger path.

## Validation
- Reviewed the failing Actions log for job `73020133723`.
- Confirmed the workflow step was missing `SUPABASE_DB_PASSWORD`.
- Pushed the branch after patching the workflow and adding the migration trigger file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Supabase migration deploy workflow by passing the DB password to `supabase db push`, and adds a no-op smoke test migration to trigger the workflow. This should allow deployments to complete once the repo secret is set.

- **Bug Fixes**
  - Pass `SUPABASE_DB_PASSWORD` into the workflow so `supabase db push` can authenticate and avoid the “permission denied to alter role” error.

- **Migration**
  - Add a no-op migration (`select 1;`) under `apps/mobile/supabase/migrations/` to exercise the deploy path without changing the schema.

<sup>Written for commit d894823cfb80fe498754582b81d4e9aea9a2d571. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

