### PR TITLE
feat(backup): add private backup API

### DIFF
--- a/apps/mobile/__tests__/backup/remote-schema.test.ts
+++ b/apps/mobile/__tests__/backup/remote-schema.test.ts
@@ -6,6 +6,10 @@ const MIGRATION = resolve(
   __dirname,
   "../../supabase/migrations/20260425100000_encrypted_backups.sql"
 );
+const WRITE_BOUNDARY_MIGRATION = resolve(
+  __dirname,
+  "../../supabase/migrations/20260427100000_private_backup_api_write_boundary.sql"
+);
 
 describe("remote encrypted backup schema", () => {
   it("stores only encrypted backup metadata and scopes table and blob access to the owner", () => {
@@ -27,5 +31,19 @@ describe("remote encrypted backup schema", () => {
     expect(sql).toContain("storage.foldername(name)");
     expect(sql).toContain("(storage.foldername(name))[1] = (select auth.uid())::text");
     expect(sql).not.toMatch(/plaintext|raw_key|derived_key|recovery_key|recovery_phrase/u);
+  });
+
+  it("removes direct authenticated writes so private-backup-api owns backup mutations", () => {
+    const sql = readFileSync(WRITE_BOUNDARY_MIGRATION, "utf8").toLowerCase();
+
+    expect(sql).toContain('drop policy if exists "users can read own encrypted backups"');
+    expect(sql).toContain('drop policy if exists "users can insert own encrypted backups"');
+    expect(sql).toContain('drop policy if exists "users can update own encrypted backups"');
+    expect(sql).toContain('drop policy if exists "users can delete own encrypted backups"');
+    expect(sql).toContain('drop policy if exists "users can read own encrypted backup objects"');
+    expect(sql).toContain('drop policy if exists "users can insert own encrypted backup objects"');
+    expect(sql).toContain('drop policy if exists "users can update own encrypted backup objects"');
+    expect(sql).toContain('drop policy if exists "users can delete own encrypted backup objects"');
+    expect(sql).not.toContain("create policy");
   });
 });

--- a/apps/mobile/__tests__/backup/remote-storage.test.ts
+++ b/apps/mobile/__tests__/backup/remote-storage.test.ts
@@ -40,16 +40,7 @@ const FORBIDDEN_REMOTE_VALUES = [
   "trusted-device-secret",
 ] as const;
 
-type RemoteMetadataRow = {
-  readonly id: string;
-  readonly user_id: string;
-  readonly created_at: string;
-  readonly schema_version: number;
-  readonly app_version: string;
-  readonly device_label: string;
-  readonly ciphertext_size_bytes: number;
-  readonly ciphertext_sha256: string;
-};
+type RemoteMetadata = ReturnType<typeof expectedRemoteMetadata>;
 
 describe("remote encrypted backup storage", () => {
   it("uploads encrypted backup blobs with metadata that excludes plaintext and secrets", async () => {
@@ -62,36 +53,39 @@ describe("remote encrypted backup storage", () => {
     expectRemotePayloadsToExclude(FORBIDDEN_REMOTE_VALUES, supabase.remotePayloads());
   });
 
-  it("removes an uploaded blob when metadata persistence fails", async () => {
+  it("surfaces confirmation failures without direct metadata or blob cleanup", async () => {
     const supabase = createRemoteBackupSupabase({
-      metadataUpsertError: { message: "metadata write failed" },
+      apiErrors: { confirmUpload: "metadata_mismatch" },
     });
 
     await expect(
       uploadEncryptedRemoteBackup(supabase.client, remoteBackupUploadInput())
-    ).rejects.toThrow("Unable to save encrypted backup metadata: metadata write failed");
-    expect(supabase.storageUpload).toHaveBeenCalledWith(
+    ).rejects.toThrow("Unable to call private backup API: metadata_mismatch");
+    expect(supabase.storageUploadToSignedUrl).toHaveBeenCalledWith(
       `${USER_ID}/${BACKUP_ID}.json`,
+      "signed-upload-token",
       JSON.stringify(ENCRYPTED_BACKUP),
-      { contentType: "application/json", upsert: true }
+      { contentType: "application/json" }
     );
-    expect(supabase.storageRemove).toHaveBeenCalledWith([`${USER_ID}/${BACKUP_ID}.json`]);
+    expect(supabase.storageRemove).not.toHaveBeenCalled();
+    expect(supabase.from).not.toHaveBeenCalled();
   });
 
   it("lists only encrypted backup metadata for the current user", async () => {
-    const supabase = createRemoteBackupSupabase({ metadataRows: [remoteMetadataRow()] });
+    const supabase = createRemoteBackupSupabase({ currentBackup: expectedRemoteMetadata() });
 
     await expect(listEncryptedRemoteBackups(supabase.client, USER_ID)).resolves.toEqual([
       expectedRemoteMetadata(),
     ]);
-    expect(supabase.metadataEq).toHaveBeenCalledWith("user_id", USER_ID);
-    expect(supabase.metadataOrder).toHaveBeenCalledWith("created_at", { ascending: false });
-    expect(supabase.storageUpload).not.toHaveBeenCalled();
+    expect(supabase.functionsInvoke).toHaveBeenCalledWith("private-backup-api", {
+      body: { action: "current" },
+    });
+    expect(supabase.storageUploadToSignedUrl).not.toHaveBeenCalled();
   });
 
   it("downloads an encrypted backup blob through user-scoped metadata", async () => {
     const supabase = createRemoteBackupSupabase({
-      metadataRows: [remoteMetadataRow()],
+      currentBackup: expectedRemoteMetadata(),
       storageBody: JSON.stringify(ENCRYPTED_BACKUP),
     });
 
@@ -101,15 +95,16 @@ describe("remote encrypted backup storage", () => {
         backupId: BACKUP_ID,
       })
     ).resolves.toEqual(ENCRYPTED_BACKUP);
-    expect(supabase.metadataEq).toHaveBeenCalledWith("user_id", USER_ID);
-    expect(supabase.metadataEq).toHaveBeenCalledWith("id", BACKUP_ID);
-    expect(supabase.storageDownload).toHaveBeenCalledWith(`${USER_ID}/${BACKUP_ID}.json`);
+    expect(supabase.functionsInvoke).toHaveBeenCalledWith("private-backup-api", {
+      body: { action: "prepareDownload" },
+    });
+    expect(supabase.fetch).toHaveBeenCalledWith("https://storage.example/download");
     expectRemotePayloadsToExclude(FORBIDDEN_REMOTE_VALUES, supabase.remotePayloads());
   });
 
   it("rejects a downloaded blob that does not match its metadata", async () => {
     const supabase = createRemoteBackupSupabase({
-      metadataRows: [remoteMetadataRow()],
+      currentBackup: expectedRemoteMetadata(),
       storageBody: JSON.stringify({ ...ENCRYPTED_BACKUP, ciphertext: "c3RhbGU=" }),
     });
 
@@ -122,7 +117,7 @@ describe("remote encrypted backup storage", () => {
   });
 
   it("deletes the encrypted backup blob and user-scoped metadata row", async () => {
-    const supabase = createRemoteBackupSupabase();
+    const supabase = createRemoteBackupSupabase({ currentBackup: expectedRemoteMetadata() });
 
     await expect(
       deleteEncryptedRemoteBackup(supabase.client, {
@@ -130,15 +125,19 @@ describe("remote encrypted backup storage", () => {
         backupId: BACKUP_ID,
       })
     ).resolves.toBeUndefined();
-    expect(supabase.storageRemove).toHaveBeenCalledWith([`${USER_ID}/${BACKUP_ID}.json`]);
-    expect(supabase.metadataDelete).toHaveBeenCalled();
-    expect(supabase.metadataDeleteEq).toHaveBeenCalledWith("user_id", USER_ID);
-    expect(supabase.metadataDeleteEq).toHaveBeenCalledWith("id", BACKUP_ID);
+    expect(supabase.functionsInvoke).toHaveBeenCalledWith("private-backup-api", {
+      body: { action: "current" },
+    });
+    expect(supabase.functionsInvoke).toHaveBeenCalledWith("private-backup-api", {
+      body: { action: "deleteCurrent" },
+    });
+    expect(supabase.from).not.toHaveBeenCalled();
   });
 
-  it("keeps the blob when metadata deletion fails", async () => {
+  it("keeps direct storage untouched when API deletion fails", async () => {
     const supabase = createRemoteBackupSupabase({
-      metadataDeleteError: { message: "metadata delete failed" },
+      currentBackup: expectedRemoteMetadata(),
+      apiErrors: { deleteCurrent: "delete_failed" },
     });
 
     await expect(
@@ -146,9 +145,9 @@ describe("remote encrypted backup storage", () => {
         userId: USER_ID,
         backupId: BACKUP_ID,
       })
-    ).rejects.toThrow("Unable to delete encrypted backup metadata: metadata delete failed");
-    expect(supabase.metadataDelete).toHaveBeenCalled();
+    ).rejects.toThrow("Unable to call private backup API: delete_failed");
     expect(supabase.storageRemove).not.toHaveBeenCalled();
+    expect(supabase.from).not.toHaveBeenCalled();
   });
 });
 
@@ -178,76 +177,92 @@ function expectedRemoteMetadata() {
 }
 
 function expectUploadCalls(supabase: ReturnType<typeof createRemoteBackupSupabase>) {
-  expect(supabase.storageUpload).toHaveBeenCalledWith(
-    `${USER_ID}/${BACKUP_ID}.json`,
-    JSON.stringify(ENCRYPTED_BACKUP),
-    { contentType: "application/json", upsert: true }
-  );
-  expect(supabase.metadataUpsert).toHaveBeenCalledWith(remoteMetadataRow(), {
-    onConflict: "user_id,id",
+  expect(supabase.functionsInvoke).toHaveBeenCalledWith("private-backup-api", {
+    body: {
+      action: "prepareUpload",
+      backupId: BACKUP_ID,
+    },
   });
-}
-
-function remoteMetadataRow(): RemoteMetadataRow {
-  return {
-    id: BACKUP_ID,
-    user_id: USER_ID,
-    created_at: CREATED_AT,
-    schema_version: 1,
-    app_version: "1.2.3",
-    device_label: "iPhone 17",
-    ciphertext_size_bytes: 10,
-    ciphertext_sha256: "305531dcc50ebca31cf1d5b31e9fc76ed51f66b3b6dd5a030c6539ae6532f979",
-  };
+  expect(supabase.storageUploadToSignedUrl).toHaveBeenCalledWith(
+    `${USER_ID}/${BACKUP_ID}.json`,
+    "signed-upload-token",
+    JSON.stringify(ENCRYPTED_BACKUP),
+    { contentType: "application/json" }
+  );
+  expect(supabase.functionsInvoke).toHaveBeenCalledWith("private-backup-api", {
+    body: {
+      action: "confirmUpload",
+      ...expectedRemoteMetadata(),
+    },
+  });
 }
 
 function createRemoteBackupSupabase(
   options: {
-    readonly metadataRows?: readonly RemoteMetadataRow[];
-    readonly metadataDeleteError?: { readonly message: string };
-    readonly metadataUpsertError?: { readonly message: string };
+    readonly apiErrors?: Partial<Record<string, string>>;
+    readonly currentBackup?: RemoteMetadata | null;
     readonly storageBody?: string;
   } = {}
 ) {
-  const metadataOrder = vi.fn(() =>
-    Promise.resolve({ data: options.metadataRows ?? [], error: null })
+  const currentBackup = options.currentBackup === undefined ? null : options.currentBackup;
+  const functionsInvoke = vi.fn(
+    (functionName: string, invokeOptions: { body: { action: string } }) => {
+      expect(functionName).toBe("private-backup-api");
+      const action = invokeOptions.body.action;
+      const apiError = options.apiErrors?.[action];
+      if (apiError !== undefined) {
+        return Promise.resolve({ data: { success: false, error: apiError }, error: null });
+      }
+      if (action === "prepareUpload") {
+        return Promise.resolve({
+          data: {
+            success: true,
+            path: `${USER_ID}/${BACKUP_ID}.json`,
+            uploadToken: "signed-upload-token",
+          },
+          error: null,
+        });
+      }
+      if (action === "confirmUpload") {
+        return Promise.resolve({
+          data: { success: true, backup: expectedRemoteMetadata() },
+          error: null,
+        });
+      }
+      if (action === "current") {
+        return Promise.resolve({
+          data: { success: true, backup: currentBackup },
+          error: null,
+        });
+      }
+      if (action === "prepareDownload") {
+        return Promise.resolve({
+          data: {
+            success: true,
+            backup: currentBackup ?? expectedRemoteMetadata(),
+            downloadUrl: "https://storage.example/download",
+          },
+          error: null,
+        });
+      }
+      return Promise.resolve({ data: { success: true }, error: null });
+    }
   );
-  const metadataSingle = vi.fn(() =>
-    Promise.resolve({ data: options.metadataRows?.[0] ?? null, error: null })
-  );
-  const metadataEq = vi.fn(() => ({
-    eq: metadataEq,
-    error: null,
-    order: metadataOrder,
-    single: metadataSingle,
-  }));
-  const metadataDeleteEq = vi.fn(() => ({
-    eq: metadataDeleteEq,
-    error: options.metadataDeleteError ?? null,
-  }));
-  const metadataSelect = vi.fn(() => ({ eq: metadataEq }));
-  const metadataDelete = vi.fn(() => ({
-    eq: metadataDeleteEq,
-    error: options.metadataDeleteError ?? null,
-  }));
-  const metadataUpsert = vi.fn(() =>
-    Promise.resolve({ error: options.metadataUpsertError ?? null })
-  );
-  const storageUpload = vi.fn(() => Promise.resolve({ error: null }));
-  const storageDownload = vi.fn(() =>
+  const storageUploadToSignedUrl = vi.fn(() => Promise.resolve({ error: null }));
+  const storageRemove = vi.fn(() => Promise.resolve({ error: null }));
+  const from = vi.fn();
+  const fetch = vi.fn(() =>
     Promise.resolve({
-      data: { text: () => Promise.resolve(options.storageBody ?? "") },
-      error: null,
+      ok: true,
+      json: () =>
+        Promise.resolve(JSON.parse(options.storageBody ?? JSON.stringify(ENCRYPTED_BACKUP))),
     })
   );
-  const storageRemove = vi.fn(() => Promise.resolve({ error: null }));
-  const table = { delete: metadataDelete, select: metadataSelect, upsert: metadataUpsert };
-  const bucket = { download: storageDownload, remove: storageRemove, upload: storageUpload };
+  vi.stubGlobal("fetch", fetch);
+  const bucket = { remove: storageRemove, uploadToSignedUrl: storageUploadToSignedUrl };
   const client = {
-    from: vi.fn((tableName: string) => {
-      expect(tableName).toBe("encrypted_backups");
-      return table;
-    }),
+    from,
+    functions: { invoke: functionsInvoke },
     storage: {
       from: vi.fn((bucketName: string) => {
         expect(bucketName).toBe("encrypted-backups");
@@ -258,21 +273,15 @@ function createRemoteBackupSupabase(
 
   return {
     client: client as unknown as SupabaseClient,
-    metadataEq,
-    metadataOrder,
-    metadataSelect,
-    metadataSingle,
-    metadataDelete,
-    metadataDeleteEq,
-    metadataUpsert,
-    storageDownload,
+    fetch,
+    from,
+    functionsInvoke,
     storageRemove,
-    storageUpload,
+    storageUploadToSignedUrl,
     remotePayloads: () => [
-      metadataEq.mock.calls,
-      metadataUpsert.mock.calls,
-      storageDownload.mock.calls,
-      storageUpload.mock.calls,
+      functionsInvoke.mock.calls,
+      storageUploadToSignedUrl.mock.calls,
+      fetch.mock.calls,
     ],
   };
 }

--- a/apps/mobile/__tests__/edge-functions/private-backup-api.test.ts
+++ b/apps/mobile/__tests__/edge-functions/private-backup-api.test.ts
@@ -1,0 +1,546 @@
+// biome-ignore-all lint/style/useNamingConvention: Supabase table and storage APIs use snake_case
+import { describe, expect, it, vi } from "vitest";
+import { handlePrivateBackupRequest } from "../../../../supabase/functions/private-backup-api/handler";
+
+const USER_ID = "00000000-0000-4000-8000-000000000001";
+const OTHER_USER_ID = "00000000-0000-4000-8000-000000000002";
+const BACKUP_ID = "backup-1";
+const CREATED_AT = "2026-04-26T10:00:00.000Z";
+const CIPHERTEXT = new TextEncoder().encode("ciphertext");
+const ENCRYPTED_BACKUP_OBJECT = new TextEncoder().encode(
+  JSON.stringify({
+    version: 1,
+    algorithm: "AES-GCM",
+    nonce: "bm9uY2U=",
+    ciphertext: "Y2lwaGVydGV4dA==",
+    wrappedDataKeys: [],
+  })
+);
+const SHA256 = "305531dcc50ebca31cf1d5b31e9fc76ed51f66b3b6dd5a030c6539ae6532f979";
+
+describe("private-backup-api Edge Function", () => {
+  it("rejects missing and invalid auth before backup actions run", async () => {
+    const missingAuth = createPrivateBackupApiDeps();
+    const missingAuthResponse = await handlePrivateBackupRequest(
+      jsonRequest({ action: "current" }),
+      missingAuth.deps
+    );
+
+    expect(missingAuthResponse.status).toBe(401);
+    await expect(missingAuthResponse.json()).resolves.toEqual({
+      success: false,
+      error: "missing_auth",
+    });
+    expectNoStoreCalls(missingAuth.store);
+
+    const invalidAuth = createPrivateBackupApiDeps({ authError: { message: "bad token" } });
+    const invalidAuthResponse = await handlePrivateBackupRequest(
+      jsonRequest({ action: "current" }, "invalid-token"),
+      invalidAuth.deps
+    );
+
+    expect(invalidAuthResponse.status).toBe(401);
+    await expect(invalidAuthResponse.json()).resolves.toEqual({
+      success: false,
+      error: "invalid_auth",
+    });
+    expectNoStoreCalls(invalidAuth.store);
+  });
+
+  it("routes only the private backup actions", async () => {
+    const api = createPrivateBackupApiDeps();
+
+    const response = await handlePrivateBackupRequest(
+      jsonRequest({ action: "listAll" }, "valid-token"),
+      api.deps
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: "unsupported_action",
+    });
+  });
+
+  it("prepares signed upload URLs only for authenticated user backup paths", async () => {
+    const api = createPrivateBackupApiDeps({ userId: USER_ID });
+
+    const response = await handlePrivateBackupRequest(
+      jsonRequest(
+        {
+          action: "prepareUpload",
+          userId: OTHER_USER_ID,
+          backupId: ` ${BACKUP_ID} `,
+        },
+        "valid-token"
+      ),
+      api.deps
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      uploadUrl: "https://storage.example/upload",
+      uploadToken: "signed-upload-token",
+      path: `${USER_ID}/${BACKUP_ID}.json`,
+      expiresInSeconds: 300,
+    });
+    expect(api.store.createdUploadUrls()).toEqual([`${USER_ID}/${BACKUP_ID}.json`]);
+    expect(api.store.uploadUrlOptions()).toEqual([undefined]);
+  });
+
+  it("rejects prepareUpload when the backup id is already confirmed", async () => {
+    const api = createPrivateBackupApiDeps({
+      backups: [metadataRow({ backupId: BACKUP_ID })],
+    });
+
+    const response = await handlePrivateBackupRequest(
+      jsonRequest({ action: "prepareUpload", backupId: BACKUP_ID }, "valid-token"),
+      api.deps
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: "backup_already_confirmed",
+    });
+    expect(api.store.createdUploadUrls()).toEqual([]);
+  });
+
+  it("returns the current authenticated-user backup metadata", async () => {
+    const current = metadataRow({ backupId: BACKUP_ID });
+    const api = createPrivateBackupApiDeps({
+      backups: [
+        metadataRow({
+          userId: OTHER_USER_ID,
+          backupId: "backup-other-user",
+          createdAt: "2026-04-27T10:00:00.000Z",
+        }),
+        current,
+      ],
+    });
+
+    const response = await handlePrivateBackupRequest(
+      jsonRequest({ action: "current" }, "valid-token"),
+      api.deps
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      backup: current,
+    });
+  });
+
+  it("confirms uploaded metadata only after server-side object verification", async () => {
+    const api = createPrivateBackupApiDeps({
+      objects: new Map([[`${USER_ID}/${BACKUP_ID}.json`, ENCRYPTED_BACKUP_OBJECT]]),
+    });
+
+    const response = await handlePrivateBackupRequest(
+      jsonRequest({ action: "confirmUpload", ...metadataPayload() }, "valid-token"),
+      api.deps
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      backup: metadataRow({ backupId: BACKUP_ID }),
+    });
+    expect(api.store.confirmedBackups()).toEqual([metadataRow({ backupId: BACKUP_ID })]);
+    expect(api.store.deletedObjects()).toEqual([]);
+  });
+
+  it("reports storage download failures as server errors during confirmation", async () => {
+    const api = createPrivateBackupApiDeps({
+      downloadObjectError: new Error("storage unavailable"),
+    });
+
+    const response = await handlePrivateBackupRequest(
+      jsonRequest({ action: "confirmUpload", ...metadataPayload() }, "valid-token"),
+      api.deps
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: "internal_error",
+    });
+    expect(api.store.confirmedBackups()).toEqual([]);
+  });
+
+  it("rejects invalid metadata before reading or changing backup storage", async () => {
+    const api = createPrivateBackupApiDeps({
+      objects: new Map([[`${USER_ID}/${BACKUP_ID}.json`, ENCRYPTED_BACKUP_OBJECT]]),
+    });
+
+    const response = await handlePrivateBackupRequest(
+      jsonRequest(
+        {
+          action: "confirmUpload",
+          ...metadataPayload(),
+          ciphertextSha256: "not-a-sha",
+        },
+        "valid-token"
+      ),
+      api.deps
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: "invalid_metadata",
+    });
+    expect(api.store.downloadObject).not.toHaveBeenCalled();
+    expect(api.store.confirmedBackups()).toEqual([]);
+    expect(api.store.deletedObjects()).toEqual([]);
+  });
+
+  it("rejects missing objects and hash mismatches without hiding the current backup", async () => {
+    const current = metadataRow({
+      backupId: "backup-current",
+      createdAt: "2026-04-25T10:00:00.000Z",
+    });
+    const missingObjectApi = createPrivateBackupApiDeps({ backups: [current] });
+
+    const missingObjectResponse = await handlePrivateBackupRequest(
+      jsonRequest({ action: "confirmUpload", ...metadataPayload() }, "valid-token"),
+      missingObjectApi.deps
+    );
+
+    expect(missingObjectResponse.status).toBe(400);
+    await expect(missingObjectResponse.json()).resolves.toEqual({
+      success: false,
+      error: "missing_object",
+    });
+    expect(missingObjectApi.store.confirmedBackups()).toEqual([]);
+    expect(missingObjectApi.store.deletedObjects()).toEqual([]);
+    expect(missingObjectApi.store.currentBackup()).toEqual(current);
+
+    const hashMismatchApi = createPrivateBackupApiDeps({
+      backups: [current],
+      objects: new Map([[`${USER_ID}/${BACKUP_ID}.json`, new TextEncoder().encode("wrong")]]),
+    });
+
+    const hashMismatchResponse = await handlePrivateBackupRequest(
+      jsonRequest({ action: "confirmUpload", ...metadataPayload() }, "valid-token"),
+      hashMismatchApi.deps
+    );
+
+    expect(hashMismatchResponse.status).toBe(400);
+    await expect(hashMismatchResponse.json()).resolves.toEqual({
+      success: false,
+      error: "metadata_mismatch",
+    });
+    expect(hashMismatchApi.store.confirmedBackups()).toEqual([]);
+    expect(hashMismatchApi.store.deletedObjects()).toEqual([]);
+    expect(hashMismatchApi.store.currentBackup()).toEqual(current);
+  });
+
+  it("treats matching confirmUpload retries as idempotent", async () => {
+    const existing = metadataRow({ backupId: BACKUP_ID });
+    const api = createPrivateBackupApiDeps({ backups: [existing] });
+
+    const response = await handlePrivateBackupRequest(
+      jsonRequest({ action: "confirmUpload", ...metadataPayload() }, "valid-token"),
+      api.deps
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      backup: existing,
+    });
+    expect(api.store.confirmedBackups()).toEqual([]);
+  });
+
+  it("persists the new backup before deleting every previous confirmed backup", async () => {
+    const previousLatest = metadataRow({
+      backupId: "backup-previous-latest",
+      createdAt: "2026-04-25T10:00:00.000Z",
+    });
+    const previousOlder = metadataRow({
+      backupId: "backup-previous-older",
+      createdAt: "2026-04-24T10:00:00.000Z",
+    });
+    const api = createPrivateBackupApiDeps({
+      backups: [previousLatest, previousOlder],
+      objects: new Map([[`${USER_ID}/${BACKUP_ID}.json`, ENCRYPTED_BACKUP_OBJECT]]),
+    });
+
+    const response = await handlePrivateBackupRequest(
+      jsonRequest({ action: "confirmUpload", ...metadataPayload() }, "valid-token"),
+      api.deps
+    );
+
+    expect(response.status).toBe(200);
+    expect(api.store.operations()).toEqual([
+      `confirm:${USER_ID}/${BACKUP_ID}`,
+      `deleteMetadata:${USER_ID}/backup-previous-latest`,
+      `deleteMetadata:${USER_ID}/backup-previous-older`,
+      `deleteObject:${USER_ID}/backup-previous-latest.json`,
+      `deleteObject:${USER_ID}/backup-previous-older.json`,
+    ]);
+    expect(api.store.currentBackup()).toEqual(metadataRow({ backupId: BACKUP_ID }));
+  });
+
+  it("returns confirmed metadata when previous backup cleanup fails", async () => {
+    const api = createPrivateBackupApiDeps({
+      backups: [legacyMetadataRow()],
+      deleteBackupMetadataError: new Error("delete failed"),
+      objects: new Map([[`${USER_ID}/${BACKUP_ID}.json`, ENCRYPTED_BACKUP_OBJECT]]),
+    });
+
+    const response = await handlePrivateBackupRequest(
+      jsonRequest({ action: "confirmUpload", ...metadataPayload() }, "valid-token"),
+      api.deps
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      backup: metadataRow({ backupId: BACKUP_ID }),
+    });
+    expect(api.store.confirmedBackups()).toEqual([metadataRow({ backupId: BACKUP_ID })]);
+  });
+
+  it("prepares downloads for the current backup and deletes every authenticated-user backup", async () => {
+    const current = metadataRow({ backupId: BACKUP_ID });
+    const api = createPrivateBackupApiDeps({ backups: [current, legacyMetadataRow()] });
+
+    const downloadResponse = await handlePrivateBackupRequest(
+      jsonRequest({ action: "prepareDownload" }, "valid-token"),
+      api.deps
+    );
+
+    await expectCurrentDownloadResponse(downloadResponse, current);
+
+    const deleteResponse = await handlePrivateBackupRequest(
+      jsonRequest({ action: "deleteCurrent", backupId: "ignored" }, "valid-token"),
+      api.deps
+    );
+
+    await expectDeleteCurrentResponse(deleteResponse);
+    expectDeletedBackupOperations(api.store.operations(), [BACKUP_ID, "backup-legacy"]);
+    expect(api.store.currentBackup()).toBeNull();
+  });
+});
+
+function jsonRequest(body: unknown, token?: string) {
+  return new Request("http://localhost/private-backup-api", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token === undefined ? {} : { Authorization: `Bearer ${token}` }),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function createPrivateBackupApiDeps(
+  options: {
+    readonly authError?: { readonly message: string };
+    readonly backups?: readonly RemoteBackupMetadata[];
+    readonly deleteBackupMetadataError?: Error;
+    readonly downloadObjectError?: Error;
+    readonly objects?: ReadonlyMap<string, Uint8Array>;
+    readonly userId?: string;
+  } = {}
+) {
+  const store = createPrivateBackupStore(options);
+  return {
+    store,
+    deps: {
+      auth: {
+        auth: {
+          getUser: vi.fn(() => Promise.resolve(authResponse(options))),
+        },
+      },
+      store,
+    },
+  };
+}
+
+function authResponse(options: {
+  readonly authError?: { readonly message: string };
+  readonly userId?: string;
+}) {
+  return {
+    data: { user: authUser(options) },
+    error: options.authError ?? null,
+  };
+}
+
+function authUser(options: {
+  readonly authError?: { readonly message: string };
+  readonly userId?: string;
+}) {
+  return options.authError === undefined ? { id: options.userId ?? USER_ID } : null;
+}
+
+type RemoteBackupMetadata = {
+  readonly userId: string;
+  readonly backupId: string;
+  readonly createdAt: string;
+  readonly schemaVersion: number;
+  readonly appVersion: string;
+  readonly deviceLabel: string;
+  readonly ciphertextSizeBytes: number;
+  readonly ciphertextSha256: string;
+};
+
+function metadataPayload() {
+  return {
+    backupId: BACKUP_ID,
+    createdAt: CREATED_AT,
+    schemaVersion: 1,
+    appVersion: "1.2.3",
+    deviceLabel: "iPhone 17",
+    ciphertextSizeBytes: CIPHERTEXT.byteLength,
+    ciphertextSha256: SHA256,
+  };
+}
+
+function metadataRow(overrides: Partial<RemoteBackupMetadata> = {}): RemoteBackupMetadata {
+  return {
+    userId: USER_ID,
+    backupId: BACKUP_ID,
+    createdAt: CREATED_AT,
+    schemaVersion: 1,
+    appVersion: "1.2.3",
+    deviceLabel: "iPhone 17",
+    ciphertextSizeBytes: CIPHERTEXT.byteLength,
+    ciphertextSha256: SHA256,
+    ...overrides,
+  };
+}
+
+function legacyMetadataRow() {
+  return metadataRow({
+    backupId: "backup-legacy",
+    createdAt: "2026-04-25T10:00:00.000Z",
+  });
+}
+
+async function expectCurrentDownloadResponse(response: Response, current: RemoteBackupMetadata) {
+  expect(response.status).toBe(200);
+  await expect(response.json()).resolves.toEqual({
+    success: true,
+    backup: current,
+    downloadUrl: "https://storage.example/download",
+    path: `${USER_ID}/${BACKUP_ID}.json`,
+    expiresInSeconds: 300,
+  });
+}
+
+async function expectDeleteCurrentResponse(response: Response) {
+  expect(response.status).toBe(200);
+  await expect(response.json()).resolves.toEqual({ success: true });
+}
+
+function expectDeletedBackupOperations(
+  operations: readonly string[],
+  backupIds: readonly string[]
+) {
+  backupIds.forEach((backupId) => {
+    expect(operations).toContain(`deleteMetadata:${USER_ID}/${backupId}`);
+    expect(operations).toContain(`deleteObject:${USER_ID}/${backupId}.json`);
+  });
+}
+
+function expectNoStoreCalls(store: ReturnType<typeof createPrivateBackupStore>) {
+  expect(store.loadBackup).not.toHaveBeenCalled();
+  expect(store.listBackups).not.toHaveBeenCalled();
+  expect(store.loadCurrentBackup).not.toHaveBeenCalled();
+  expect(store.createSignedUploadUrl).not.toHaveBeenCalled();
+  expect(store.createSignedDownloadUrl).not.toHaveBeenCalled();
+  expect(store.downloadObject).not.toHaveBeenCalled();
+  expect(store.confirmBackup).not.toHaveBeenCalled();
+  expect(store.deleteBackupMetadata).not.toHaveBeenCalled();
+  expect(store.deleteObject).not.toHaveBeenCalled();
+}
+
+function createPrivateBackupStore(options: {
+  readonly backups?: readonly RemoteBackupMetadata[];
+  readonly deleteBackupMetadataError?: Error;
+  readonly downloadObjectError?: Error;
+  readonly objects?: ReadonlyMap<string, Uint8Array>;
+}) {
+  const backups = new Map(
+    (options.backups ?? []).map((backup) => [`${backup.userId}/${backup.backupId}`, backup])
+  );
+  const confirmed: RemoteBackupMetadata[] = [];
+  const uploadUrls: string[] = [];
+  const uploadUrlOptions: unknown[] = [];
+  const downloadUrls: string[] = [];
+  const deletedObjects: string[] = [];
+  const operationLog: string[] = [];
+
+  const store = {
+    loadBackup: vi.fn((userId: string, backupId: string) =>
+      Promise.resolve(backups.get(`${userId}/${backupId}`) ?? null)
+    ),
+    listBackups: vi.fn((userId: string) =>
+      Promise.resolve(
+        [...backups.values()]
+          .filter((backup) => backup.userId === userId)
+          .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
+      )
+    ),
+    loadCurrentBackup: vi.fn((userId: string) =>
+      Promise.resolve(
+        [...backups.values()]
+          .filter((backup) => backup.userId === userId)
+          .sort((left, right) => right.createdAt.localeCompare(left.createdAt))[0] ?? null
+      )
+    ),
+    createSignedUploadUrl: vi.fn((path: string, options?: unknown) => {
+      uploadUrls.push(path);
+      uploadUrlOptions.push(options);
+      return Promise.resolve({
+        signedUrl: "https://storage.example/upload",
+        token: "signed-upload-token",
+      });
+    }),
+    createSignedDownloadUrl: vi.fn((path: string) => {
+      downloadUrls.push(path);
+      return Promise.resolve("https://storage.example/download");
+    }),
+    downloadObject: vi.fn((path: string) =>
+      options.downloadObjectError === undefined
+        ? Promise.resolve(options.objects?.get(path) ?? null)
+        : Promise.reject(options.downloadObjectError)
+    ),
+    confirmBackup: vi.fn((backup: RemoteBackupMetadata) => {
+      operationLog.push(`confirm:${backup.userId}/${backup.backupId}`);
+      confirmed.push(backup);
+      backups.set(`${backup.userId}/${backup.backupId}`, backup);
+      return Promise.resolve();
+    }),
+    deleteBackupMetadata: vi.fn((userId: string, backupId: string) => {
+      operationLog.push(`deleteMetadata:${userId}/${backupId}`);
+      if (options.deleteBackupMetadataError !== undefined) {
+        return Promise.reject(options.deleteBackupMetadataError);
+      }
+      backups.delete(`${userId}/${backupId}`);
+      return Promise.resolve();
+    }),
+    deleteObject: vi.fn((path: string) => {
+      operationLog.push(`deleteObject:${path}`);
+      deletedObjects.push(path);
+      return Promise.resolve();
+    }),
+    confirmedBackups: () => confirmed,
+    createdUploadUrls: () => uploadUrls,
+    uploadUrlOptions: () => uploadUrlOptions,
+    createdDownloadUrls: () => downloadUrls,
+    deletedObjects: () => deletedObjects,
+    operations: () => operationLog,
+    currentBackup: () =>
+      [...backups.values()]
+        .filter((backup) => backup.userId === USER_ID)
+        .sort((left, right) => right.createdAt.localeCompare(left.createdAt))[0] ?? null,
+  };
+
+  return store;
+}

--- a/apps/mobile/features/backup/remote-storage.ts
+++ b/apps/mobile/features/backup/remote-storage.ts
@@ -1,7 +1,6 @@
 // biome-ignore-all lint/style/useNamingConvention: Supabase tables use snake_case fields
 
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { requireBackupId, requireIsoDateTime, requireUserId } from "@/shared/types/assertions";
 import type { BackupId, IsoDateTime, UserId } from "@/shared/types/branded";
 import { fromBase64 } from "./local-ledger-crypto";
 import type { EncryptedLocalLedgerBackupSnapshot } from "./local-ledger-encryption";
@@ -9,8 +8,6 @@ import { assertLocalLedgerBackupSecretSafeForRemote } from "./local-ledger-encry
 
 export const REMOTE_BACKUP_BUCKET = "encrypted-backups";
 export const REMOTE_BACKUP_METADATA_TABLE = "encrypted_backups";
-const REMOTE_BACKUP_METADATA_COLUMNS =
-  "id,user_id,created_at,schema_version,app_version,device_label,ciphertext_size_bytes,ciphertext_sha256";
 
 export type RemoteBackupMetadata = {
   readonly userId: UserId;
@@ -40,82 +37,85 @@ export type DownloadEncryptedRemoteBackupInput = {
 
 export type DeleteEncryptedRemoteBackupInput = DownloadEncryptedRemoteBackupInput;
 
-type RemoteBackupMetadataRow = {
-  readonly id: string;
-  readonly user_id: string;
-  readonly created_at: string;
-  readonly schema_version: number;
-  readonly app_version: string;
-  readonly device_label: string;
-  readonly ciphertext_size_bytes: number;
-  readonly ciphertext_sha256: string;
-};
-
 type RemoteBackupErrorLike = {
   readonly message?: string;
 };
+
+type PrivateBackupApiResponse<T> =
+  | ({ readonly success: true } & T)
+  | { readonly success: false; readonly error: string };
+
+type PrepareUploadResponse = PrivateBackupApiResponse<{
+  readonly path: string;
+  readonly uploadToken: string;
+}>;
+
+type ConfirmUploadResponse = PrivateBackupApiResponse<{
+  readonly backup: RemoteBackupMetadata;
+}>;
+
+type CurrentResponse = PrivateBackupApiResponse<{
+  readonly backup: RemoteBackupMetadata | null;
+}>;
+
+type PrepareDownloadResponse = PrivateBackupApiResponse<{
+  readonly backup: RemoteBackupMetadata;
+  readonly downloadUrl: string;
+}>;
 
 export async function uploadEncryptedRemoteBackup(
   supabase: SupabaseClient,
   input: UploadEncryptedRemoteBackupInput
 ): Promise<RemoteBackupMetadata> {
   assertLocalLedgerBackupSecretSafeForRemote(input.encryptedBackup);
-  const storagePath = buildRemoteBackupStoragePath(input.userId, input.backupId);
   const metadata = await buildRemoteBackupMetadata(input);
-  const metadataRow = toRemoteBackupMetadataRow(metadata);
-  assertLocalLedgerBackupSecretSafeForRemote(metadataRow);
+  assertLocalLedgerBackupSecretSafeForRemote(metadata);
 
+  const prepared = await invokePrivateBackupApi<PrepareUploadResponse>(supabase, {
+    action: "prepareUpload",
+    backupId: input.backupId,
+  });
   const uploadResponse = await supabase.storage
     .from(REMOTE_BACKUP_BUCKET)
-    .upload(storagePath, JSON.stringify(input.encryptedBackup), {
+    .uploadToSignedUrl(prepared.path, prepared.uploadToken, JSON.stringify(input.encryptedBackup), {
       contentType: "application/json",
-      upsert: true,
     });
   throwIfRemoteBackupError(uploadResponse.error, "upload encrypted backup");
 
-  const metadataResponse = await supabase
-    .from(REMOTE_BACKUP_METADATA_TABLE)
-    .upsert(metadataRow, { onConflict: "user_id,id" });
-  if (metadataResponse.error !== null) {
-    await deleteRemoteBackupObject(supabase, storagePath, "roll back encrypted backup object");
-  }
-  throwIfRemoteBackupError(metadataResponse.error, "save encrypted backup metadata");
-
-  return metadata;
+  const confirmed = await invokePrivateBackupApi<ConfirmUploadResponse>(supabase, {
+    action: "confirmUpload",
+    ...metadata,
+  });
+  return confirmed.backup;
 }
 
 export async function listEncryptedRemoteBackups(
   supabase: SupabaseClient,
-  userId: UserId
+  _userId: UserId
 ): Promise<readonly RemoteBackupMetadata[]> {
-  const response = await supabase
-    .from(REMOTE_BACKUP_METADATA_TABLE)
-    .select(REMOTE_BACKUP_METADATA_COLUMNS)
-    .eq("user_id", userId)
-    .order("created_at", { ascending: false });
-  throwIfRemoteBackupError(response.error, "list encrypted backup metadata");
-
-  return ((response.data ?? []) as RemoteBackupMetadataRow[]).map(fromRemoteBackupMetadataRow);
+  const response = await invokePrivateBackupApi<CurrentResponse>(supabase, { action: "current" });
+  return response.backup === null ? [] : [response.backup];
 }
 
 export async function downloadEncryptedRemoteBackup(
   supabase: SupabaseClient,
   input: DownloadEncryptedRemoteBackupInput
 ): Promise<EncryptedLocalLedgerBackupSnapshot> {
-  const metadata = await getRemoteBackupMetadata(supabase, input);
-  const response = await supabase.storage
-    .from(REMOTE_BACKUP_BUCKET)
-    .download(buildRemoteBackupStoragePath(input.userId, input.backupId));
-  throwIfRemoteBackupError(response.error, "download encrypted backup");
-  if (response.data === null) {
-    throw new Error("Unable to download encrypted backup: missing storage object");
+  const prepared = await invokePrivateBackupApi<PrepareDownloadResponse>(supabase, {
+    action: "prepareDownload",
+  });
+  if (prepared.backup.backupId !== input.backupId) {
+    throw new Error("Unable to download encrypted backup: backup not found");
   }
 
-  const encryptedBackup = JSON.parse(
-    await response.data.text()
-  ) as EncryptedLocalLedgerBackupSnapshot;
+  const response = await fetch(prepared.downloadUrl);
+  if (!response.ok) {
+    throw new Error("Unable to download encrypted backup: storage download failed");
+  }
+
+  const encryptedBackup = (await response.json()) as EncryptedLocalLedgerBackupSnapshot;
   assertLocalLedgerBackupSecretSafeForRemote(encryptedBackup);
-  await assertEncryptedBackupMatchesMetadata(encryptedBackup, metadata);
+  await assertEncryptedBackupMatchesMetadata(encryptedBackup, prepared.backup);
   return encryptedBackup;
 }
 
@@ -123,48 +123,14 @@ export async function deleteEncryptedRemoteBackup(
   supabase: SupabaseClient,
   input: DeleteEncryptedRemoteBackupInput
 ): Promise<void> {
-  const metadataResponse = await supabase
-    .from(REMOTE_BACKUP_METADATA_TABLE)
-    .delete()
-    .eq("user_id", input.userId)
-    .eq("id", input.backupId);
-  throwIfRemoteBackupError(metadataResponse.error, "delete encrypted backup metadata");
-
-  await deleteRemoteBackupObject(
-    supabase,
-    buildRemoteBackupStoragePath(input.userId, input.backupId),
-    "delete encrypted backup object"
-  );
-}
-
-async function getRemoteBackupMetadata(
-  supabase: SupabaseClient,
-  input: DownloadEncryptedRemoteBackupInput
-): Promise<RemoteBackupMetadata> {
-  const response = await supabase
-    .from(REMOTE_BACKUP_METADATA_TABLE)
-    .select(REMOTE_BACKUP_METADATA_COLUMNS)
-    .eq("user_id", input.userId)
-    .eq("id", input.backupId)
-    .single();
-  throwIfRemoteBackupError(response.error, "load encrypted backup metadata");
-  if (response.data === null) {
-    throw new Error("Unable to load encrypted backup metadata: backup not found");
+  const current = await invokePrivateBackupApi<CurrentResponse>(supabase, { action: "current" });
+  if (current.backup !== null && current.backup.backupId !== input.backupId) {
+    throw new Error("Unable to delete encrypted backup metadata: backup not found");
   }
-  return fromRemoteBackupMetadataRow(response.data as RemoteBackupMetadataRow);
-}
 
-function buildRemoteBackupStoragePath(userId: UserId, backupId: BackupId) {
-  return `${userId}/${backupId}.json`;
-}
-
-async function deleteRemoteBackupObject(
-  supabase: SupabaseClient,
-  storagePath: string,
-  operation: string
-) {
-  const storageResponse = await supabase.storage.from(REMOTE_BACKUP_BUCKET).remove([storagePath]);
-  throwIfRemoteBackupError(storageResponse.error, operation);
+  await invokePrivateBackupApi<PrivateBackupApiResponse<Record<string, never>>>(supabase, {
+    action: "deleteCurrent",
+  });
 }
 
 async function buildRemoteBackupMetadata(
@@ -182,30 +148,19 @@ async function buildRemoteBackupMetadata(
   };
 }
 
-function toRemoteBackupMetadataRow(metadata: RemoteBackupMetadata): RemoteBackupMetadataRow {
-  return {
-    id: metadata.backupId,
-    user_id: metadata.userId,
-    created_at: metadata.createdAt,
-    schema_version: metadata.schemaVersion,
-    app_version: metadata.appVersion,
-    device_label: metadata.deviceLabel,
-    ciphertext_size_bytes: metadata.ciphertextSizeBytes,
-    ciphertext_sha256: metadata.ciphertextSha256,
-  };
-}
-
-function fromRemoteBackupMetadataRow(row: RemoteBackupMetadataRow): RemoteBackupMetadata {
-  return {
-    userId: requireUserId(row.user_id),
-    backupId: requireBackupId(row.id),
-    createdAt: requireIsoDateTime(row.created_at),
-    schemaVersion: row.schema_version,
-    appVersion: row.app_version,
-    deviceLabel: row.device_label,
-    ciphertextSizeBytes: row.ciphertext_size_bytes,
-    ciphertextSha256: row.ciphertext_sha256,
-  };
+async function invokePrivateBackupApi<T extends PrivateBackupApiResponse<unknown>>(
+  supabase: SupabaseClient,
+  body: Record<string, unknown>
+): Promise<Extract<T, { readonly success: true }>> {
+  const response = await supabase.functions.invoke<T>("private-backup-api", { body });
+  throwIfRemoteBackupError(response.error, "call private backup API");
+  if (response.data === null) {
+    throw new Error("Unable to call private backup API: missing response");
+  }
+  if (!response.data.success) {
+    throw new Error(`Unable to call private backup API: ${response.data.error}`);
+  }
+  return response.data as Extract<T, { readonly success: true }>;
 }
 
 async function sha256Hex(value: Uint8Array): Promise<string> {

--- a/apps/mobile/supabase/migrations/20260427100000_private_backup_api_write_boundary.sql
+++ b/apps/mobile/supabase/migrations/20260427100000_private_backup_api_write_boundary.sql
@@ -1,0 +1,9 @@
+drop policy if exists "Users can read own encrypted backups" on public.encrypted_backups;
+drop policy if exists "Users can insert own encrypted backups" on public.encrypted_backups;
+drop policy if exists "Users can update own encrypted backups" on public.encrypted_backups;
+drop policy if exists "Users can delete own encrypted backups" on public.encrypted_backups;
+
+drop policy if exists "Users can read own encrypted backup objects" on storage.objects;
+drop policy if exists "Users can insert own encrypted backup objects" on storage.objects;
+drop policy if exists "Users can update own encrypted backup objects" on storage.objects;
+drop policy if exists "Users can delete own encrypted backup objects" on storage.objects;

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -6,6 +6,7 @@
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true,
     "noImplicitReturns": true,
+    "allowImportingTsExtensions": true,
     "types": [],
     "paths": {
       "@/*": ["./*"],

--- a/supabase/functions/private-backup-api/handler.ts
+++ b/supabase/functions/private-backup-api/handler.ts
@@ -1,0 +1,235 @@
+import {
+  metadataMatches,
+  readRemoteBackupMetadata,
+  uploadedObjectMatchesMetadata,
+} from "./metadata.ts";
+import type { RemoteBackupMetadata, SignedUploadUrl } from "./model.ts";
+
+type SupabaseError = { readonly message?: string } | null;
+
+type AuthClient = {
+  readonly auth: {
+    getUser(token: string): Promise<{
+      readonly data: { readonly user: { readonly id: string } | null };
+      readonly error: SupabaseError;
+    }>;
+  };
+};
+
+type ServiceClient = {
+  loadBackup(userId: string, backupId: string): Promise<RemoteBackupMetadata | null>;
+  listBackups(userId: string): Promise<readonly RemoteBackupMetadata[]>;
+  loadCurrentBackup(userId: string): Promise<RemoteBackupMetadata | null>;
+  createSignedUploadUrl(path: string): Promise<SignedUploadUrl>;
+  createSignedDownloadUrl(path: string): Promise<string>;
+  downloadObject(path: string): Promise<Uint8Array | null>;
+  confirmBackup(metadata: RemoteBackupMetadata): Promise<void>;
+  deleteBackupMetadata(userId: string, backupId: string): Promise<void>;
+  deleteObject(path: string): Promise<void>;
+};
+
+export type PrivateBackupApiDeps = {
+  readonly auth: AuthClient;
+  readonly store: ServiceClient;
+};
+
+const SIGNED_URL_EXPIRES_IN_SECONDS = 300;
+
+export async function handlePrivateBackupRequest(
+  request: Request,
+  deps: PrivateBackupApiDeps
+): Promise<Response> {
+  if (request.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders() });
+  }
+  if (request.method !== "POST") {
+    return jsonResponse({ success: false, error: "method_not_allowed" }, 405);
+  }
+
+  const authHeader = request.headers.get("Authorization");
+  if (authHeader === null) {
+    return jsonResponse({ success: false, error: "missing_auth" }, 401);
+  }
+
+  const token = authHeader.replace("Bearer ", "");
+  const {
+    data: { user },
+    error,
+  } = await deps.auth.auth.getUser(token);
+
+  if (error !== null || user === null) {
+    return jsonResponse({ success: false, error: "invalid_auth" }, 401);
+  }
+
+  const body = await readJsonBody(request);
+  try {
+    return await routeAuthenticatedRequest(deps.store, user.id, body);
+  } catch {
+    return jsonResponse({ success: false, error: "internal_error" }, 500);
+  }
+}
+
+async function routeAuthenticatedRequest(store: ServiceClient, userId: string, body: unknown) {
+  const action = readAction(body);
+  if (action === "current") {
+    return currentResponse(store, userId);
+  }
+  if (action === "prepareUpload") {
+    return prepareUploadResponse(store, userId, body);
+  }
+  if (action === "confirmUpload") {
+    return confirmUploadResponse(store, userId, body);
+  }
+  if (action === "prepareDownload") {
+    return prepareDownloadResponse(store, userId);
+  }
+  if (action === "deleteCurrent") {
+    return deleteCurrentResponse(store, userId);
+  }
+
+  return jsonResponse({ success: false, error: "unsupported_action" }, 400);
+}
+
+async function currentResponse(store: ServiceClient, userId: string) {
+  const backup = await store.loadCurrentBackup(userId);
+  return jsonResponse({ success: true, backup });
+}
+
+async function prepareUploadResponse(store: ServiceClient, userId: string, body: unknown) {
+  const backupId = readRequiredString(body, "backupId");
+  if (backupId === null) {
+    return jsonResponse({ success: false, error: "invalid_metadata" }, 400);
+  }
+
+  const existing = await store.loadBackup(userId, backupId);
+  if (existing !== null) {
+    return jsonResponse({ success: false, error: "backup_already_confirmed" }, 409);
+  }
+
+  const path = buildBackupPath(userId, backupId);
+  const upload = await store.createSignedUploadUrl(path);
+  return jsonResponse({
+    success: true,
+    uploadUrl: upload.signedUrl,
+    uploadToken: upload.token,
+    path,
+    expiresInSeconds: SIGNED_URL_EXPIRES_IN_SECONDS,
+  });
+}
+
+async function confirmUploadResponse(store: ServiceClient, userId: string, body: unknown) {
+  const metadata = readRemoteBackupMetadata(body, userId);
+  if (metadata === null) {
+    return jsonResponse({ success: false, error: "invalid_metadata" }, 400);
+  }
+
+  const existing = await store.loadBackup(userId, metadata.backupId);
+  if (existing !== null) {
+    return metadataMatches(existing, metadata)
+      ? jsonResponse({ success: true, backup: existing })
+      : jsonResponse({ success: false, error: "backup_already_confirmed" }, 409);
+  }
+
+  const path = buildBackupPath(userId, metadata.backupId);
+  const bytes = await store.downloadObject(path);
+  if (bytes === null) {
+    return jsonResponse({ success: false, error: "missing_object" }, 400);
+  }
+  if (!(await uploadedObjectMatchesMetadata(bytes, metadata))) {
+    return jsonResponse({ success: false, error: "metadata_mismatch" }, 400);
+  }
+
+  const previousBackups = await store.listBackups(userId);
+  await store.confirmBackup(metadata);
+  await deletePreviousBackups(store, userId, metadata.backupId, previousBackups);
+
+  return jsonResponse({ success: true, backup: metadata });
+}
+
+async function prepareDownloadResponse(store: ServiceClient, userId: string) {
+  const backup = await store.loadCurrentBackup(userId);
+  if (backup === null) {
+    return jsonResponse({ success: false, error: "backup_not_found" }, 404);
+  }
+
+  const path = buildBackupPath(userId, backup.backupId);
+  const downloadUrl = await store.createSignedDownloadUrl(path);
+  return jsonResponse({
+    success: true,
+    backup,
+    downloadUrl,
+    path,
+    expiresInSeconds: SIGNED_URL_EXPIRES_IN_SECONDS,
+  });
+}
+
+async function deleteCurrentResponse(store: ServiceClient, userId: string) {
+  const backups = await store.listBackups(userId);
+  await deleteBackups(store, userId, backups);
+  return jsonResponse({ success: true });
+}
+
+function buildBackupPath(userId: string, backupId: string) {
+  return `${userId}/${backupId}.json`;
+}
+
+async function deletePreviousBackups(
+  store: ServiceClient,
+  userId: string,
+  confirmedBackupId: string,
+  previousBackups: readonly RemoteBackupMetadata[]
+) {
+  await Promise.allSettled(
+    previousBackups
+      .filter((backup) => backup.backupId !== confirmedBackupId)
+      .map((backup) => deleteBackup(store, userId, backup.backupId))
+  );
+}
+
+async function deleteBackups(
+  store: ServiceClient,
+  userId: string,
+  backups: readonly RemoteBackupMetadata[]
+) {
+  await Promise.all(backups.map((backup) => deleteBackup(store, userId, backup.backupId)));
+}
+
+async function deleteBackup(store: ServiceClient, userId: string, backupId: string) {
+  await store.deleteBackupMetadata(userId, backupId);
+  await store.deleteObject(buildBackupPath(userId, backupId));
+}
+
+async function readJsonBody(request: Request): Promise<unknown> {
+  try {
+    return await request.json();
+  } catch {
+    return null;
+  }
+}
+
+function readAction(body: unknown) {
+  return readRequiredString(body, "action");
+}
+
+function readRequiredString(body: unknown, key: string): string | null {
+  if (body === null || typeof body !== "object" || !(key in body)) {
+    return null;
+  }
+  const value = (body as Record<string, unknown>)[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...corsHeaders() },
+  });
+}
+
+function corsHeaders() {
+  return {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Authorization, Content-Type",
+  };
+}

--- a/supabase/functions/private-backup-api/index.ts
+++ b/supabase/functions/private-backup-api/index.ts
@@ -1,0 +1,20 @@
+import { createClient } from "npm:@supabase/supabase-js@2";
+import { handlePrivateBackupRequest } from "./handler.ts";
+import { createPrivateBackupStore } from "./store.ts";
+
+const authClient = createClient(
+  Deno.env.get("SUPABASE_URL") ?? "",
+  Deno.env.get("SUPABASE_ANON_KEY") ?? ""
+);
+
+Deno.serve((request) => {
+  const serviceClient = createClient(
+    Deno.env.get("SUPABASE_URL") ?? "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+  );
+
+  return handlePrivateBackupRequest(request, {
+    auth: authClient,
+    store: createPrivateBackupStore(serviceClient),
+  });
+});

--- a/supabase/functions/private-backup-api/metadata.ts
+++ b/supabase/functions/private-backup-api/metadata.ts
@@ -1,0 +1,104 @@
+import type { RemoteBackupMetadata } from "./model.ts";
+
+export async function uploadedObjectMatchesMetadata(
+  objectBytes: Uint8Array,
+  metadata: RemoteBackupMetadata
+): Promise<boolean> {
+  const ciphertext = readCiphertext(objectBytes);
+  if (ciphertext === null) {
+    return false;
+  }
+
+  return (
+    ciphertext.byteLength === metadata.ciphertextSizeBytes &&
+    (await sha256Hex(ciphertext)) === metadata.ciphertextSha256
+  );
+}
+
+export function readRemoteBackupMetadata(
+  body: unknown,
+  userId: string
+): RemoteBackupMetadata | null {
+  const backupId = readRequiredString(body, "backupId");
+  const createdAt = readRequiredString(body, "createdAt");
+  const schemaVersion = readRequiredPositiveInteger(body, "schemaVersion");
+  const appVersion = readRequiredString(body, "appVersion");
+  const deviceLabel = readRequiredString(body, "deviceLabel");
+  const ciphertextSizeBytes = readRequiredPositiveInteger(body, "ciphertextSizeBytes");
+  const ciphertextSha256 = readRequiredString(body, "ciphertextSha256");
+  if (
+    backupId === null ||
+    createdAt === null ||
+    schemaVersion === null ||
+    appVersion === null ||
+    deviceLabel === null ||
+    ciphertextSizeBytes === null ||
+    ciphertextSha256 === null ||
+    !/^[0-9a-f]{64}$/.test(ciphertextSha256)
+  ) {
+    return null;
+  }
+
+  return {
+    userId,
+    backupId,
+    createdAt,
+    schemaVersion,
+    appVersion,
+    deviceLabel,
+    ciphertextSizeBytes,
+    ciphertextSha256,
+  };
+}
+
+export function metadataMatches(left: RemoteBackupMetadata, right: RemoteBackupMetadata) {
+  return (
+    left.userId === right.userId &&
+    left.backupId === right.backupId &&
+    left.createdAt === right.createdAt &&
+    left.schemaVersion === right.schemaVersion &&
+    left.appVersion === right.appVersion &&
+    left.deviceLabel === right.deviceLabel &&
+    left.ciphertextSizeBytes === right.ciphertextSizeBytes &&
+    left.ciphertextSha256 === right.ciphertextSha256
+  );
+}
+
+function readCiphertext(objectBytes: Uint8Array): Uint8Array | null {
+  try {
+    const parsed = JSON.parse(new TextDecoder().decode(objectBytes)) as {
+      readonly ciphertext?: unknown;
+    };
+    return typeof parsed.ciphertext === "string" ? fromBase64(parsed.ciphertext) : null;
+  } catch {
+    return null;
+  }
+}
+
+function fromBase64(value: string): Uint8Array {
+  const binary = atob(value);
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}
+
+async function sha256Hex(value: Uint8Array): Promise<string> {
+  const copy = new Uint8Array(new ArrayBuffer(value.byteLength));
+  copy.set(value);
+  const digest = await crypto.subtle.digest("SHA-256", copy);
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function readRequiredString(body: unknown, key: string): string | null {
+  if (body === null || typeof body !== "object" || !(key in body)) {
+    return null;
+  }
+  const value = (body as Record<string, unknown>)[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function readRequiredPositiveInteger(body: unknown, key: string): number | null {
+  if (body === null || typeof body !== "object" || !(key in body)) {
+    return null;
+  }
+  const value = (body as Record<string, unknown>)[key];
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
+}

--- a/supabase/functions/private-backup-api/model.ts
+++ b/supabase/functions/private-backup-api/model.ts
@@ -1,0 +1,15 @@
+export type RemoteBackupMetadata = {
+  readonly userId: string;
+  readonly backupId: string;
+  readonly createdAt: string;
+  readonly schemaVersion: number;
+  readonly appVersion: string;
+  readonly deviceLabel: string;
+  readonly ciphertextSizeBytes: number;
+  readonly ciphertextSha256: string;
+};
+
+export type SignedUploadUrl = {
+  readonly signedUrl: string;
+  readonly token: string;
+};

--- a/supabase/functions/private-backup-api/store.ts
+++ b/supabase/functions/private-backup-api/store.ts
@@ -1,0 +1,271 @@
+// biome-ignore-all lint/style/useNamingConvention: Supabase tables use snake_case fields
+import type { RemoteBackupMetadata, SignedUploadUrl } from "./model.ts";
+
+type SupabaseError = { readonly message?: string } | null;
+
+type RemoteBackupMetadataRow = {
+  readonly id: string;
+  readonly user_id: string;
+  readonly created_at: string;
+  readonly schema_version: number;
+  readonly app_version: string;
+  readonly device_label: string;
+  readonly ciphertext_size_bytes: number;
+  readonly ciphertext_sha256: string;
+};
+
+type SupabaseLike = {
+  from(tableName: string): {
+    select(columns: string): {
+      eq(column: string, value: string): unknown;
+    };
+    upsert(
+      row: RemoteBackupMetadataRow,
+      options: { readonly onConflict: string }
+    ): Promise<{ readonly error: SupabaseError }>;
+    delete(): {
+      eq(
+        column: string,
+        value: string
+      ): {
+        eq(column: string, value: string): Promise<{ readonly error: SupabaseError }>;
+      };
+    };
+  };
+  readonly storage: {
+    from(bucketName: string): {
+      createSignedUploadUrl(path: string): Promise<{
+        readonly data: { readonly signedUrl: string; readonly token?: string } | null;
+        readonly error: SupabaseError;
+      }>;
+      createSignedUrl(
+        path: string,
+        expiresIn: number
+      ): Promise<{
+        readonly data: { readonly signedUrl: string } | null;
+        readonly error: SupabaseError;
+      }>;
+      download(path: string): Promise<{
+        readonly data: { arrayBuffer(): Promise<ArrayBuffer> } | null;
+        readonly error: SupabaseError;
+      }>;
+      remove(paths: readonly string[]): Promise<{ readonly error: SupabaseError }>;
+    };
+  };
+};
+
+const BACKUP_TABLE = "encrypted_backups";
+const BACKUP_BUCKET = "encrypted-backups";
+const BACKUP_COLUMNS =
+  "id,user_id,created_at,schema_version,app_version,device_label,ciphertext_size_bytes,ciphertext_sha256";
+const SIGNED_URL_EXPIRES_IN_SECONDS = 300;
+
+export function createPrivateBackupStore(supabase: SupabaseLike) {
+  return {
+    loadBackup: (userId: string, backupId: string) => loadBackup(supabase, userId, backupId),
+    listBackups: (userId: string) => listBackups(supabase, userId),
+    loadCurrentBackup: (userId: string) => loadCurrentBackup(supabase, userId),
+    createSignedUploadUrl: (path: string) => createSignedUploadUrl(supabase, path),
+    createSignedDownloadUrl: (path: string) => createSignedDownloadUrl(supabase, path),
+    downloadObject: (path: string) => downloadObject(supabase, path),
+    confirmBackup: (metadata: RemoteBackupMetadata) => confirmBackup(supabase, metadata),
+    deleteBackupMetadata: (userId: string, backupId: string) =>
+      deleteBackupMetadata(supabase, userId, backupId),
+    deleteObject: (path: string) => deleteObject(supabase, path),
+  };
+}
+
+async function loadBackup(
+  supabase: SupabaseLike,
+  userId: string,
+  backupId: string
+): Promise<RemoteBackupMetadata | null> {
+  const query = supabase.from(BACKUP_TABLE).select(BACKUP_COLUMNS).eq("user_id", userId);
+  const response = await eqSingle(query, "id", backupId);
+  throwIfError(response.error, "load encrypted backup metadata");
+  return response.data === null ? null : fromRow(response.data);
+}
+
+async function loadCurrentBackup(
+  supabase: SupabaseLike,
+  userId: string
+): Promise<RemoteBackupMetadata | null> {
+  const query = supabase.from(BACKUP_TABLE).select(BACKUP_COLUMNS).eq("user_id", userId);
+  const response = await orderLimitSingle(query, "created_at", false, 1);
+  throwIfError(response.error, "load current encrypted backup metadata");
+  return response.data === null ? null : fromRow(response.data);
+}
+
+async function listBackups(
+  supabase: SupabaseLike,
+  userId: string
+): Promise<readonly RemoteBackupMetadata[]> {
+  const query = supabase.from(BACKUP_TABLE).select(BACKUP_COLUMNS).eq("user_id", userId);
+  const response = await orderMany(query, "created_at", false);
+  throwIfError(response.error, "list encrypted backup metadata");
+  return (response.data ?? []).map(fromRow);
+}
+
+async function createSignedUploadUrl(
+  supabase: SupabaseLike,
+  path: string
+): Promise<SignedUploadUrl> {
+  const { data, error } = await supabase.storage.from(BACKUP_BUCKET).createSignedUploadUrl(path);
+  throwIfError(error, "create signed encrypted backup upload URL");
+  if (data === null) {
+    throw new Error("Unable to create signed encrypted backup upload URL: missing URL");
+  }
+  if (typeof data.token !== "string" || data.token.length === 0) {
+    throw new Error("Unable to create signed encrypted backup upload URL: missing token");
+  }
+  return {
+    signedUrl: data.signedUrl,
+    token: data.token,
+  };
+}
+
+async function createSignedDownloadUrl(supabase: SupabaseLike, path: string): Promise<string> {
+  const { data, error } = await supabase.storage
+    .from(BACKUP_BUCKET)
+    .createSignedUrl(path, SIGNED_URL_EXPIRES_IN_SECONDS);
+  throwIfError(error, "create signed encrypted backup download URL");
+  if (data === null) {
+    throw new Error("Unable to create signed encrypted backup download URL: missing URL");
+  }
+  return data.signedUrl;
+}
+
+async function downloadObject(supabase: SupabaseLike, path: string): Promise<Uint8Array | null> {
+  const { data, error } = await supabase.storage.from(BACKUP_BUCKET).download(path);
+  throwIfError(error, "download encrypted backup object");
+  return data === null ? null : new Uint8Array(await data.arrayBuffer());
+}
+
+async function confirmBackup(
+  supabase: SupabaseLike,
+  metadata: RemoteBackupMetadata
+): Promise<void> {
+  const { error } = await supabase.from(BACKUP_TABLE).upsert(toRow(metadata), {
+    onConflict: "user_id,id",
+  });
+  throwIfError(error, "confirm encrypted backup metadata");
+}
+
+async function deleteBackupMetadata(
+  supabase: SupabaseLike,
+  userId: string,
+  backupId: string
+): Promise<void> {
+  const { error } = await supabase
+    .from(BACKUP_TABLE)
+    .delete()
+    .eq("user_id", userId)
+    .eq("id", backupId);
+  throwIfError(error, "delete encrypted backup metadata");
+}
+
+async function deleteObject(supabase: SupabaseLike, path: string): Promise<void> {
+  const { error } = await supabase.storage.from(BACKUP_BUCKET).remove([path]);
+  throwIfError(error, "delete encrypted backup object");
+}
+
+function fromRow(row: RemoteBackupMetadataRow): RemoteBackupMetadata {
+  return {
+    userId: row.user_id,
+    backupId: row.id,
+    createdAt: row.created_at,
+    schemaVersion: row.schema_version,
+    appVersion: row.app_version,
+    deviceLabel: row.device_label,
+    ciphertextSizeBytes: row.ciphertext_size_bytes,
+    ciphertextSha256: row.ciphertext_sha256,
+  };
+}
+
+function toRow(metadata: RemoteBackupMetadata): RemoteBackupMetadataRow {
+  return {
+    id: metadata.backupId,
+    user_id: metadata.userId,
+    created_at: metadata.createdAt,
+    schema_version: metadata.schemaVersion,
+    app_version: metadata.appVersion,
+    device_label: metadata.deviceLabel,
+    ciphertext_size_bytes: metadata.ciphertextSizeBytes,
+    ciphertext_sha256: metadata.ciphertextSha256,
+  };
+}
+
+async function eqSingle(
+  query: unknown,
+  column: string,
+  value: string
+): Promise<{ readonly data: RemoteBackupMetadataRow | null; readonly error: SupabaseError }> {
+  return await (
+    query as {
+      eq(
+        column: string,
+        value: string
+      ): {
+        maybeSingle(): Promise<{
+          readonly data: RemoteBackupMetadataRow | null;
+          readonly error: SupabaseError;
+        }>;
+      };
+    }
+  )
+    .eq(column, value)
+    .maybeSingle();
+}
+
+async function orderLimitSingle(
+  query: unknown,
+  column: string,
+  ascending: boolean,
+  count: number
+): Promise<{ readonly data: RemoteBackupMetadataRow | null; readonly error: SupabaseError }> {
+  return await (
+    query as {
+      order(
+        column: string,
+        options: { readonly ascending: boolean }
+      ): {
+        limit(count: number): {
+          maybeSingle(): Promise<{
+            readonly data: RemoteBackupMetadataRow | null;
+            readonly error: SupabaseError;
+          }>;
+        };
+      };
+    }
+  )
+    .order(column, { ascending })
+    .limit(count)
+    .maybeSingle();
+}
+
+async function orderMany(
+  query: unknown,
+  column: string,
+  ascending: boolean
+): Promise<{
+  readonly data: readonly RemoteBackupMetadataRow[] | null;
+  readonly error: SupabaseError;
+}> {
+  return await (
+    query as {
+      order(
+        column: string,
+        options: { readonly ascending: boolean }
+      ): Promise<{
+        readonly data: readonly RemoteBackupMetadataRow[] | null;
+        readonly error: SupabaseError;
+      }>;
+    }
+  ).order(column, { ascending });
+}
+
+function throwIfError(error: SupabaseError, operation: string) {
+  if (error !== null) {
+    throw new Error(`Unable to ${operation}: ${error.message ?? "unknown error"}`);
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a private backup API as a Supabase Edge Function that owns all encrypted backup mutations via signed URLs, and update the mobile app to use it. This removes direct authenticated writes and adds server-side verification for safer backups.

- **New Features**
  - Added `private-backup-api` with actions: `prepareUpload`, `confirmUpload`, `current`, `prepareDownload`, `deleteCurrent`. Verifies object size/hash, issues 300s signed URLs, cleans older backups on confirm, and `deleteCurrent` removes all backups for the user.
  - Mobile now uses `functions.invoke('private-backup-api')`; uploads use `storage.uploadToSignedUrl` with API-issued tokens, downloads use signed URL fetch. No direct table or bucket writes. Lists return only the current backup. Tests added for the Edge Function and updated mobile client tests.

- **Migration**
  - Apply `20260427100000_private_backup_api_write_boundary.sql` to drop direct RLS policies on `encrypted_backups` and `storage.objects`.
  - Deploy the `private-backup-api` Edge Function with `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and `SUPABASE_SERVICE_ROLE_KEY` set.

<sup>Written for commit 650b5fca47acb08218befc40c6d23dd5444bcd98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

