### PR TITLE
fix(mobile): reopen recent dev client

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -52,7 +52,7 @@ const config: ExpoConfig & { newArchEnabled?: boolean } = {
       "expo-dev-client",
       {
         ios: {
-          launchMode: "launcher",
+          launchMode: "most-recent",
         },
       },
     ],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
On iOS, set `expo-dev-client` launchMode to `most-recent` so it reopens the last used dev app instead of the launcher. This speeds up local testing by reducing relaunch steps.

<sup>Written for commit 6d3f254625168b0e35aa1167fdfb568c064d8dc1. Summary will update on new commits. <a href="https://cubic.dev/pr/B4rz99/fidy/pull/367?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

