### PR TITLE
docs(skills): update agent guidance

### DIFF
--- a/.agents/skills/domain-model/SKILL.md
+++ b/.agents/skills/domain-model/SKILL.md
@@ -67,6 +67,7 @@ When the user states how something works, check whether the code agrees. If you 
 ### Update CONTEXT.md inline
 
 When a term is resolved, update `CONTEXT.md` right there. Don't batch these up - capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+Don't couple `CONTEXT.md` to implementation details. Only include terms that are meaningful to domain experts.
 
 ### Offer ADRs sparingly
 

--- a/.agents/skills/improving-codebase-architecture/DEEPENING.md
+++ b/.agents/skills/improving-codebase-architecture/DEEPENING.md
@@ -1,0 +1,37 @@
+# Deepening
+
+How to deepen a cluster of shallow modules safely, given its dependencies. This complements [REFERENCE.md](REFERENCE.md), which keeps the local functional-core and atomic-testing guidance.
+
+## Dependency categories
+
+When assessing a candidate for deepening, classify its dependencies. The category determines how the deepened module is tested across its seam.
+
+### 1. In-process
+
+Pure computation, in-memory state, no I/O. Always deepenable: merge the modules and test through the new interface directly. No adapter needed.
+
+### 2. Local-substitutable
+
+Dependencies that have local test stand-ins, such as PGLite for Postgres, an in-memory filesystem, or a fake clock. Deepenable if the stand-in exists. The deepened module is tested with the stand-in running in the test suite. The seam can stay internal; no port is needed at the module's external interface unless production also varies.
+
+### 3. Remote but owned
+
+Your own services across a network seam, such as microservices or internal APIs. Define a port at the seam. The deep module owns the logic; the transport is injected as an adapter. Tests use an in-memory adapter. Production uses an HTTP, gRPC, queue, or platform adapter.
+
+Recommendation shape: "Define a port at the seam, implement a production adapter and an in-memory adapter for testing, so the logic sits in one deep module even though it is deployed across a network."
+
+### 4. True external
+
+Third-party services you do not control, such as Stripe or Twilio. The deepened module takes the external dependency as an injected port; tests provide a mock adapter. Extract as much logic as possible into the pure core so the mock is only used for the unavoidable side effect.
+
+## Seam discipline
+
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Do not introduce a port unless at least two adapters are justified, usually production plus test.
+- **Internal seams vs external seams.** A deep module can have internal seams private to its implementation and used by its own tests, as well as the external seam at its interface. Do not expose internal seams through the interface just because tests use them.
+
+## Testing strategy: replace, don't layer
+
+- Old unit tests on shallow modules become waste once tests at the deepened module's interface exist: delete them.
+- Write new tests at the deepened module's interface. The **interface is the test surface**.
+- Tests assert on observable outcomes through the interface, not internal state.
+- Tests should survive internal refactors. They describe behavior, not implementation.

--- a/.agents/skills/improving-codebase-architecture/INTERFACE-DESIGN.md
+++ b/.agents/skills/improving-codebase-architecture/INTERFACE-DESIGN.md
@@ -1,0 +1,44 @@
+# Interface Design
+
+When the user wants to explore alternative interfaces for a chosen deepening candidate, use this parallel sub-agent pattern. Based on "Design It Twice" from Ousterhout: your first idea is unlikely to be the best.
+
+Use the vocabulary in [LANGUAGE.md](LANGUAGE.md): **module**, **interface**, **seam**, **adapter**, **leverage**, and **locality**.
+
+## Process
+
+### 1. Frame the problem space
+
+Before spawning sub-agents, write a user-facing explanation of the problem space for the chosen candidate:
+
+- The constraints any new interface would need to satisfy
+- The dependencies it would rely on, and which category they fall into from [REFERENCE.md](REFERENCE.md) and [DEEPENING.md](DEEPENING.md)
+- A rough illustrative code sketch to ground the constraints. This is not a proposal; it only makes the constraints concrete.
+
+Show this to the user, then immediately proceed to Step 2. The user reads and thinks while the sub-agents work in parallel.
+
+### 2. Spawn sub-agents
+
+Spawn 3+ sub-agents in parallel. Each must produce a **radically different** interface for the deepened module.
+
+Prompt each sub-agent with a separate technical brief: file paths, coupling details, dependency category, and what sits behind the seam. Include both [LANGUAGE.md](LANGUAGE.md) vocabulary and `CONTEXT.md` vocabulary so each sub-agent names things consistently with the architecture language and the project's domain language.
+
+Give each agent a different design constraint:
+
+- Agent 1: "Minimize the interface: aim for 1-3 entry points max. Maximize leverage per entry point."
+- Agent 2: "Maximize flexibility: support many use cases and extension."
+- Agent 3: "Optimize for the most common caller: make the default case trivial."
+- Agent 4, if applicable: "Design around ports and adapters for cross-seam dependencies."
+
+Each sub-agent outputs:
+
+1. Interface: types, methods, params, invariants, ordering, and error modes
+2. Usage example showing how callers use it
+3. What the implementation hides behind the seam
+4. Dependency strategy and adapters
+5. Trade-offs: where leverage is high and where it is thin
+
+### 3. Present and compare
+
+Present designs sequentially so the user can absorb each one, then compare them in prose. Contrast by **depth**, **locality**, and **seam placement**.
+
+After comparing, give your own recommendation: which design you think is strongest and why. If elements from different designs would combine well, propose a hybrid. Be opinionated: the user wants a strong read, not just a menu.

