### PR TITLE
fix(db): harden remote security

### DIFF
--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -34,3 +34,9 @@ jobs:
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      - name: Lint linked database
+        run: supabase db lint --linked --workdir apps/mobile
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}

--- a/apps/mobile/__tests__/edge-functions/rate-limit-security.test.ts
+++ b/apps/mobile/__tests__/edge-functions/rate-limit-security.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(
+  resolve(__dirname, "../../../../supabase/functions/_shared/rate-limit.ts"),
+  "utf8"
+);
+
+describe("Edge Function rate limiting", () => {
+  it("fails closed when the backing RPC is unavailable", () => {
+    expect(source).toContain("failing closed");
+    expect(source).not.toContain("failing open");
+    expect(source).not.toContain("allowed: true, count: 0");
+  });
+});

--- a/apps/mobile/supabase/migrations/20260426120000_harden_remote_security.sql
+++ b/apps/mobile/supabase/migrations/20260426120000_harden_remote_security.sql
@@ -1,0 +1,114 @@
+-- Harden the active remote surface after plaintext financial tables were retired.
+
+alter table public.bank_senders enable row level security;
+drop policy if exists "Authenticated users can read bank senders" on public.bank_senders;
+create policy "Authenticated users can read bank senders"
+  on public.bank_senders for select to authenticated
+  using (true);
+alter table public.bank_senders force row level security;
+
+alter table public.user_memories enable row level security;
+drop policy if exists "Users can read own memories" on public.user_memories;
+create policy "Users can read own memories"
+  on public.user_memories for select to authenticated
+  using ((select auth.uid()) = user_id);
+
+drop policy if exists "Users can insert own memories" on public.user_memories;
+create policy "Users can insert own memories"
+  on public.user_memories for insert to authenticated
+  with check ((select auth.uid()) = user_id);
+
+drop policy if exists "Users can update own memories" on public.user_memories;
+create policy "Users can update own memories"
+  on public.user_memories for update to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+drop policy if exists "Users can delete own memories" on public.user_memories;
+create policy "Users can delete own memories"
+  on public.user_memories for delete to authenticated
+  using ((select auth.uid()) = user_id);
+alter table public.user_memories force row level security;
+
+alter table public.push_devices enable row level security;
+drop policy if exists "Users can manage own push devices" on public.push_devices;
+drop policy if exists "Users can read own push devices" on public.push_devices;
+create policy "Users can read own push devices"
+  on public.push_devices for select to authenticated
+  using ((select auth.uid()) = user_id);
+
+drop policy if exists "Users can insert own push devices" on public.push_devices;
+create policy "Users can insert own push devices"
+  on public.push_devices for insert to authenticated
+  with check ((select auth.uid()) = user_id);
+
+drop policy if exists "Users can update own push devices" on public.push_devices;
+create policy "Users can update own push devices"
+  on public.push_devices for update to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+drop policy if exists "Users can delete own push devices" on public.push_devices;
+create policy "Users can delete own push devices"
+  on public.push_devices for delete to authenticated
+  using ((select auth.uid()) = user_id);
+alter table public.push_devices force row level security;
+
+alter table public.notification_preferences enable row level security;
+drop policy if exists "Users can manage own notification preferences" on public.notification_preferences;
+drop policy if exists "Users can read own notification preferences" on public.notification_preferences;
+create policy "Users can read own notification preferences"
+  on public.notification_preferences for select to authenticated
+  using ((select auth.uid()) = user_id);
+
+drop policy if exists "Users can insert own notification preferences" on public.notification_preferences;
+create policy "Users can insert own notification preferences"
+  on public.notification_preferences for insert to authenticated
+  with check ((select auth.uid()) = user_id);
+
+drop policy if exists "Users can update own notification preferences" on public.notification_preferences;
+create policy "Users can update own notification preferences"
+  on public.notification_preferences for update to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+drop policy if exists "Users can delete own notification preferences" on public.notification_preferences;
+create policy "Users can delete own notification preferences"
+  on public.notification_preferences for delete to authenticated
+  using ((select auth.uid()) = user_id);
+alter table public.notification_preferences force row level security;
+
+alter table public.encrypted_backups force row level security;
+alter table public.waitlist_emails force row level security;
+alter table public.rate_limits force row level security;
+
+create or replace function public.check_rate_limit(
+  p_user_id uuid,
+  p_function_name text,
+  p_window_key text,
+  p_max_count integer
+)
+returns table (current_count integer, allowed boolean)
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  if random() < 0.01 then
+    delete from public.rate_limits
+    where window_key < to_char(now() - interval '2 hours', 'YYYY-MM-DD"T"HH24:MI');
+  end if;
+
+  return query
+    insert into public.rate_limits (user_id, function_name, window_key, request_count)
+    values (p_user_id, p_function_name, p_window_key, 1)
+    on conflict on constraint rate_limits_pkey
+    do update set request_count = public.rate_limits.request_count + 1
+    returning
+      public.rate_limits.request_count as current_count,
+      (public.rate_limits.request_count <= p_max_count) as allowed;
+end;
+$$;
+
+revoke execute on function public.check_rate_limit(uuid, text, text, integer) from public, anon, authenticated;
+grant execute on function public.check_rate_limit(uuid, text, text, integer) to service_role;

