### PR TITLE
fix(backup): constrain backup paths

### DIFF
--- a/apps/mobile/__tests__/edge-functions/private-backup-api.test.ts
+++ b/apps/mobile/__tests__/edge-functions/private-backup-api.test.ts
@@ -107,6 +107,23 @@ describe("private-backup-api Edge Function", () => {
     expect(api.store.createdUploadUrls()).toEqual([]);
   });
 
+  it("rejects path-breaking backup ids before creating signed upload URLs", async () => {
+    const api = createPrivateBackupApiDeps();
+
+    const response = await handlePrivateBackupRequest(
+      jsonRequest({ action: "prepareUpload", backupId: "../backup-1" }, "valid-token"),
+      api.deps
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: "invalid_metadata",
+    });
+    expect(api.store.loadBackup).not.toHaveBeenCalled();
+    expect(api.store.createdUploadUrls()).toEqual([]);
+  });
+
   it("returns the current authenticated-user backup metadata", async () => {
     const current = metadataRow({ backupId: BACKUP_ID });
     const api = createPrivateBackupApiDeps({
@@ -167,6 +184,34 @@ describe("private-backup-api Edge Function", () => {
       error: "internal_error",
     });
     expect(api.store.confirmedBackups()).toEqual([]);
+  });
+
+  it("rejects path-breaking confirmUpload backup ids before reading or changing storage", async () => {
+    const api = createPrivateBackupApiDeps({
+      objects: new Map([[`${USER_ID}/nested/backup-1.json`, ENCRYPTED_BACKUP_OBJECT]]),
+    });
+
+    const response = await handlePrivateBackupRequest(
+      jsonRequest(
+        {
+          action: "confirmUpload",
+          ...metadataPayload(),
+          backupId: "nested/backup-1",
+        },
+        "valid-token"
+      ),
+      api.deps
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: "invalid_metadata",
+    });
+    expect(api.store.loadBackup).not.toHaveBeenCalled();
+    expect(api.store.downloadObject).not.toHaveBeenCalled();
+    expect(api.store.confirmedBackups()).toEqual([]);
+    expect(api.store.deletedObjects()).toEqual([]);
   });
 
   it("rejects invalid metadata before reading or changing backup storage", async () => {

--- a/supabase/functions/private-backup-api/handler.ts
+++ b/supabase/functions/private-backup-api/handler.ts
@@ -34,6 +34,7 @@ export type PrivateBackupApiDeps = {
 };
 
 const SIGNED_URL_EXPIRES_IN_SECONDS = 300;
+const BACKUP_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
 
 export async function handlePrivateBackupRequest(
   request: Request,
@@ -96,7 +97,7 @@ async function currentResponse(store: ServiceClient, userId: string) {
 }
 
 async function prepareUploadResponse(store: ServiceClient, userId: string, body: unknown) {
-  const backupId = readRequiredString(body, "backupId");
+  const backupId = readRequiredBackupId(body);
   if (backupId === null) {
     return jsonResponse({ success: false, error: "invalid_metadata" }, 400);
   }
@@ -119,7 +120,7 @@ async function prepareUploadResponse(store: ServiceClient, userId: string, body:
 
 async function confirmUploadResponse(store: ServiceClient, userId: string, body: unknown) {
   const metadata = readRemoteBackupMetadata(body, userId);
-  if (metadata === null) {
+  if (metadata === null || !isBackupIdSegment(metadata.backupId)) {
     return jsonResponse({ success: false, error: "invalid_metadata" }, 400);
   }
 
@@ -209,6 +210,15 @@ async function readJsonBody(request: Request): Promise<unknown> {
 
 function readAction(body: unknown) {
   return readRequiredString(body, "action");
+}
+
+function readRequiredBackupId(body: unknown): string | null {
+  const backupId = readRequiredString(body, "backupId");
+  return backupId !== null && isBackupIdSegment(backupId) ? backupId : null;
+}
+
+function isBackupIdSegment(value: string): boolean {
+  return BACKUP_ID_PATTERN.test(value);
 }
 
 function readRequiredString(body: unknown, key: string): string | null {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Constrain `backupId` to a single safe path segment to prevent path traversal and nested paths in the private backup API. Invalid IDs now return 400 with `invalid_metadata` before any storage operations.

- **Bug Fixes**
  - Enforce `backupId` pattern `/^[A-Za-z0-9_-]+$/` via `isBackupIdSegment` and `readRequiredBackupId`.
  - Validate in `prepareUpload` and `confirmUpload`; reject early (no reads/writes, no signed URLs).
  - Add tests for `../backup-1` and `nested/backup-1` to ensure early rejection.

<sup>Written for commit 578667960f41ffb40a5f370fc4ae44f83ccf3363. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

