### PR TITLE
fix(account): delete private backups

### DIFF
--- a/apps/mobile/__tests__/edge-functions/delete-account-cleanup.test.ts
+++ b/apps/mobile/__tests__/edge-functions/delete-account-cleanup.test.ts
@@ -1,0 +1,143 @@
+// biome-ignore-all lint/style/useNamingConvention: Supabase table and storage APIs use snake_case
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { deleteAccountRemoteData } from "../../../../supabase/functions/delete-account/cleanup";
+
+const USER_ID = "00000000-0000-4000-8000-000000000001";
+
+describe("delete-account remote cleanup", () => {
+  it("deletes encrypted backups, operational rows, legacy plaintext rows, and the auth user", async () => {
+    const supabase = createDeleteAccountSupabase({
+      backupRows: [{ id: "backup-1" }, { id: "backup-2" }],
+    });
+
+    await expect(deleteAccountRemoteData(supabase.client, USER_ID)).resolves.toEqual({
+      success: true,
+      failures: [],
+    });
+
+    expect(supabase.tableDeletes()).toEqual([
+      "encrypted_backups",
+      "push_devices",
+      "notification_preferences",
+      "rate_limits",
+      "account_suggestion_dismissals",
+      "capture_evidence",
+      "financial_account_identifiers",
+      "opening_balances",
+      "transfers",
+      "transactions",
+      "financial_accounts",
+    ]);
+    expect(supabase.storageRemove).toHaveBeenCalledWith([
+      `${USER_ID}/backup-1.json`,
+      `${USER_ID}/backup-2.json`,
+    ]);
+    expect(supabase.deleteUser).toHaveBeenCalledWith(USER_ID);
+  });
+
+  it("reports partial remote failures while keeping backup metadata retryable", async () => {
+    const supabase = createDeleteAccountSupabase({
+      backupRows: [{ id: "backup-1" }],
+      storageError: { message: "storage unavailable" },
+    });
+
+    await expect(deleteAccountRemoteData(supabase.client, USER_ID)).resolves.toEqual({
+      success: false,
+      failures: [{ target: "encrypted-backups", message: "storage unavailable" }],
+    });
+
+    expect(supabase.tableDeletes()).not.toContain("encrypted_backups");
+    expect(supabase.storageRemove).toHaveBeenCalledWith([`${USER_ID}/backup-1.json`]);
+    expect(supabase.deleteUser).not.toHaveBeenCalled();
+  });
+
+  it("deletes every backup blob page before removing backup metadata", async () => {
+    const backupRows = Array.from({ length: 1001 }, (_, index) => ({ id: `backup-${index}` }));
+    const supabase = createDeleteAccountSupabase({ backupRows });
+
+    await expect(deleteAccountRemoteData(supabase.client, USER_ID)).resolves.toEqual({
+      success: true,
+      failures: [],
+    });
+
+    expect(supabase.storageRemove).toHaveBeenNthCalledWith(
+      1,
+      backupRows.slice(0, 1000).map((row) => `${USER_ID}/${row.id}.json`)
+    );
+    expect(supabase.storageRemove).toHaveBeenNthCalledWith(2, [`${USER_ID}/backup-1000.json`]);
+    expect(supabase.tableDeletes()[0]).toBe("encrypted_backups");
+  });
+
+  it("does not expose cleanup target names in the delete-account response", () => {
+    const source = readDeleteAccountFunctionSource();
+
+    expect(source).toContain("failureCount: deleteResult.failures.length");
+    expect(source).not.toContain("failures: deleteResult.failures.map");
+  });
+
+  it("reports backup metadata list failures before deleting the auth user", async () => {
+    const supabase = createDeleteAccountSupabase({
+      backupRows: [],
+      backupListError: { message: "metadata unavailable" },
+    });
+
+    await expect(deleteAccountRemoteData(supabase.client, USER_ID)).resolves.toEqual({
+      success: false,
+      failures: [{ target: "encrypted_backups", message: "metadata unavailable" }],
+    });
+
+    expect(supabase.tableDeletes()).toEqual([]);
+    expect(supabase.storageRemove).not.toHaveBeenCalled();
+    expect(supabase.deleteUser).not.toHaveBeenCalled();
+  });
+});
+
+function createDeleteAccountSupabase(options: {
+  readonly backupRows: readonly { id: string }[];
+  readonly backupListError?: { readonly message: string };
+  readonly storageError?: { readonly message: string };
+}) {
+  const tableDeleteCalls: string[] = [];
+  const eq = vi.fn(() => Promise.resolve({ error: null }));
+  const deleteTable = vi.fn((tableName: string) => {
+    tableDeleteCalls.push(tableName);
+    return { eq };
+  });
+  const range = vi.fn((from: number, to: number) =>
+    Promise.resolve({
+      data: options.backupRows.slice(from, to + 1),
+      error: options.backupListError ?? null,
+    })
+  );
+  const order = vi.fn(() => ({ range }));
+  const selectEq = vi.fn(() => ({ order }));
+  const select = vi.fn(() => ({ eq: selectEq }));
+  const storageRemove = vi.fn(() => Promise.resolve({ error: options.storageError ?? null }));
+  const deleteUser = vi.fn(() => Promise.resolve({ error: null }));
+  const client = {
+    auth: { admin: { deleteUser } },
+    from: vi.fn((tableName: string) => ({
+      delete: () => deleteTable(tableName),
+      select,
+    })),
+    storage: {
+      from: vi.fn(() => ({ remove: storageRemove })),
+    },
+  };
+
+  return {
+    client,
+    deleteUser,
+    storageRemove,
+    tableDeletes: () => tableDeleteCalls,
+  };
+}
+
+function readDeleteAccountFunctionSource() {
+  return readFileSync(
+    resolve(__dirname, "../../../../supabase/functions/delete-account/index.ts"),
+    "utf-8"
+  );
+}

