### PR TITLE
fix(backup): use signed upload URLs

### DIFF
--- a/apps/mobile/__tests__/backup/remote-storage.test.ts
+++ b/apps/mobile/__tests__/backup/remote-storage.test.ts
@@ -61,14 +61,14 @@ describe("remote encrypted backup storage", () => {
     await expect(
       uploadEncryptedRemoteBackup(supabase.client, remoteBackupUploadInput())
     ).rejects.toThrow("Unable to call private backup API: metadata_mismatch");
-    expect(supabase.storageUploadToSignedUrl).toHaveBeenCalledWith(
-      `${USER_ID}/${BACKUP_ID}.json`,
-      "signed-upload-token",
-      JSON.stringify(ENCRYPTED_BACKUP),
-      { contentType: "application/json" }
-    );
+    expect(supabase.fetch).toHaveBeenCalledWith("https://storage.example/upload", {
+      body: JSON.stringify(ENCRYPTED_BACKUP),
+      headers: { "Content-Type": "application/json" },
+      method: "PUT",
+    });
     expect(supabase.storageRemove).not.toHaveBeenCalled();
     expect(supabase.from).not.toHaveBeenCalled();
+    expect(supabase.storageFrom).not.toHaveBeenCalled();
   });
 
   it("lists only encrypted backup metadata for the current user", async () => {
@@ -183,12 +183,13 @@ function expectUploadCalls(supabase: ReturnType<typeof createRemoteBackupSupabas
       backupId: BACKUP_ID,
     },
   });
-  expect(supabase.storageUploadToSignedUrl).toHaveBeenCalledWith(
-    `${USER_ID}/${BACKUP_ID}.json`,
-    "signed-upload-token",
-    JSON.stringify(ENCRYPTED_BACKUP),
-    { contentType: "application/json" }
-  );
+  expect(supabase.fetch).toHaveBeenCalledWith("https://storage.example/upload", {
+    body: JSON.stringify(ENCRYPTED_BACKUP),
+    headers: { "Content-Type": "application/json" },
+    method: "PUT",
+  });
+  expect(supabase.storageUploadToSignedUrl).not.toHaveBeenCalled();
+  expect(supabase.storageFrom).not.toHaveBeenCalled();
   expect(supabase.functionsInvoke).toHaveBeenCalledWith("private-backup-api", {
     body: {
       action: "confirmUpload",
@@ -218,6 +219,7 @@ function createRemoteBackupSupabase(
           data: {
             success: true,
             path: `${USER_ID}/${BACKUP_ID}.json`,
+            uploadUrl: "https://storage.example/upload",
             uploadToken: "signed-upload-token",
           },
           error: null,
@@ -277,6 +279,7 @@ function createRemoteBackupSupabase(
     from,
     functionsInvoke,
     storageRemove,
+    storageFrom: client.storage.from,
     storageUploadToSignedUrl,
     remotePayloads: () => [
       functionsInvoke.mock.calls,

--- a/apps/mobile/features/backup/remote-storage.ts
+++ b/apps/mobile/features/backup/remote-storage.ts
@@ -47,6 +47,7 @@ type PrivateBackupApiResponse<T> =
 
 type PrepareUploadResponse = PrivateBackupApiResponse<{
   readonly path: string;
+  readonly uploadUrl: string;
   readonly uploadToken: string;
 }>;
 
@@ -75,12 +76,14 @@ export async function uploadEncryptedRemoteBackup(
     action: "prepareUpload",
     backupId: input.backupId,
   });
-  const uploadResponse = await supabase.storage
-    .from(REMOTE_BACKUP_BUCKET)
-    .uploadToSignedUrl(prepared.path, prepared.uploadToken, JSON.stringify(input.encryptedBackup), {
-      contentType: "application/json",
-    });
-  throwIfRemoteBackupError(uploadResponse.error, "upload encrypted backup");
+  const uploadResponse = await fetch(prepared.uploadUrl, {
+    body: JSON.stringify(input.encryptedBackup),
+    headers: { "Content-Type": "application/json" },
+    method: "PUT",
+  });
+  if (!uploadResponse.ok) {
+    throw new Error("Unable to upload encrypted backup: storage upload failed");
+  }
 
   const confirmed = await invokePrivateBackupApi<ConfirmUploadResponse>(supabase, {
     action: "confirmUpload",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch encrypted backup uploads to use the signed `uploadUrl` from the private backup API and send a direct PUT request. This removes the app’s dependency on Supabase Storage helpers and fixes failed uploads when storage access is restricted.

- **Bug Fixes**
  - Use `uploadUrl` from `prepareUpload` and PUT the JSON backup with `Content-Type: application/json`.
  - Stop calling Supabase Storage `uploadToSignedUrl`/`from`; rely on HTTP upload instead.
  - Add clear error when the PUT fails; update tests to assert the new upload path.

<sup>Written for commit dce515daba80aaa75f0b704b669b6b09610ad4c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

