### PR TITLE
feat(ai-chat): use context packets

### DIFF
--- a/apps/mobile/__tests__/advisor/financial-context-packet.test.ts
+++ b/apps/mobile/__tests__/advisor/financial-context-packet.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  createFinancialContextPacketBuilder,
+  type FinancialContextPacketPorts,
+} from "@/features/advisor/public";
+import { requireMonth, requireUserId } from "@/shared/types/assertions";
+
+const db = {} as never;
+const userId = requireUserId("user-1");
+
+function createPorts(): FinancialContextPacketPorts {
+  return {
+    getBalance: () => 1000000,
+    getSpendingByCategory: (_db, _userId, month) =>
+      month === "2026-04"
+        ? [{ categoryId: "food", total: 120000 }]
+        : [{ categoryId: "food", total: 90000 }],
+    getRecentTransactions: () => [
+      {
+        type: "expense",
+        amount: 120000,
+        categoryId: "food",
+        description: "Groceries",
+        date: "2026-04-20",
+      },
+    ],
+    getBudgetsForMonth: () => [
+      { categoryId: "food", amount: 300000, month: requireMonth("2026-04") },
+    ],
+    getGoals: () => [
+      { id: "goal-1", name: "Emergency fund", type: "savings", targetAmount: 1000000 },
+    ],
+    getGoalCurrentAmount: () => 250000,
+    getAccounts: () => [{ name: "Cash", kind: "cash", isDefault: true }],
+    getCaptureEvidence: () => [
+      {
+        scope: "merchant",
+        value: "Market",
+        sourceFamily: "email",
+        evidenceType: "merchant",
+        occurrences: 3,
+      },
+    ],
+  };
+}
+
+describe("financial context packet", () => {
+  it("builds task-scoped summaries and recent records from local ports", () => {
+    const builder = createFinancialContextPacketBuilder(createPorts());
+
+    expect(builder({ db, userId, now: new Date("2026-04-25T12:00:00.000Z") })).toMatchObject({
+      summary: {
+        balance: 1000000,
+        currentMonthSpending: [{ categoryId: "food", total: 120000 }],
+        previousMonthSpending: [{ categoryId: "food", total: 90000 }],
+        monthOverMonthDeltas: [
+          { categoryId: "food", current: 120000, previous: 90000, delta: 30000 },
+        ],
+      },
+      recentTransactions: [{ description: "Groceries" }],
+      budgets: [{ categoryId: "food", amount: 300000, month: "2026-04" }],
+      goals: [{ name: "Emergency fund", currentAmount: 250000, progressPct: 25 }],
+      accounts: [{ name: "Cash" }],
+      captureEvidence: [{ value: "Market", occurrences: 3 }],
+      memories: [],
+    });
+  });
+});

--- a/apps/mobile/__tests__/ai-chat/ai-chat-api-service.test.ts
+++ b/apps/mobile/__tests__/ai-chat/ai-chat-api-service.test.ts
@@ -6,6 +6,7 @@ vi.mock("expo/fetch", () => ({
 }));
 
 import { createAiChatApiService } from "@/features/ai-chat/services/create-ai-chat-api-service";