--- a/apps/mobile/__tests__/settings/remote-data.test.ts
+++ b/apps/mobile/__tests__/settings/remote-data.test.ts
@@ -15,6 +15,8 @@ import {
   toNotificationPreferences,
 } from "@/features/settings/data/notification-preferences";
 import { getSupabase } from "@/shared/db";
+import en from "@/shared/i18n/locales/en";
+import es from "@/shared/i18n/locales/es";
 
 const mockSelect = vi.fn();
 const mockEq = vi.fn();
@@ -108,5 +110,12 @@ describe("settings remote callers", () => {
 
     expect(source).toContain("useDeleteAccountMutation");
     expect(source).not.toContain("deleteAccount = useSettingsStore");
+  });
+
+  test("delete-account confirmation copy says encrypted backups are unrecoverable", () => {
+    expect(en.settings.deleteAccountWarning).toContain("encrypted backups");
+    expect(en.settings.deleteAccountWarning).toContain("cannot be recovered");
+    expect(es.settings.deleteAccountWarning).toContain("copias privadas");
+    expect(es.settings.deleteAccountWarning).toContain("no se podrán recuperar");
   });
 });

--- a/apps/mobile/shared/i18n/locales/en.ts
+++ b/apps/mobile/shared/i18n/locales/en.ts
@@ -717,7 +717,7 @@ const en = {
     deleteAccount: "Delete Account",
     deleteAccountTitle: "Delete Account",
     deleteAccountWarning:
-      "This will permanently delete your account and all your data. This action cannot be undone.",
+      "This will permanently delete your account, encrypted backups, and all remote data. Old encrypted backups cannot be recovered after deletion.",
     deleteAccountUnsyncedWarning: {
       one: "You have %{count} unsynced change that will be lost.",
       other: "You have %{count} unsynced changes that will be lost.",

--- a/apps/mobile/shared/i18n/locales/es.ts
+++ b/apps/mobile/shared/i18n/locales/es.ts
@@ -726,7 +726,7 @@ const es = {
     deleteAccount: "Eliminar Cuenta",
     deleteAccountTitle: "Eliminar Cuenta",
     deleteAccountWarning:
-      "Esto eliminará permanentemente tu cuenta y todos tus datos. Esta acción no se puede deshacer.",
+      "Esto eliminará permanentemente tu cuenta, tus copias privadas y todos tus datos remotos. Las copias privadas anteriores no se podrán recuperar después.",
     deleteAccountUnsyncedWarning: {
       one: "Tienes %{count} cambio sin sincronizar que se perderá.",
       other: "Tienes %{count} cambios sin sincronizar que se perderán.",

--- a/supabase/functions/delete-account/cleanup.ts
+++ b/supabase/functions/delete-account/cleanup.ts
@@ -1,0 +1,182 @@
+type SupabaseError = { readonly message?: string } | null;
+
+type DeleteResponse =
+  | Promise<{ readonly error: SupabaseError }>
+  | { readonly error: SupabaseError };
+type SelectResponse<Row> = Promise<{
+  readonly data: readonly Row[] | null;
+  readonly error: SupabaseError;
+}>;
+
+type DeleteQuery = {
+  eq(column: string, value: string): DeleteResponse;
+};
+
+type SelectQuery<Row> = {
+  eq(column: string, value: string): OrderedSelectQuery<Row>;
+};
+
+type OrderedSelectQuery<Row> = {
+  order(column: string, options: { readonly ascending: boolean }): RangedSelectQuery<Row>;
+};
+
+type RangedSelectQuery<Row> = {
+  range(from: number, to: number): SelectResponse<Row>;
+};
+
+export type DeleteAccountSupabaseClient = {
+  readonly auth: {
+    readonly admin: {
+      deleteUser(userId: string): DeleteResponse;
+    };
+  };
+  from(tableName: string): {
+    delete(): DeleteQuery;
+    select(columns: string): SelectQuery<{ readonly id: string }>;
+  };
+  readonly storage: {
+    from(bucketName: string): {
+      remove(paths: readonly string[]): DeleteResponse;
+    };
+  };
+};
+
+export type DeleteAccountRemoteFailure = {
+  readonly target: string;
+  readonly message: string;
+};
+
+export type DeleteAccountRemoteResult = {
+  readonly success: boolean;
+  readonly failures: readonly DeleteAccountRemoteFailure[];
+};
+
+const ENCRYPTED_BACKUPS_TABLE = "encrypted_backups";
+const ENCRYPTED_BACKUPS_BUCKET = "encrypted-backups";
+const BACKUP_DELETE_PAGE_SIZE = 1000;
+
+const OPERATIONAL_REMOTE_TABLES = [
+  "push_devices",
+  "notification_preferences",
+  "rate_limits",
+] as const;
+
+const LEGACY_PLAINTEXT_FINANCIAL_TABLES = [
+  "account_suggestion_dismissals",
+  "capture_evidence",
+  "financial_account_identifiers",
+  "opening_balances",
+  "transfers",
+  "transactions",
+  "financial_accounts",
+] as const;
+
+export async function deleteAccountRemoteData(
+  supabase: DeleteAccountSupabaseClient,
+  userId: string
+): Promise<DeleteAccountRemoteResult> {
+  const backupBlobFailure = await deleteBackupBlobs(supabase, userId);
+  if (backupBlobFailure !== null) {
+    return { success: false, failures: [backupBlobFailure] };
+  }
+
+  const cleanupFailures = [
+    await deleteUserRows(supabase, ENCRYPTED_BACKUPS_TABLE, userId),
+    ...(await Promise.all(
+      [...OPERATIONAL_REMOTE_TABLES, ...LEGACY_PLAINTEXT_FINANCIAL_TABLES].map((tableName) =>
+        deleteUserRows(supabase, tableName, userId)
+      )
+    )),
+  ].filter((failure): failure is DeleteAccountRemoteFailure => failure !== null);
+
+  if (cleanupFailures.length > 0) {
+    return { success: false, failures: cleanupFailures };
+  }
+
+  const authFailure = await deleteAuthUser(supabase, userId);
+  return {
+    success: authFailure === null,
+    failures: authFailure === null ? [] : [authFailure],
+  };
+}
+
+async function listBackupRows(
+  supabase: DeleteAccountSupabaseClient,
+  userId: string,
+  pageIndex: number
+): Promise<
+  | { readonly rows: readonly { readonly id: string }[] }
+  | { readonly failure: DeleteAccountRemoteFailure }
+> {
+  const pageStart = pageIndex * BACKUP_DELETE_PAGE_SIZE;
+  const pageEnd = pageStart + BACKUP_DELETE_PAGE_SIZE - 1;
+  const { data, error } = await supabase
+    .from(ENCRYPTED_BACKUPS_TABLE)
+    .select("id")
+    .eq("user_id", userId)
+    .order("id", { ascending: true })
+    .range(pageStart, pageEnd);
+
+  if (error != null) {
+    return {
+      failure: {
+        target: ENCRYPTED_BACKUPS_TABLE,
+        message: error.message ?? "Unable to list encrypted backups",
+      },
+    };
+  }
+
+  return { rows: data ?? [] };
+}
+
+async function deleteUserRows(
+  supabase: DeleteAccountSupabaseClient,
+  tableName: string,
+  userId: string
+): Promise<DeleteAccountRemoteFailure | null> {
+  const { error } = await supabase.from(tableName).delete().eq("user_id", userId);
+  return error === null ? null : { target: tableName, message: error.message ?? "delete_failed" };
+}
+
+async function deleteBackupBlobs(
+  supabase: DeleteAccountSupabaseClient,
+  userId: string
+): Promise<DeleteAccountRemoteFailure | null> {
+  return deleteBackupBlobPage(supabase, userId, 0);
+}
+
+async function deleteBackupBlobPage(
+  supabase: DeleteAccountSupabaseClient,
+  userId: string,
+  pageIndex: number
+): Promise<DeleteAccountRemoteFailure | null> {
+  const backupRowsResult = await listBackupRows(supabase, userId, pageIndex);
+  if ("failure" in backupRowsResult) {
+    return backupRowsResult.failure;
+  }
+
+  const backupRows = backupRowsResult.rows;
+  if (backupRows.length === 0) {
+    return null;
+  }
+
+  const paths = backupRows.map((row) => `${userId}/${row.id}.json`);
+  const { error } = await supabase.storage.from(ENCRYPTED_BACKUPS_BUCKET).remove(paths);
+  if (error !== null) {
+    return { target: ENCRYPTED_BACKUPS_BUCKET, message: error.message ?? "delete_failed" };
+  }
+
+  return backupRows.length < BACKUP_DELETE_PAGE_SIZE
+    ? null
+    : deleteBackupBlobPage(supabase, userId, pageIndex + 1);
+}
+
+async function deleteAuthUser(
+  supabase: DeleteAccountSupabaseClient,
+  userId: string
+): Promise<DeleteAccountRemoteFailure | null> {
+  const { error } = await supabase.auth.admin.deleteUser(userId);
+  return error === null
+    ? null
+    : { target: "auth.users", message: error.message ?? "delete_failed" };
+}

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -1,5 +1,6 @@
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { checkRateLimit } from "../_shared/rate-limit.ts";
+import { deleteAccountRemoteData } from "./cleanup.ts";
 
 const supabase = createClient(
   Deno.env.get("SUPABASE_URL") ?? "",
@@ -72,12 +73,18 @@ Deno.serve(async (req) => {
       Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
     );
 
-    // Delete user (CASCADE on foreign keys handles data cleanup)
-    const { error: deleteError } = await serviceClient.auth.admin.deleteUser(userId);
+    const deleteResult = await deleteAccountRemoteData(serviceClient, userId);
 
-    if (deleteError) {
-      console.error("Failed to delete user:", deleteError.message);
-      return jsonResponse({ success: false, error: "delete_failed" }, 500);
+    if (!deleteResult.success) {
+      console.error("Failed to delete account remote data:", deleteResult.failures);
+      return jsonResponse(
+        {
+          success: false,
+          error: "delete_failed",
+          failureCount: deleteResult.failures.length,
+        },
+        500
+      );
     }
 
     return jsonResponse({ success: true });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Delete-account now deletes private encrypted backups (blobs first, then metadata), cleans up remaining remote data, and finally deletes the auth user. The delete warning copy (en/es) clearly states encrypted backups cannot be recovered. Aligns with Linear issue 300.

- **Bug Fixes**
  - Added `deleteAccountRemoteData`: lists from `encrypted_backups`, deletes blobs in `encrypted-backups` (paged), then removes backup metadata.
  - Cleans operational and legacy plaintext tables; aborts early and reports failures when listing or storage deletion fails; finally deletes the auth user.
  - Edge function returns 500 with `failureCount` only (no target names) on partial cleanup; detailed failures are logged for retries.
  - Added unit tests for success/partial-failure paths and updated i18n delete-warning copy (en/es).

<sup>Written for commit 57237d7530f5d69e763182c5a9c176ba4716897c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

