### PR TITLE
fix(sync): retire plaintext sync

### DIFF
--- a/apps/mobile/__tests__/sync/sync-module.test.ts
+++ b/apps/mobile/__tests__/sync/sync-module.test.ts
@@ -61,11 +61,16 @@ describe("sync module", () => {
     mockUpsertTransaction.mockReset();
   });
 
-  it("syncs by pulling first, then pushing queued rows when online", async () => {
+  it("syncs by pulling first, then pushing queued rows when legacy sync is explicit", async () => {
     const { sync } = await import("@/features/sync/services/sync");
     const db = {} as any;
 
-    const result = await sync({ db, userId: "user-1", reason: "foreground" });
+    const result = await sync({
+      db,
+      userId: "user-1",
+      reason: "foreground",
+      remoteFinancialSync: "legacy",
+    });
 
     expect(mockIsOnline).toHaveBeenCalled();
     expect(mockSyncPull).toHaveBeenCalledWith(db, expect.any(Object), "user-1");
@@ -76,6 +81,22 @@ describe("sync module", () => {
     expect(mockRefreshTransactions).toHaveBeenCalledTimes(1);
     expect(result.status).toBe("synced");
     expect(result.unresolvedConflicts).toBe(0);
+  });
+
+  it("uses Private Backup mode by default", async () => {
+    const { sync } = await import("@/features/sync/services/sync");
+    const db = {} as any;
+
+    const result = await sync({ db, userId: "user-1", reason: "foreground" });
+
+    expect(mockGetSupabase).toHaveBeenCalled();
+    expect(mockSyncPull).not.toHaveBeenCalled();
+    expect(mockSyncPush).toHaveBeenCalledWith(db, expect.any(Object), {
+      userId: "user-1",
+      remoteFinancialSync: "privateBackup",
+    });
+    expect(mockRefreshTransactions).not.toHaveBeenCalled();
+    expect(result.status).toBe("synced");
   });
 
   it("returns skipped_offline without touching remote sync when offline", async () => {
@@ -91,7 +112,7 @@ describe("sync module", () => {
     expect(result.status).toBe("skipped_offline");
   });
 
-  it("does not run legacy Remote Financial Sync in Private Backup mode", async () => {
+  it("runs only push cleanup in Private Backup mode", async () => {
     const { sync } = await import("@/features/sync/services/sync");
     const db = {} as any;
 
@@ -101,9 +122,12 @@ describe("sync module", () => {
       remoteFinancialSync: "privateBackup",
     });
 
-    expect(mockGetSupabase).not.toHaveBeenCalled();
+    expect(mockGetSupabase).toHaveBeenCalled();
     expect(mockSyncPull).not.toHaveBeenCalled();
-    expect(mockSyncPush).not.toHaveBeenCalled();
+    expect(mockSyncPush).toHaveBeenCalledWith(db, expect.any(Object), {
+      userId: "user-1",
+      remoteFinancialSync: "privateBackup",
+    });
     expect(mockRefreshTransactions).not.toHaveBeenCalled();
     expect(result.status).toBe("synced");
   });

--- a/apps/mobile/__tests__/sync/sync-service.test.ts
+++ b/apps/mobile/__tests__/sync/sync-service.test.ts
@@ -64,7 +64,7 @@ describe("createSyncService", () => {
     });
   });
 
-  it("skips legacy Remote Financial Sync for Private Backup users", async () => {
+  it("cleans skipped plaintext queue entries for Private Backup users", async () => {
     const supabase = {};
     const { service, ports } = createService({
       supabase: { getSupabase: vi.fn().mockReturnValue(supabase) },
@@ -80,13 +80,16 @@ describe("createSyncService", () => {
     });
 
     expect(result.status).toBe("synced");
-    expect(ports.supabase.getSupabase).not.toHaveBeenCalled();
+    expect(ports.supabase.getSupabase).toHaveBeenCalled();
     expect(ports.syncPull).not.toHaveBeenCalled();
-    expect(ports.syncPush).not.toHaveBeenCalled();
+    expect(ports.syncPush).toHaveBeenCalledWith(TEST_DB, supabase, {
+      userId: TEST_USER_ID,
+      remoteFinancialSync: "privateBackup",
+    });
     expect(ports.refreshTransactions).not.toHaveBeenCalled();
   });
 
-  it("keeps legacy Remote Financial Sync as the default push capability", async () => {
+  it("uses Private Backup mode by default", async () => {
     const supabase = {};
     const { service, ports } = createService({
       supabase: { getSupabase: vi.fn().mockReturnValue(supabase) },
@@ -100,6 +103,31 @@ describe("createSyncService", () => {
       userId: TEST_USER_ID,
     });
 
+    expect(ports.supabase.getSupabase).toHaveBeenCalled();
+    expect(ports.syncPull).not.toHaveBeenCalled();
+    expect(ports.syncPush).toHaveBeenCalledWith(TEST_DB, supabase, {
+      userId: TEST_USER_ID,
+      remoteFinancialSync: "privateBackup",
+    });
+    expect(ports.refreshTransactions).not.toHaveBeenCalled();
+  });
+
+  it("runs legacy Remote Financial Sync only when explicitly requested", async () => {
+    const supabase = {};
+    const { service, ports } = createService({
+      supabase: { getSupabase: vi.fn().mockReturnValue(supabase) },
+      syncPull: vi.fn().mockResolvedValue(true),
+      syncPush: vi.fn().mockResolvedValue(undefined),
+      refreshTransactions: vi.fn().mockResolvedValue(undefined),
+    });
+
+    await service.run({
+      db: TEST_DB,
+      userId: TEST_USER_ID,
+      remoteFinancialSync: "legacy",
+    });
+
+    expect(ports.syncPull).toHaveBeenCalledWith(TEST_DB, supabase, TEST_USER_ID);
     expect(ports.syncPush).toHaveBeenCalledWith(TEST_DB, supabase, {
       userId: TEST_USER_ID,
       remoteFinancialSync: "legacy",

--- a/apps/mobile/__tests__/sync/syncEngine.test.ts
+++ b/apps/mobile/__tests__/sync/syncEngine.test.ts
@@ -271,9 +271,9 @@ function createCompositeSyncMeta(updatedAt: string, id: string) {
   return syncMeta;
 }
 
-async function runSyncPush(mockSupabase: any, userId = SYNC_USER_ID, options?: any) {
+async function runSyncPush(mockSupabase: any, userId = SYNC_USER_ID, options: any = {}) {
   const { syncPush } = await import("@/features/sync/services/syncEngine");
-  await syncPush(mockDb, mockSupabase, { userId, ...options });
+  await syncPush(mockDb, mockSupabase, { userId, remoteFinancialSync: "legacy", ...options });
 }
 
 async function runSyncPull(mockSupabase: any, userId = SYNC_USER_ID) {
@@ -470,10 +470,21 @@ describe("syncEngine", () => {
       const mockSupabase = createMockSupabase();
 
       const { syncPush } = await import("@/features/sync/services/syncEngine");
-      await syncPush(mockDb, mockSupabase, { userId: "user-1" });
+      await syncPush(mockDb, mockSupabase, { userId: "user-1", remoteFinancialSync: "legacy" });
 
       expect(mockSupabase.from).not.toHaveBeenCalled();
       expect(mockClearSyncEntries).not.toHaveBeenCalled();
+    });
+
+    it("does not push plaintext financial rows by default", async () => {
+      mockGetQueuedSyncEntries.mockReturnValueOnce(PRIVATE_BACKUP_BLOCKED_PUSH_ENTRIES);
+      const mockSupabase = createMockSupabase();
+
+      const { syncPush } = await import("@/features/sync/services/syncEngine");
+      await syncPush(mockDb, mockSupabase, { userId: SYNC_USER_ID });
+
+      expect(mockSupabase.from).not.toHaveBeenCalled();
+      expectQueueCleared(...PRIVATE_BACKUP_BLOCKED_PUSH_ENTRY_IDS);
     });
 
     it("upserts transaction row to supabase and clears queue on success", async () => {
@@ -532,7 +543,7 @@ describe("syncEngine", () => {
       const mockSupabase = createMockSupabase();
 
       const { syncPush } = await import("@/features/sync/services/syncEngine");
-      await syncPush(mockDb, mockSupabase, { userId: "user-1" });
+      await syncPush(mockDb, mockSupabase, { userId: "user-1", remoteFinancialSync: "legacy" });
 
       expect(mockClearSyncEntries).not.toHaveBeenCalled();
     });
@@ -724,7 +735,7 @@ describe("syncEngine", () => {
       const mockSupabase = createMockSupabase();
 
       const { syncPush } = await import("@/features/sync/services/syncEngine");
-      await syncPush(mockDb, mockSupabase, { userId: "user-1" });
+      await syncPush(mockDb, mockSupabase, { userId: "user-1", remoteFinancialSync: "legacy" });
 
       expect(mockClearSyncEntries).toHaveBeenCalledWith(mockDb, ["sq-1"]);
     });
@@ -971,7 +982,10 @@ describe("syncEngine", () => {
       const mockSupabase = createMockSupabase({ data: [], error: null });
 
       const { fullSync } = await import("@/features/sync/services/syncEngine");
-      const result = await fullSync(mockDb, mockSupabase, { userId: "user-1" });
+      const result = await fullSync(mockDb, mockSupabase, {
+        userId: "user-1",
+        remoteFinancialSync: "legacy",
+      });
 
       expect(result).toBe(true);
       expect(mockGetSyncMeta).toHaveBeenCalled();
@@ -984,7 +998,10 @@ describe("syncEngine", () => {
       const mockSupabase = createMockSupabase({ data: null, error: { message: "fail" } });
 
       const { fullSync } = await import("@/features/sync/services/syncEngine");
-      const result = await fullSync(mockDb, mockSupabase, { userId: "user-1" });
+      const result = await fullSync(mockDb, mockSupabase, {
+        userId: "user-1",
+        remoteFinancialSync: "legacy",
+      });
 
       expect(result).toBe(false);
       expect(mockGetSyncMeta).toHaveBeenCalled();
@@ -1006,10 +1023,26 @@ describe("syncEngine", () => {
       });
 
       const { fullSync } = await import("@/features/sync/services/syncEngine");
-      const result = await fullSync(mockDb, mockSupabase, { userId: "user-1" });
+      const result = await fullSync(mockDb, mockSupabase, {
+        userId: "user-1",
+        remoteFinancialSync: "legacy",
+      });
 
       expect(result).toBe(true);
       expect(mockGetQueuedSyncEntries).toHaveBeenCalled();
+    });
+
+    it("does not pull or push plaintext financial tables by default", async () => {
+      mockGetQueuedSyncEntries.mockReturnValueOnce(PRIVATE_BACKUP_BLOCKED_PUSH_ENTRIES);
+      const mockSupabase = createMockSupabase();
+
+      const { fullSync } = await import("@/features/sync/services/syncEngine");
+      const result = await fullSync(mockDb, mockSupabase, { userId: SYNC_USER_ID });
+
+      expect(result).toBe(true);
+      expect(mockSupabase.from).not.toHaveBeenCalled();
+      expect(mockGetSyncMeta).not.toHaveBeenCalled();
+      expectQueueCleared(...PRIVATE_BACKUP_BLOCKED_PUSH_ENTRY_IDS);
     });
   });
 

--- a/apps/mobile/features/sync/services/create-sync-service.ts
+++ b/apps/mobile/features/sync/services/create-sync-service.ts
@@ -204,7 +204,7 @@ function runSyncEffect({
   db,
   userId,
   reason: _reason = "foreground",
-  remoteFinancialSync = "legacy",
+  remoteFinancialSync = "privateBackup",
 }: SyncInput) {
   return Effect.gen(function* () {
     void _reason;
@@ -219,6 +219,8 @@ function runSyncEffect({
     }
 
     if (remoteFinancialSync === "privateBackup") {
+      const supabase = yield* currentSupabaseClientEffect;
+      yield* fromPromise(() => syncPush(db, supabase, { userId, remoteFinancialSync }));
       return {
         status: "synced" as const,
         unresolvedConflicts: yield* unresolvedConflictCountEffect(db),

--- a/apps/mobile/features/sync/services/sync-engine/push-queue.ts
+++ b/apps/mobile/features/sync/services/sync-engine/push-queue.ts
@@ -4,6 +4,7 @@ import type { SyncQueueId } from "@/shared/types/branded";
 import type { SyncPushOptions } from "./types";
 
 const PRIVATE_BACKUP_SYNC_MODE = "privateBackup";
+const DEFAULT_REMOTE_FINANCIAL_SYNC_MODE = PRIVATE_BACKUP_SYNC_MODE;
 const PLAINTEXT_FINANCIAL_PUSH_TABLES = new Set<string>([
   "transactions",
   "budgets",
@@ -21,8 +22,9 @@ export type PushQueueEntry = { id: SyncQueueId; tableName: string; rowId: string
 export type PushQueueResult = PromiseSettledResult<SyncQueueId | null>;
 
 export function shouldSkipPlaintextFinancialPush(tableName: string, options: SyncPushOptions) {
+  const remoteFinancialSync = options.remoteFinancialSync ?? DEFAULT_REMOTE_FINANCIAL_SYNC_MODE;
   return (
-    options.remoteFinancialSync === PRIVATE_BACKUP_SYNC_MODE &&
+    remoteFinancialSync === PRIVATE_BACKUP_SYNC_MODE &&
     PLAINTEXT_FINANCIAL_PUSH_TABLES.has(tableName)
   );
 }

--- a/apps/mobile/features/sync/services/sync-engine/types.ts
+++ b/apps/mobile/features/sync/services/sync-engine/types.ts
@@ -28,6 +28,9 @@ export type RemoteFinancialSyncMode = "legacy" | "privateBackup";
 export type SyncPushOptions = {
   readonly remoteFinancialSync?: RemoteFinancialSyncMode;
 };
+export type SyncPullOptions = {
+  readonly remoteFinancialSync?: RemoteFinancialSyncMode;
+};
 export type SyncPushRequest = {
   readonly userId: string;
   readonly remoteFinancialSync?: RemoteFinancialSyncMode;

--- a/apps/mobile/features/sync/services/syncEngine.ts
+++ b/apps/mobile/features/sync/services/syncEngine.ts
@@ -13,7 +13,8 @@ export async function fullSync(
   supabase: SupabaseClient,
   request: SyncPushRequest
 ): Promise<boolean> {
-  const pullOk = await syncPull(db, supabase, request.userId);
+  const pullOk =
+    request.remoteFinancialSync === "legacy" ? await syncPull(db, supabase, request.userId) : true;
   if (pullOk) {
     await syncPush(db, supabase, request);
   }

--- a/docs/adr/0002-local-ledger-encrypted-backup-and-cloud-ai.md
+++ b/docs/adr/0002-local-ledger-encrypted-backup-and-cloud-ai.md
@@ -11,3 +11,7 @@ Fidy will stop treating plaintext Supabase financial tables as the durability me
 **Consequences**
 
 Cloud features must receive data through explicit task boundaries, such as capture interpretation or advisor context packets, instead of querying plaintext financial rows from Supabase. Backup restore depends on the user's Recovery Key or platform-held key material; if Fidy cannot decrypt the backup, Fidy also cannot recover it when the user loses that recovery material.
+
+**Legacy Table Retention**
+
+The plaintext Supabase financial tables are retained temporarily for migration and rollback inspection only. Default app sync must not pull from or push to `transactions`, `budgets`, `goals`, `goal_contributions`, `financial_accounts`, `financial_account_identifiers`, `opening_balances`, `transfers`, `capture_evidence`, or `account_suggestion_dismissals`. Any remaining use must opt into `remoteFinancialSync: "legacy"` explicitly and should be removed once migrated users have confirmed healthy Private Backup restore coverage and account deletion has deleted both encrypted backup blobs and any retained legacy rows.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches the default sync to Private Backup. Legacy plaintext Supabase sync is disabled by default and only runs when `remoteFinancialSync: "legacy"` is explicitly set.

- **Refactors**
  - Default `remoteFinancialSync` set to `"privateBackup"` in the mobile sync service.
  - `fullSync` only pulls in legacy mode; otherwise it skips pull and runs push cleanup.
  - Push queue skips plaintext financial tables by default and clears those queued entries.
  - Added `SyncPullOptions`; updated tests to require explicit legacy mode.
  - ADR updated to note temporary legacy table retention and default no-op for plaintext tables.

- **Migration**
  - If you still need plaintext Supabase sync, pass `remoteFinancialSync: "legacy"` when running sync. Remove this once migration is complete.

<sup>Written for commit 342390e236e08fc9b7ef8332e1cab55f4b5bd6bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

