### PR TITLE
fix(mobile): harden security boundaries

### DIFF
--- a/apps/mobile/__tests__/auth/store.test.ts
+++ b/apps/mobile/__tests__/auth/store.test.ts
@@ -325,6 +325,30 @@ describe("useAuthStore", () => {
     expect(useAuthStore.getState().session).toBeNull();
   });
 
+  it("signIn rejects callback URLs on a different port", async () => {
+    mockOpenAuthSession.mockResolvedValueOnce({
+      type: "success",
+      url: "fidy://auth:123/callback#access_token=tok&refresh_token=ref",
+    });
+
+    await useAuthStore.getState().signIn("google");
+
+    expect(mockSetSession).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().session).toBeNull();
+  });
+
+  it("signIn rejects empty callback tokens", async () => {
+    mockOpenAuthSession.mockResolvedValueOnce({
+      type: "success",
+      url: "fidy://auth/callback#access_token=&refresh_token=ref",
+    });
+
+    await useAuthStore.getState().signIn("google");
+
+    expect(mockSetSession).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().session).toBeNull();
+  });
+
   it("signOut clears session", async () => {
     useAuthStore.setState({
       session: { access_token: "token" } as never,

--- a/apps/mobile/__tests__/auth/store.test.ts
+++ b/apps/mobile/__tests__/auth/store.test.ts
@@ -313,6 +313,18 @@ describe("useAuthStore", () => {
     expect(mockSetSession).not.toHaveBeenCalled();
   });
 
+  it("signIn rejects callback URLs that do not match the registered redirect URI", async () => {
+    mockOpenAuthSession.mockResolvedValueOnce({
+      type: "success",
+      url: "fidy://evil/callback#access_token=tok&refresh_token=ref",
+    });
+
+    await useAuthStore.getState().signIn("google");
+
+    expect(mockSetSession).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().session).toBeNull();
+  });
+
   it("signOut clears session", async () => {
     useAuthStore.setState({
       session: { access_token: "token" } as never,

--- a/apps/mobile/__tests__/capture-sources/hooks.test.ts
+++ b/apps/mobile/__tests__/capture-sources/hooks.test.ts
@@ -95,6 +95,22 @@ describe("setupApplePayCapture", () => {
       merchant: "Farmatodo",
     });
   });
+
+  it("ignores malformed Apple Pay intent payloads", async () => {
+    const { setupApplePayCapture } = await loadSetup();
+    let capturedListener: (event: any) => void = vi.fn();
+    mockAddLogTransactionListener.mockImplementationOnce((listener: any) => {
+      capturedListener = listener;
+      return { remove: vi.fn() };
+    });
+
+    await setupApplePayCapture(mockDb, USER_ID);
+    capturedListener({ amount: "50000", merchant: "Farmatodo" });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockProcessApplePayIntent).not.toHaveBeenCalled();
+  });
 });
 
 describe("setupSmsDetection", () => {
@@ -174,6 +190,21 @@ describe("setupSmsDetection", () => {
     expect(mockInsertDetectedSmsEvent).not.toHaveBeenCalled();
     expect(mockRefreshDetectedSms).not.toHaveBeenCalled();
   });
+
+  it("ignores malformed SMS payloads before reading fields", async () => {
+    const { setupSmsDetection } = await loadSetup();
+    let capturedListener: (event: any) => void = vi.fn();
+    mockAddDetectBankSmsListener.mockImplementationOnce((listener: any) => {
+      capturedListener = listener;
+      return { remove: vi.fn() };
+    });
+
+    await setupSmsDetection(mockDb, USER_ID, mockRefreshDetectedSms);
+
+    expect(() => capturedListener({ senderName: "", timestamp: Date.now() })).not.toThrow();
+    expect(mockInsertDetectedSmsEvent).not.toHaveBeenCalled();
+    expect(mockRefreshDetectedSms).not.toHaveBeenCalled();
+  });
 });
 
 describe("setupNotificationCapture", () => {
@@ -219,6 +250,26 @@ describe("setupNotificationCapture", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(mockProcessNotification).toHaveBeenCalledWith(mockDb, USER_ID, notificationData);
+  });
+
+  it("ignores malformed notification payloads", async () => {
+    const { setupNotificationCapture } = await loadSetup();
+    let capturedListener: (event: any) => void = vi.fn();
+    mockAndroidAddListener.mockImplementationOnce((_event: any, listener: any) => {
+      capturedListener = listener;
+      return { remove: vi.fn() };
+    });
+
+    await setupNotificationCapture(mockDb, USER_ID, ["com.todo1.mobile.co.bancolombia"]);
+    capturedListener({
+      packageName: "com.todo1.mobile.co.bancolombia",
+      text: 123,
+      timestamp: "today",
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockProcessNotification).not.toHaveBeenCalled();
   });
 
   it("returns no-op when no packages provided", async () => {

--- a/apps/mobile/__tests__/email-capture/email-adapter.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-adapter.test.ts
@@ -125,10 +125,34 @@ describe("createAdapter", () => {
       expect(result).toEqual({ success: false, error: "no_code" });
     });
 
+    it("returns no_code when callback URL has an empty code", async () => {
+      mockOpenAuthSession.mockResolvedValueOnce({
+        type: "success",
+        url: "fidy://test/callback?code=&state=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      });
+
+      const adapter = createAdapter(testConfig, stubFetch);
+      const result = await adapter.connect("client-id");
+      expect(result).toEqual({ success: false, error: "no_code" });
+    });
+
     it("rejects callback URLs that do not match the configured redirect URI", async () => {
       mockOpenAuthSession.mockResolvedValueOnce({
         type: "success",
         url: "fidy://other/callback?code=auth-code&state=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      });
+
+      const adapter = createAdapter(testConfig, stubFetch);
+      const result = await adapter.connect("client-id");
+
+      expect(result).toEqual({ success: false, error: "invalid_callback" });
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects callback URLs on a different port", async () => {
+      mockOpenAuthSession.mockResolvedValueOnce({
+        type: "success",
+        url: "fidy://test:123/callback?code=auth-code&state=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
       });
 
       const adapter = createAdapter(testConfig, stubFetch);

--- a/apps/mobile/__tests__/email-capture/email-adapter.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-adapter.test.ts
@@ -88,7 +88,7 @@ describe("createAdapter", () => {
     it("returns email on successful OAuth flow", async () => {
       mockOpenAuthSession.mockResolvedValueOnce({
         type: "success",
-        url: "fidy://test/callback?code=auth-code",
+        url: "fidy://test/callback?code=auth-code&state=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
       });
 
       mockFetch.mockResolvedValueOnce({
@@ -117,7 +117,7 @@ describe("createAdapter", () => {
     it("returns no_code when callback URL has no code", async () => {
       mockOpenAuthSession.mockResolvedValueOnce({
         type: "success",
-        url: "fidy://test/callback?error=access_denied",
+        url: "fidy://test/callback?error=access_denied&state=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
       });
 
       const adapter = createAdapter(testConfig, stubFetch);
@@ -125,10 +125,36 @@ describe("createAdapter", () => {
       expect(result).toEqual({ success: false, error: "no_code" });
     });
 
+    it("rejects callback URLs that do not match the configured redirect URI", async () => {
+      mockOpenAuthSession.mockResolvedValueOnce({
+        type: "success",
+        url: "fidy://other/callback?code=auth-code&state=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      });
+
+      const adapter = createAdapter(testConfig, stubFetch);
+      const result = await adapter.connect("client-id");
+
+      expect(result).toEqual({ success: false, error: "invalid_callback" });
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects callback URLs with a missing or mismatched state", async () => {
+      mockOpenAuthSession.mockResolvedValueOnce({
+        type: "success",
+        url: "fidy://test/callback?code=auth-code&state=attacker-state",
+      });
+
+      const adapter = createAdapter(testConfig, stubFetch);
+      const result = await adapter.connect("client-id");
+
+      expect(result).toEqual({ success: false, error: "invalid_callback" });
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
     it("returns token_exchange_failed when token POST fails", async () => {
       mockOpenAuthSession.mockResolvedValueOnce({
         type: "success",
-        url: "fidy://test/callback?code=auth-code",
+        url: "fidy://test/callback?code=auth-code&state=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
       });
 
       mockFetch.mockResolvedValueOnce({ ok: false, status: 400 });
@@ -141,7 +167,7 @@ describe("createAdapter", () => {
     it("returns profile_fetch_failed when profile GET fails", async () => {
       mockOpenAuthSession.mockResolvedValueOnce({
         type: "success",
-        url: "fidy://test/callback?code=auth-code",
+        url: "fidy://test/callback?code=auth-code&state=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
       });
 
       mockFetch.mockResolvedValueOnce({
@@ -159,7 +185,7 @@ describe("createAdapter", () => {
     it("returns no_email_found when extractEmail returns null", async () => {
       mockOpenAuthSession.mockResolvedValueOnce({
         type: "success",
-        url: "fidy://test/callback?code=auth-code",
+        url: "fidy://test/callback?code=auth-code&state=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
       });
 
       mockFetch.mockResolvedValueOnce({
@@ -180,7 +206,7 @@ describe("createAdapter", () => {
     it("returns no_email_found when extractEmail returns an empty string", async () => {
       mockOpenAuthSession.mockResolvedValueOnce({
         type: "success",
-        url: "fidy://test/callback?code=auth-code",
+        url: "fidy://test/callback?code=auth-code&state=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
       });
 
       mockFetch.mockResolvedValueOnce({
@@ -201,7 +227,7 @@ describe("createAdapter", () => {
     it("stores tokens in SecureStore with correct keys", async () => {
       mockOpenAuthSession.mockResolvedValueOnce({
         type: "success",
-        url: "fidy://test/callback?code=auth-code",
+        url: "fidy://test/callback?code=auth-code&state=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
       });
 
       mockFetch.mockResolvedValueOnce({
@@ -224,7 +250,7 @@ describe("createAdapter", () => {
     it("stores refresh_token only when present", async () => {
       mockOpenAuthSession.mockResolvedValueOnce({
         type: "success",
-        url: "fidy://test/callback?code=auth-code",
+        url: "fidy://test/callback?code=auth-code&state=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
       });
 
       mockFetch.mockResolvedValueOnce({
@@ -268,7 +294,7 @@ describe("createAdapter", () => {
 
       mockOpenAuthSession.mockResolvedValueOnce({
         type: "success",
-        url: "fidy://test/callback?code=auth-code",
+        url: "fidy://test/callback?code=auth-code&state=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
       });
 
       mockFetch.mockResolvedValueOnce({ ok: false, status: 400 });

--- a/apps/mobile/__tests__/security/build-config.test.ts
+++ b/apps/mobile/__tests__/security/build-config.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const ORIGINAL_APP_ENV = process.env.APP_ENV;
+const ORIGINAL_ENABLE_LOCAL_QA = process.env.EXPO_PUBLIC_ENABLE_LOCAL_QA;
+
+afterEach(() => {
+  process.env.APP_ENV = ORIGINAL_APP_ENV;
+  process.env.EXPO_PUBLIC_ENABLE_LOCAL_QA = ORIGINAL_ENABLE_LOCAL_QA;
+  vi.resetModules();
+});
+
+describe("production build security config", () => {
+  it("does not include the Expo dev client plugin in production app config", async () => {
+    process.env.APP_ENV = "production";
+    vi.resetModules();
+
+    const { default: config } = await import("../../app.config");
+    const pluginNames = config.plugins?.map((plugin) =>
+      Array.isArray(plugin) ? plugin[0] : plugin
+    );
+
+    expect(pluginNames).not.toContain("expo-dev-client");
+  });
+
+  it("ignores the public local QA flag in production builds", async () => {
+    process.env.APP_ENV = "production";
+    process.env.EXPO_PUBLIC_ENABLE_LOCAL_QA = "1";
+    vi.resetModules();
+
+    const { isLocalQaAvailable } = await import("@/features/qa/local-session");
+
+    expect(isLocalQaAvailable()).toBe(false);
+  });
+});

--- a/apps/mobile/__tests__/security/build-config.test.ts
+++ b/apps/mobile/__tests__/security/build-config.test.ts
@@ -1,11 +1,22 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const ORIGINAL_APP_ENV = process.env.APP_ENV;
+const ORIGINAL_EXPO_PUBLIC_APP_ENV = process.env.EXPO_PUBLIC_APP_ENV;
 const ORIGINAL_ENABLE_LOCAL_QA = process.env.EXPO_PUBLIC_ENABLE_LOCAL_QA;
 
+const restoreEnv = (key: string, value: string | undefined) => {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+
+  process.env[key] = value;
+};
+
 afterEach(() => {
-  process.env.APP_ENV = ORIGINAL_APP_ENV;
-  process.env.EXPO_PUBLIC_ENABLE_LOCAL_QA = ORIGINAL_ENABLE_LOCAL_QA;
+  restoreEnv("APP_ENV", ORIGINAL_APP_ENV);
+  restoreEnv("EXPO_PUBLIC_APP_ENV", ORIGINAL_EXPO_PUBLIC_APP_ENV);
+  restoreEnv("EXPO_PUBLIC_ENABLE_LOCAL_QA", ORIGINAL_ENABLE_LOCAL_QA);
   vi.resetModules();
 });
 
@@ -23,7 +34,7 @@ describe("production build security config", () => {
   });
 
   it("ignores the public local QA flag in production builds", async () => {
-    process.env.APP_ENV = "production";
+    process.env.EXPO_PUBLIC_APP_ENV = "production";
     process.env.EXPO_PUBLIC_ENABLE_LOCAL_QA = "1";
     vi.resetModules();
 

--- a/apps/mobile/__tests__/security/telemetry-redaction.test.ts
+++ b/apps/mobile/__tests__/security/telemetry-redaction.test.ts
@@ -1,0 +1,71 @@
+// biome-ignore-all lint/style/useNamingConvention: mock exports must match Sentry API names
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sentryMocks = vi.hoisted(() => {
+  const scope = {
+    setContext: vi.fn(),
+    setLevel: vi.fn(),
+  };
+  return {
+    captureException: vi.fn(),
+    captureMessage: vi.fn(),
+    init: vi.fn(),
+    scope,
+    setUser: vi.fn(),
+    withScope: vi.fn(
+      (
+        callback: (scopeArg: {
+          setContext: typeof scope.setContext;
+          setLevel: typeof scope.setLevel;
+        }) => void
+      ) => callback(scope)
+    ),
+    wrap: vi.fn((component: unknown) => component),
+  };
+});
+
+vi.mock("@sentry/react-native", () => ({
+  init: sentryMocks.init,
+  captureException: sentryMocks.captureException,
+  captureMessage: sentryMocks.captureMessage,
+  setUser: sentryMocks.setUser,
+  withScope: sentryMocks.withScope,
+  ErrorBoundary: "SentryErrorBoundary",
+  wrap: sentryMocks.wrap,
+}));
+
+describe("telemetry redaction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("scrubs sensitive warning context before sending it to Sentry", async () => {
+    const { captureWarning } = await import("@/shared/lib/sentry");
+
+    captureWarning("email_capture_failed", {
+      rawBodyPreview: "Compra en Farmatodo por $50000 user@example.com",
+      authHeader: "Bearer access-token-123",
+      recoveryKey: "RK-AAAA-BBBB-CCCC-DDDD-EEEE-FFFF",
+      signedUrl: "https://storage.example/upload?token=secret-token&signature=abc",
+    });
+
+    expect(sentryMocks.scope.setContext).toHaveBeenCalledWith("warning_detail", {
+      rawBodyPreview: "[Filtered]",
+      authHeader: "Bearer [Filtered]",
+      recoveryKey: "[Filtered]",
+      signedUrl: "https://storage.example/upload?token=[Filtered]&signature=[Filtered]",
+    });
+  });
+
+  it("scrubs sensitive exception messages before sending them to Sentry", async () => {
+    const { captureError } = await import("@/shared/lib/sentry");
+
+    captureError(
+      new Error("Upload failed for RK-AAAA-BBBB-CCCC-DDDD-EEEE-FFFF with Bearer access-token-123")
+    );
+
+    const capturedError = sentryMocks.captureException.mock.calls[0]?.[0] as Error;
+    expect(capturedError.message).toBe("Upload failed for [Filtered] with Bearer [Filtered]");
+  });
+});

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -1,5 +1,15 @@
 import type { ExpoConfig } from "expo/config";
 
+const isProductionBuild = process.env.APP_ENV === "production";
+const devClientPlugin: NonNullable<ExpoConfig["plugins"]>[number] = [
+  "expo-dev-client",
+  {
+    ios: {
+      launchMode: "most-recent",
+    },
+  },
+];
+
 // Cast: newArchEnabled, edgeToEdgeEnabled, predictiveBackGestureEnabled
 // exist in SDK 55 but @expo/config-types hasn't caught up yet.
 const config: ExpoConfig & { newArchEnabled?: boolean } = {
@@ -48,14 +58,7 @@ const config: ExpoConfig & { newArchEnabled?: boolean } = {
   },
   plugins: [
     "expo-router",
-    [
-      "expo-dev-client",
-      {
-        ios: {
-          launchMode: "most-recent",
-        },
-      },
-    ],
+    ...(isProductionBuild ? [] : [devClientPlugin]),
     "expo-secure-store",
     // biome-ignore lint/style/useNamingConvention: expo-sqlite config key
     ["expo-sqlite", { useSQLCipher: true }],

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -11,7 +11,8 @@
         "simulator": false
       },
       "env": {
-        "APP_ENV": "development"
+        "APP_ENV": "development",
+        "EXPO_PUBLIC_APP_ENV": "development"
       }
     },
     "preview": {
@@ -20,13 +21,15 @@
         "simulator": false
       },
       "env": {
-        "APP_ENV": "preview"
+        "APP_ENV": "preview",
+        "EXPO_PUBLIC_APP_ENV": "preview"
       }
     },
     "production": {
       "autoIncrement": true,
       "env": {
-        "APP_ENV": "production"
+        "APP_ENV": "production",
+        "EXPO_PUBLIC_APP_ENV": "production"
       }
     }
   }

--- a/apps/mobile/features/auth/oauth-callback.ts
+++ b/apps/mobile/features/auth/oauth-callback.ts
@@ -14,13 +14,15 @@ const parseUrl = (url: string): URL | null => {
 const hasRedirectTarget = (callbackUrl: URL, redirectUrl: URL): boolean =>
   callbackUrl.protocol === redirectUrl.protocol &&
   callbackUrl.hostname === redirectUrl.hostname &&
+  callbackUrl.port === redirectUrl.port &&
   callbackUrl.pathname === redirectUrl.pathname;
 
 const createSupabaseAuthTokens = (
   accessToken: string | null,
   refreshToken: string | null
 ): SupabaseAuthTokens | null => {
-  if (accessToken === null || refreshToken === null) return null;
+  if (accessToken === null || accessToken.length === 0) return null;
+  if (refreshToken === null || refreshToken.length === 0) return null;
   return { accessToken, refreshToken };
 };
 

--- a/apps/mobile/features/auth/oauth-callback.ts
+++ b/apps/mobile/features/auth/oauth-callback.ts
@@ -1,0 +1,39 @@
+export type SupabaseAuthTokens = {
+  readonly accessToken: string;
+  readonly refreshToken: string;
+};
+
+const parseUrl = (url: string): URL | null => {
+  try {
+    return new URL(url);
+  } catch {
+    return null;
+  }
+};
+
+const hasRedirectTarget = (callbackUrl: URL, redirectUrl: URL): boolean =>
+  callbackUrl.protocol === redirectUrl.protocol &&
+  callbackUrl.hostname === redirectUrl.hostname &&
+  callbackUrl.pathname === redirectUrl.pathname;
+
+const createSupabaseAuthTokens = (
+  accessToken: string | null,
+  refreshToken: string | null
+): SupabaseAuthTokens | null => {
+  if (accessToken === null || refreshToken === null) return null;
+  return { accessToken, refreshToken };
+};
+
+export const readSupabaseSessionTokens = (
+  callbackUrl: string,
+  redirectUri: string
+): SupabaseAuthTokens | null => {
+  const parsedCallbackUrl = parseUrl(callbackUrl);
+  const parsedRedirectUrl = parseUrl(redirectUri);
+  if (parsedCallbackUrl === null) return null;
+  if (parsedRedirectUrl === null) return null;
+  if (!hasRedirectTarget(parsedCallbackUrl, parsedRedirectUrl)) return null;
+
+  const params = new URLSearchParams(parsedCallbackUrl.hash.slice(1));
+  return createSupabaseAuthTokens(params.get("access_token"), params.get("refresh_token"));
+};

--- a/apps/mobile/features/auth/store.ts
+++ b/apps/mobile/features/auth/store.ts
@@ -11,6 +11,7 @@ import {
 } from "@/features/qa/local-session";
 import { getSupabase } from "@/shared/db/supabase";
 import { captureWarning, identifyUser, resetAnalyticsUser } from "@/shared/lib";
+import { readSupabaseSessionTokens, type SupabaseAuthTokens } from "./oauth-callback";
 
 // biome-ignore lint/style/useNamingConvention: OAuth is a proper noun
 type OAuthProvider = "google" | "azure";
@@ -136,11 +137,6 @@ async function handleRestoreSessionException(
   clearLocalOnboardingState();
 }
 
-type SupabaseAuthTokens = {
-  readonly accessToken: string;
-  readonly refreshToken: string;
-};
-
 async function requestOauthUrl(provider: OAuthProvider): Promise<string | null> {
   await clearLocalQaSession().catch(() => undefined);
   const supabase = getSupabase();
@@ -157,24 +153,15 @@ async function openOauthBrowser(url: string): Promise<string | null> {
   return result.type === "success" && result.url ? result.url : null;
 }
 
-function getSupabaseSessionTokens(url: string): SupabaseAuthTokens | null {
-  const params = new URLSearchParams(new URL(url).hash.slice(1));
-  return createSupabaseAuthTokens(params.get("access_token"), params.get("refresh_token"));
-}
+const getSupabaseSessionTokens = (url: string): SupabaseAuthTokens | null => {
+  return readSupabaseSessionTokens(url, REDIRECT_URI);
+};
 
 async function signInWithProvider(provider: OAuthProvider): Promise<Session | null> {
   const authUrl = await requestOauthUrl(provider);
   if (authUrl === null) return null;
 
   return restoreProviderSession(authUrl);
-}
-
-function createSupabaseAuthTokens(
-  accessToken: string | null,
-  refreshToken: string | null
-): SupabaseAuthTokens | null {
-  if (accessToken === null || refreshToken === null) return null;
-  return { accessToken, refreshToken };
 }
 
 async function restoreProviderSession(authUrl: string): Promise<Session | null> {

--- a/apps/mobile/features/capture-sources/hooks/setup.ts
+++ b/apps/mobile/features/capture-sources/hooks/setup.ts
@@ -5,7 +5,11 @@ import type { AnyDb } from "@/shared/db";
 import { captureError, generateDetectedSmsEventId, toIsoDateTime } from "@/shared/lib";
 import type { UserId } from "@/shared/types/branded";
 import { parseSmsDetectedAt } from "../lib/parse-sms-detected-at";
-import type { ApplePayIntentData, NotificationData } from "../schema";
+import {
+  applePayIntentDataSchema,
+  notificationDataSchema,
+  smsDetectionDataSchema,
+} from "../schema";
 import { createCaptureIngestionPort } from "../services/capture-ingestion";
 
 const noop = () => undefined;
@@ -22,11 +26,14 @@ export async function setupApplePayCapture(db: AnyDb, userId: UserId): Promise<(
   if (!mod.isAvailable()) return noop;
 
   const subscription = mod.addLogTransactionListener((event) => {
+    const parsed = applePayIntentDataSchema.safeParse(event);
+    if (!parsed.success) return;
+
     captureIngestion
       .ingest({
         kind: "apple_pay",
         userId,
-        intent: event as ApplePayIntentData,
+        intent: parsed.data,
       })
       .catch(captureError);
   });
@@ -43,17 +50,20 @@ export async function setupSmsDetection(
   if (!mod.isAvailable()) return noop;
 
   const subscription = mod.addDetectBankSmsListener((event) => {
-    const detectedAt = parseSmsDetectedAt(event.timestamp);
+    const parsed = smsDetectionDataSchema.safeParse(event);
+    if (!parsed.success) return;
+
+    const detectedAt = parseSmsDetectedAt(parsed.data.timestamp);
 
     if (detectedAt == null) {
-      captureError(new Error(`Invalid SMS detection timestamp: ${event.timestamp}`));
+      captureError(new Error(`Invalid SMS detection timestamp: ${parsed.data.timestamp}`));
       return;
     }
 
     insertDetectedSmsEvent(db, {
       id: generateDetectedSmsEventId(),
       userId,
-      senderLabel: event.senderName,
+      senderLabel: parsed.data.senderName,
       detectedAt,
       dismissed: false,
       linkedTransactionId: null,
@@ -85,11 +95,14 @@ export async function setupNotificationCapture(
   mod.setAllowedPackages(packages);
 
   const subscription = mod.addListener("onNotificationReceived", (event: unknown) => {
+    const parsed = notificationDataSchema.safeParse(event);
+    if (!parsed.success) return;
+
     captureIngestion
       .ingest({
         kind: "notification",
         userId,
-        notification: event as NotificationData,
+        notification: parsed.data,
       })
       .catch(captureError);
   });

--- a/apps/mobile/features/email-capture/services/create-email-adapter.ts
+++ b/apps/mobile/features/email-capture/services/create-email-adapter.ts
@@ -2,6 +2,7 @@
 import * as SecureStore from "expo-secure-store";
 import { captureError, captureWarning } from "@/shared/lib";
 import type { ConnectResult, RawEmail } from "../schema";
+import { readOauthCallbackCode } from "./email-adapter-callback";
 import { generatePkce } from "./email-adapter-pkce";
 import type { EmailAdapter, EmailProviderConfig, FetchEmailsFn } from "./email-adapter-types";
 
@@ -9,8 +10,6 @@ type TokenResponse = {
   access_token: string;
   refresh_token?: string;
 };
-
-type ConnectError = Extract<ConnectResult, { success: false }>["error"];
 
 type AuthorizationCodeResult =
   | {
@@ -21,7 +20,7 @@ type AuthorizationCodeResult =
     }
   | {
       success: false;
-      error: ConnectError;
+      error: Extract<ConnectResult, { success: false }>["error"];
     };
 
 type ProfileEmailResult =
@@ -54,6 +53,7 @@ function buildAuthParams(input: {
   clientId: string;
   redirectUri: string;
   codeChallenge: string;
+  state: string;
 }) {
   return new URLSearchParams({
     client_id: input.clientId,
@@ -63,22 +63,25 @@ function buildAuthParams(input: {
     ...input.config.extraAuthParams,
     code_challenge: input.codeChallenge,
     code_challenge_method: "S256",
+    state: input.state,
   });
 }
 
-async function requestAuthorizationCode(input: {
+const requestAuthorizationCode = async (input: {
   config: EmailProviderConfig;
   clientId: string;
-}): Promise<AuthorizationCodeResult> {
+}): Promise<AuthorizationCodeResult> => {
   const { openAuthSessionAsync } = await import("expo-web-browser");
   const redirectUri = input.config.getRedirectUri();
   const { codeVerifier, codeChallenge } = await generatePkce();
+  const { codeVerifier: state } = await generatePkce();
   const result = await openAuthSessionAsync(
     `${input.config.authUrl}?${buildAuthParams({
       config: input.config,
       clientId: input.clientId,
       redirectUri,
       codeChallenge,
+      state,
     })}`,
     redirectUri
   );
@@ -87,11 +90,11 @@ async function requestAuthorizationCode(input: {
     return { success: false, error: "cancelled" };
   }
 
-  const code = new URL(result.url).searchParams.get("code");
-  return code == null
-    ? { success: false, error: "no_code" }
-    : { success: true, code, redirectUri, codeVerifier };
-}
+  const callback = readOauthCallbackCode({ callbackUrl: result.url, redirectUri, state });
+  return callback.success
+    ? { success: true, code: callback.code, redirectUri, codeVerifier }
+    : callback;
+};
 
 function buildTokenExchangeBody(input: {
   config: EmailProviderConfig;

--- a/apps/mobile/features/email-capture/services/email-adapter-callback.ts
+++ b/apps/mobile/features/email-capture/services/email-adapter-callback.ts
@@ -17,6 +17,7 @@ const parseUrl = (url: string): URL | null => {
 const hasCallbackTarget = (actual: URL, expected: URL): boolean =>
   actual.protocol === expected.protocol &&
   actual.hostname === expected.hostname &&
+  actual.port === expected.port &&
   actual.pathname === expected.pathname;
 
 const invalidCallback = (): CallbackCodeResult => ({ success: false, error: "invalid_callback" });
@@ -40,7 +41,7 @@ const readValidCallbackUrl = (input: {
 
 const readCodeParam = (callbackUrl: URL): CallbackCodeResult => {
   const code = callbackUrl.searchParams.get("code");
-  if (code === null) return { success: false, error: "no_code" };
+  if (code === null || code.length === 0) return { success: false, error: "no_code" };
   return { success: true, code };
 };
 

--- a/apps/mobile/features/email-capture/services/email-adapter-callback.ts
+++ b/apps/mobile/features/email-capture/services/email-adapter-callback.ts
@@ -1,0 +1,54 @@
+import type { ConnectResult } from "../schema";
+
+type ConnectError = Extract<ConnectResult, { success: false }>["error"];
+
+export type CallbackCodeResult =
+  | { readonly success: true; readonly code: string }
+  | { readonly success: false; readonly error: ConnectError };
+
+const parseUrl = (url: string): URL | null => {
+  try {
+    return new URL(url);
+  } catch {
+    return null;
+  }
+};
+
+const hasCallbackTarget = (actual: URL, expected: URL): boolean =>
+  actual.protocol === expected.protocol &&
+  actual.hostname === expected.hostname &&
+  actual.pathname === expected.pathname;
+
+const invalidCallback = (): CallbackCodeResult => ({ success: false, error: "invalid_callback" });
+
+const hasExpectedState = (callbackUrl: URL, state: string): boolean =>
+  callbackUrl.searchParams.get("state") === state;
+
+const readValidCallbackUrl = (input: {
+  readonly callbackUrl: string;
+  readonly redirectUri: string;
+  readonly state: string;
+}): URL | null => {
+  const callbackUrl = parseUrl(input.callbackUrl);
+  const redirectUri = parseUrl(input.redirectUri);
+  if (callbackUrl === null) return null;
+  if (redirectUri === null) return null;
+  if (!hasCallbackTarget(callbackUrl, redirectUri)) return null;
+  if (!hasExpectedState(callbackUrl, input.state)) return null;
+  return callbackUrl;
+};
+
+const readCodeParam = (callbackUrl: URL): CallbackCodeResult => {
+  const code = callbackUrl.searchParams.get("code");
+  if (code === null) return { success: false, error: "no_code" };
+  return { success: true, code };
+};
+
+export const readOauthCallbackCode = (input: {
+  readonly callbackUrl: string;
+  readonly redirectUri: string;
+  readonly state: string;
+}): CallbackCodeResult => {
+  const callbackUrl = readValidCallbackUrl(input);
+  return callbackUrl === null ? invalidCallback() : readCodeParam(callbackUrl);
+};

--- a/apps/mobile/features/qa/local-session.ts
+++ b/apps/mobile/features/qa/local-session.ts
@@ -32,7 +32,7 @@ function getLocalQaBuildFlag() {
 }
 
 function isProductionBuild() {
-  return process.env.APP_ENV === "production";
+  return process.env.EXPO_PUBLIC_APP_ENV === "production";
 }
 
 export function isLocalQaProfile(value: string | null | undefined): value is LocalQaProfile {

--- a/apps/mobile/features/qa/local-session.ts
+++ b/apps/mobile/features/qa/local-session.ts
@@ -31,11 +31,16 @@ function getLocalQaBuildFlag() {
   return process.env.EXPO_PUBLIC_ENABLE_LOCAL_QA === "1";
 }
 
+function isProductionBuild() {
+  return process.env.APP_ENV === "production";
+}
+
 export function isLocalQaProfile(value: string | null | undefined): value is LocalQaProfile {
   return LOCAL_QA_PROFILES.includes(value as LocalQaProfile);
 }
 
 export function isLocalQaAvailable(): boolean {
+  if (isProductionBuild()) return false;
   return getRuntimeDevFlag() === true || process.env.NODE_ENV === "test" || getLocalQaBuildFlag();
 }
 

--- a/apps/mobile/shared/lib/sentry.ts
+++ b/apps/mobile/shared/lib/sentry.ts
@@ -6,11 +6,12 @@ export function initSentry(dsn: string): void {
     tracesSampleRate: 0.2,
     profilesSampleRate: 0,
     environment: __DEV__ ? "development" : "production",
+    beforeSend: (event) => sanitizeTelemetryValue(event) as typeof event,
   });
 }
 
 export function captureError(error: unknown): void {
-  Sentry.captureException(error);
+  Sentry.captureException(sanitizeError(error));
 }
 
 export function setSentryUser(userId: string | null): void {
@@ -19,7 +20,7 @@ export function setSentryUser(userId: string | null): void {
 
 export function capturePipelineEvent(data: Record<string, string | number | boolean>): void {
   Sentry.withScope((scope) => {
-    scope.setContext("pipeline", data);
+    scope.setContext("pipeline", sanitizeTelemetryRecord(data));
     scope.setLevel("info");
     Sentry.captureMessage(`pipeline:${String(data.source)}`);
   });
@@ -31,7 +32,7 @@ export function captureWarning(
 ): void {
   Sentry.withScope((scope) => {
     if (context) {
-      scope.setContext("warning_detail", context);
+      scope.setContext("warning_detail", sanitizeTelemetryRecord(context));
     }
     scope.setLevel("warning");
     Sentry.captureMessage(message);
@@ -40,3 +41,72 @@ export function captureWarning(
 
 export const SentryErrorBoundary = Sentry.ErrorBoundary;
 export const wrapWithSentry = Sentry.wrap;
+
+const FILTERED = "[Filtered]";
+
+const SENSITIVE_KEY_FRAGMENTS = [
+  "auth",
+  "body",
+  "email",
+  "notification",
+  "rawbody",
+  "recoverykey",
+  "recovery_key",
+  "subject",
+  "text",
+  "token",
+] as const;
+
+const sanitizeError = (error: unknown): unknown => {
+  if (!(error instanceof Error)) {
+    return sanitizeTelemetryValue(error);
+  }
+
+  const sanitized = new Error(sanitizeString(error.message));
+  sanitized.name = error.name;
+  sanitized.stack = error.stack ? sanitizeString(error.stack) : error.stack;
+  return sanitized;
+};
+
+const sanitizeTelemetryRecord = <T extends Record<string, unknown>>(record: T): T => {
+  return Object.fromEntries(
+    Object.entries(record).map(([key, value]) => [key, sanitizeTelemetryEntry(key, value)])
+  ) as T;
+};
+
+const sanitizeTelemetryValue = (value: unknown): unknown => {
+  if (typeof value === "string") {
+    return sanitizeString(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(sanitizeTelemetryValue);
+  }
+
+  if (typeof value === "object" && value !== null) {
+    return sanitizeTelemetryRecord(value as Record<string, unknown>);
+  }
+
+  return value;
+};
+
+const sanitizeTelemetryEntry = (key: string, value: unknown): unknown => {
+  if (typeof value === "string" && isSensitiveKey(key)) {
+    return key.toLowerCase().includes("auth") ? sanitizeString(value) : FILTERED;
+  }
+
+  return sanitizeTelemetryValue(value);
+};
+
+const isSensitiveKey = (key: string): boolean => {
+  const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, "");
+  return SENSITIVE_KEY_FRAGMENTS.some((fragment) => normalized.includes(fragment));
+};
+
+const sanitizeString = (value: string): string => {
+  return value
+    .replace(/RK-(?:[0-9A-F]{4}-){5}[0-9A-F]{4}/giu, FILTERED)
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gu, `Bearer ${FILTERED}`)
+    .replace(/([?&](?:access_token|refresh_token|signature|token)=)[^&#\s]+/giu, `$1${FILTERED}`)
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/giu, FILTERED);
+};


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Strengthens mobile security by validating OAuth callbacks (state, tokens, and redirect URI), sanitizing telemetry, and dropping malformed capture payloads. Removes dev tooling from production and disables local QA in prod builds.

- Bug Fixes
  - OAuth: require callback URL to match the registered redirect URI (scheme/host/path/port) and non-empty access/refresh tokens; ignore invalid callbacks to avoid setting sessions.
  - Email adapters: enforce `state`; validate redirect URI (incl. port); reject missing/empty `code`.
  - Capture sources: schema-validate Apple Pay, SMS, and notification events; ignore malformed payloads before reading fields.
  - Telemetry: sanitize events via `beforeSend` and exceptions in `@sentry/react-native`; redact tokens, emails, recovery keys, and signed URL secrets.
  - Build config: exclude `expo-dev-client` in production; gate local QA by `EXPO_PUBLIC_APP_ENV` and force `isLocalQaAvailable()` to false in prod even if `EXPO_PUBLIC_ENABLE_LOCAL_QA=1`.
  - Tests: add coverage for OAuth callback validation, email adapter `state`/redirect checks, build security config, telemetry redaction, and malformed payload handling.

<sup>Written for commit 81f3f6f557b4180f8a75578ae75ecf462ebd7444. Summary will update on new commits. <a href="https://cubic.dev/pr/B4rz99/fidy/pull/368?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