+import { requireMonth } from "@/shared/types/assertions";
 
 describe("createAiChatApiService", () => {
   it("streams chunks with auth headers from Supabase session", async () => {
@@ -59,6 +60,86 @@ describe("createAiChatApiService", () => {
     expect(onChunk).toHaveBeenCalledWith("Hello");
     expect(onDone).toHaveBeenCalledTimes(1);
     expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("sends an app-built financial context packet with chat messages", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response("data: [DONE]\n\n", {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      })
+    );
+
+    const service = createAiChatApiService({
+      fetchImpl: fetchImpl as never,
+      getBaseUrl: () => "https://example.supabase.co",
+      supabase: {
+        getSupabase: () =>
+          ({
+            auth: {
+              getSession: vi.fn().mockResolvedValue({
+                data: { session: { access_token: "token-123" } },
+              }),
+            },
+          }) as never,
+      },
+      telemetry: {
+        captureError: vi.fn(),
+        captureWarning: vi.fn(),
+        capturePipelineEvent: vi.fn(),
+      },
+    });
+
+    await service.streamChat(
+      [{ role: "user", content: "how am I doing?" }],
+      {
+        onChunk: vi.fn(),
+        onDone: vi.fn(),
+        onError: vi.fn(),
+      },
+      {
+        financialContextPacket: {
+          summary: {
+            balance: 125000,
+            currentMonthSpending: [{ categoryId: "food", total: 50000 }],
+            previousMonthSpending: [],
+            monthOverMonthDeltas: [
+              { categoryId: "food", current: 50000, previous: 0, delta: 50000 },
+            ],
+          },
+          recentTransactions: [
+            {
+              type: "expense",
+              amount: 50000,
+              categoryId: "food",
+              description: "Lunch",
+              date: "2026-04-20",
+            },
+          ],
+          budgets: [{ categoryId: "food", amount: 200000, month: requireMonth("2026-04") }],
+          goals: [],
+          accounts: [],
+          captureEvidence: [],
+          memories: [{ fact: "Prefers cash envelopes", category: "preference" }],
+        },
+      }
+    );
+
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      messages: [{ role: "user", content: "how am I doing?" }],
+      financialContextPacket: {
+        summary: {
+          balance: 125000,
+        },
+        recentTransactions: [
+          {
+            description: "Lunch",
+          },
+        ],
+        memories: [{ fact: "Prefers cash envelopes", category: "preference" }],
+      },
+    });
   });
 
   it("captures chunk callback failures without crashing the stream", async () => {

--- a/apps/mobile/__tests__/ai-chat/streaming-context-packet-source.test.ts
+++ b/apps/mobile/__tests__/ai-chat/streaming-context-packet-source.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(
+  resolve(__dirname, "../../features/ai-chat/hooks/use-streaming-chat.ts"),
+  "utf8"
+);
+
+describe("streaming chat context packet source", () => {
+  it("keeps saved memory enrichment best-effort and capped", () => {
+    expect(source).toContain("const MAX_CONTEXT_MEMORIES = 20");
+    expect(source).toContain("listUserMemories(input.userId).catch(() => [])");
+    expect(source).toContain("memories.slice(0, MAX_CONTEXT_MEMORIES).map");
+  });
+});

--- a/apps/mobile/__tests__/ai-chat/streaming-service.test.ts
+++ b/apps/mobile/__tests__/ai-chat/streaming-service.test.ts
@@ -33,6 +33,23 @@ function makeAddAction(): ChatAction {
   };
 }
 
+function makeFinancialContextPacket() {
+  return {
+    summary: {
+      balance: 750000,
+      currentMonthSpending: [],
+      previousMonthSpending: [],
+      monthOverMonthDeltas: [],
+    },
+    recentTransactions: [],
+    budgets: [],
+    goals: [],
+    accounts: [],
+    captureEvidence: [],
+    memories: [{ fact: "Prefers cash envelopes", category: "preference" }],
+  };
+}
+
 function createState() {
   let state: {
     isStreaming: boolean;
@@ -159,6 +176,47 @@ describe("streaming chat service", () => {
     });
   });
 
+  it("builds a local financial context packet before calling the chat stream", async () => {
+    const state = createState();
+    state.setCurrentSessionId("chat-1" as ChatSessionId);
+    const packet = makeFinancialContextPacket();
+    const buildFinancialContextPacket = vi.fn().mockResolvedValue(packet);
+    const streamChat = vi.fn(async (_messages, callbacks) => {
+      callbacks.onDone();
+    });
+
+    const service = createStreamingChatService({
+      getState: state.getState,
+      setStreaming: state.setStreaming,
+      setStreamingContent: state.setStreamingContent,
+      streamChat,
+      buildFinancialContextPacket,
+      createChatSession: vi.fn(),
+      addUserChatMessage: vi.fn().mockResolvedValue(undefined),
+      addAssistantChatMessage: vi.fn().mockResolvedValue(makeAssistantMessage("")),
+      parseActionFromResponse: () => null,
+      trackAiMessageSent: vi.fn(),
+      telemetry: makeTelemetry().telemetry,
+    });
+
+    await service.sendMessage({
+      db: mockDb,
+      userId: USER_ID,
+      text: "how am I doing?",
+      executeAction: vi.fn(),
+    });
+
+    expect(buildFinancialContextPacket).toHaveBeenCalledWith({ db: mockDb, userId: USER_ID });
+    expect(streamChat).toHaveBeenCalledWith(
+      [{ role: "user", content: "how am I doing?" }],
+      expect.any(Object),
+      {
+        signal: expect.any(AbortSignal),
+        financialContextPacket: packet,
+      }
+    );
+  });
+
   it("captures action failures without breaking the assistant reply", async () => {
     const state = createState();
     state.setCurrentSessionId("chat-1" as ChatSessionId);
@@ -242,11 +300,11 @@ describe("streaming chat service", () => {
       getState: state.getState,
       setStreaming: state.setStreaming,
       setStreamingContent: state.setStreamingContent,
-      streamChat: (_messages, _callbacks, signal) =>
+      streamChat: (_messages, _callbacks, options) =>
         new Promise<void>((resolve) => {
-          capturedSignal = signal;
+          capturedSignal = options?.signal;
           resolveStarted?.();
-          signal?.addEventListener("abort", () => resolve());
+          options?.signal?.addEventListener("abort", () => resolve());
         }),
       createChatSession: vi.fn(),
       addUserChatMessage: vi.fn().mockResolvedValue(undefined),
@@ -295,23 +353,23 @@ describe("streaming chat service", () => {
       getState: state.getState,
       setStreaming: state.setStreaming,
       setStreamingContent: state.setStreamingContent,
-      streamChat: (_messages, callbacks, signal) => {
+      streamChat: (_messages, callbacks, options) => {
         invocation += 1;
 
         if (invocation === 1) {
           return new Promise<void>((resolve) => {
-            firstSignal = signal;
+            firstSignal = options?.signal;
             resolveFirst = resolve;
             resolveFirstStarted?.();
           });
         }
 
         return new Promise<void>((resolve) => {
-          secondSignal = signal;
+          secondSignal = options?.signal;
           callbacks.onChunk("new stream");
           resolveSecond = resolve;
           resolveSecondStarted?.();
-          signal?.addEventListener("abort", () => resolve());
+          options?.signal?.addEventListener("abort", () => resolve());
         });
       },
       createChatSession: vi.fn(),

--- a/apps/mobile/__tests__/edge-functions/ai-chat-privacy-boundary.test.ts
+++ b/apps/mobile/__tests__/edge-functions/ai-chat-privacy-boundary.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync("../../supabase/functions/ai-chat/index.ts", "utf8");
+
+describe("ai-chat Edge Function privacy boundary", () => {
+  it("does not query plaintext financial tables while building advisor context", () => {
+    expect(source).not.toContain('.from("transactions")');
+    expect(source).not.toContain('.from("budgets")');
+    expect(source).not.toContain('.from("goals")');
+    expect(source).not.toContain('.from("goal_contributions")');
+    expect(source).not.toContain('.from("transfers")');
+    expect(source).not.toContain('.from("financial_accounts")');
+    expect(source).not.toContain('.from("capture_evidence")');
+    expect(source).not.toContain('.rpc("get_user_balance")');
+  });
+
+  it("requires the app-provided financial context packet for chat mode", () => {
+    expect(source).toContain("financialContextPacket");
+    expect(source).toContain("invalid_context_packet");
+    expect(source).toContain("buildSystemPrompt({ packet: financialContextPacket })");
+  });
+
+  it("keeps saved memories in chat prompts through the app-provided packet", () => {
+    expect(source).toContain("context.packet.memories");
+    expect(source).toContain("## What you know about this user");
+    expect(source).not.toContain('from("user_memories").select("fact, category")');
+  });
+});

--- a/apps/mobile/__tests__/edge-functions/ai-chat-privacy-boundary.test.ts
+++ b/apps/mobile/__tests__/edge-functions/ai-chat-privacy-boundary.test.ts
@@ -26,4 +26,11 @@ describe("ai-chat Edge Function privacy boundary", () => {
     expect(source).toContain("## What you know about this user");
     expect(source).not.toContain('from("user_memories").select("fact, category")');
   });
+
+  it("validates packet collections before building chat prompts", () => {
+    expect(source).toContain("isOptionalArrayOf(value.memories, isMemorySummary)");
+    expect(source).toContain("isOptionalArrayOf(value.goals, isGoalSummary)");
+    expect(source).toContain('typeof value.targetAmount === "number"');
+    expect(source).toContain("invalid_context_packet");
+  });
 });

--- a/apps/mobile/features/advisor/build-financial-context-packet.ts
+++ b/apps/mobile/features/advisor/build-financial-context-packet.ts
@@ -1,0 +1,58 @@
+import { getBudgetsForMonth } from "@/features/budget/query.public";
+import { getRepeatedCaptureEvidenceForUser } from "@/features/capture-evidence/query.public";
+import { getFinancialAccountsForUser } from "@/features/financial-accounts/query.public";
+import { getGoalCurrentAmount, getGoalsForUser } from "@/features/goals/query.public";
+import {
+  getBalanceAggregate,
+  getRecentTransactions,
+  getSpendingByCategoryAggregate,
+} from "@/features/transactions/query.public";
+import {
+  createFinancialContextPacketBuilder,
+  type FinancialContextPacketPorts,
+} from "./financial-context-packet";
+
+const financialContextPacketPorts = {
+  getBalance: getBalanceAggregate,
+  getSpendingByCategory: getSpendingByCategoryAggregate,
+  getRecentTransactions: (input) =>
+    getRecentTransactions({
+      db: input.db,
+      userId: input.userId,
+      currentMonth: input.currentMonth,
+      previousMonth: input.previousMonth,
+    })
+      .slice(0, 20)
+      .map((transaction) => ({
+        type: transaction.type,
+        amount: transaction.amount,
+        categoryId: transaction.categoryId,
+        description: transaction.description ?? "",
+        date: transaction.date,
+      })),
+  getBudgetsForMonth: (db, userId, month) =>
+    getBudgetsForMonth(db, userId, month).map((budget) => ({
+      categoryId: budget.categoryId,
+      amount: budget.amount,
+      month: budget.month,
+    })),
+  getGoals: (db, userId) =>
+    getGoalsForUser(db, userId).map((goal) => ({
+      id: goal.id,
+      name: goal.name,
+      type: goal.type,
+      targetAmount: goal.targetAmount,
+    })),
+  getGoalCurrentAmount,
+  getAccounts: (db, userId) =>
+    getFinancialAccountsForUser(db, userId).map((account) => ({
+      name: account.name,
+      kind: account.kind,
+      isDefault: account.isDefault,
+    })),
+  getCaptureEvidence: getRepeatedCaptureEvidenceForUser,
+} satisfies FinancialContextPacketPorts;
+
+export const buildFinancialContextPacket = createFinancialContextPacketBuilder(
+  financialContextPacketPorts
+);

--- a/apps/mobile/features/advisor/financial-context-packet.ts
+++ b/apps/mobile/features/advisor/financial-context-packet.ts
@@ -1,0 +1,183 @@
+import type { AnyDb } from "@/shared/db/client";
+import { requireMonth } from "@/shared/types/assertions";
+import type { Month, UserId } from "@/shared/types/branded";
+
+export type FinancialContextCategoryTotal = {
+  readonly categoryId: string;
+  readonly total: number;
+};
+
+export type FinancialContextCategoryDelta = {
+  readonly categoryId: string;
+  readonly current: number;
+  readonly previous: number;
+  readonly delta: number;
+};
+
+export type FinancialContextPacket = {
+  readonly summary: {
+    readonly balance: number;
+    readonly currentMonthSpending: readonly FinancialContextCategoryTotal[];
+    readonly previousMonthSpending: readonly FinancialContextCategoryTotal[];
+    readonly monthOverMonthDeltas: readonly FinancialContextCategoryDelta[];
+  };
+  readonly recentTransactions: readonly {
+    readonly type: string;
+    readonly amount: number;
+    readonly categoryId: string;
+    readonly description: string;
+    readonly date: string;
+  }[];
+  readonly budgets: readonly {
+    readonly categoryId: string;
+    readonly amount: number;
+    readonly month: Month;
+  }[];
+  readonly goals: readonly {
+    readonly name: string;
+    readonly type: string;
+    readonly targetAmount: number;
+    readonly currentAmount: number;
+    readonly progressPct: number;
+  }[];
+  readonly accounts: readonly {
+    readonly name: string;
+    readonly kind: string;
+    readonly isDefault: boolean;
+  }[];
+  readonly captureEvidence: readonly {
+    readonly scope: string;
+    readonly value: string;
+    readonly sourceFamily: string;
+    readonly evidenceType: string;
+    readonly occurrences: number;
+  }[];
+  readonly memories: readonly {
+    readonly fact: string;
+    readonly category: string;
+  }[];
+};
+
+export type BuildFinancialContextPacketInput = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly now?: Date;
+};
+
+export type FinancialContextPacketPorts = {
+  readonly getBalance: (db: AnyDb, userId: UserId) => number;
+  readonly getSpendingByCategory: (
+    db: AnyDb,
+    userId: UserId,
+    month: Month
+  ) => readonly FinancialContextCategoryTotal[];
+  readonly getRecentTransactions: (
+    input: BuildFinancialContextPacketInput & {
+      readonly currentMonth: Month;
+      readonly previousMonth: Month;
+    }
+  ) => FinancialContextPacket["recentTransactions"];
+  readonly getBudgetsForMonth: (
+    db: AnyDb,
+    userId: UserId,
+    month: Month
+  ) => FinancialContextPacket["budgets"];
+  readonly getGoals: (
+    db: AnyDb,
+    userId: UserId
+  ) => readonly {
+    readonly id: string;
+    readonly name: string;
+    readonly type: string;
+    readonly targetAmount: number;
+  }[];
+  readonly getGoalCurrentAmount: (db: AnyDb, goalId: string) => number;
+  readonly getAccounts: (db: AnyDb, userId: UserId) => FinancialContextPacket["accounts"];
+  readonly getCaptureEvidence: (
+    db: AnyDb,
+    userId: UserId
+  ) => FinancialContextPacket["captureEvidence"];
+};
+
+export const toContextMonth = (date: Date): Month =>
+  requireMonth(`${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`);
+
+export const previousContextMonth = (month: Month): Month => {
+  const [year = 0, monthNumber = 1] = month.split("-").map(Number);
+  const previousMonth = monthNumber === 1 ? 12 : monthNumber - 1;
+  const previousYear = monthNumber === 1 ? year - 1 : year;
+  return requireMonth(`${previousYear}-${String(previousMonth).padStart(2, "0")}`);
+};
+
+export const deriveFinancialContextDeltas = (
+  current: readonly FinancialContextCategoryTotal[],
+  previous: readonly FinancialContextCategoryTotal[]
+): readonly FinancialContextCategoryDelta[] => {
+  const currentByCategory = new Map(current.map((item) => [item.categoryId, item.total]));
+  const previousByCategory = new Map(previous.map((item) => [item.categoryId, item.total]));
+  return [
+    ...new Set([
+      ...current.map((item) => item.categoryId),
+      ...previous.map((item) => item.categoryId),
+    ]),
+  ].map((categoryId) =>
+    toCategoryDelta(
+      categoryId,
+      currentByCategory.get(categoryId) ?? 0,
+      previousByCategory.get(categoryId) ?? 0
+    )
+  );
+};
+
+const toCategoryDelta = (
+  categoryId: string,
+  current: number,
+  previous: number
+): FinancialContextCategoryDelta => ({
+  categoryId,
+  current,
+  previous,
+  delta: current - previous,
+});
+
+export function createFinancialContextPacketBuilder(ports: FinancialContextPacketPorts) {
+  return (input: BuildFinancialContextPacketInput): FinancialContextPacket => {
+    const currentMonth = toContextMonth(input.now ?? new Date());
+    const previousMonth = previousContextMonth(currentMonth);
+    const currentMonthSpending = ports.getSpendingByCategory(input.db, input.userId, currentMonth);
+    const previousMonthSpending = ports.getSpendingByCategory(
+      input.db,
+      input.userId,
+      previousMonth
+    );
+    const goals = ports.getGoals(input.db, input.userId).map((goal) => {
+      const currentAmount = ports.getGoalCurrentAmount(input.db, goal.id);
+      return {
+        name: goal.name,
+        type: goal.type,
+        targetAmount: goal.targetAmount,
+        currentAmount,
+        progressPct:
+          goal.targetAmount > 0 ? Math.round((currentAmount / goal.targetAmount) * 100) : 0,
+      };
+    });
+
+    return {
+      summary: {
+        balance: ports.getBalance(input.db, input.userId),
+        currentMonthSpending,
+        previousMonthSpending,
+        monthOverMonthDeltas: deriveFinancialContextDeltas(
+          currentMonthSpending,
+          previousMonthSpending
+        ),
+      },
+      recentTransactions: ports.getRecentTransactions({ ...input, currentMonth, previousMonth }),
+      budgets: ports.getBudgetsForMonth(input.db, input.userId, currentMonth),
+      goals,
+      accounts: ports.getAccounts(input.db, input.userId),
+      captureEvidence: ports.getCaptureEvidence(input.db, input.userId),
+      memories: [],
+    };
+  };
+}

--- a/apps/mobile/features/advisor/index.ts
+++ b/apps/mobile/features/advisor/index.ts
@@ -1,2 +1,1 @@
-// advisor — V2 placeholder
-export {};
+export * from "./public";

--- a/apps/mobile/features/advisor/public.ts
+++ b/apps/mobile/features/advisor/public.ts
@@ -1,0 +1,12 @@
+export { buildFinancialContextPacket } from "./build-financial-context-packet";
+export type {
+  BuildFinancialContextPacketInput,
+  FinancialContextPacket,
+  FinancialContextPacketPorts,
+} from "./financial-context-packet";
+export {
+  createFinancialContextPacketBuilder,
+  deriveFinancialContextDeltas,
+  previousContextMonth,
+  toContextMonth,
+} from "./financial-context-packet";

--- a/apps/mobile/features/ai-chat/hooks/use-streaming-chat.ts
+++ b/apps/mobile/features/ai-chat/hooks/use-streaming-chat.ts
@@ -1,8 +1,10 @@
 import { useCallback } from "react";
+import { buildFinancialContextPacket } from "@/features/advisor/public";
 import { useOptionalUserId } from "@/features/auth/public";
 import { saveCurrentTransaction, useTransactionStore } from "@/features/transactions/store.public";
 import { tryGetDb } from "@/shared/db";
 import { parseIsoDate, trackAiMessageSent, trackTransactionCreated } from "@/shared/lib";
+import { listUserMemories } from "../data/user-memories";
 import { parseActionFromResponse } from "../lib/parse-action";
 import type { ChatAction } from "../schema";
 import { streamChat } from "../services/ai-chat-api";
@@ -26,6 +28,19 @@ const streamingChatService = createStreamingChatService({
   setStreaming: (isStreaming) => useChatStore.getState().setStreaming(isStreaming),
   setStreamingContent: (content) => useChatStore.getState().setStreamingContent(content),
   streamChat,
+  buildFinancialContextPacket: async (input) => {
+    const [packet, memories] = await Promise.all([
+      buildFinancialContextPacket(input),
+      listUserMemories(input.userId),
+    ]);
+    return {
+      ...packet,
+      memories: memories.map((memory) => ({
+        fact: memory.fact,
+        category: memory.category,
+      })),
+    };
+  },
   createChatSession,
   addUserChatMessage,
   addAssistantChatMessage,

--- a/apps/mobile/features/ai-chat/hooks/use-streaming-chat.ts
+++ b/apps/mobile/features/ai-chat/hooks/use-streaming-chat.ts
@@ -16,6 +16,8 @@ import {
   useChatStore,
 } from "../store";
 
+const MAX_CONTEXT_MEMORIES = 20;
+
 const streamingChatService = createStreamingChatService({
   getState: () => {
     const state = useChatStore.getState();
@@ -31,11 +33,11 @@ const streamingChatService = createStreamingChatService({
   buildFinancialContextPacket: async (input) => {
     const [packet, memories] = await Promise.all([
       buildFinancialContextPacket(input),
-      listUserMemories(input.userId),
+      listUserMemories(input.userId).catch(() => []),
     ]);
     return {
       ...packet,
-      memories: memories.map((memory) => ({
+      memories: memories.slice(0, MAX_CONTEXT_MEMORIES).map((memory) => ({
         fact: memory.fact,
         category: memory.category,
       })),

--- a/apps/mobile/features/ai-chat/services/ai-chat-api.ts
+++ b/apps/mobile/features/ai-chat/services/ai-chat-api.ts
@@ -1,3 +1,4 @@
+import type { FinancialContextPacket } from "@/features/advisor/public";
 import { createAiChatApiService } from "./create-ai-chat-api-service";
 
 type ChatMessage = { readonly role: "user" | "assistant"; readonly content: string };
@@ -8,12 +9,17 @@ type StreamCallbacks = {
   readonly onError: (error: string) => void;
 };
 
+type StreamChatOptions = {
+  readonly signal?: AbortSignal;
+  readonly financialContextPacket?: FinancialContextPacket;
+};
+
 const aiChatApi = createAiChatApiService();
 
 export async function streamChat(
   messages: readonly ChatMessage[],
   callbacks: StreamCallbacks,
-  signal?: AbortSignal
+  options?: StreamChatOptions
 ): Promise<void> {
-  return aiChatApi.streamChat(messages, callbacks, signal);
+  return aiChatApi.streamChat(messages, callbacks, options);
 }

--- a/apps/mobile/features/ai-chat/services/create-ai-chat-api-service.ts
+++ b/apps/mobile/features/ai-chat/services/create-ai-chat-api-service.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect";
 import { fetch as expoFetch } from "expo/fetch";
+import type { FinancialContextPacket } from "@/features/advisor/public";
 import { fromPromise } from "@/shared/effect/runtime";
 import {
   type AppSupabase,
@@ -16,6 +17,11 @@ type StreamCallbacks = {
   readonly onError: (error: string) => void;
 };
 
+type StreamChatOptions = {
+  readonly signal?: AbortSignal;
+  readonly financialContextPacket?: FinancialContextPacket;
+};
+
 type CreateAiChatApiServiceDeps = {
   readonly fetchImpl?: typeof expoFetch;
   readonly getBaseUrl?: () => string;
@@ -27,7 +33,7 @@ export type AiChatApiService = {
   readonly streamChat: (
     messages: readonly ChatMessage[],
     callbacks: StreamCallbacks,
-    signal?: AbortSignal
+    options?: StreamChatOptions
   ) => Promise<void>;
 };
 
@@ -45,6 +51,160 @@ function authHeadersEffect() {
   );
 }
 
+async function resolveAuthHeaders(input: {
+  readonly runSupabaseEffect: <A>(effect: Effect.Effect<A, unknown, AppSupabase>) => Promise<A>;
+  readonly callbacks: StreamCallbacks;
+  readonly signal?: AbortSignal;
+}): Promise<Record<string, string> | null> {
+  try {
+    return await input.runSupabaseEffect(authHeadersEffect());
+  } catch (error) {
+    if (!input.signal?.aborted) {
+      input.callbacks.onError(error instanceof Error ? error.message : "Auth error");
+    }
+    return null;
+  }
+}
+
+async function postChat(input: {
+  readonly fetchImpl: typeof expoFetch;
+  readonly url: string;
+  readonly headers: Record<string, string>;
+  readonly messages: readonly ChatMessage[];
+  readonly financialContextPacket?: FinancialContextPacket;
+  readonly signal?: AbortSignal;
+  readonly callbacks: StreamCallbacks;
+}): Promise<Response | null> {
+  try {
+    return await input.fetchImpl(input.url, {
+      method: "POST",
+      headers: input.headers,
+      body: JSON.stringify({
+        messages: input.messages,
+        financialContextPacket: input.financialContextPacket,
+      }),
+      signal: input.signal,
+    });
+  } catch (error) {
+    if (!input.signal?.aborted) {
+      input.callbacks.onError(error instanceof Error ? error.message : "Network error");
+    }
+    return null;
+  }
+}
+
+type SsePayloadResult = "continue" | "done";
+
+function emitChunk(input: {
+  readonly callbacks: StreamCallbacks;
+  readonly captureCallbackError: (error: unknown) => void;
+  readonly content: unknown;
+}): void {
+  try {
+    input.callbacks.onChunk(String(input.content));
+  } catch (callbackError) {
+    input.captureCallbackError(callbackError);
+  }
+}
+
+function handleSsePayload(input: {
+  readonly payload: string;
+  readonly callbacks: StreamCallbacks;
+  readonly captureCallbackError: (error: unknown) => void;
+}): SsePayloadResult {
+  if (input.payload === "[DONE]") {
+    input.callbacks.onDone();
+    return "done";
+  }
+
+  try {
+    const parsed = JSON.parse(input.payload) as Record<string, unknown>;
+    if (parsed.error) {
+      input.callbacks.onError(String(parsed.error));
+      return "done";
+    }
+    if (parsed.content) {
+      emitChunk({ ...input, content: parsed.content });
+    }
+  } catch {
+    // Skip malformed SSE lines
+  }
+  return "continue";
+}
+
+async function consumeSseStream(input: {
+  readonly reader: ReadableStreamDefaultReader<Uint8Array>;
+  readonly callbacks: StreamCallbacks;
+  readonly signal?: AbortSignal;
+  readonly captureCallbackError: (error: unknown) => void;
+}): Promise<void> {
+  const decoder = new TextDecoder();
+  // FP exemption: streaming SSE requires imperative buffering.
+  let buffer = "";
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional streaming loop
+    while (true) {
+      const { done, value } = await input.reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        if (!line.startsWith("data: ")) continue;
+        const result = handleSsePayload({
+          payload: line.slice(6).trim(),
+          callbacks: input.callbacks,
+          captureCallbackError: input.captureCallbackError,
+        });
+        if (result === "done") return;
+      }
+    }
+
+    input.callbacks.onDone();
+  } catch (error) {
+    if (input.signal?.aborted) return;
+    input.callbacks.onError(error instanceof Error ? error.message : "Stream error");
+  }
+}
+
+function getStreamReader(
+  response: Response,
+  callbacks: StreamCallbacks
+): ReadableStreamDefaultReader<Uint8Array> | null {
+  if (!response.ok) {
+    callbacks.onError(`HTTP ${response.status}`);
+    return null;
+  }
+
+  const reader = response.body?.getReader();
+  if (!reader) {
+    callbacks.onError("No response body");
+    return null;
+  }
+  return reader;
+}
+
+async function openChatStream(input: {
+  readonly runSupabaseEffect: <A>(effect: Effect.Effect<A, unknown, AppSupabase>) => Promise<A>;
+  readonly fetchImpl: typeof expoFetch;
+  readonly url: string;
+  readonly messages: readonly ChatMessage[];
+  readonly financialContextPacket?: FinancialContextPacket;
+  readonly callbacks: StreamCallbacks;
+  readonly signal?: AbortSignal;
+}): Promise<ReadableStreamDefaultReader<Uint8Array> | null> {
+  const headers = await resolveAuthHeaders(input);
+  if (!headers) return null;
+
+  const response = await postChat({ ...input, headers });
+  if (!response) return null;
+
+  return getStreamReader(response, input.callbacks);
+}
+
 export function createAiChatApiService({
   fetchImpl = expoFetch,
   getBaseUrl = () => process.env.EXPO_PUBLIC_SUPABASE_URL ?? "",
@@ -59,90 +219,20 @@ export function createAiChatApiService({
     telemetryRuntime.run(captureErrorEffect(error)).catch(() => undefined);
 
   return {
-    async streamChat(messages, callbacks, signal) {
-      let headers: Record<string, string>;
-      try {
-        headers = await runSupabaseEffect(authHeadersEffect());
-      } catch (error) {
-        if (signal?.aborted) return;
-        callbacks.onError(error instanceof Error ? error.message : "Auth error");
-        return;
-      }
+    async streamChat(messages, callbacks, options) {
+      const { signal, financialContextPacket } = options ?? {};
+      const reader = await openChatStream({
+        runSupabaseEffect,
+        fetchImpl,
+        url: `${getBaseUrl()}/functions/v1/ai-chat`,
+        messages,
+        financialContextPacket,
+        callbacks,
+        signal,
+      });
+      if (!reader) return;
 
-      const url = `${getBaseUrl()}/functions/v1/ai-chat`;
-
-      let response: Response;
-      try {
-        response = await fetchImpl(url, {
-          method: "POST",
-          headers,
-          body: JSON.stringify({ messages }),
-          signal,
-        });
-      } catch (error) {
-        if (signal?.aborted) return;
-        callbacks.onError(error instanceof Error ? error.message : "Network error");
-        return;
-      }
-
-      if (!response.ok) {
-        callbacks.onError(`HTTP ${response.status}`);
-        return;
-      }
-
-      const reader = response.body?.getReader();
-      if (!reader) {
-        callbacks.onError("No response body");
-        return;
-      }
-
-      const decoder = new TextDecoder();
-      // FP exemption: streaming SSE requires imperative buffering.
-      let buffer = "";
-
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional streaming loop
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-
-          buffer += decoder.decode(value, { stream: true });
-          const lines = buffer.split("\n");
-          buffer = lines.pop() ?? "";
-
-          for (const line of lines) {
-            if (!line.startsWith("data: ")) continue;
-            const payload = line.slice(6).trim();
-
-            if (payload === "[DONE]") {
-              callbacks.onDone();
-              return;
-            }
-
-            try {
-              const parsed = JSON.parse(payload) as Record<string, unknown>;
-              if (parsed.error) {
-                callbacks.onError(String(parsed.error));
-                return;
-              }
-              if (parsed.content) {
-                try {
-                  callbacks.onChunk(String(parsed.content));
-                } catch (callbackError) {
-                  void captureCallbackError(callbackError);
-                }
-              }
-            } catch {
-              // Skip malformed SSE lines
-            }
-          }
-        }
-
-        callbacks.onDone();
-      } catch (error) {
-        if (signal?.aborted) return;
-        callbacks.onError(error instanceof Error ? error.message : "Stream error");
-      }
+      await consumeSseStream({ reader, callbacks, signal, captureCallbackError });
     },
   };
 }

--- a/apps/mobile/features/ai-chat/services/create-streaming-chat-service.ts
+++ b/apps/mobile/features/ai-chat/services/create-streaming-chat-service.ts
@@ -1,3 +1,7 @@
+import type {
+  BuildFinancialContextPacketInput,
+  FinancialContextPacket,
+} from "@/features/advisor/public";
 import type { AnyDb } from "@/shared/db";
 import {
   type AppTelemetry,
@@ -37,8 +41,14 @@ type CreateStreamingChatServiceDeps = StreamStateDeps & {
       readonly onDone: () => void;
       readonly onError: (error: string) => void;
     },
-    signal?: AbortSignal
+    options?: {
+      readonly signal?: AbortSignal;
+      readonly financialContextPacket?: FinancialContextPacket;
+    }
   ) => Promise<void>;
+  readonly buildFinancialContextPacket?: (
+    input: BuildFinancialContextPacketInput
+  ) => FinancialContextPacket | Promise<FinancialContextPacket>;
   readonly createChatSession: (db: AnyDb, userId: UserId, firstMessage: string) => Promise<unknown>;
   readonly addUserChatMessage: (db: AnyDb, userId: UserId, content: string) => Promise<unknown>;
   readonly addAssistantChatMessage: (
@@ -101,11 +111,14 @@ async function consumeStream(
   recorder: StreamRecorder
 ): Promise<void> {
   try {
-    await run.deps.streamChat(
-      conversation,
-      createStreamCallbacks(run, recorder),
-      run.controller.signal
-    );
+    const financialContextPacket = await run.deps.buildFinancialContextPacket?.({
+      db: run.request.db,
+      userId: run.request.userId,
+    });
+    await run.deps.streamChat(conversation, createStreamCallbacks(run, recorder), {
+      signal: run.controller.signal,
+      financialContextPacket,
+    });
   } catch (error) {
     if (run.controller.signal.aborted) return;
     setStreamOutcome(recorder, { type: "error", message: toThrownErrorMessage(error) });

--- a/apps/mobile/features/budget/query.public.ts
+++ b/apps/mobile/features/budget/query.public.ts
@@ -1,0 +1,1 @@
+export { getBudgetsForMonth } from "./lib/repository";

--- a/apps/mobile/features/capture-evidence/query.public.ts
+++ b/apps/mobile/features/capture-evidence/query.public.ts
@@ -1,0 +1,1 @@
+export { getRepeatedCaptureEvidenceForUser } from "./lib/repository";

--- a/apps/mobile/features/financial-accounts/query.public.ts
+++ b/apps/mobile/features/financial-accounts/query.public.ts
@@ -1,0 +1,1 @@
+export { getFinancialAccountsForUser } from "./lib/repository";

--- a/apps/mobile/features/goals/query.public.ts
+++ b/apps/mobile/features/goals/query.public.ts
@@ -1,0 +1,1 @@
+export { getGoalCurrentAmount, getGoalsForUser } from "./lib/repository";

--- a/apps/mobile/features/transactions/query.public.ts
+++ b/apps/mobile/features/transactions/query.public.ts
@@ -2,8 +2,10 @@ export { toStoredTransaction, toTransactionRow } from "./lib/build-transaction";
 export type { TransactionRow } from "./lib/repository";
 export {
   clearSyncEntries,
+  getBalanceAggregate,
   getMonthlyTotalsByType,
   getQueuedSyncEntries,
+  getRecentTransactions,
   getSpendingByCategoryAggregate,
   getSyncMeta,
   getTransactionById,

--- a/scripts/check-feature-public-imports.test.ts
+++ b/scripts/check-feature-public-imports.test.ts
@@ -18,6 +18,8 @@ const writeSourceFile = (root: string, relativePath: string, source: string): vo
   writeFileSync(absolutePath, source);
 };
 
+const normalizePathSeparators = (value: string): string => value.replaceAll("\\", "/");
+
 afterEach(() => {
   tempDirs.splice(0).forEach((dir) => {
     rmSync(dir, { recursive: true, force: true });
@@ -45,10 +47,9 @@ test("reports broad barrel imports across feature boundaries", () => {
   });
 
   expect(result.exitCode).toBe(0);
-  expect(result.stdout.toString()).toContain("Broad cross-feature barrel imports: 1");
-  expect(result.stdout.toString()).toContain(
-    "apps/mobile/features/budget/store.ts:1 imports @/features/auth"
-  );
+  const stdout = normalizePathSeparators(result.stdout.toString());
+  expect(stdout).toContain("Broad cross-feature barrel imports: 1");
+  expect(stdout).toContain("apps/mobile/features/budget/store.ts:1 imports @/features/auth");
 });
 
 test("ignores same-feature barrels, tests, and explicit public imports", () => {
@@ -97,8 +98,9 @@ test("fails in enforce mode when violations are present", () => {
   });
 
   expect(result.exitCode).toBe(1);
-  expect(result.stdout.toString()).toContain("Broad cross-feature barrel imports: 1");
-  expect(result.stdout.toString()).toContain(
+  const stdout = normalizePathSeparators(result.stdout.toString());
+  expect(stdout).toContain("Broad cross-feature barrel imports: 1");
+  expect(stdout).toContain(
     "apps/mobile/features/search/store.ts:1 imports @/features/transactions"
   );
 });
@@ -132,9 +134,10 @@ test("ignores comment and string matches while still catching multiline imports"
   });
 
   expect(result.exitCode).toBe(1);
-  expect(result.stdout.toString()).toContain("Broad cross-feature barrel imports: 1");
-  expect(result.stdout.toString()).toContain(
+  const stdout = normalizePathSeparators(result.stdout.toString());
+  expect(stdout).toContain("Broad cross-feature barrel imports: 1");
+  expect(stdout).toContain(
     "apps/mobile/features/budget/store.ts:3 imports @/features/transactions"
   );
-  expect(result.stdout.toString()).not.toContain("@/features/auth");
+  expect(stdout).not.toContain("@/features/auth");
 });

--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -178,8 +178,43 @@ function buildSystemPrompt(context: { packet: FinancialContextPacket }): string 
   return parts.join("\n");
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isOptionalArrayOf(value: unknown, isItemValid: (item: unknown) => boolean): boolean {
+  return value === undefined || (Array.isArray(value) && value.every(isItemValid));
+}
+
+function isUnknownItem(_value: unknown): boolean {
+  return true;
+}
+
+function isMemorySummary(value: unknown): boolean {
+  return isRecord(value) && typeof value.fact === "string" && typeof value.category === "string";
+}
+
+function isGoalSummary(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    typeof value.name === "string" &&
+    typeof value.type === "string" &&
+    typeof value.targetAmount === "number" &&
+    typeof value.currentAmount === "number" &&
+    typeof value.progressPct === "number"
+  );
+}
+
 function isFinancialContextPacket(value: unknown): value is FinancialContextPacket {
-  return typeof value === "object" && value !== null && "summary" in value;
+  if (!isRecord(value) || !("summary" in value)) return false;
+  return (
+    isOptionalArrayOf(value.recentTransactions, isUnknownItem) &&
+    isOptionalArrayOf(value.budgets, isUnknownItem) &&
+    isOptionalArrayOf(value.memories, isMemorySummary) &&
+    isOptionalArrayOf(value.goals, isGoalSummary) &&
+    isOptionalArrayOf(value.accounts, isUnknownItem) &&
+    isOptionalArrayOf(value.captureEvidence, isUnknownItem)
+  );
 }
 
 Deno.serve(async (req) => {

--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -90,64 +90,6 @@ function createUserClient(token: string) {
   });
 }
 
-function currentMonthString(): string {
-  const now = new Date();
-  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
-}
-
-function previousMonthString(month: string): string {
-  const [year, m] = month.split("-").map(Number);
-  const prevM = m === 1 ? 12 : m - 1;
-  const prevY = m === 1 ? year - 1 : year;
-  return `${prevY}-${String(prevM).padStart(2, "0")}`;
-}
-
-function nextMonthString(month: string): string {
-  const [year, m] = month.split("-").map(Number);
-  const nextM = m === 12 ? 1 : m + 1;
-  const nextY = m === 12 ? year + 1 : year;
-  return `${nextY}-${String(nextM).padStart(2, "0")}`;
-}
-
-type CategorySpending = { categoryId: string; total: number };
-type CategoryDelta = { categoryId: string; current: number; previous: number; delta: number };
-
-function computeSpendingByCategory(
-  transactions: { category_id: string; amount: number; type: string; date: string }[],
-  month: string
-): CategorySpending[] {
-  const start = `${month}-01`;
-  const end = `${nextMonthString(month)}-01`;
-  const map = transactions
-    .filter((t) => t.type === "expense" && t.date >= start && t.date < end)
-    .reduce(
-      (acc, t) => acc.set(t.category_id, (acc.get(t.category_id) ?? 0) + t.amount),
-      new Map<string, number>()
-    );
-  return Array.from(map.entries()).map(([categoryId, total]) => ({
-    categoryId,
-    total,
-  }));
-}
-
-function computeDeltas(current: CategorySpending[], previous: CategorySpending[]): CategoryDelta[] {
-  const prevMap = new Map(previous.map((p) => [p.categoryId, p.total]));
-  const allCategories = new Set([
-    ...current.map((c) => c.categoryId),
-    ...previous.map((p) => p.categoryId),
-  ]);
-  return Array.from(allCategories).map((categoryId) => {
-    const currentTotal = current.find((c) => c.categoryId === categoryId)?.total ?? 0;
-    const previousTotal = prevMap.get(categoryId) ?? 0;
-    return {
-      categoryId,
-      current: currentTotal,
-      previous: previousTotal,
-      delta: currentTotal - previousTotal,
-    };
-  });
-}
-
 function jsonResponse(
   body: unknown,
   status = 200,
@@ -178,95 +120,66 @@ function structuredLog(fields: {
 }
 
 type GoalSummary = {
-  name: string;
-  type: string;
-  targetAmount: number;
-  currentAmount: number;
-  progressPct: number;
+  readonly name: string;
+  readonly type: string;
+  readonly targetAmount: number;
+  readonly currentAmount: number;
+  readonly progressPct: number;
 };
 
-async function fetchGoalsContext(
-  userClient: ReturnType<typeof createClient>
-): Promise<GoalSummary[]> {
-  try {
-    const { data: goals, error: goalsError } = await userClient
-      .from("goals")
-      .select("id, name, type, target_amount, target_date")
-      .is("deleted_at", null);
-
-    if (goalsError || !goals || goals.length === 0) return [];
-
-    const { data: contributions, error: contribError } = await userClient
-      .from("goal_contributions")
-      .select("goal_id, amount")
-      .is("deleted_at", null)
-      .in(
-        "goal_id",
-        goals.map((g: { id: string }) => g.id)
-      );
-
-    if (contribError) return [];
-
-    const totals = (contributions ?? []).reduce((acc, c) => {
-      const contrib = c as { goal_id: string; amount: number };
-      acc.set(contrib.goal_id, (acc.get(contrib.goal_id) ?? 0) + contrib.amount);
-      return acc;
-    }, new Map<string, number>());
-
-    return goals.map(
-      (g: {
-        id: string;
-        name: string;
-        type: string;
-        target_amount: number;
-        target_date: string | null;
-      }) => {
-        const current = totals.get(g.id) ?? 0;
-        const progressPct = g.target_amount > 0 ? Math.round((current / g.target_amount) * 100) : 0;
-        return {
-          name: g.name,
-          type: g.type,
-          targetAmount: g.target_amount,
-          currentAmount: current,
-          progressPct,
-        };
-      }
-    );
-  } catch {
-    return [];
-  }
-}
+type FinancialContextPacket = {
+  readonly summary: unknown;
+  readonly recentTransactions?: readonly unknown[];
+  readonly budgets?: readonly unknown[];
+  readonly memories?: readonly { readonly fact: string; readonly category: string }[];
+  readonly goals?: readonly GoalSummary[];
+  readonly accounts?: readonly unknown[];
+  readonly captureEvidence?: readonly unknown[];
+};
 
 function formatGoalLine(g: GoalSummary): string {
   const amounts = `$${g.currentAmount.toLocaleString("es-CO")} / $${g.targetAmount.toLocaleString("es-CO")} (${g.progressPct}%)`;
   return `- "${g.name}" (${g.type}): ${amounts}`;
 }
 
-function buildSystemPrompt(context: {
-  transactions: unknown[];
-  summary: unknown;
-  memories: { fact: string; category: string }[];
-  goals: GoalSummary[];
-}): string {
+function buildSystemPrompt(context: { packet: FinancialContextPacket }): string {
   const parts = [SYSTEM_PROMPT];
 
-  if (context.memories.length > 0) {
-    const memoryLines = context.memories.map((m) => `- [${m.category}] ${m.fact}`).join("\n");
+  if ((context.packet.memories ?? []).length > 0) {
+    const memoryLines = (context.packet.memories ?? [])
+      .map((memory) => `- [${memory.category}] ${memory.fact}`)
+      .join("\n");
     parts.push(`\n## What you know about this user\n${memoryLines}`);
   }
 
-  if (context.goals.length > 0) {
-    const goalLines = context.goals.map(formatGoalLine).join("\n");
+  if ((context.packet.goals ?? []).length > 0) {
+    const goalLines = (context.packet.goals ?? []).map(formatGoalLine).join("\n");
     parts.push(`\n## User's Financial Goals\n${goalLines}`);
   }
 
-  parts.push(`\n## Current financial context\n${JSON.stringify(context.summary)}`);
+  parts.push(`\n## Current financial context\n${JSON.stringify(context.packet.summary)}`);
 
-  if (context.transactions.length > 0) {
-    parts.push(`\n## Recent transactions\n${JSON.stringify(context.transactions)}`);
+  if ((context.packet.budgets ?? []).length > 0) {
+    parts.push(`\n## Current budgets\n${JSON.stringify(context.packet.budgets)}`);
+  }
+
+  if ((context.packet.accounts ?? []).length > 0) {
+    parts.push(`\n## Financial accounts\n${JSON.stringify(context.packet.accounts)}`);
+  }
+
+  if ((context.packet.captureEvidence ?? []).length > 0) {
+    parts.push(`\n## Capture evidence signals\n${JSON.stringify(context.packet.captureEvidence)}`);
+  }
+
+  if ((context.packet.recentTransactions ?? []).length > 0) {
+    parts.push(`\n## Recent transactions\n${JSON.stringify(context.packet.recentTransactions)}`);
   }
 
   return parts.join("\n");
+}
+
+function isFinancialContextPacket(value: unknown): value is FinancialContextPacket {
+  return typeof value === "object" && value !== null && "summary" in value;
 }
 
 Deno.serve(async (req) => {
@@ -488,71 +401,20 @@ Deno.serve(async (req) => {
       return jsonResponse({ success: false, error: "invalid_request" }, 400);
     }
 
-    // Server-side context building
-    const userClient = createUserClient(token);
-    const month = currentMonthString();
-    const prevMonth = previousMonthString(month);
-
-    const contextStartTime = Date.now();
-    const [balanceResult, txResult, memoriesResult, goals] = await Promise.all([
-      userClient.rpc("get_user_balance"),
-      userClient
-        .from("transactions")
-        .select("type, amount, category_id, description, date")
-        .is("deleted_at", null)
-        .gte("date", `${prevMonth}-01`)
-        .order("date", { ascending: false }),
-      userClient.from("user_memories").select("fact, category").is("deleted_at", null),
-      fetchGoalsContext(userClient),
-    ]);
-    const contextQueryMs = Date.now() - contextStartTime;
-
-    const contextError =
-      balanceResult.error?.message ?? txResult.error?.message ?? memoriesResult.error?.message;
-    if (contextError) {
+    const { financialContextPacket } = body;
+    if (!isFinancialContextPacket(financialContextPacket)) {
       structuredLog({
         request_id: requestId,
         user_id: userId,
         mode,
         success: false,
         latency_ms: Date.now() - startTime,
-        error_type: "context_query_error",
-        context_query_ms: contextQueryMs,
+        error_type: "invalid_context_packet",
       });
-      return jsonResponse({ success: false, error: "context_query_error" }, 500);
+      return jsonResponse({ success: false, error: "invalid_context_packet" }, 400);
     }
 
-    const txData = txResult.data ?? [];
-    const currentSpending = computeSpendingByCategory(txData, month);
-    const prevSpending = computeSpendingByCategory(txData, prevMonth);
-
-    const context = {
-      transactions: txData.map(
-        (t: {
-          type: string;
-          amount: number;
-          category_id: string;
-          description: string;
-          date: string;
-        }) => ({
-          type: t.type,
-          amount: t.amount,
-          categoryId: t.category_id,
-          description: t.description,
-          date: t.date,
-        })
-      ),
-      summary: {
-        balance: (balanceResult.data as number) ?? 0,
-        currentMonthSpending: currentSpending,
-        previousMonthSpending: prevSpending,
-        monthOverMonthDeltas: computeDeltas(currentSpending, prevSpending),
-      },
-      memories: (memoriesResult.data ?? []) as { fact: string; category: string }[],
-      goals,
-    };
-
-    const systemPrompt = buildSystemPrompt(context);
+    const systemPrompt = buildSystemPrompt({ packet: financialContextPacket });
 
     const stream = await openai.chat.completions.create({
       model: MODEL,
@@ -581,7 +443,7 @@ Deno.serve(async (req) => {
             latency_ms: Date.now() - startTime,
             error_type: null,
             message_count: messages.length,
-            context_query_ms: contextQueryMs,
+            context_query_ms: 0,
           });
         } catch (err) {
           const errorMsg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch AI chat to app-built financial context packets. The app builds and sends a financial snapshot with each chat; the Edge Function validates it, builds prompts from it, and no longer queries user financial or memory tables. Implements Linear issue 297.

- **New Features**
  - Added `FinancialContextPacket`, ports-based `createFinancialContextPacketBuilder`, and `buildFinancialContextPacket` using `query.public` getters; includes balance, MoM deltas, recent transactions (max 20), budgets, goals (with progress), accounts, and capture evidence; memories are added client-side best-effort and capped at 20.
  - Streaming API now accepts `{ financialContextPacket, signal }`; `use-streaming-chat`/`create-streaming-chat-service` build the packet (including saved memories) and pass it to `streamChat` (tests cover builder, forwarding, and request payload).
  - Edge Function requires and validates the packet, builds the system prompt from it (summary, budgets, accounts, capture evidence, goals, recent transactions), and returns `invalid_context_packet` on bad input; adds a privacy boundary test to ensure no plaintext or `user_memories` queries.

- **Refactors**
  - Split auth/network/SSE handling in `create-ai-chat-api-service` into helpers with clearer error handling; added tests to capture chunk callback failures without breaking the stream.
  - Exposed `query.public` for budgets, goals (+current amounts), financial accounts, capture evidence, and transactions (recent, balance, category aggregates); added unit tests for the packet builder and month utilities, plus tooling updates to normalize path separators.

<sup>Written for commit 40dba125946456cdd60ab65a61a00a2d68cc8de8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