--- a/.agents/skills/improving-codebase-architecture/LANGUAGE.md
+++ b/.agents/skills/improving-codebase-architecture/LANGUAGE.md
@@ -1,0 +1,53 @@
+# Language
+
+Shared vocabulary for every suggestion this skill makes. Use these terms consistently. Avoid drifting into "component," "service," "API," or "boundary" when the more precise terms below apply.
+
+## Terms
+
+**Module**
+Anything with an interface and an implementation. Deliberately scale-agnostic: applies equally to a function, class, package, or tier-spanning slice.
+_Avoid_: unit, component, service.
+
+**Interface**
+Everything a caller must know to use the module correctly. Includes the type signature, but also invariants, ordering constraints, error modes, required configuration, and performance characteristics.
+_Avoid_: API, signature, when those would narrow the idea to type-level surface only.
+
+**Implementation**
+What's inside a module: its body of code. Distinct from **Adapter**: a thing can be a small adapter with a large implementation, or a large adapter with a small implementation.
+
+**Depth**
+Leverage at the interface: the amount of behavior a caller or test can exercise per unit of interface they have to learn. A module is **deep** when a large amount of behavior sits behind a small interface. A module is **shallow** when the interface is nearly as complex as the implementation.
+
+**Seam**
+A place where behavior can be altered without editing in that place. The location at which a module's interface lives. Choosing where to put the seam is distinct from deciding what goes behind it.
+_Avoid_: boundary, which is overloaded with DDD's bounded context.
+
+**Adapter**
+A concrete thing that satisfies an interface at a seam. Describes role, not substance.
+
+**Leverage**
+What callers get from depth: more capability per unit of interface they have to learn.
+
+**Locality**
+What maintainers get from depth: change, bugs, knowledge, and verification concentrated in one place rather than spread across callers.
+
+## Principles
+
+- **Depth is a property of the interface, not the implementation.** A deep module can be internally composed of small, mockable, swappable parts; they just are not part of the external interface.
+- **The deletion test.** Imagine deleting the module. If complexity vanishes, the module was not hiding anything. If complexity reappears across many callers, the module was earning its keep.
+- **The interface is the test surface.** Callers and tests cross the same seam. If you need to test past the interface, the module is probably the wrong shape.
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Do not introduce a seam unless something actually varies across it.
+
+## Relationships
+
+- A **Module** has exactly one **Interface**: the surface it presents to callers and tests.
+- **Depth** is a property of a **Module**, measured against its **Interface**.
+- A **Seam** is where a **Module**'s **Interface** lives.
+- An **Adapter** sits at a **Seam** and satisfies the **Interface**.
+- **Depth** produces **Leverage** for callers and **Locality** for maintainers.
+
+## Rejected framings
+
+- **Depth as ratio of implementation-lines to interface-lines**: rewards padding the implementation. Use depth-as-leverage instead.
+- **"Interface" as only the TypeScript `interface` keyword or public methods**: too narrow.
+- **"Boundary"**: overloaded with DDD's bounded context. Say **seam** or **interface**.

--- a/.agents/skills/improving-codebase-architecture/SKILL.md
+++ b/.agents/skills/improving-codebase-architecture/SKILL.md
@@ -9,9 +9,38 @@ Explore a codebase like an AI would, surface architectural friction, discover op
 
 A **deep module** (John Ousterhout, "A Philosophy of Software Design") has a small interface hiding a large implementation. Deep modules are more testable, more AI-navigable, and let you test at the boundary instead of inside.
 