--- a/supabase/functions/_shared/rate-limit.ts
+++ b/supabase/functions/_shared/rate-limit.ts
@@ -17,6 +17,7 @@ export async function checkRateLimit(
 ): Promise<RateLimitResult> {
   const now = new Date();
   const windowKey = now.toISOString().slice(0, 16); // YYYY-MM-DDTHH:MM
+  const retryAfterSeconds = 60 - now.getSeconds();
 
   try {
     const { data, error } = await serviceClient.rpc("check_rate_limit", {
@@ -27,24 +28,23 @@ export async function checkRateLimit(
     });
 
     if (error) {
-      console.error("Rate limit RPC error, failing open:", error.message);
-      return { allowed: true, count: 0 };
+      console.error("Rate limit RPC error, failing closed:", error.message);
+      return { allowed: false, count: 0, retryAfterSeconds };
     }
 
     const row = Array.isArray(data) ? data[0] : data;
     if (!row || typeof row.allowed !== "boolean") {
-      console.error("Rate limit RPC returned no data, failing open");
-      return { allowed: true, count: 0 };
+      console.error("Rate limit RPC returned no data, failing closed");
+      return { allowed: false, count: 0, retryAfterSeconds };
     }
 
     if (row.allowed) {
       return { allowed: true, count: row.current_count };
     }
 
-    const retryAfterSeconds = 60 - now.getSeconds();
     return { allowed: false, count: row.current_count, retryAfterSeconds };
   } catch (err) {
-    console.error("Rate limit check failed, failing open:", err);
-    return { allowed: true, count: 0 };
+    console.error("Rate limit check failed, failing closed:", err);
+    return { allowed: false, count: 0, retryAfterSeconds };
   }
 }


### PR DESCRIPTION
- fail closed rate limits- tighten active RLS policies- lint linked database deploys

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Supabase security by failing closed on rate limiting, enforcing stricter RLS across user tables, and linting the linked database in CI after migration deploy. This reduces data exposure risk and blocks abuse if the rate-limit RPC is unavailable.

- **Bug Fixes**
  - Rate limiting now fails closed with `retryAfterSeconds` when `public.check_rate_limit` errors, returns no data, or the call fails; test added to lock this behavior.
  - Enforced RLS: enabled/forced on `bank_senders`, `user_memories`, `push_devices`, `notification_preferences`; forced on `encrypted_backups`, `waitlist_emails`, `rate_limits`; per-user read/write policies for user-owned tables.
  - Added `public.check_rate_limit(uuid, text, text, integer)` with hardened `search_path`, upsert-based counting, opportunistic cleanup of stale windows, and execute permission limited to `service_role`.

- **Migration**
  - Ensure Edge Functions call `public.check_rate_limit` using a `service_role` client.

<sup>Written for commit 49328941bcc79190fc16927aca7b37cb40e13fe6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

