### PR TITLE
docs(backup): align recovery key language

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,9 +24,9 @@ _Avoid_: Cloud sync, server ledger
 The user-facing recovery feature that creates and restores Encrypted Backups without exposing Plaintext Financial Data to Fidy servers.
 _Avoid_: Encryption setup, recovery-secret setup
 
-**Recovery Secret**:
-User-held key material needed to decrypt an Encrypted Backup after reinstall.
-_Avoid_: Password reset, server key
+**Recovery Key**:
+User-held generated key needed to decrypt an Encrypted Backup after reinstall when platform-held key material is unavailable.
+_Avoid_: Recovery phrase, passphrase, password reset, server key
 
 **Cloud AI Processing**:
 Explicit, transient processing of selected capture evidence or financial context by a remote AI service.
@@ -48,11 +48,11 @@ _Avoid_: Backup, recovery
 - Fidy-controlled servers must not store **Plaintext Financial Data** as ordinary database rows for recovery
 - An **Encrypted Backup** may contain financial records before encryption, but remote storage only receives ciphertext and non-financial backup metadata
 - An **Encrypted Backup** exists to restore the **Local Ledger** after app deletion, reinstall, or device loss
-- A **Recovery Secret** decrypts an **Encrypted Backup**
-- Fidy should not be able to decrypt an **Encrypted Backup** without the user's **Recovery Secret**
-- The **Recovery Secret** should be handled through platform-native storage and recovery where possible, with manual recovery as a fallback
+- A **Recovery Key** decrypts an **Encrypted Backup** when platform-held key material is unavailable
+- Fidy should not be able to decrypt an **Encrypted Backup** without the user's **Recovery Key** or platform-held key material
+- The **Recovery Key** is the manual recovery fallback; platform-native storage should make same-device recovery invisible where possible
 - Fidy login can locate a user's **Encrypted Backup**, but it must not by itself decrypt the backup
-- A lost-phone restore requires either platform-backed recovery of the **Recovery Secret** or the user's manual recovery fallback
+- A lost-phone restore requires either platform-backed recovery or the user's **Recovery Key**
 - If the user loses both the device-held secret and the manual recovery fallback, Fidy must not imply that the old **Local Ledger** can be recovered
 - Fidy must not offer server-side recovery that lets Fidy decrypt an **Encrypted Backup**
 - Strong recovery means accepting that the old **Local Ledger** is unrecoverable when all user-held recovery material is lost
@@ -67,7 +67,7 @@ _Avoid_: Backup, recovery
 ## Example dialogue
 
 > **Dev:** "If we stop syncing readable transactions to Supabase, how does the user recover after deleting the app?"
-> **Domain expert:** "The device creates an **Encrypted Backup** of the **Local Ledger**; Supabase stores only ciphertext, and restore requires the user's **Recovery Secret**."
+> **Domain expert:** "The device creates an **Encrypted Backup** of the **Local Ledger**; Supabase stores only ciphertext, and restore requires the user's **Recovery Key** or platform-held key material."
 
 ## Flagged ambiguities
 

--- a/docs/adr/0002-local-ledger-encrypted-backup-and-cloud-ai.md
+++ b/docs/adr/0002-local-ledger-encrypted-backup-and-cloud-ai.md
@@ -10,4 +10,4 @@ Fidy will stop treating plaintext Supabase financial tables as the durability me
 
 **Consequences**
 
-Cloud features must receive data through explicit task boundaries, such as capture interpretation or advisor context packets, instead of querying plaintext financial rows from Supabase. Backup restore depends on user-held recovery material; if Fidy cannot decrypt the backup, Fidy also cannot recover it when the user loses the recovery secret.
+Cloud features must receive data through explicit task boundaries, such as capture interpretation or advisor context packets, instead of querying plaintext financial rows from Supabase. Backup restore depends on the user's Recovery Key or platform-held key material; if Fidy cannot decrypt the backup, Fidy also cannot recover it when the user loses that recovery material.

--- a/plans/local-ledger-encrypted-backup-and-cloud-ai.md
+++ b/plans/local-ledger-encrypted-backup-and-cloud-ai.md
@@ -53,27 +53,27 @@ The app exports a canonical backup snapshot, encrypts it on device, and uploads 
 
 The backup payload should be versioned so restore can run migrations before opening the Local Ledger.
 
-### Recovery Secret
+### Recovery Key
 
-The recovery secret should be user-held, but the user-facing experience should be **Private Backup**, not "manage an encryption key." The default flow should feel like turning on a protected app backup, with the secret handled by platform-native storage where possible and manual recovery only as the fallback.
+The manual recovery fallback is a generated **Recovery Key**, but the user-facing experience should be **Private Backup**, not "manage an encryption key." The default flow should feel like turning on a protected app backup, with platform-native storage handling same-device recovery where possible and the Recovery Key kept by the user for lost-phone or new-device restore.
 
 UX target:
 
 - Non-technical mobile users should understand the promise in one sentence: Fidy can save an encrypted backup, but only they can unlock it.
 - Google, Microsoft, or Apple login should locate the user's backup account, not decrypt the backup by itself.
 - Same-device restore should be nearly invisible when platform secure storage still has the key.
-- New-device or lost-device restore should use the user's manual recovery phrase/passphrase or a platform-backed recovery mechanism.
-- Losing the recovery secret must be treated as a clear product state, not hidden in fine print.
+- New-device or lost-device restore should use the user's Recovery Key or a platform-backed recovery mechanism.
+- Losing the Recovery Key must be treated as a clear product state, not hidden in fine print.
 
 Security target:
 
 - Fidy must never store plaintext financial records remotely.
 - Fidy must never store a raw backup encryption key remotely.
