### PR TITLE
fix(mobile): harden onboarding email sync

### DIFF
--- a/.github/workflows/deploy-edge-functions.yml
+++ b/.github/workflows/deploy-edge-functions.yml
@@ -1,16 +1,32 @@
 name: Deploy Edge Functions
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
     paths:
+      - ".github/workflows/deploy-edge-functions.yml"
       - "supabase/functions/**"
 
 jobs:
   deploy:
     name: Deploy to Supabase
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - function: parse-email
+            verify_jwt: false
+          - function: ai-chat
+            verify_jwt: false
+          - function: weekly-digest
+            verify_jwt: false
+          - function: delete-account
+            verify_jwt: true
+          - function: private-backup-api
+            verify_jwt: true
     steps:
       - uses: actions/checkout@v4
 
@@ -18,22 +34,12 @@ jobs:
         with:
           version: 2.75.0
 
-      - name: Deploy parse-email
-        run: supabase functions deploy parse-email --no-verify-jwt --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-
-      - name: Deploy ai-chat
-        run: supabase functions deploy ai-chat --no-verify-jwt --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-
-      - name: Deploy weekly-digest
-        run: supabase functions deploy weekly-digest --no-verify-jwt --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-
-      - name: Deploy delete-account
-        run: supabase functions deploy delete-account --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+      - name: Deploy ${{ matrix.function }}
+        run: |
+          args=("${{ matrix.function }}" --project-ref "${{ secrets.SUPABASE_PROJECT_REF }}")
+          if [[ "${{ matrix.verify_jwt }}" == "false" ]]; then
+            args+=(--no-verify-jwt)
+          fi
+          supabase functions deploy "${args[@]}"
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/apps/mobile/__tests__/ai-chat/user-memories.test.ts
+++ b/apps/mobile/__tests__/ai-chat/user-memories.test.ts
@@ -15,6 +15,7 @@ const mockOrder = vi.fn();
 const mockUpdate = vi.fn();
 const mockEqUpdate = vi.fn();
 const mockInvoke = vi.fn();
