### PR TITLE
test(mobile): guard backup boundary

### DIFF
--- a/apps/mobile/__tests__/backup/private-backup.test.ts
+++ b/apps/mobile/__tests__/backup/private-backup.test.ts
@@ -50,6 +50,57 @@ const SNAPSHOT = {
   },
 } satisfies BackupSnapshot;
 
+const SNAPSHOT_WITH_FINANCIAL_DATA = {
+  ...SNAPSHOT,
+  data: {
+    ...SNAPSHOT.data,
+    userCategories: [
+      {
+        id: "category-1",
+        userId: "user-1",
+        name: "Food",
+        iconName: "utensils",
+        colorHex: "#ff0000",
+        createdAt: "2026-04-25T12:00:00.000Z",
+        updatedAt: "2026-04-25T12:00:00.000Z",
+        deletedAt: null,
+      },
+    ] as unknown as BackupSnapshot["data"]["userCategories"],
+    financialAccounts: [
+      {
+        id: "account-1",
+        userId: "user-1",
+        name: "Main checking",
+        kind: "checking",
+        isDefault: true,
+        statementClosingDay: null,
+        paymentDueDay: null,
+        createdAt: "2026-04-25T12:00:00.000Z",
+        updatedAt: "2026-04-25T12:00:00.000Z",
+        deletedAt: null,
+      },
+    ] as unknown as BackupSnapshot["data"]["financialAccounts"],
+    transactions: [
+      {
+        id: "txn-1",
+        userId: "user-1",
+        type: "expense",
+        amount: 42_000,
+        categoryId: "category-1",
+        description: "Lunch at El Prado",
+        date: "2026-04-25",
+        accountId: "account-1",
+        accountAttributionState: "confirmed",
+        supersededAt: null,
+        createdAt: "2026-04-25T12:00:00.000Z",
+        updatedAt: "2026-04-25T12:00:00.000Z",
+        deletedAt: null,
+        source: "manual",
+      },
+    ] as unknown as BackupSnapshot["data"]["transactions"],
+  },
+} satisfies BackupSnapshot;
+
 describe("private backup health", () => {
   it("keeps Private Backup in warning state until the Recovery Key is confirmed", () => {
     expect(
@@ -97,6 +148,29 @@ describe("createPrivateBackup", () => {
     );
   });
 
+  it("sends only encrypted payloads and remote metadata to backup upload", async () => {
+    const exportSnapshot = vi.fn().mockReturnValue(SNAPSHOT_WITH_FINANCIAL_DATA);
+    const encryptSnapshot = vi.fn().mockResolvedValue(ENCRYPTED_BACKUP);
+    const uploadBackup = vi.fn().mockResolvedValue(METADATA);
+
+    await createPrivateBackup(
+      privateBackupInput({ exportSnapshot, encryptSnapshot, uploadBackup })
+    );
+
+    const remotePayload = JSON.stringify(uploadBackup.mock.calls);
+
+    expect(uploadBackup).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        encryptedBackup: ENCRYPTED_BACKUP,
+      })
+    );
+    expect(remotePayload).not.toContain("Lunch at El Prado");
+    expect(remotePayload).not.toContain("txn-1");
+    expect(remotePayload).not.toContain("RK-AAAA-BBBB-CCCC-DDDD-EEEE-FFFF");
+    expect(remotePayload).not.toContain("trusted-device-secret");
+  });
+
   it("refuses to encrypt or upload an invalid local ledger snapshot", async () => {
     const exportSnapshot = vi.fn().mockReturnValue({
       ...SNAPSHOT,
@@ -127,6 +201,27 @@ describe("createPrivateBackup", () => {
     expect(uploadBackup).not.toHaveBeenCalled();
   });
 });
+
+function privateBackupInput(
+  overrides: Pick<
+    Parameters<typeof createPrivateBackup>[0],
+    "encryptSnapshot" | "exportSnapshot" | "uploadBackup"
+  >
+): Parameters<typeof createPrivateBackup>[0] {
+  return {
+    db: {} as Parameters<typeof createPrivateBackup>[0]["db"],
+    supabase: {} as Parameters<typeof createPrivateBackup>[0]["supabase"],
+    userId: METADATA.userId,
+    backupId: METADATA.backupId,
+    recoveryKey: "RK-AAAA-BBBB-CCCC-DDDD-EEEE-FFFF",
+    confirmedRecoveryKey: "RK-AAAA-BBBB-CCCC-DDDD-EEEE-FFFF",
+    trustedDeviceSecret: "trusted-device-secret",
+    exportedAt: METADATA.createdAt,
+    appVersion: METADATA.appVersion,
+    deviceLabel: METADATA.deviceLabel,
+    ...overrides,
+  };
+}
 
 describe("rotatePrivateBackupRecoveryKeySafely", () => {
   it("keeps the old backup metadata when replacement upload fails", async () => {

--- a/apps/mobile/__tests__/backup/remote-schema.test.ts
+++ b/apps/mobile/__tests__/backup/remote-schema.test.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { readdirSync, readFileSync } from "node:fs";
+import { basename, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const MIGRATION = resolve(
@@ -10,6 +10,9 @@ const WRITE_BOUNDARY_MIGRATION = resolve(
   __dirname,
   "../../supabase/migrations/20260427100000_private_backup_api_write_boundary.sql"
 );
+const MOBILE_BACKUP_SOURCE_ROOT = resolve(__dirname, "../../features/backup");
+const MIGRATIONS_ROOT = resolve(__dirname, "../../supabase/migrations");
+const WRITE_BOUNDARY_MIGRATION_NAME = basename(WRITE_BOUNDARY_MIGRATION);
 
 describe("remote encrypted backup schema", () => {
   it("stores only encrypted backup metadata and scopes table and blob access to the owner", () => {
@@ -56,4 +59,59 @@ describe("remote encrypted backup schema", () => {
     expect(sql).toContain("set public = false");
     expect(sql).toContain("where id = 'encrypted-backups'");
   });
+
+  it("keeps later migrations from restoring direct authenticated backup access", () => {
+    const laterMigrationSql = readdirSync(MIGRATIONS_ROOT)
+      .filter((fileName) => fileName >= WRITE_BOUNDARY_MIGRATION_NAME && fileName.endsWith(".sql"))
+      .map((fileName) => readFileSync(resolve(MIGRATIONS_ROOT, fileName), "utf8").toLowerCase())
+      .join("\n");
+
+    expect(laterMigrationSql).not.toMatch(
+      /create\s+policy[\s\S]*\bon\s+public\.encrypted_backups[\s\S]*\bto\s+authenticated/u
+    );
+    expect(hasDirectAuthenticatedBackupObjectPolicy(laterMigrationSql)).toBe(false);
+  });
 });
+
+describe("mobile backup source boundary", () => {
+  it("keeps normal backup operations behind private-backup-api instead of direct table or bucket access", () => {
+    const backupSource = readSourceTree(MOBILE_BACKUP_SOURCE_ROOT);
+
+    expect(backupSource).not.toMatch(
+      /\.from\(\s*(["']encrypted_backups["']|remote_backup_metadata_table)\s*\)/u
+    );
+    expect(backupSource).not.toMatch(
+      /\.storage\s*\.from\(\s*(["']encrypted-backups["']|remote_backup_bucket)\s*\)/u
+    );
+    expect(backupSource).toContain('functions.invoke<t>("private-backup-api"');
+  });
+});
+
+function readSourceTree(root: string): string {
+  return readdirSync(root, { withFileTypes: true })
+    .flatMap((entry) => {
+      const path = resolve(root, entry.name);
+      if (entry.isDirectory()) {
+        return readSourceTree(path);
+      }
+      if (!entry.isFile() || !/\.(ts|tsx)$/u.test(entry.name)) {
+        return [];
+      }
+      return readFileSync(path, "utf8");
+    })
+    .join("\n")
+    .toLowerCase();
+}
+
+function hasDirectAuthenticatedBackupObjectPolicy(sql: string) {
+  return policyStatements(sql).some(
+    (statement) =>
+      statement.includes("on storage.objects") &&
+      statement.includes("to authenticated") &&
+      statement.includes("encrypted-backups")
+  );
+}
+
+function policyStatements(sql: string) {
+  return sql.match(/create\s+policy[\s\S]*?;/gu) ?? [];
+}

--- a/apps/mobile/__tests__/edge-functions/private-backup-api.test.ts
+++ b/apps/mobile/__tests__/edge-functions/private-backup-api.test.ts
@@ -147,6 +147,33 @@ describe("private-backup-api Edge Function", () => {
       success: true,
       backup: current,
     });
+    expect(api.store.loadCurrentBackup).toHaveBeenCalledWith(USER_ID);
+    expect(api.store.listBackups).not.toHaveBeenCalled();
+  });
+
+  it("does not expose backup history while the API contract is current-backup only", async () => {
+    const current = metadataRow({
+      backupId: "backup-current",
+      createdAt: "2026-04-27T10:00:00.000Z",
+    });
+    const legacy = metadataRow({
+      backupId: "backup-legacy",
+      createdAt: "2026-04-26T10:00:00.000Z",
+    });
+    const api = createPrivateBackupApiDeps({ backups: [legacy, current] });
+
+    const response = await handlePrivateBackupRequest(
+      jsonRequest({ action: "current" }, "valid-token"),
+      api.deps
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      success: true,
+      backup: current,
+    });
+    expect(JSON.stringify(body)).not.toContain("backup-legacy");
   });
 
   it("confirms uploaded metadata only after server-side object verification", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add tests to guard the private backup boundary and prevent data leaks. They ensure uploads include only encrypted payloads/metadata, the mobile app uses the `private-backup-api` (not direct table/bucket access), migrations keep blocking authenticated direct access, and the API returns only the current backup.

<sup>Written for commit fc247b96270be175ea6b76fb4126b19b569ef825. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

