### PR TITLE
chore(codex): add mempalace plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "fidy",
+  "interface": {
+    "displayName": "Fidy Plugins"
+  },
+  "plugins": [
+    {
+      "name": "mempalace",
+      "source": {
+        "source": "local",
+        "path": "./plugins/mempalace"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coding"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ ios/
 
 # MCP (contains tokens)
 .mcp.json
+!plugins/*/.mcp.json
 
 # Supabase local
 .supabase/
@@ -82,6 +83,8 @@ TODOS.md
 .agents/*
 !.agents/skills/
 !.agents/skills/**
+!.agents/plugins/
+!.agents/plugins/marketplace.json
 skills-lock.json
 .continue/
 .kiro/
@@ -105,3 +108,7 @@ apps/mobile/.claude/settings.local.json
 *~
 *.orig
 .vercel
+
+# MemPalace per-project files
+mempalace.yaml
+entities.json

--- a/plugins/mempalace/.codex-plugin/plugin.json
+++ b/plugins/mempalace/.codex-plugin/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "mempalace",
+  "version": "3.3.3",
+  "description": "Give your AI a memory - mine projects and conversations into a searchable palace with MCP tools and guided setup.",
+  "author": {
+    "name": "milla-jovovich"
+  },
+  "homepage": "https://github.com/MemPalace/mempalace",
+  "repository": "https://github.com/MemPalace/mempalace",
+  "license": "MIT",
+  "keywords": ["memory", "ai", "rag", "mcp", "chromadb", "palace", "search"],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "MemPalace",
+    "shortDescription": "AI memory system for Codex",
+    "longDescription": "Give your AI a persistent memory - mine projects and conversations into a searchable palace backed by ChromaDB, with MCP tools and guided skills.",
+    "developerName": "milla-jovovich",
+    "category": "Coding",
+    "capabilities": ["Interactive", "Read", "Write"],
+    "websiteURL": "https://github.com/MemPalace/mempalace",
+    "privacyPolicyURL": "https://github.com/MemPalace/mempalace",
+    "termsOfServiceURL": "https://github.com/MemPalace/mempalace",
+    "defaultPrompt": [
+      "Search my memories for recent decisions",
+      "Mine this project into my memory palace",
+      "Show my palace status and room counts"
+    ],
+    "brandColor": "#7C3AED"
+  }
+}

--- a/plugins/mempalace/.mcp.json
+++ b/plugins/mempalace/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "mempalace": {
+      "command": "python",
+      "args": ["-X", "utf8", "-m", "mempalace.mcp_server"]
+    }
+  }
+}

--- a/plugins/mempalace/README.md
+++ b/plugins/mempalace/README.md
@@ -1,0 +1,38 @@
+# MemPalace - Codex Plugin
+
+Give your AI a persistent memory by mining projects and conversations into a searchable palace backed by ChromaDB.
+
+## Prerequisites
+
+- Python 3.9+
+- Codex installed and configured
+- `pip install mempalace`
+
+## Installation
+
+This repository exposes MemPalace through the repo-local marketplace at `.agents/plugins/marketplace.json`. In Codex, open `/plugins`, find MemPalace in the Fidy marketplace, and install or enable it.
+
+After installation, initialize your palace:
+
+```bash
+codex /init
+```
+
+## Available Skills
+
+| Skill | Description |
+|-------|-------------|
+| `/help` | Show available commands and usage tips |
+| `/init` | Initialize a new memory palace |
+| `/search` | Semantic search across all mined memories |
+| `/mine` | Mine a project or conversation into your palace |
+| `/status` | Show palace status, room counts, and health |
+
+## MCP
+
+The plugin registers the MemPalace MCP server through `.mcp.json`.
+
+## Support
+
+- Repository: https://github.com/MemPalace/mempalace
+- Issues: https://github.com/MemPalace/mempalace/issues

--- a/plugins/mempalace/skills/help/SKILL.md
+++ b/plugins/mempalace/skills/help/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: help
+description: Show MemPalace help - available commands, usage tips, and getting started guidance.
+allowed-tools: Bash, Read
+---
+
+# MemPalace Help
+
+Run the following command and follow the returned instructions step by step:
+
+```bash
+python -X utf8 -m mempalace instructions help
+```

--- a/plugins/mempalace/skills/init/SKILL.md
+++ b/plugins/mempalace/skills/init/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: init
+description: Initialize a new MemPalace - guided setup for your AI memory palace with ChromaDB backend.
+allowed-tools: Bash, Read, Write, Edit
+---
+
+# MemPalace Init
+
+Run the following command and follow the returned instructions step by step:
+
+```bash
+python -X utf8 -m mempalace instructions init
+```

--- a/plugins/mempalace/skills/mine/SKILL.md
+++ b/plugins/mempalace/skills/mine/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: mine
+description: Mine a project or conversation into your MemPalace - extract and store memories for later retrieval.
+allowed-tools: Bash, Read, Glob, Grep
+---
+
+# MemPalace Mine
+
+Run the following command and follow the returned instructions step by step:
+
+```bash
+python -X utf8 -m mempalace instructions mine
+```

--- a/plugins/mempalace/skills/search/SKILL.md
+++ b/plugins/mempalace/skills/search/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: search
+description: Search your MemPalace - semantic search across all mined memories, projects, and conversations.
+allowed-tools: Bash, Read
+---
+
+# MemPalace Search
+
+Run the following command and follow the returned instructions step by step:
+
+```bash
+python -X utf8 -m mempalace instructions search
+```

--- a/plugins/mempalace/skills/status/SKILL.md
+++ b/plugins/mempalace/skills/status/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: status
+description: Show MemPalace status - room counts, storage usage, and palace health.
+allowed-tools: Bash, Read
+---
+
+# MemPalace Status
+
+Run the following command and follow the returned instructions step by step:
+
+```bash
+python -X utf8 -m mempalace instructions status
+```


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds the `mempalace` Codex plugin for persistent memory backed by ChromaDB with guided skills and an MCP server. Exposes the plugin in the repo-local Fidy marketplace and documents setup.

- **New Features**
  - Adds `.codex-plugin/plugin.json` and `.mcp.json` to run `python -X utf8 -m mempalace.mcp_server`.
  - Adds skills: `/help`, `/init`, `/mine`, `/search`, `/status`.
  - Adds README with install and `/init` setup steps.
  - Adds `.agents/plugins/marketplace.json` entry to list `mempalace` in the Fidy marketplace.
  - Updates `.gitignore` to include plugin `.mcp.json`, keep the marketplace JSON, and ignore `mempalace.yaml` and `entities.json`.

<sup>Written for commit da03fc491763b40ae7be3550b485f4230f4c4b17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