+## Glossary
+
+Use these terms consistently in every suggestion. Full definitions live in [LANGUAGE.md](LANGUAGE.md).
+
+- **Module**: anything with an interface and an implementation (function, class, package, slice).
+- **Interface**: everything a caller must know to use the module correctly: types, invariants, ordering, error modes, config, and performance characteristics.
+- **Implementation**: the code inside a module.
+- **Depth**: leverage at the interface. **Deep** means a lot of behavior behind a small interface; **shallow** means the interface is nearly as complex as the implementation.
+- **Seam**: where an interface lives; a place behavior can be altered without editing in place. Prefer this over "boundary" when discussing architecture.
+- **Adapter**: a concrete thing satisfying an interface at a seam.
+- **Leverage**: what callers get from depth.
+- **Locality**: what maintainers get from depth: change, bugs, knowledge, and verification concentrated in one place.
+
+Key principles:
+
+- **Deletion test**: imagine deleting the module. If complexity vanishes, it was a pass-through. If complexity reappears across many callers, it was earning its keep.
+- **The interface is the test surface.**
+- **One adapter = hypothetical seam. Two adapters = real seam.**
+- Prefer the local functional style in [REFERENCE.md](REFERENCE.md): pure cores, immutable data in/out, atomic tests, and effectful shells at infrastructure edges.
+
+This skill is informed by the project's domain model: `CONTEXT.md`, `CONTEXT-MAP.md`, and ADRs. Domain language gives names to good seams; ADRs record decisions the skill should not re-litigate.
+
 ## Process
 
 ### 1. Explore the codebase
+
+Read existing documentation first:
+
+- `CONTEXT.md` or `CONTEXT-MAP.md` plus each mapped `CONTEXT.md`
+- Relevant ADRs in `docs/adr/` and any context-scoped `docs/adr/` directories
+
+If these files don't exist, proceed silently. Don't flag their absence or suggest creating them upfront.
 
 Use `functions.task` with `subagent_type: "explore"` to navigate the codebase naturally. When multiple explorations are independent, launch them in parallel with `multi_tool_use.parallel`. Do NOT follow rigid heuristics - explore organically and note where you experience friction:
 
@@ -21,56 +50,72 @@ Use `functions.task` with `subagent_type: "explore"` to navigate the codebase na
 - Where do tightly-coupled modules create integration risk in the seams between them?
 - Which parts of the codebase are untested, or hard to test?
 
-The friction you encounter IS the signal.
+Apply the **deletion test** to suspected shallow modules: would deleting it concentrate complexity, or just move it around? The friction you encounter IS the signal.
 
 ### 2. Present candidates
 
 Present a numbered list of deepening opportunities. For each candidate, show:
 
-- **Cluster**: Which modules/concepts are involved
+- **Files**: Which files/modules are involved
+- **Problem**: Why the current architecture is causing friction
+- **Solution**: Plain English description of what would change
+- **Benefits**: Explained in terms of locality, leverage, and how tests would improve
 - **Why they're coupled**: Shared types, call patterns, co-ownership of a concept
 - **Dependency category**: See [REFERENCE.md](REFERENCE.md) for the four categories
 - **Test impact**: What existing tests would be replaced by boundary tests
+
+Use `CONTEXT.md` vocabulary for the domain and [LANGUAGE.md](LANGUAGE.md) vocabulary for architecture. If a candidate contradicts an existing ADR, only surface it when the friction is real enough to warrant revisiting the ADR. Mark the conflict clearly.
 
 Do NOT propose interfaces yet. Ask the user: "Which of these would you like to explore?"
 
 ### 3. User picks a candidate
 
