### PR TITLE
chore(tooling): clarify file-size guidance

### DIFF
--- a/scripts/check-max-file-lines.test.ts
+++ b/scripts/check-max-file-lines.test.ts
@@ -40,6 +40,9 @@ test("reports oversized non-exempt files grouped by category in report-only mode
 
   expect(result.exitCode).toBe(0);
   expect(result.stdout.toString()).toContain("Oversized files: 1");
+  expect(result.stdout.toString()).toContain(
+    "File is too long. Split by responsibility boundary, not arbitrary chunks."
+  );
   expect(result.stdout.toString()).toContain("components: 1");
   expect(result.stdout.toString()).toContain(
     "apps/mobile/features/demo/components/LargeScreen.tsx"
@@ -88,6 +91,7 @@ test("does not overcount a file that ends with a trailing newline", () => {
   expect(result.exitCode).toBe(0);
   expect(result.stdout.toString()).toContain("Oversized files: 0");
   expect(result.stdout.toString()).toContain("No oversized files found.");
+  expect(result.stdout.toString()).not.toContain("File is too long.");
   expect(result.stdout.toString()).not.toContain("ThresholdScreen.tsx");
 });
 

--- a/scripts/check-max-file-lines.ts
+++ b/scripts/check-max-file-lines.ts
@@ -129,11 +129,13 @@ const formatReport = (root: string, maxLines: number, violations: readonly Viola
   const filesSection = violations
     .map((violation) => `${violation.lineCount} ${violation.path} [${violation.category}]`)
     .join("\n");
+  const splitGuidance = "File is too long. Split by responsibility boundary, not arbitrary chunks.";
 
   return [
     `Root: ${normalizePath(relative(process.cwd(), root) || ".")}`,
     `Max lines: ${maxLines}`,
     `Oversized files: ${violations.length}`,
+    violations.length > 0 ? splitGuidance : "",
     violations.length > 0 ? "" : "No oversized files found.",
     violations.length > 0 ? "By category:" : "",
     violations.length > 0 ? categorySummary : "",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a clear guidance message to the max-file-lines report: "File is too long. Split by responsibility boundary, not arbitrary chunks." The message shows only when violations exist; tests updated to assert its presence/absence.

<sup>Written for commit 7dd564e88cae7bfe6cc507562bea83b7658375cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

