### PR TITLE
fix(mobile): harden backup access

### DIFF
--- a/apps/mobile/__tests__/backup/remote-schema.test.ts
+++ b/apps/mobile/__tests__/backup/remote-schema.test.ts
@@ -46,4 +46,14 @@ describe("remote encrypted backup schema", () => {
     expect(sql).toContain('drop policy if exists "users can delete own encrypted backup objects"');
     expect(sql).not.toContain("create policy");
   });
+
+  it("keeps encrypted backups locked down after direct policies are removed", () => {
+    const sql = readFileSync(WRITE_BOUNDARY_MIGRATION, "utf8").toLowerCase();
+
+    expect(sql).toContain("alter table public.encrypted_backups enable row level security");
+    expect(sql).toContain("alter table public.encrypted_backups force row level security");
+    expect(sql).toContain("update storage.buckets");
+    expect(sql).toContain("set public = false");
+    expect(sql).toContain("where id = 'encrypted-backups'");
+  });
 });

--- a/apps/mobile/supabase/migrations/20260427100000_private_backup_api_write_boundary.sql
+++ b/apps/mobile/supabase/migrations/20260427100000_private_backup_api_write_boundary.sql
@@ -3,7 +3,14 @@ drop policy if exists "Users can insert own encrypted backups" on public.encrypt
 drop policy if exists "Users can update own encrypted backups" on public.encrypted_backups;
 drop policy if exists "Users can delete own encrypted backups" on public.encrypted_backups;
 
+alter table public.encrypted_backups enable row level security;
+alter table public.encrypted_backups force row level security;
+
 drop policy if exists "Users can read own encrypted backup objects" on storage.objects;
 drop policy if exists "Users can insert own encrypted backup objects" on storage.objects;
 drop policy if exists "Users can update own encrypted backup objects" on storage.objects;
 drop policy if exists "Users can delete own encrypted backup objects" on storage.objects;
+
+update storage.buckets
+set public = false
+where id = 'encrypted-backups';


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Lock down mobile encrypted backups by forcing RLS and making the backups bucket private. Backups remain inaccessible without explicit policies, even if per-object policies are removed.

- **Bug Fixes**
  - Enabled and forced RLS on public.encrypted_backups to default-deny access.
  - Set storage bucket 'encrypted-backups' to public = false.
  - Added tests to verify the migration keeps backups locked down after removing direct policies.

<sup>Written for commit 313f436fbd28cd551fd9bc9c91d3c07bc590d9ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