-- Fidy must never store an unwrap-capable server secret that can decrypt a user's backup without user-held material.
+- Fidy must never store an unwrap-capable server secret that can decrypt a user's backup without the user's Recovery Key or platform-held key material.
 - Recovery key wrapping must happen on device.
 - Every remote backup should be encrypted with a random backup data key and authenticated encryption.
-- The backup data key may have multiple wrapped copies, but every wrap must require user-held or platform-held material.
-- If all user-held and platform-held recovery material is gone, the old Local Ledger is unrecoverable.
+- The backup data key may have multiple wrapped copies, but every wrap must require the user's Recovery Key or platform-held key material.
+- If the Recovery Key and all platform-held key material are gone, the old Local Ledger is unrecoverable.
 
 Platform constraints:
 
@@ -86,7 +86,7 @@ Recommended recovery ladder:
 
 1. **Device unlock**: use stored local key material for normal app use and same-device reinstall when available.
 2. **Private Backup restore**: after login, locate the encrypted backup and try platform-backed recovery.
-3. **Manual recovery**: ask for a recovery phrase/passphrase only when platform recovery cannot unlock the backup.
+3. **Manual recovery**: ask for the Recovery Key only when platform recovery cannot unlock the backup.
 4. **No-secret state**: if the user cannot unlock the backup, let them start fresh without implying Fidy can recover the old ledger.
 
 Lost-phone UX:
@@ -94,21 +94,21 @@ Lost-phone UX:
 - Treat "I lost my phone" as a primary restore path on the sign-in/restoration screen.
 - First ask the user to sign in with Google, Microsoft, or Apple so Fidy can find backup metadata.
 - If platform-backed key recovery is available, unlock the backup without asking the user to understand encryption.
-- If platform recovery is not available, ask for the manual recovery phrase/passphrase with calm copy and clear examples of where they may have saved it.
-- If the user cannot provide the recovery fallback, explain that the backup is still private but cannot be unlocked, then offer "Start fresh" as the next step.
-- Do not frame this as an account problem: login identifies the backup; the recovery secret unlocks it.
-- In settings, show a backup health check that warns users before a lost-phone event if they have no manual recovery fallback saved.
+- If platform recovery is not available, ask for the Recovery Key with calm copy and clear examples of where they may have saved it.
+- If the user cannot provide the Recovery Key, explain that the backup is still private but cannot be unlocked, then offer "Start fresh" as the next step.
+- Do not frame this as an account problem: login identifies the backup; the Recovery Key or platform-held key material unlocks it.
+- In settings, show a backup health check that warns users before a lost-phone event if they have not confirmed their Recovery Key.
 
 Strict security stance:
 
 - Do not add Fidy-managed escrow for MVP.
-- Do not add "forgot recovery secret" reset for encrypted backups.
+- Do not add "forgot Recovery Key" reset for encrypted backups.
 - Do not auto-restore from login alone.
-- Do not send the manual recovery phrase/passphrase to Supabase or AI providers.
-- Do not log recovery phrases, derived keys, wrapped keys, or backup plaintext.
-- Prefer a generated recovery phrase over a user-created password because non-technical users commonly choose weak passwords.
-- Require the user to confirm the recovery phrase before considering Private Backup healthy.
-- Let users rotate recovery material by decrypting locally, generating a new recovery phrase, rewrapping the backup key, and uploading new wrapped-key metadata.
+- Do not send the Recovery Key to Supabase or AI providers.
+- Do not log Recovery Keys, derived keys, wrapped keys, or backup plaintext.
+- Use a generated Recovery Key instead of a user-created password because non-technical users commonly choose weak passwords.
+- Require the user to confirm the Recovery Key before considering Private Backup healthy.
+- Let users rotate the Recovery Key by decrypting locally, generating a new Recovery Key, rewrapping the backup key, and uploading new wrapped-key metadata.
 
 Recommended auth direction:
 
@@ -144,7 +144,7 @@ Cloud AI is not allowed to become remote storage:
 
 3. Add on-device encryption
    - Generate backup encryption keys on device.
-   - Derive or wrap the key with the Recovery Secret.
+   - Derive or wrap the key with the Recovery Key.
    - Encrypt/decrypt snapshots locally.
    - Add corruption, wrong-secret, and schema-version tests.
 
@@ -177,7 +177,6 @@ Cloud AI is not allowed to become remote storage:
 ## Open Decisions
 
 - Should Private Backup be automatic after first successful onboarding, or should users explicitly enable it before their first captured data is saved?
-- Should manual recovery use a generated recovery phrase, a user-created passphrase, or both?
-- Should the generated recovery phrase be 12 words for lower friction or 24 words for a stricter security posture?
+- Resolved: manual recovery uses a generated Recovery Key, not a phrase, passphrase, or user-created password.
 - Are cloud AI ingestion and advisor enabled by default with disclosure, or opt-in before first use?
 - What exact retention promise applies to cloud AI request payloads and provider logs?


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized terminology across backup docs to use “Recovery Key” and clarified recovery flows. This makes the manual recovery story clear and consistent, and removes references to phrases/passphrases.

- **Refactors**
  - Renamed “Recovery Secret” to “Recovery Key” in `CONTEXT.md`, ADR-0002, and the backup plan.
  - Defined Recovery Key as a user-held, generated fallback used when platform-held key material isn’t available.
  - Clarified UX: same-device restore via platform storage; lost/new device uses the Recovery Key; login locates backups but does not decrypt.
  - Tightened security posture: no server-side decrypt or resets; do not transmit or log Recovery Keys; require confirmation and support rotation.
  - Resolved open decision: manual recovery uses a generated Recovery Key, not a phrase, passphrase, or user password.

<sup>Written for commit cf31bdf7d7be4f1d394a46fd0b3ffd6739d49e5a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

