### PR TITLE
fix(mobile): gate private backup sync

### DIFF
--- a/apps/mobile/__tests__/sync/sync-module.test.ts
+++ b/apps/mobile/__tests__/sync/sync-module.test.ts
@@ -69,7 +69,8 @@ describe("sync module", () => {
 
     expect(mockIsOnline).toHaveBeenCalled();
     expect(mockSyncPull).toHaveBeenCalledWith(db, expect.any(Object), "user-1");
-    expect(mockSyncPush).toHaveBeenCalledWith(db, expect.any(Object), "user-1", {
+    expect(mockSyncPush).toHaveBeenCalledWith(db, expect.any(Object), {
+      userId: "user-1",
       remoteFinancialSync: "legacy",
     });
     expect(mockRefreshTransactions).toHaveBeenCalledTimes(1);

--- a/apps/mobile/__tests__/sync/sync-module.test.ts
+++ b/apps/mobile/__tests__/sync/sync-module.test.ts
@@ -69,7 +69,9 @@ describe("sync module", () => {
 
     expect(mockIsOnline).toHaveBeenCalled();
     expect(mockSyncPull).toHaveBeenCalledWith(db, expect.any(Object), "user-1");
-    expect(mockSyncPush).toHaveBeenCalledWith(db, expect.any(Object), "user-1");
+    expect(mockSyncPush).toHaveBeenCalledWith(db, expect.any(Object), "user-1", {
+      remoteFinancialSync: "legacy",
+    });
     expect(mockRefreshTransactions).toHaveBeenCalledTimes(1);
     expect(result.status).toBe("synced");
     expect(result.unresolvedConflicts).toBe(0);
@@ -86,6 +88,23 @@ describe("sync module", () => {
     expect(mockSyncPush).not.toHaveBeenCalled();
     expect(mockRefreshTransactions).not.toHaveBeenCalled();
     expect(result.status).toBe("skipped_offline");
+  });
+
+  it("does not run legacy Remote Financial Sync in Private Backup mode", async () => {
+    const { sync } = await import("@/features/sync/services/sync");
+    const db = {} as any;
+
+    const result = await sync({
+      db,
+      userId: "user-1",
+      remoteFinancialSync: "privateBackup",
+    });
+
+    expect(mockGetSupabase).not.toHaveBeenCalled();
+    expect(mockSyncPull).not.toHaveBeenCalled();
+    expect(mockSyncPush).not.toHaveBeenCalled();
+    expect(mockRefreshTransactions).not.toHaveBeenCalled();
+    expect(result.status).toBe("synced");
   });
 
   it("lists unresolved conflicts through the boundary", async () => {

--- a/apps/mobile/__tests__/sync/sync-service.test.ts
+++ b/apps/mobile/__tests__/sync/sync-service.test.ts
@@ -100,7 +100,8 @@ describe("createSyncService", () => {
       userId: TEST_USER_ID,
     });
 
-    expect(ports.syncPush).toHaveBeenCalledWith(TEST_DB, supabase, TEST_USER_ID, {
+    expect(ports.syncPush).toHaveBeenCalledWith(TEST_DB, supabase, {
+      userId: TEST_USER_ID,
       remoteFinancialSync: "legacy",
     });
   });

--- a/apps/mobile/__tests__/sync/sync-service.test.ts
+++ b/apps/mobile/__tests__/sync/sync-service.test.ts
@@ -64,6 +64,47 @@ describe("createSyncService", () => {
     });
   });
 
+  it("skips legacy Remote Financial Sync for Private Backup users", async () => {
+    const supabase = {};
+    const { service, ports } = createService({
+      supabase: { getSupabase: vi.fn().mockReturnValue(supabase) },
+      syncPull: vi.fn().mockResolvedValue(true),
+      syncPush: vi.fn().mockResolvedValue(undefined),
+      refreshTransactions: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const result = await service.run({
+      db: TEST_DB,
+      userId: TEST_USER_ID,
+      remoteFinancialSync: "privateBackup",
+    });
+
+    expect(result.status).toBe("synced");
+    expect(ports.supabase.getSupabase).not.toHaveBeenCalled();
+    expect(ports.syncPull).not.toHaveBeenCalled();
+    expect(ports.syncPush).not.toHaveBeenCalled();
+    expect(ports.refreshTransactions).not.toHaveBeenCalled();
+  });
+
+  it("keeps legacy Remote Financial Sync as the default push capability", async () => {
+    const supabase = {};
+    const { service, ports } = createService({
+      supabase: { getSupabase: vi.fn().mockReturnValue(supabase) },
+      syncPull: vi.fn().mockResolvedValue(true),
+      syncPush: vi.fn().mockResolvedValue(undefined),
+      refreshTransactions: vi.fn().mockResolvedValue(undefined),
+    });
+
+    await service.run({
+      db: TEST_DB,
+      userId: TEST_USER_ID,
+    });
+
+    expect(ports.syncPush).toHaveBeenCalledWith(TEST_DB, supabase, TEST_USER_ID, {
+      remoteFinancialSync: "legacy",
+    });
+  });
+
   it("re-enqueues the local transaction when resolving a conflict in favor of local data", async () => {
     const resolvedAt = requireIsoDateTime("2026-04-18T12:34:56.000Z");
     const { service, ports } = createService({

--- a/apps/mobile/__tests__/sync/syncEngine.test.ts
+++ b/apps/mobile/__tests__/sync/syncEngine.test.ts
@@ -271,9 +271,9 @@ function createCompositeSyncMeta(updatedAt: string, id: string) {
   return syncMeta;
 }
 
-async function runSyncPush(mockSupabase: any, userId = SYNC_USER_ID) {
+async function runSyncPush(mockSupabase: any, userId = SYNC_USER_ID, options?: any) {
   const { syncPush } = await import("@/features/sync/services/syncEngine");
-  await syncPush(mockDb, mockSupabase, userId);
+  await syncPush(mockDb, mockSupabase, userId, options);
 }
 
 async function runSyncPull(mockSupabase: any, userId = SYNC_USER_ID) {
@@ -721,6 +721,65 @@ describe("syncEngine", () => {
           errorMessage: "lookup exploded",
           errorCode: "unknown",
         })
+      );
+    });
+
+    it("does not push plaintext financial rows for Private Backup users", async () => {
+      const blockedEntries = [
+        createSyncQueueEntry({ id: "sq-transactions", tableName: "transactions", rowId: "tx-1" }),
+        createSyncQueueEntry({ id: "sq-budgets", tableName: "budgets", rowId: "budget-1" }),
+        createSyncQueueEntry({ id: "sq-goals", tableName: "goals", rowId: "goal-1" }),
+        createSyncQueueEntry({
+          id: "sq-accounts",
+          tableName: "financialAccounts",
+          rowId: "fa-1",
+        }),
+        createSyncQueueEntry({ id: "sq-transfers", tableName: "transfers", rowId: "tr-1" }),
+        createSyncQueueEntry({
+          id: "sq-opening-balances",
+          tableName: "openingBalances",
+          rowId: "ob-1",
+        }),
+        createSyncQueueEntry({
+          id: "sq-identifiers",
+          tableName: "financialAccountIdentifiers",
+          rowId: "fai-1",
+        }),
+        createSyncQueueEntry({
+          id: "sq-capture-evidence",
+          tableName: "captureEvidence",
+          rowId: "ce-1",
+        }),
+        createSyncQueueEntry({
+          id: "sq-dismissals",
+          tableName: "accountSuggestionDismissals",
+          rowId: "asd-1",
+        }),
+        createSyncQueueEntry({
+          id: "sq-contributions",
+          tableName: "goalContributions",
+          rowId: "gc-1",
+        }),
+      ];
+      mockGetQueuedSyncEntries.mockReturnValueOnce(blockedEntries);
+      const mockSupabase = createMockSupabase();
+
+      await runSyncPush(mockSupabase, SYNC_USER_ID, {
+        remoteFinancialSync: "privateBackup",
+      });
+
+      expect(mockSupabase.from).not.toHaveBeenCalled();
+      expectQueueCleared(
+        "sq-transactions",
+        "sq-budgets",
+        "sq-goals",
+        "sq-accounts",
+        "sq-transfers",
+        "sq-opening-balances",
+        "sq-identifiers",
+        "sq-capture-evidence",
+        "sq-dismissals",
+        "sq-contributions"
       );
     });
   });

--- a/apps/mobile/__tests__/sync/syncEngine.test.ts
+++ b/apps/mobile/__tests__/sync/syncEngine.test.ts
@@ -273,7 +273,7 @@ function createCompositeSyncMeta(updatedAt: string, id: string) {
 
 async function runSyncPush(mockSupabase: any, userId = SYNC_USER_ID, options?: any) {
   const { syncPush } = await import("@/features/sync/services/syncEngine");
-  await syncPush(mockDb, mockSupabase, userId, options);
+  await syncPush(mockDb, mockSupabase, { userId, ...options });
 }
 
 async function runSyncPull(mockSupabase: any, userId = SYNC_USER_ID) {
@@ -434,6 +434,31 @@ function expectCompositeTransactionsQuery(mockSupabase: any) {
   });
 }
 
+const PRIVATE_BACKUP_BLOCKED_PUSH_ENTRIES = [
+  createSyncQueueEntry({ id: "sq-transactions", tableName: "transactions", rowId: "tx-1" }),
+  createSyncQueueEntry({ id: "sq-budgets", tableName: "budgets", rowId: "budget-1" }),
+  createSyncQueueEntry({ id: "sq-goals", tableName: "goals", rowId: "goal-1" }),
+  createSyncQueueEntry({ id: "sq-accounts", tableName: "financialAccounts", rowId: "fa-1" }),
+  createSyncQueueEntry({ id: "sq-transfers", tableName: "transfers", rowId: "tr-1" }),
+  createSyncQueueEntry({ id: "sq-opening-balances", tableName: "openingBalances", rowId: "ob-1" }),
+  createSyncQueueEntry({
+    id: "sq-identifiers",
+    tableName: "financialAccountIdentifiers",
+    rowId: "fai-1",
+  }),
+  createSyncQueueEntry({ id: "sq-capture-evidence", tableName: "captureEvidence", rowId: "ce-1" }),
+  createSyncQueueEntry({
+    id: "sq-dismissals",
+    tableName: "accountSuggestionDismissals",
+    rowId: "asd-1",
+  }),
+  createSyncQueueEntry({ id: "sq-contributions", tableName: "goalContributions", rowId: "gc-1" }),
+];
+
+const PRIVATE_BACKUP_BLOCKED_PUSH_ENTRY_IDS = PRIVATE_BACKUP_BLOCKED_PUSH_ENTRIES.map(
+  (entry) => entry.id
+);
+
 describe("syncEngine", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -445,7 +470,7 @@ describe("syncEngine", () => {
       const mockSupabase = createMockSupabase();
 
       const { syncPush } = await import("@/features/sync/services/syncEngine");
-      await syncPush(mockDb, mockSupabase, "user-1");
+      await syncPush(mockDb, mockSupabase, { userId: "user-1" });
 
       expect(mockSupabase.from).not.toHaveBeenCalled();
       expect(mockClearSyncEntries).not.toHaveBeenCalled();
@@ -507,7 +532,7 @@ describe("syncEngine", () => {
       const mockSupabase = createMockSupabase();
 
       const { syncPush } = await import("@/features/sync/services/syncEngine");
-      await syncPush(mockDb, mockSupabase, "user-1");
+      await syncPush(mockDb, mockSupabase, { userId: "user-1" });
 
       expect(mockClearSyncEntries).not.toHaveBeenCalled();
     });
@@ -699,7 +724,7 @@ describe("syncEngine", () => {
       const mockSupabase = createMockSupabase();
 
       const { syncPush } = await import("@/features/sync/services/syncEngine");
-      await syncPush(mockDb, mockSupabase, "user-1");
+      await syncPush(mockDb, mockSupabase, { userId: "user-1" });
 
       expect(mockClearSyncEntries).toHaveBeenCalledWith(mockDb, ["sq-1"]);
     });
@@ -725,43 +750,7 @@ describe("syncEngine", () => {
     });
 
     it("does not push plaintext financial rows for Private Backup users", async () => {
-      const blockedEntries = [
-        createSyncQueueEntry({ id: "sq-transactions", tableName: "transactions", rowId: "tx-1" }),
-        createSyncQueueEntry({ id: "sq-budgets", tableName: "budgets", rowId: "budget-1" }),
-        createSyncQueueEntry({ id: "sq-goals", tableName: "goals", rowId: "goal-1" }),
-        createSyncQueueEntry({
-          id: "sq-accounts",
-          tableName: "financialAccounts",
-          rowId: "fa-1",
-        }),
-        createSyncQueueEntry({ id: "sq-transfers", tableName: "transfers", rowId: "tr-1" }),
-        createSyncQueueEntry({
-          id: "sq-opening-balances",
-          tableName: "openingBalances",
-          rowId: "ob-1",
-        }),
-        createSyncQueueEntry({
-          id: "sq-identifiers",
-          tableName: "financialAccountIdentifiers",
-          rowId: "fai-1",
-        }),
-        createSyncQueueEntry({
-          id: "sq-capture-evidence",
-          tableName: "captureEvidence",
-          rowId: "ce-1",
-        }),
-        createSyncQueueEntry({
-          id: "sq-dismissals",
-          tableName: "accountSuggestionDismissals",
-          rowId: "asd-1",
-        }),
-        createSyncQueueEntry({
-          id: "sq-contributions",
-          tableName: "goalContributions",
-          rowId: "gc-1",
-        }),
-      ];
-      mockGetQueuedSyncEntries.mockReturnValueOnce(blockedEntries);
+      mockGetQueuedSyncEntries.mockReturnValueOnce(PRIVATE_BACKUP_BLOCKED_PUSH_ENTRIES);
       const mockSupabase = createMockSupabase();
 
       await runSyncPush(mockSupabase, SYNC_USER_ID, {
@@ -769,18 +758,7 @@ describe("syncEngine", () => {
       });
 
       expect(mockSupabase.from).not.toHaveBeenCalled();
-      expectQueueCleared(
-        "sq-transactions",
-        "sq-budgets",
-        "sq-goals",
-        "sq-accounts",
-        "sq-transfers",
-        "sq-opening-balances",
-        "sq-identifiers",
-        "sq-capture-evidence",
-        "sq-dismissals",
-        "sq-contributions"
-      );
+      expectQueueCleared(...PRIVATE_BACKUP_BLOCKED_PUSH_ENTRY_IDS);
     });
   });
 
@@ -993,7 +971,7 @@ describe("syncEngine", () => {
       const mockSupabase = createMockSupabase({ data: [], error: null });
 
       const { fullSync } = await import("@/features/sync/services/syncEngine");
-      const result = await fullSync(mockDb, mockSupabase, "user-1");
+      const result = await fullSync(mockDb, mockSupabase, { userId: "user-1" });
 
       expect(result).toBe(true);
       expect(mockGetSyncMeta).toHaveBeenCalled();
@@ -1006,7 +984,7 @@ describe("syncEngine", () => {
       const mockSupabase = createMockSupabase({ data: null, error: { message: "fail" } });
 
       const { fullSync } = await import("@/features/sync/services/syncEngine");
-      const result = await fullSync(mockDb, mockSupabase, "user-1");
+      const result = await fullSync(mockDb, mockSupabase, { userId: "user-1" });
 
       expect(result).toBe(false);
       expect(mockGetSyncMeta).toHaveBeenCalled();
@@ -1028,7 +1006,7 @@ describe("syncEngine", () => {
       });
 
       const { fullSync } = await import("@/features/sync/services/syncEngine");
-      const result = await fullSync(mockDb, mockSupabase, "user-1");
+      const result = await fullSync(mockDb, mockSupabase, { userId: "user-1" });
 
       expect(result).toBe(true);
       expect(mockGetQueuedSyncEntries).toHaveBeenCalled();

--- a/apps/mobile/features/sync/services/create-sync-service.ts
+++ b/apps/mobile/features/sync/services/create-sync-service.ts
@@ -9,6 +9,7 @@ import {
   currentSupabaseClientEffect,
 } from "@/shared/effect/supabase";
 import type { IsoDateTime } from "@/shared/types/branded";
+import type { SyncPushOptions } from "./sync-engine/types";
 import type {
   ConflictResolution,
   ResolveConflictResult,
@@ -21,7 +22,12 @@ import type {
 } from "./types";
 
 type SyncPull = (db: SyncInput["db"], supabase: SupabaseClient, userId: string) => Promise<boolean>;
-type SyncPush = (db: SyncInput["db"], supabase: SupabaseClient, userId: string) => Promise<void>;
+type SyncPush = (
+  db: SyncInput["db"],
+  supabase: SupabaseClient,
+  userId: string,
+  options: SyncPushOptions
+) => Promise<void>;
 type ConflictRow = {
   readonly id: string;
   readonly transactionId: string;
@@ -195,7 +201,12 @@ function resolveConflictEffect({ db, conflictId, resolution }: ResolveTransactio
   });
 }
 
-function runSyncEffect({ db, userId, reason: _reason = "foreground" }: SyncInput) {
+function runSyncEffect({
+  db,
+  userId,
+  reason: _reason = "foreground",
+  remoteFinancialSync = "legacy",
+}: SyncInput) {
   return Effect.gen(function* () {
     void _reason;
 
@@ -208,10 +219,17 @@ function runSyncEffect({ db, userId, reason: _reason = "foreground" }: SyncInput
       };
     }
 
+    if (remoteFinancialSync === "privateBackup") {
+      return {
+        status: "synced" as const,
+        unresolvedConflicts: yield* unresolvedConflictCountEffect(db),
+      };
+    }
+
     const supabase = yield* currentSupabaseClientEffect;
     const pullOk = yield* fromPromise(() => syncPull(db, supabase, userId));
     if (pullOk) {
-      yield* fromPromise(() => syncPush(db, supabase, userId));
+      yield* fromPromise(() => syncPush(db, supabase, userId, { remoteFinancialSync }));
       yield* fromThunk(() => refreshTransactions({ db, userId }));
     }
 

--- a/apps/mobile/features/sync/services/create-sync-service.ts
+++ b/apps/mobile/features/sync/services/create-sync-service.ts
@@ -9,7 +9,7 @@ import {
   currentSupabaseClientEffect,
 } from "@/shared/effect/supabase";
 import type { IsoDateTime } from "@/shared/types/branded";
-import type { SyncPushOptions } from "./sync-engine/types";
+import type { SyncPushRequest } from "./sync-engine/types";
 import type {
   ConflictResolution,
   ResolveConflictResult,
@@ -25,8 +25,7 @@ type SyncPull = (db: SyncInput["db"], supabase: SupabaseClient, userId: string) 
 type SyncPush = (
   db: SyncInput["db"],
   supabase: SupabaseClient,
-  userId: string,
-  options: SyncPushOptions
+  request: SyncPushRequest
 ) => Promise<void>;
 type ConflictRow = {
   readonly id: string;
@@ -229,7 +228,7 @@ function runSyncEffect({
     const supabase = yield* currentSupabaseClientEffect;
     const pullOk = yield* fromPromise(() => syncPull(db, supabase, userId));
     if (pullOk) {
-      yield* fromPromise(() => syncPush(db, supabase, userId, { remoteFinancialSync }));
+      yield* fromPromise(() => syncPush(db, supabase, { userId, remoteFinancialSync }));
       yield* fromThunk(() => refreshTransactions({ db, userId }));
     }
 

--- a/apps/mobile/features/sync/services/sync-engine/push-queue.ts
+++ b/apps/mobile/features/sync/services/sync-engine/push-queue.ts
@@ -1,0 +1,45 @@
+import { clearSyncEntries } from "@/features/transactions/lib/repository";
+import type { AnyDb } from "@/shared/db";
+import type { SyncQueueId } from "@/shared/types/branded";
+import type { SyncPushOptions } from "./types";
+
+const PRIVATE_BACKUP_SYNC_MODE = "privateBackup";
+const PLAINTEXT_FINANCIAL_PUSH_TABLES = new Set<string>([
+  "transactions",
+  "budgets",
+  "goals",
+  "financialAccounts",
+  "transfers",
+  "openingBalances",
+  "financialAccountIdentifiers",
+  "captureEvidence",
+  "accountSuggestionDismissals",
+  "goalContributions",
+]);
+
+export type PushQueueEntry = { id: SyncQueueId; tableName: string; rowId: string };
+export type PushQueueResult = PromiseSettledResult<SyncQueueId | null>;
+
+export function shouldSkipPlaintextFinancialPush(tableName: string, options: SyncPushOptions) {
+  return (
+    options.remoteFinancialSync === PRIVATE_BACKUP_SYNC_MODE &&
+    PLAINTEXT_FINANCIAL_PUSH_TABLES.has(tableName)
+  );
+}
+
+export function getProcessedSyncQueueIds(results: readonly PushQueueResult[]) {
+  return results
+    .filter(
+      (result): result is PromiseFulfilledResult<SyncQueueId> =>
+        result.status === "fulfilled" && result.value !== null
+    )
+    .map((result) => result.value);
+}
+
+export async function clearProcessedSyncEntries(db: AnyDb, processedIds: SyncQueueId[]) {
+  if (processedIds.length === 0) {
+    return;
+  }
+
+  await clearSyncEntries(db, processedIds);
+}

--- a/apps/mobile/features/sync/services/sync-engine/push.ts
+++ b/apps/mobile/features/sync/services/sync-engine/push.ts
@@ -31,9 +31,28 @@ import {
   toSupabaseTransactionRow,
   toSupabaseTransferRow,
 } from "./to-supabase";
-import type { PushEntryContext, PushEntryHandler, PushEntryOutcome, UpsertPushSpec } from "./types";
+import type {
+  PushEntryContext,
+  PushEntryHandler,
+  PushEntryOutcome,
+  SyncPushOptions,
+  UpsertPushSpec,
+} from "./types";
 
 const PUSH_ENTRY_PROCESSED: PushEntryOutcome = { ok: true };
+const PRIVATE_BACKUP_SYNC_MODE = "privateBackup";
+const PLAINTEXT_FINANCIAL_PUSH_TABLES = new Set<string>([
+  "transactions",
+  "budgets",
+  "goals",
+  "financialAccounts",
+  "transfers",
+  "openingBalances",
+  "financialAccountIdentifiers",
+  "captureEvidence",
+  "accountSuggestionDismissals",
+  "goalContributions",
+]);
 
 async function upsertPushRow<TRow, TSupabaseRow>(
   context: PushEntryContext,
@@ -222,8 +241,16 @@ function captureRejectedPushEntries(
 async function processEntry(
   db: AnyDb,
   supabase: SupabaseClient,
-  entry: { id: SyncQueueId; tableName: string; rowId: string }
+  entry: { id: SyncQueueId; tableName: string; rowId: string },
+  options: SyncPushOptions
 ): Promise<SyncQueueId | null> {
+  if (
+    options.remoteFinancialSync === PRIVATE_BACKUP_SYNC_MODE &&
+    PLAINTEXT_FINANCIAL_PUSH_TABLES.has(entry.tableName)
+  ) {
+    return entry.id;
+  }
+
   const handler = getPushEntryHandler(entry.tableName);
   if (!handler) {
     captureWarning("sync_push_unknown_table", { tableName: entry.tableName });
@@ -240,13 +267,14 @@ async function processEntry(
 export async function syncPush(
   db: AnyDb,
   supabase: SupabaseClient,
-  _userId: string
+  _userId: string,
+  options: SyncPushOptions = { remoteFinancialSync: "legacy" }
 ): Promise<void> {
   const entries = await getQueuedSyncEntries(db);
   if (entries.length === 0) return;
 
   const results = await Promise.allSettled(
-    entries.map((entry) => processEntry(db, supabase, entry))
+    entries.map((entry) => processEntry(db, supabase, entry, options))
   );
   captureRejectedPushEntries(entries, results);
   const processedIds = results

--- a/apps/mobile/features/sync/services/sync-engine/push.ts
+++ b/apps/mobile/features/sync/services/sync-engine/push.ts
@@ -8,16 +8,19 @@ import { getFinancialAccountIdentifierById } from "@/features/financial-accounts
 import { getOpeningBalanceById } from "@/features/financial-accounts/lib/opening-balances-repository";
 import { getFinancialAccountById } from "@/features/financial-accounts/lib/repository";
 import { getContributionById, getGoalById } from "@/features/goals/lib/repository";
-import {
-  clearSyncEntries,
-  getQueuedSyncEntries,
-  getTransactionById,
-} from "@/features/transactions/lib/repository";
+import { getQueuedSyncEntries, getTransactionById } from "@/features/transactions/lib/repository";
 import { getTransferById } from "@/features/transfers/lib/repository";
 import type { AnyDb } from "@/shared/db";
 import { capturePipelineEvent, captureWarning } from "@/shared/lib";
 import { requireBudgetId, requireTransactionId } from "@/shared/types/assertions";
 import type { SyncQueueId } from "@/shared/types/branded";
+import {
+  clearProcessedSyncEntries,
+  getProcessedSyncQueueIds,
+  type PushQueueEntry,
+  type PushQueueResult,
+  shouldSkipPlaintextFinancialPush,
+} from "./push-queue";
 import {
   toPushEntryFailure,
   toSupabaseAccountSuggestionDismissalRow,
@@ -36,23 +39,11 @@ import type {
   PushEntryHandler,
   PushEntryOutcome,
   SyncPushOptions,
+  SyncPushRequest,
   UpsertPushSpec,
 } from "./types";
 
 const PUSH_ENTRY_PROCESSED: PushEntryOutcome = { ok: true };
-const PRIVATE_BACKUP_SYNC_MODE = "privateBackup";
-const PLAINTEXT_FINANCIAL_PUSH_TABLES = new Set<string>([
-  "transactions",
-  "budgets",
-  "goals",
-  "financialAccounts",
-  "transfers",
-  "openingBalances",
-  "financialAccountIdentifiers",
-  "captureEvidence",
-  "accountSuggestionDismissals",
-  "goalContributions",
-]);
 
 async function upsertPushRow<TRow, TSupabaseRow>(
   context: PushEntryContext,
@@ -224,7 +215,7 @@ function toRejectedPushWarningPayload(
 
 function captureRejectedPushEntries(
   entries: readonly { tableName: string; rowId: string }[],
-  results: readonly PromiseSettledResult<SyncQueueId | null>[]
+  results: readonly PushQueueResult[]
 ) {
   results.forEach((result, index) => {
     if (result.status === "fulfilled") {
@@ -238,16 +229,16 @@ function captureRejectedPushEntries(
   });
 }
 
-async function processEntry(
-  db: AnyDb,
-  supabase: SupabaseClient,
-  entry: { id: SyncQueueId; tableName: string; rowId: string },
-  options: SyncPushOptions
-): Promise<SyncQueueId | null> {
-  if (
-    options.remoteFinancialSync === PRIVATE_BACKUP_SYNC_MODE &&
-    PLAINTEXT_FINANCIAL_PUSH_TABLES.has(entry.tableName)
-  ) {
+type ProcessEntryInput = {
+  readonly db: AnyDb;
+  readonly supabase: SupabaseClient;
+  readonly entry: PushQueueEntry;
+  readonly options: SyncPushOptions;
+};
+
+async function processEntry(input: ProcessEntryInput): Promise<SyncQueueId | null> {
+  const { db, supabase, entry, options } = input;
+  if (shouldSkipPlaintextFinancialPush(entry.tableName, options)) {
     return entry.id;
   }
 
@@ -264,29 +255,30 @@ async function processEntry(
   return outcome.ok ? entry.id : null;
 }
 
+type ProcessEntriesInput = {
+  readonly db: AnyDb;
+  readonly supabase: SupabaseClient;
+  readonly entries: readonly PushQueueEntry[];
+  readonly options: SyncPushOptions;
+};
+
+async function processEntries(input: ProcessEntriesInput) {
+  return Promise.allSettled(input.entries.map((entry) => processEntry({ ...input, entry })));
+}
+
 export async function syncPush(
   db: AnyDb,
   supabase: SupabaseClient,
-  _userId: string,
-  options: SyncPushOptions = { remoteFinancialSync: "legacy" }
+  request: SyncPushRequest
 ): Promise<void> {
+  const options: SyncPushOptions = { remoteFinancialSync: request.remoteFinancialSync };
   const entries = await getQueuedSyncEntries(db);
   if (entries.length === 0) return;
 
-  const results = await Promise.allSettled(
-    entries.map((entry) => processEntry(db, supabase, entry, options))
-  );
+  const results = await processEntries({ db, supabase, entries, options });
   captureRejectedPushEntries(entries, results);
-  const processedIds = results
-    .filter(
-      (result): result is PromiseFulfilledResult<SyncQueueId> =>
-        result.status === "fulfilled" && result.value !== null
-    )
-    .map((result) => result.value);
-
-  if (processedIds.length > 0) {
-    await clearSyncEntries(db, processedIds);
-  }
+  const processedIds = getProcessedSyncQueueIds(results);
+  await clearProcessedSyncEntries(db, processedIds);
 
   capturePipelineEvent({
     source: "sync_push",

--- a/apps/mobile/features/sync/services/sync-engine/types.ts
+++ b/apps/mobile/features/sync/services/sync-engine/types.ts
@@ -24,6 +24,11 @@ export const LAST_SYNC_AT_BY_TABLE = {
 } as const;
 export const PULL_PAGE_SIZE = 1000;
 
+export type RemoteFinancialSyncMode = "legacy" | "privateBackup";
+export type SyncPushOptions = {
+  readonly remoteFinancialSync?: RemoteFinancialSyncMode;
+};
+
 export type SupabaseTransactionRow = {
   id: string;
   user_id: string;

--- a/apps/mobile/features/sync/services/sync-engine/types.ts
+++ b/apps/mobile/features/sync/services/sync-engine/types.ts
@@ -28,6 +28,10 @@ export type RemoteFinancialSyncMode = "legacy" | "privateBackup";
 export type SyncPushOptions = {
   readonly remoteFinancialSync?: RemoteFinancialSyncMode;
 };
+export type SyncPushRequest = {
+  readonly userId: string;
+  readonly remoteFinancialSync?: RemoteFinancialSyncMode;
+};
 
 export type SupabaseTransactionRow = {
   id: string;

--- a/apps/mobile/features/sync/services/syncEngine.ts
+++ b/apps/mobile/features/sync/services/syncEngine.ts
@@ -4,17 +4,18 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { AnyDb } from "@/shared/db";
 import { syncPull } from "./sync-engine/pull";
 import { syncPush } from "./sync-engine/push";
+import type { SyncPushRequest } from "./sync-engine/types";
 
 export { syncPull, syncPush };
 
 export async function fullSync(
   db: AnyDb,
   supabase: SupabaseClient,
-  userId: string
+  request: SyncPushRequest
 ): Promise<boolean> {
-  const pullOk = await syncPull(db, supabase, userId);
+  const pullOk = await syncPull(db, supabase, request.userId);
   if (pullOk) {
-    await syncPush(db, supabase, userId);
+    await syncPush(db, supabase, request);
   }
   return pullOk;
 }

--- a/apps/mobile/features/sync/services/types.ts
+++ b/apps/mobile/features/sync/services/types.ts
@@ -1,5 +1,6 @@
 import type { AnyDb } from "@/shared/db";
 import type { SyncConflictId } from "@/shared/types/branded";
+import type { RemoteFinancialSyncMode } from "./sync-engine/types";
 
 export type TransactionSnapshot = {
   readonly id: string;
@@ -32,6 +33,7 @@ export type SyncReason = "startup" | "foreground" | "reconnected" | "manual";
 export type SyncInput = SyncContext & {
   readonly userId: string;
   readonly reason?: SyncReason;
+  readonly remoteFinancialSync?: RemoteFinancialSyncMode;
 };
 
 export type SyncRunResult =


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop running legacy Remote Financial Sync for Private Backup users to prevent plaintext financial data from being pushed or pulled. Legacy remains the default for everyone else.

- Bug Fixes
  - Added `remoteFinancialSync` mode (`legacy` | `privateBackup`, default `legacy`) and pass it via `SyncPushRequest` to `syncPush` and `fullSync`.
  - In `privateBackup`, skip Supabase init, `syncPull`, `syncPush`, and transaction refresh; return "synced".
  - When `syncPush` runs in `privateBackup`, block plaintext financial table pushes and clear those queue entries.
  - Aligns with Linear issue 295 to gate legacy sync for Private Backup users.

<sup>Written for commit 9ee6a51ba1b4b3040e3448c00fee7ddcb7b8b3a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