-### 4. Frame the problem space
+### 4. Grilling loop
+
+Once the user picks a candidate, walk the design tree with them: constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive, and where the pure core ends and the effectful shell begins.
+
+Side effects happen inline as decisions crystallize:
+
+- **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md` using the same discipline as `/domain-model`. Create the file lazily if it doesn't exist.
+- **Sharpening a fuzzy domain term during the conversation?** Update `CONTEXT.md` right there.
+- **User rejects the candidate with a load-bearing reason?** Offer an ADR only when future architecture reviews would need that reason to avoid re-suggesting the same thing.
+- **Want to explore alternative interfaces for the deepened module?** Use the parallel design workflow in [INTERFACE-DESIGN.md](INTERFACE-DESIGN.md).
+
+### 5. Frame the problem space
 
 Before launching sub-agents, write a user-facing explanation of the problem space for the chosen candidate:
 
 - The constraints any new interface would need to satisfy
-- The dependencies it would need to rely on
+- The dependencies it would need to rely on, including their category from [REFERENCE.md](REFERENCE.md) and [DEEPENING.md](DEEPENING.md)
 - A rough illustrative code sketch to make the constraints concrete — this is not a proposal, just a way to ground the constraints
 
-Show this to the user, then immediately proceed to Step 5. The user reads and thinks about the problem while the sub-agents work in parallel.
+Show this to the user, then immediately proceed to Step 6. The user reads and thinks about the problem while the sub-agents work in parallel.
 
-### 5. Design multiple interfaces
+### 6. Design multiple interfaces
 
 Launch 3+ sub-agents in parallel using `functions.task` wrapped by `multi_tool_use.parallel`. Use `subagent_type: "general"` for design generation. Each must produce a **radically different** interface for the deepened module.
 
-Prompt each sub-agent with a separate technical brief (file paths, coupling details, dependency category, what's being hidden). This brief is independent of the user-facing explanation in Step 4. Give each agent a different design constraint:
+Prompt each sub-agent with a separate technical brief (file paths, coupling details, dependency category, what's being hidden). Include both [LANGUAGE.md](LANGUAGE.md) vocabulary and `CONTEXT.md` vocabulary so each design names things consistently. This brief is independent of the user-facing explanation in Step 5. Give each agent a different design constraint:
 
-- Agent 1: "Minimize the interface — aim for 1-3 entry points max"
+- Agent 1: "Minimize the interface — aim for 1-3 entry points max. Maximize leverage per entry point."
 - Agent 2: "Maximize flexibility — support many use cases and extension"
 - Agent 3: "Optimize for the most common caller — make the default case trivial"
 - Agent 4 (if applicable): "Design around the ports & adapters pattern for cross-boundary dependencies"
 
 Each sub-agent outputs:
 
-1. Interface signature (types, methods, params)
+1. Interface signature (types, methods, params, invariants, ordering, error modes)
 2. Usage example showing how callers use it
-3. What complexity it hides internally
-4. Dependency strategy (how deps are handled — see [REFERENCE.md](REFERENCE.md))
-5. Trade-offs
+3. What implementation complexity it hides behind the seam
+4. Dependency strategy and adapters (how deps are handled — see [REFERENCE.md](REFERENCE.md) and [DEEPENING.md](DEEPENING.md))
+5. Trade-offs: where leverage is high and where it is thin
 
-Present designs sequentially, then compare them in prose.
+Present designs sequentially, then compare them in prose. Contrast by **depth**, **locality**, and **seam placement**.
 
 After comparing, give your own recommendation: which design you think is strongest and why. If elements from different designs would combine well, propose a hybrid. Be opinionated — the user wants a strong read, not just a menu.
 
-### 6. User picks an interface (or accepts recommendation)
+### 7. User picks an interface (or accepts recommendation)
 
-### 7. Create GitHub issue
+### 8. Create GitHub issue
 
 If the user wants the outcome captured as a GitHub issue, create a refactor RFC using `gh issue create`. Use the template in [REFERENCE.md](REFERENCE.md). Otherwise, stop at the recommendation.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expanded the architecture skill with a shared vocabulary, a deepening playbook, and a parallel interface design workflow. Tightened the main process and clarified when and how to update `CONTEXT.md` without coupling to implementation details.

- **New Features**
  - Added `LANGUAGE.md`: shared terms (Module, Interface, Implementation, Depth, Seam, Adapter, Leverage, Locality) with principles and relationships.
  - Added `DEEPENING.md`: dependency categories, seam discipline, and “replace, don’t layer” testing strategy.
  - Added `INTERFACE-DESIGN.md`: parallel “design it twice” workflow with sub-agents, comparison, and recommendation.

- **Refactors**
  - Reworked `SKILL.md`: adds glossary, reads domain docs first, applies the deletion test, and introduces a “grilling loop” before parallel design.
  - Clarifies candidate presentation and evaluation using architecture and domain vocabulary; contrasts designs by depth, locality, and seam placement.
  - Updates process to define ports/adapters by dependency category and to test at the interface.
  - `domain-model/SKILL.md`: emphasize updating `CONTEXT.md` with domain terms only, not implementation details.

<sup>Written for commit 04aa833caedef0e261c4a9175e94e632dbae6200. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

