### PR TITLE
fix(backup): rate limit API

### DIFF
--- a/apps/mobile/__tests__/edge-functions/private-backup-api.test.ts
+++ b/apps/mobile/__tests__/edge-functions/private-backup-api.test.ts
@@ -47,6 +47,44 @@ describe("private-backup-api Edge Function", () => {
     expectNoStoreCalls(invalidAuth.store);
   });
 
+  it("rate limits authenticated backup API requests before actions run", async () => {
+    const api = createPrivateBackupApiDeps({
+      rateLimit: { allowed: false, retryAfterSeconds: 41 },
+    });
+
+    const response = await handlePrivateBackupRequest(
+      jsonRequest({ action: "current" }, "valid-token"),
+      api.deps
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBe("41");
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: "rate_limited",
+    });
+    expect(api.rateLimit).toHaveBeenCalledWith(USER_ID);
+    expectNoStoreCalls(api.store);
+  });
+
+  it("fails closed when rate limiting is unavailable", async () => {
+    const api = createPrivateBackupApiDeps({
+      rateLimitError: new Error("rate limit unavailable"),
+    });
+
+    const response = await handlePrivateBackupRequest(
+      jsonRequest({ action: "current" }, "valid-token"),
+      api.deps
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: "rate_limit_unavailable",
+    });
+    expectNoStoreCalls(api.store);
+  });
+
   it("routes only the private backup actions", async () => {
     const api = createPrivateBackupApiDeps();
 
@@ -416,11 +454,20 @@ function createPrivateBackupApiDeps(
     readonly deleteBackupMetadataError?: Error;
     readonly downloadObjectError?: Error;
     readonly objects?: ReadonlyMap<string, Uint8Array>;
+    readonly rateLimit?: RateLimitResult;
+    readonly rateLimitError?: Error;
     readonly userId?: string;
   } = {}
 ) {
   const store = createPrivateBackupStore(options);
+  const allowedRateLimit = { allowed: true } satisfies RateLimitResult;
+  const rateLimit = vi.fn(() =>
+    options.rateLimitError === undefined
+      ? Promise.resolve(options.rateLimit ?? allowedRateLimit)
+      : Promise.reject(options.rateLimitError)
+  );
   return {
+    rateLimit,
     store,
     deps: {
       auth: {
@@ -428,6 +475,7 @@ function createPrivateBackupApiDeps(
           getUser: vi.fn(() => Promise.resolve(authResponse(options))),
         },
       },
+      rateLimit,
       store,
     },
   };
@@ -460,6 +508,10 @@ type RemoteBackupMetadata = {
   readonly ciphertextSizeBytes: number;
   readonly ciphertextSha256: string;
 };
+
+type RateLimitResult =
+  | { readonly allowed: true }
+  | { readonly allowed: false; readonly retryAfterSeconds: number };
 
 function metadataPayload() {
   return {

--- a/apps/mobile/__tests__/edge-functions/private-backup-api.test.ts
+++ b/apps/mobile/__tests__/edge-functions/private-backup-api.test.ts
@@ -69,6 +69,24 @@ describe("private-backup-api Edge Function", () => {
 
   it("fails closed when rate limiting is unavailable", async () => {
     const api = createPrivateBackupApiDeps({
+      rateLimit: { allowed: false, retryAfterSeconds: 41, unavailable: true },
+    });
+
+    const response = await handlePrivateBackupRequest(
+      jsonRequest({ action: "current" }, "valid-token"),
+      api.deps
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: "rate_limit_unavailable",
+    });
+    expectNoStoreCalls(api.store);
+  });
+
+  it("fails closed when the rate limit dependency throws", async () => {
+    const api = createPrivateBackupApiDeps({
       rateLimitError: new Error("rate limit unavailable"),
     });
 
@@ -511,7 +529,7 @@ type RemoteBackupMetadata = {
 
 type RateLimitResult =
   | { readonly allowed: true }
-  | { readonly allowed: false; readonly retryAfterSeconds: number };
+  | { readonly allowed: false; readonly retryAfterSeconds: number; readonly unavailable?: true };
 
 function metadataPayload() {
   return {

--- a/apps/mobile/__tests__/edge-functions/rate-limit-security.test.ts
+++ b/apps/mobile/__tests__/edge-functions/rate-limit-security.test.ts
@@ -10,6 +10,7 @@ const source = readFileSync(
 describe("Edge Function rate limiting", () => {
   it("fails closed when the backing RPC is unavailable", () => {
     expect(source).toContain("failing closed");
+    expect(source).toContain("unavailable: true");
     expect(source).not.toContain("failing open");
     expect(source).not.toContain("allowed: true, count: 0");
   });

--- a/supabase/functions/_shared/rate-limit.ts
+++ b/supabase/functions/_shared/rate-limit.ts
@@ -8,7 +8,7 @@ const serviceClient = createClient(
 
 type RateLimitResult =
   | { allowed: true; count: number }
-  | { allowed: false; count: number; retryAfterSeconds: number };
+  | { allowed: false; count: number; retryAfterSeconds: number; unavailable?: true };
 
 export async function checkRateLimit(
   userId: string,
@@ -29,13 +29,13 @@ export async function checkRateLimit(
 
     if (error) {
       console.error("Rate limit RPC error, failing closed:", error.message);
-      return { allowed: false, count: 0, retryAfterSeconds };
+      return { allowed: false, count: 0, retryAfterSeconds, unavailable: true };
     }
 
     const row = Array.isArray(data) ? data[0] : data;
     if (!row || typeof row.allowed !== "boolean") {
       console.error("Rate limit RPC returned no data, failing closed");
-      return { allowed: false, count: 0, retryAfterSeconds };
+      return { allowed: false, count: 0, retryAfterSeconds, unavailable: true };
     }
 
     if (row.allowed) {
@@ -45,6 +45,6 @@ export async function checkRateLimit(
     return { allowed: false, count: row.current_count, retryAfterSeconds };
   } catch (err) {
     console.error("Rate limit check failed, failing closed:", err);
-    return { allowed: false, count: 0, retryAfterSeconds };
+    return { allowed: false, count: 0, retryAfterSeconds, unavailable: true };
   }
 }

--- a/supabase/functions/private-backup-api/handler.ts
+++ b/supabase/functions/private-backup-api/handler.ts
@@ -30,7 +30,7 @@ type ServiceClient = {
 
 type RateLimitResult =
   | { readonly allowed: true }
-  | { readonly allowed: false; readonly retryAfterSeconds: number };
+  | { readonly allowed: false; readonly retryAfterSeconds: number; readonly unavailable?: true };
 
 export type PrivateBackupApiDeps = {
   readonly auth: AuthClient;
@@ -72,6 +72,9 @@ export async function handlePrivateBackupRequest(
     return jsonResponse({ success: false, error: "rate_limit_unavailable" }, 503);
   }
   if (!rateLimit.allowed) {
+    if (rateLimit.unavailable === true) {
+      return jsonResponse({ success: false, error: "rate_limit_unavailable" }, 503);
+    }
     return jsonResponse({ success: false, error: "rate_limited" }, 429, {
       "Retry-After": String(rateLimit.retryAfterSeconds),
     });

--- a/supabase/functions/private-backup-api/handler.ts
+++ b/supabase/functions/private-backup-api/handler.ts
@@ -28,8 +28,13 @@ type ServiceClient = {
   deleteObject(path: string): Promise<void>;
 };
 
+type RateLimitResult =
+  | { readonly allowed: true }
+  | { readonly allowed: false; readonly retryAfterSeconds: number };
+
 export type PrivateBackupApiDeps = {
   readonly auth: AuthClient;
+  readonly rateLimit: (userId: string) => Promise<RateLimitResult>;
   readonly store: ServiceClient;
 };
 
@@ -60,6 +65,16 @@ export async function handlePrivateBackupRequest(
 
   if (error !== null || user === null) {
     return jsonResponse({ success: false, error: "invalid_auth" }, 401);
+  }
+
+  const rateLimit = await readRateLimit(deps, user.id);
+  if (rateLimit === null) {
+    return jsonResponse({ success: false, error: "rate_limit_unavailable" }, 503);
+  }
+  if (!rateLimit.allowed) {
+    return jsonResponse({ success: false, error: "rate_limited" }, 429, {
+      "Retry-After": String(rateLimit.retryAfterSeconds),
+    });
   }
 
   const body = await readJsonBody(request);
@@ -229,10 +244,25 @@ function readRequiredString(body: unknown, key: string): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
-function jsonResponse(body: unknown, status = 200): Response {
+async function readRateLimit(
+  deps: PrivateBackupApiDeps,
+  userId: string
+): Promise<RateLimitResult | null> {
+  try {
+    return await deps.rateLimit(userId);
+  } catch {
+    return null;
+  }
+}
+
+function jsonResponse(
+  body: unknown,
+  status = 200,
+  extraHeaders?: Record<string, string>
+): Response {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { "Content-Type": "application/json", ...corsHeaders() },
+    headers: { "Content-Type": "application/json", ...corsHeaders(), ...extraHeaders },
   });
 }
 

--- a/supabase/functions/private-backup-api/index.ts
+++ b/supabase/functions/private-backup-api/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from "npm:@supabase/supabase-js@2";
+import { checkRateLimit } from "../_shared/rate-limit.ts";
 import { handlePrivateBackupRequest } from "./handler.ts";
 import { createPrivateBackupStore } from "./store.ts";
 
@@ -15,6 +16,7 @@ Deno.serve((request) => {
 
   return handlePrivateBackupRequest(request, {
     auth: authClient,
+    rateLimit: (userId) => checkRateLimit(userId, "private-backup-api", 20),
     store: createPrivateBackupStore(serviceClient),
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add per-user rate limiting to the private backup API and classify limiter failures. Over-limit requests are blocked early with 429; limiter outages fail closed with 503.

- **Bug Fixes**
  - Enforce per-user rate limiting before actions; returns 429 with a Retry-After header.
  - Mark limiter outages with `unavailable: true` and treat both flagged outages and thrown errors as 503 with error code `rate_limit_unavailable`.
  - Wire the limiter in the function entry with a limit of 20; add tests for 429, both 503 paths, and ensure no store calls when blocked.

<sup>Written for commit e3eea23e9209a2c758f43169997c857553effca3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