+const AUTHORIZATION_HEADER = "Authorization";
 const mockFrom = vi.fn((table: string) => {
   if (table === "user_memories") {
     return {
@@ -32,6 +33,13 @@ const userMemoryRemoteService = createUserMemoryRemoteService({
   supabase: {
     getSupabase: () =>
       ({
+        auth: {
+          getSession: () =>
+            Promise.resolve({
+              data: { session: { access_token: "memory-access-token" } },
+              error: null,
+            }),
+        },
         from: mockFrom,
         functions: { invoke: mockInvoke },
       }) as never,
@@ -149,6 +157,10 @@ describe("user memories remote adapters", () => {
       await userMemoryRemoteService.extractMemoriesFromConversation(memoryConversation);
 
     expect(result).toEqual(extractedMemoryExpectation);
+    expect(mockInvoke).toHaveBeenCalledWith("ai-chat", {
+      body: { mode: "extract_memories", messages: memoryConversation },
+      headers: { [AUTHORIZATION_HEADER]: "Bearer memory-access-token" },
+    });
   });
 
   test("rejects invalid extract-memories payloads", async () => {

--- a/apps/mobile/__tests__/backup/remote-storage.test.ts
+++ b/apps/mobile/__tests__/backup/remote-storage.test.ts
@@ -14,6 +14,7 @@ import { requireBackupId, requireIsoDateTime, requireUserId } from "@/shared/typ
 const USER_ID = requireUserId("00000000-0000-4000-8000-000000000001");
 const BACKUP_ID = requireBackupId("backup-1");
 const CREATED_AT = requireIsoDateTime("2026-04-24T10:30:00.000Z");
+const AUTHORIZATION_HEADER = "Authorization";
 
 const ENCRYPTED_BACKUP = {
   version: 1,
@@ -79,6 +80,7 @@ describe("remote encrypted backup storage", () => {
     ]);
     expect(supabase.functionsInvoke).toHaveBeenCalledWith("private-backup-api", {
       body: { action: "current" },
+      headers: { [AUTHORIZATION_HEADER]: "Bearer backup-access-token" },
     });
     expect(supabase.storageUploadToSignedUrl).not.toHaveBeenCalled();
   });
@@ -97,6 +99,7 @@ describe("remote encrypted backup storage", () => {
     ).resolves.toEqual(ENCRYPTED_BACKUP);
     expect(supabase.functionsInvoke).toHaveBeenCalledWith("private-backup-api", {
       body: { action: "prepareDownload" },
+      headers: { [AUTHORIZATION_HEADER]: "Bearer backup-access-token" },
     });
     expect(supabase.fetch).toHaveBeenCalledWith("https://storage.example/download");
     expectRemotePayloadsToExclude(FORBIDDEN_REMOTE_VALUES, supabase.remotePayloads());
@@ -127,9 +130,11 @@ describe("remote encrypted backup storage", () => {
     ).resolves.toBeUndefined();
     expect(supabase.functionsInvoke).toHaveBeenCalledWith("private-backup-api", {
       body: { action: "current" },
+      headers: { [AUTHORIZATION_HEADER]: "Bearer backup-access-token" },
     });
     expect(supabase.functionsInvoke).toHaveBeenCalledWith("private-backup-api", {
       body: { action: "deleteCurrent" },
+      headers: { [AUTHORIZATION_HEADER]: "Bearer backup-access-token" },
     });
     expect(supabase.from).not.toHaveBeenCalled();
   });
@@ -182,6 +187,7 @@ function expectUploadCalls(supabase: ReturnType<typeof createRemoteBackupSupabas
       action: "prepareUpload",
       backupId: BACKUP_ID,
     },
+    headers: { [AUTHORIZATION_HEADER]: "Bearer backup-access-token" },
   });
   expect(supabase.fetch).toHaveBeenCalledWith("https://storage.example/upload", {
     body: JSON.stringify(ENCRYPTED_BACKUP),
@@ -195,6 +201,7 @@ function expectUploadCalls(supabase: ReturnType<typeof createRemoteBackupSupabas
       action: "confirmUpload",
       ...expectedRemoteMetadata(),
     },
+    headers: { [AUTHORIZATION_HEADER]: "Bearer backup-access-token" },
   });
 }
 
@@ -263,6 +270,13 @@ function createRemoteBackupSupabase(
   vi.stubGlobal("fetch", fetch);
   const bucket = { remove: storageRemove, uploadToSignedUrl: storageUploadToSignedUrl };
   const client = {
+    auth: {
+      getSession: () =>
+        Promise.resolve({
+          data: { session: { access_token: "backup-access-token" } },
+          error: null,
+        }),
+    },
     from,
     functions: { invoke: functionsInvoke },
     storage: {

--- a/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
@@ -188,6 +188,29 @@ function resetCaptureEvidenceMocks() {
   mockLinkCaptureEvidenceToTransaction.mockResolvedValue(undefined);
 }
 
+function createTestEmailPipelineService(overrides: Record<string, unknown> = {}) {
+  return createEmailPipelineService({
+    parseEmailApi: mockParseEmailApi,
+    lookupMerchantRule: mockLookupMerchantRule,
+    findDuplicateTransaction: mockFindDuplicateTransaction,
+    getProcessedExternalIds: mockGetProcessedExternalIds,
+    getPendingRetryEmails: mockGetPendingRetryEmails,
+    insertProcessedEmail: mockInsertProcessedEmail,
+    markForRetry: mockMarkForRetry,
+    markPermanentlyFailed: mockMarkPermanentlyFailed,
+    markRetrySuccess: mockMarkRetrySuccess,
+    updateProcessedEmailStatus: mockUpdateProcessedEmailStatus,
+    ensureDefaultFinancialAccount: mockEnsureDefaultFinancialAccount,
+    buildEmailCaptureEvidence: mockBuildEmailCaptureEvidence,
+    saveCaptureEvidenceRows: mockSaveCaptureEvidenceRows,
+    linkCaptureEvidenceToTransaction: mockLinkCaptureEvidenceToTransaction,
+    insertTransaction: mockInsertTransaction,
+    insertMerchantRule: mockInsertMerchantRule,
+    trackTransactionCreated: vi.fn(),
+    ...overrides,
+  });
+}
+
 function expectSavedTransaction(matcher: Record<string, unknown>) {
   expect(mockInsertTransaction).toHaveBeenCalledWith(mockDb, expect.objectContaining(matcher));
 }
@@ -345,24 +368,7 @@ describe("email processing pipeline", () => {
 
   it("uses the injected clock for persisted email timestamps and retry backoff", async () => {
     const fixedNow = requireIsoDateTime("2026-04-18T12:34:56.000Z");
-    const service = createEmailPipelineService({
-      parseEmailApi: mockParseEmailApi,
-      lookupMerchantRule: mockLookupMerchantRule,
-      findDuplicateTransaction: mockFindDuplicateTransaction,
-      getProcessedExternalIds: mockGetProcessedExternalIds,
-      getPendingRetryEmails: mockGetPendingRetryEmails,
-      insertProcessedEmail: mockInsertProcessedEmail,
-      markForRetry: mockMarkForRetry,
-      markPermanentlyFailed: mockMarkPermanentlyFailed,
-      markRetrySuccess: mockMarkRetrySuccess,
-      updateProcessedEmailStatus: mockUpdateProcessedEmailStatus,
-      ensureDefaultFinancialAccount: mockEnsureDefaultFinancialAccount,
-      buildEmailCaptureEvidence: mockBuildEmailCaptureEvidence,
-      saveCaptureEvidenceRows: mockSaveCaptureEvidenceRows,
-      linkCaptureEvidenceToTransaction: mockLinkCaptureEvidenceToTransaction,
-      insertTransaction: mockInsertTransaction,
-      insertMerchantRule: mockInsertMerchantRule,
-      trackTransactionCreated: vi.fn(),
+    const service = createTestEmailPipelineService({
       clock: {
         now: () => new Date(fixedNow),
         nowIsoDateTime: () => fixedNow,
@@ -380,6 +386,36 @@ describe("email processing pipeline", () => {
         nextRetryAt: "2026-04-18T12:35:56.000Z",
       })
     );
+  });
+
+  it("waits between parse-email calls when a rate-limit delay is configured", async () => {
+    const events: string[] = [];
+    const service = createTestEmailPipelineService({
+      parseRateLimit: {
+        delayMs: 3000,
+        sleep: async (delayMs: number) => {
+          events.push(`sleep:${delayMs}`);
+        },
+      },
+    });
+    mockParseEmailApi.mockImplementation(async (body: string) => {
+      events.push(`parse:${body}`);
+      return makeParsedEmailResult({ description: body });
+    });
+
+    await service.processEmails(mockDb, USER_ID, [
+      makeRawEmail({ externalId: "ext-1", body: "Compra 1" }),
+      makeRawEmail({ externalId: "ext-2", body: "Compra 2" }),
+      makeRawEmail({ externalId: "ext-3", body: "Compra 3" }),
+    ]);
+
+    expect(events).toEqual([
+      "parse:Compra 1",
+      "sleep:3000",
+      "parse:Compra 2",
+      "sleep:3000",
+      "parse:Compra 3",
+    ]);
   });
 
   it("saves transaction as needs_review when LLM returns low confidence", async () => {

--- a/apps/mobile/__tests__/email-capture/parse-email-api.test.ts
+++ b/apps/mobile/__tests__/email-capture/parse-email-api.test.ts
@@ -147,14 +147,13 @@ describe("parseEmailApi", () => {
     });
   });
 
-  it("returns null on edge function error", async () => {
+  it("throws on edge function error", async () => {
     mockInvoke.mockResolvedValueOnce({
       data: null,
       error: { message: "timeout" },
     });
 
-    const result = await parseEmailApi("email body");
-    expect(result).toBeNull();
+    await expect(parseEmailApi("email body")).rejects.toThrow("timeout");
   });
 
   it("returns null when Zod validation fails", async () => {

--- a/apps/mobile/__tests__/email-capture/parse-email-service.test.ts
+++ b/apps/mobile/__tests__/email-capture/parse-email-service.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { createParseEmailService } from "@/features/email-capture/services/create-parse-email-service";
 
+const ACCESS_TOKEN_KEY = "access_token";
+const AUTHORIZATION_HEADER = "Authorization";
+
 describe("createParseEmailService", () => {
   it("classifies merchants through the parse-email edge function", async () => {
     const mockInvoke = vi.fn().mockResolvedValue({
@@ -71,6 +74,84 @@ describe("createParseEmailService", () => {
         fromAccountHint: "Tarjeta credito Bancolombia",
       })
     );
+  });
+
+  it("passes the current user access token to the parse-email function", async () => {
+    const mockInvoke = vi.fn().mockResolvedValue({
+      data: {
+        success: true,
+        data: {
+          kind: "transaction",
+          type: "expense",
+          amount: 50000,
+          categoryId: "food",
+          description: "Exito",
+          date: "2026-03-05",
+          confidence: 0.9,
+          fromAccountHint: null,
+          toAccountHint: null,
+        },
+      },
+      error: null,
+    });
+
+    const service = createParseEmailService({
+      validCategoryIds: ["food"],
+      supabase: {
+        getSupabase: () =>
+          ({
+            auth: {
+              getSession: () =>
+                Promise.resolve({
+                  data: { session: { [ACCESS_TOKEN_KEY]: "user-access-token" } },
+                  error: null,
+                }),
+            },
+            functions: { invoke: mockInvoke },
+          }) as never,
+      },
+      telemetry: {
+        captureError: vi.fn(),
+        captureWarning: vi.fn(),
+        capturePipelineEvent: vi.fn(),
+      },
+    });
+
+    await service.parseEmail("Compra por $50,000");
+
+    expect(mockInvoke).toHaveBeenCalledWith("parse-email", {
+      body: { body: "Compra por $50,000", mode: "full_parse" },
+      headers: { [AUTHORIZATION_HEADER]: "Bearer user-access-token" },
+    });
+  });
+
+  it("throws when the parse-email function rejects the authenticated request", async () => {
+    const captureWarning = vi.fn();
+    const mockInvoke = vi.fn().mockResolvedValue({
+      data: { success: false, error: "invalid_auth" },
+      error: { message: "Invalid JWT" },
+    });
+
+    const service = createParseEmailService({
+      validCategoryIds: ["food"],
+      supabase: {
+        getSupabase: () =>
+          ({
+            functions: { invoke: mockInvoke },
+          }) as never,
+      },
+      telemetry: {
+        captureError: vi.fn(),
+        captureWarning,
+        capturePipelineEvent: vi.fn(),
+      },
+    });
+
+    await expect(service.parseEmail("Compra por $50,000")).rejects.toThrow("Invalid JWT");
+    expect(captureWarning).toHaveBeenCalledWith("parse_email_api_failed", {
+      errorMessage: "Invalid JWT",
+      hasData: true,
+    });
   });
 
   it("returns null and captures a warning when local notification validation rejects a candidate", async () => {

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -555,6 +555,17 @@ describe("email capture boundary", () => {
       );
     });
 
+    it("returns the awaited processing outcome", async () => {
+      setAccounts();
+      mockAdapter.fetchEmails.mockResolvedValueOnce([makeRawEmail()]);
+      mockProcessResult({ saved: 2, needsReview: 1 });
+      mockEmptyReviewLoads();
+
+      const result = await runFetchAndProcess();
+
+      expect(result).toEqual({ savedCount: 2, needsReviewCount: 1, failedCount: 0 });
+    });
+
     it("sets phase to processing when showing progress", async () => {
       setAccounts();
       const mockRawEmails = [makeRawEmail()];
@@ -591,6 +602,18 @@ describe("email capture boundary", () => {
 
       const updatedAccount = useEmailCaptureStore.getState().accounts[0]!;
       expect(updatedAccount.lastFetchedAt).not.toBeNull();
+    });
+
+    it("does not advance lastFetchedAt when fetched emails fail processing", async () => {
+      setAccounts();
+      mockAdapter.fetchEmails.mockResolvedValueOnce([makeRawEmail()]);
+      mockProcessResult({ failed: 1 });
+      mockEmptyReviewLoads();
+
+      await runFetchAndProcess();
+
+      expect(updateLastFetchedAt).not.toHaveBeenCalled();
+      expect(useEmailCaptureStore.getState().accounts[0]?.lastFetchedAt).toBeNull();
     });
 
     it("auto-clears phase after 2s timeout when phase is complete", async () => {

--- a/apps/mobile/features/ai-chat/data/create-user-memory-remote-service.ts
+++ b/apps/mobile/features/ai-chat/data/create-user-memory-remote-service.ts
@@ -41,6 +41,8 @@ type CreateUserMemoryRemoteServiceDeps = {
   readonly clock?: AppClock;
 };
 
+const AUTHORIZATION_HEADER = "Authorization";
+
 export type UserMemoryRemoteService = {
   readonly listUserMemories: (userId: UserId) => Promise<readonly UserMemory[]>;
   readonly softDeleteUserMemory: (id: UserMemoryId) => Promise<void>;
@@ -105,23 +107,26 @@ function softDeleteUserMemoryEffect(id: UserMemoryId) {
 
 function extractMemoriesEffect(messages: readonly ConversationMessage[]) {
   return Effect.flatMap(currentSupabaseClientEffect, (supabase) =>
-    Effect.map(
-      fromPromise(() =>
-        supabase.functions.invoke("ai-chat", {
+    Effect.flatMap(
+      fromPromise(async () => {
+        const sessionResult = await supabase.auth.getSession();
+        const accessToken = sessionResult.data.session?.access_token;
+        return supabase.functions.invoke("ai-chat", {
           body: { mode: "extract_memories", messages },
-        })
-      ),
+          ...(accessToken ? { headers: { [AUTHORIZATION_HEADER]: `Bearer ${accessToken}` } } : {}),
+        });
+      }),
       ({ data, error }) => {
         if (error != null) {
-          throw error;
+          return Effect.fail(error);
         }
 
         const result = extractMemoriesResponseSchema.safeParse(data);
         if (!result.success) {
-          throw new Error("extract_memories_failed");
+          return Effect.fail(new Error("extract_memories_failed"));
         }
 
-        return result.data.data.map(toUserMemory);
+        return Effect.succeed(result.data.data.map(toUserMemory));
       }
     )
   );

--- a/apps/mobile/features/backup/remote-storage.ts
+++ b/apps/mobile/features/backup/remote-storage.ts
@@ -41,6 +41,8 @@ type RemoteBackupErrorLike = {
   readonly message?: string;
 };
 
+const AUTHORIZATION_HEADER = "Authorization";
+
 type PrivateBackupApiResponse<T> =
   | ({ readonly success: true } & T)
   | { readonly success: false; readonly error: string };
@@ -155,7 +157,12 @@ async function invokePrivateBackupApi<T extends PrivateBackupApiResponse<unknown
   supabase: SupabaseClient,
   body: Record<string, unknown>
 ): Promise<Extract<T, { readonly success: true }>> {
-  const response = await supabase.functions.invoke<T>("private-backup-api", { body });
+  const sessionResult = await supabase.auth.getSession();
+  const accessToken = sessionResult.data.session?.access_token;
+  const response = await supabase.functions.invoke<T>("private-backup-api", {
+    body,
+    ...(accessToken ? { headers: { [AUTHORIZATION_HEADER]: `Bearer ${accessToken}` } } : {}),
+  });
   throwIfRemoteBackupError(response.error, "call private backup API");
   if (response.data === null) {
     throw new Error("Unable to call private backup API: missing response");

--- a/apps/mobile/features/email-capture/services/create-parse-email-service.ts
+++ b/apps/mobile/features/email-capture/services/create-parse-email-service.ts
@@ -49,6 +49,8 @@ type CreateParseEmailServiceDeps = {
   readonly telemetry?: AppTelemetry;
 };
 
+const AUTHORIZATION_HEADER = "Authorization";
+
 export type ParseEmailService = {
   readonly classifyMerchant: (merchant: string) => Promise<string>;
   readonly parseEmail: (emailBody: string) => Promise<LlmParsedTransaction | null>;
@@ -57,11 +59,15 @@ export type ParseEmailService = {
 
 function invokeParseEmailFunctionEffect<Response>(body: string, mode: ParseMode) {
   return Effect.flatMap(currentSupabaseClientEffect, (supabase) =>
-    fromPromise(() =>
-      supabase.functions.invoke<Response>("parse-email", {
+    fromPromise(async () => {
+      const sessionResult = await supabase.auth?.getSession?.();
+      const accessToken = sessionResult?.data.session?.access_token;
+
+      return supabase.functions.invoke<Response>("parse-email", {
         body: { body, mode },
-      })
-    )
+        ...(accessToken ? { headers: { [AUTHORIZATION_HEADER]: `Bearer ${accessToken}` } } : {}),
+      });
+    })
   );
 }
 
@@ -74,7 +80,7 @@ function logParseApiFailureEffect(
       errorMessage: response.error?.message ?? "unknown",
       hasData: response.data != null,
     }),
-    Effect.succeed(null)
+    Effect.fail(new Error(response.error?.message ?? "parse-email request failed"))
   );
 }
 
@@ -148,12 +154,13 @@ function parseApiResponseEffect(
 }
 
 function parseTransactionEffect(input: ParseTransactionInput) {
-  const request = invokeParseEmailFunctionEffect<ParseEmailResponse>(input.body, input.mode);
-
-  return Effect.catchAll(
-    Effect.flatMap(request, (response) => parseApiResponseEffect(input, response)),
-    (error) => logParseExceptionEffect(input.warningPrefix, error)
+  const request = Effect.catchAll(
+    invokeParseEmailFunctionEffect<ParseEmailResponse>(input.body, input.mode),
+    (error) =>
+      Effect.zipRight(logParseExceptionEffect(input.warningPrefix, error), Effect.fail(error))
   );
+
+  return Effect.flatMap(request, (response) => parseApiResponseEffect(input, response));
 }
 
 function logClassifyApiFailureEffect(response: ParseFunctionResult<ClassifyResponse>) {

--- a/apps/mobile/features/email-capture/services/email-capture-fetch-service.ts
+++ b/apps/mobile/features/email-capture/services/email-capture-fetch-service.ts
@@ -6,13 +6,21 @@ import type { EmailAccountId, IsoDateTime, UserId } from "@/shared/types/branded
 import { isFirstFetchForAny, shouldShowProgress } from "../lib/progress-phases";
 import type { EmailAccountRow, ProcessedEmailRow } from "../lib/repository";
 import { getFailedEmails, getNeedsReviewEmails, updateLastFetchedAt } from "../lib/repository";
-import type { ProgressCallback, RawEmail } from "../pipeline.public";
+import type { PipelineResult, ProgressCallback, RawEmail } from "../pipeline.public";
 import { processEmails, processRetries } from "../pipeline.public";
 import { ensureBankSenders } from "../queries/bank-senders";
 import type { EmailProvider } from "../schema";
 import { getAdapter } from "./email-adapter";
 
 const EMPTY_RAW_EMAILS: RawEmail[] = [];
+const EMPTY_PIPELINE_RESULT: PipelineResult = {
+  filtered: 0,
+  skippedDuplicate: 0,
+  skippedCrossSource: 0,
+  saved: 0,
+  failed: 0,
+  needsReview: 0,
+};
 const FETCH_LOOKBACK_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
 
 type EmailFetchClientIds = Record<EmailProvider, string>;
@@ -54,6 +62,7 @@ type FetchEmailAccountCommand = {
 type PersistFetchedAccountsCommand = {
   readonly db: AnyDb;
   readonly fetchResults: readonly EmailAccountFetchResult[];
+  readonly processingResult: PipelineResult;
 };
 
 const createEmptyFetchResult = (account: EmailAccountRow): EmailAccountFetchResult => ({
@@ -76,11 +85,6 @@ const createFetchSummary = (
     showProgress: shouldShowProgress(allEmails.length, isFirstFetchForAny(accounts)),
   };
 };
-
-const createSuccessfulAccountIds = (
-  fetchResults: readonly EmailAccountFetchResult[]
-): ReadonlySet<EmailAccountId> =>
-  new Set(fetchResults.filter((result) => result.fetchOk).map((result) => result.account.id));
 
 const getSuccessfulFetches = (
   fetchResults: readonly EmailAccountFetchResult[]
@@ -150,31 +154,35 @@ export async function ingestFetchedEmails(input: {
   readonly userId: UserId;
   readonly emails: readonly RawEmail[];
   readonly onProgress?: ProgressCallback;
-}): Promise<void> {
+}): Promise<PipelineResult> {
   const captureIngestion = createCaptureIngestionPort(input.db, {
     processEmails,
     processRetries,
   });
 
-  if (input.emails.length > 0) {
-    await captureIngestion.ingest({
-      kind: "email_batch",
-      userId: input.userId,
-      emails: [...input.emails],
-      onProgress: input.onProgress,
-    });
-  }
+  const processingResult: PipelineResult =
+    input.emails.length > 0
+      ? ((await captureIngestion.ingest({
+          kind: "email_batch",
+          userId: input.userId,
+          emails: [...input.emails],
+          onProgress: input.onProgress,
+        })) as PipelineResult)
+      : EMPTY_PIPELINE_RESULT;
 
   await captureIngestion.ingest({
     kind: "email_retry",
     userId: input.userId,
   });
+
+  return processingResult;
 }
 
 export async function persistFetchedAccounts(
   command: PersistFetchedAccountsCommand
 ): Promise<PersistedFetchedAccounts> {
-  const successfulFetches = getSuccessfulFetches(command.fetchResults);
+  const successfulFetches =
+    command.processingResult.failed === 0 ? getSuccessfulFetches(command.fetchResults) : [];
   const fetchedAt = toIsoDateTime(new Date());
 
   await Promise.all(
@@ -183,7 +191,7 @@ export async function persistFetchedAccounts(
 
   return {
     fetchedAt,
-    updatedAccountIds: createSuccessfulAccountIds(command.fetchResults),
+    updatedAccountIds: new Set(successfulFetches.map((result) => result.account.id)),
   };
 }
 

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-batch.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-batch.ts
@@ -63,13 +63,21 @@ async function captureIncomingBatchEvent(
   );
 }
 
-const EMAIL_WORKER_CONCURRENCY = 5;
+const EMAIL_WORKER_CONCURRENCY = 1;
+
+async function waitForParseRateLimit(context: EmailBatchContext): Promise<void> {
+  const delayMs = context.runtime.parseRateLimit.delayMs;
+  if (context.completed === 0 || delayMs <= 0) return;
+
+  await context.runtime.parseRateLimit.sleep(delayMs);
+}
 
 async function runEmailWorker(context: EmailBatchContext, queue: EmailQueue): Promise<void> {
-  // FP exemption: a shared queue keeps concurrency bounded while preserving real-time progress updates.
+  // FP exemption: the worker queue keeps parse-email calls serialized for Edge Function rate limits.
   while (true) {
     const email = getNextQueuedEmail(queue);
     if (!email) return;
+    await waitForParseRateLimit(context);
     await processIncomingEmail(context, email);
     completeEmailStep(context);
   }

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/internal-types.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/internal-types.ts
@@ -31,6 +31,10 @@ export type PipelineRuntime = {
   readonly runEmailWithClock: <A>(
     effect: Effect.Effect<A, unknown, CreateEmailPipelineServiceDeps | AppClock>
   ) => Promise<A>;
+  readonly parseRateLimit: {
+    readonly delayMs: number;
+    readonly sleep: (delayMs: number) => Promise<void>;
+  };
 };
 
 export type CaptureEvidenceRowsInput = {

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/public-types.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/public-types.ts
@@ -123,6 +123,10 @@ export type CreateEmailPipelineServiceDeps = {
   }) => void | Promise<void>;
   readonly clock?: AppClock;
   readonly telemetry?: AppTelemetry;
+  readonly parseRateLimit?: {
+    readonly delayMs?: number;
+    readonly sleep?: (delayMs: number) => Promise<void>;
+  };
 };
 
 export type EmailPipelineService = {

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/runtime.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/runtime.ts
@@ -30,6 +30,11 @@ export const EmailPipelineDeps = makeAppService<CreateEmailPipelineServiceDeps>(
   "@/features/email-capture/EmailPipelineDeps"
 );
 
+const DEFAULT_PARSE_RATE_LIMIT_DELAY_MS = process.env.NODE_ENV === "test" ? 0 : 3000;
+
+const sleep = (delayMs: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, delayMs));
+
 export function parseBodyEffect(db: AnyDb, userId: UserId, body: string) {
   return Effect.gen(function* () {
     const { parseEmailApi, lookupMerchantRule } = yield* EmailPipelineDeps.tag;
@@ -206,7 +211,7 @@ export function nextRetryAtEffect(retryCount: number) {
 }
 
 export function createPipelineRuntime(deps: CreateEmailPipelineServiceDeps): PipelineRuntime {
-  const { clock, telemetry, ...runtimeDeps } = deps;
+  const { clock, telemetry, parseRateLimit, ...runtimeDeps } = deps;
   const clockRuntime = bindAppClock(clock as AppClock | undefined);
   const telemetryRuntime = bindAppTelemetry(telemetry as AppTelemetry | undefined);
   const runtime = EmailPipelineDeps.bind(runtimeDeps);
@@ -216,5 +221,9 @@ export function createPipelineRuntime(deps: CreateEmailPipelineServiceDeps): Pip
     runTelemetryEffect: (effect) => telemetryRuntime.run(effect),
     runEmailEffect: (effect) => runtime.run(effect),
     runEmailWithClock: (effect) => runtime.run(clockRuntime.provide(effect)),
+    parseRateLimit: {
+      delayMs: parseRateLimit?.delayMs ?? DEFAULT_PARSE_RATE_LIMIT_DELAY_MS,
+      sleep: parseRateLimit?.sleep ?? sleep,
+    },
   };
 }

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -44,6 +44,18 @@ export { confirmReviewedEmail } from "./store/reviewed-email";
 
 const noopRefreshTransactions: RefreshTransactions = () => undefined;
 
+export type EmailCaptureFetchOutcome = {
+  readonly savedCount: number;
+  readonly needsReviewCount: number;
+  readonly failedCount: number;
+};
+
+const EMPTY_FETCH_OUTCOME: EmailCaptureFetchOutcome = {
+  savedCount: 0,
+  needsReviewCount: 0,
+  failedCount: 0,
+};
+
 export { useEmailCaptureStore };
 
 registerEmailCaptureStoreRuntime({
@@ -171,15 +183,15 @@ export async function fetchAndProcessEmails(
   gmailClientId: string,
   outlookClientId: string,
   refreshTransactions: RefreshTransactions = noopRefreshTransactions
-): Promise<void> {
+): Promise<EmailCaptureFetchOutcome> {
   const fetchStart = beginEmailCaptureFetchRun(userId);
   if (fetchStart.kind === "missing_context") {
     warnFetchMissingContext(userId);
-    return;
+    return EMPTY_FETCH_OUTCOME;
   }
   if (fetchStart.kind === "already_fetching") {
     captureWarning("email_capture_fetch_already_running");
-    return;
+    return EMPTY_FETCH_OUTCOME;
   }
 
   const run = fetchStart.run;
@@ -188,7 +200,7 @@ export async function fetchAndProcessEmails(
     const accounts = useEmailCaptureStore.getState().accounts;
     if (accounts.length === 0) {
       captureWarning("email_capture_fetch_no_accounts");
-      return;
+      return EMPTY_FETCH_OUTCOME;
     }
 
     const summary = await fetchEmailAccountBatch({
@@ -200,7 +212,7 @@ export async function fetchAndProcessEmails(
       showProgress: summary.showProgress,
       emailCount: summary.allEmails.length,
     });
-    await ingestFetchedEmails({
+    const processingResult = await ingestFetchedEmails({
       db,
       userId,
       emails: summary.allEmails,
@@ -210,12 +222,23 @@ export async function fetchAndProcessEmails(
     await applyEmailCaptureFetchOutcome({
       run,
       showProgress: summary.showProgress,
-      persistedAccounts: await persistFetchedAccounts({ db, fetchResults: summary.fetchResults }),
+      persistedAccounts: await persistFetchedAccounts({
+        db,
+        fetchResults: summary.fetchResults,
+        processingResult,
+      }),
       queues: await loadEmailCaptureQueues(db),
       refreshTransactions,
     });
+
+    return {
+      savedCount: processingResult.saved,
+      needsReviewCount: processingResult.needsReview,
+      failedCount: processingResult.failed,
+    };
   } catch (error) {
     captureError(error);
+    return EMPTY_FETCH_OUTCOME;
   } finally {
     finalizeEmailCaptureFetchRun(run);
   }

--- a/apps/mobile/features/onboarding/components/SyncProgressStep.tsx
+++ b/apps/mobile/features/onboarding/components/SyncProgressStep.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { createAccountSuggestionService } from "@/features/account-suggestions/public";
 import { useOptionalUserId } from "@/features/auth/public";
@@ -25,7 +25,10 @@ export function SyncProgressStep() {
 
   const accounts = useEmailCaptureStore((s) => s.accounts);
   const progress = useEmailCaptureStore((s) => s.progress);
-  const isFetching = useEmailCaptureStore((s) => s.isFetching);
+  const [syncOutcome, setSyncOutcome] = useState<{
+    readonly savedCount: number;
+    readonly hasAccountSuggestions: boolean;
+  } | null>(null);
 
   const recentTransactions = useTransactionStore(useShallow((s) => s.pages.slice(0, 3)));
 
@@ -34,21 +37,40 @@ export function SyncProgressStep() {
   const accentGreen = useThemeColor("accentGreen");
 
   const fetchStarted = useRef(false);
-  // Snapshot final values so they persist after the store clears progress
-  const finalPercent = useRef(0);
-  const finalSavedCount = useRef(0);
+  const suggestionService = useMemo(() => createAccountSuggestionService(), []);
 
   // Start fetch on mount if we have accounts
   useMountEffect(() => {
+    let isMounted = true;
     if (accounts.length > 0 && !fetchStarted.current && db && userId) {
       fetchStarted.current = true;
       trackOnboardingEvent("email_sync_start", { accountCount: accounts.length });
-      void fetchAndProcessEmails(db, userId, getGmailClientId(), getOutlookClientId(), () =>
-        refreshTransactions(db, userId)
-      );
+      void (async () => {
+        const outcome = await fetchAndProcessEmails(
+          db,
+          userId,
+          getGmailClientId(),
+          getOutlookClientId(),
+          () => refreshTransactions(db, userId)
+        );
+        if (!isMounted) return;
+        setSyncOutcome({
+          savedCount: outcome.savedCount,
+          hasAccountSuggestions:
+            suggestionService.listSuggestions({
+              db,
+              userId,
+              limit: 2,
+            }).length > 0,
+        });
+      })();
     } else if (accounts.length === 0) {
       logOnboardingEvent("email_sync_no_accounts");
     }
+
+    return () => {
+      isMounted = false;
+    };
   });
 
   const livePercent = progress
@@ -57,28 +79,10 @@ export function SyncProgressStep() {
       : 0
     : 0;
 
-  // Keep the high-water mark so the bar doesn't reset when the store clears progress
-  if (livePercent > finalPercent.current) {
-    finalPercent.current = livePercent;
-  }
-  if (progress && progress.saved > finalSavedCount.current) {
-    finalSavedCount.current = progress.saved;
-  }
-
-  // Fetch is done when: it was started and is no longer fetching
-  // (covers both progress-shown and silent-processing paths)
-  const fetchDone = fetchStarted.current && !isFetching;
-  const percent = fetchDone ? 100 : finalPercent.current;
-  const savedCount = finalSavedCount.current;
-  const suggestionService = useMemo(() => createAccountSuggestionService(), []);
-  const hasAccountSuggestions =
-    fetchDone && db && userId
-      ? suggestionService.listSuggestions({
-          db,
-          userId,
-          limit: 2,
-        }).length > 0
-      : false;
+  const fetchDone = syncOutcome !== null;
+  const percent = fetchDone ? 100 : livePercent;
+  const savedCount = syncOutcome?.savedCount ?? progress?.saved ?? 0;
+  const hasAccountSuggestions = syncOutcome?.hasAccountSuggestions ?? false;
 
   return (
     <View style={styles.container}>


### PR DESCRIPTION
- Edge function auth headers

- Retry-safe fetch timestamps

- Rate-limited email parsing

- Local checks passed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened onboarding email sync by authenticating edge function calls, serializing/rate-limiting email parsing, and making fetch timestamps retry-safe. This reduces flaky progress, avoids throttling, and prevents advancing `lastFetchedAt` on failed runs.

- **Bug Fixes**
  - Send `Authorization: Bearer <access_token>` to `parse-email`, `ai-chat`, and `private-backup-api`; updated tests to assert headers.
  - Update timestamps only when processing has no failures; `ingestFetchedEmails` returns counts used by the store and onboarding UI.
  - Throw on edge function errors and capture warnings; improves error visibility and prevents silent failures.

- **Refactors**
  - Rate-limit parsing by serializing workers (concurrency 1) and inserting a configurable delay (default 3s; 0 in tests).
  - CI: deploy Supabase edge functions via a matrix with per-function `verify_jwt` settings and `workflow_dispatch` support.

<sup>Written for commit d4cbe0bbcc9e2447c5f28b708b60d554e920d25a. Summary will update on new commits. <a href="https://cubic.dev/pr/B4rz99/fidy/pull/370?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

