### PR TITLE
fix(mobile): refine email sync hardening

### DIFF
--- a/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
@@ -90,6 +90,7 @@ vi.mock("@/features/email-capture/lib/merchant-rules", () => ({
 
 vi.mock("@/features/email-capture/services/parse-email-api", () => ({
   parseEmailApi: (...args: unknown[]) => mockParseEmailApi(...args),
+  retryableParseEmailApi: (...args: unknown[]) => mockParseEmailApi(...args),
 }));
 
 vi.mock("@/features/financial-accounts", () => ({

--- a/apps/mobile/__tests__/email-capture/parse-email-api.test.ts
+++ b/apps/mobile/__tests__/email-capture/parse-email-api.test.ts
@@ -147,13 +147,14 @@ describe("parseEmailApi", () => {
     });
   });
 
-  it("throws on edge function error", async () => {
+  it("returns null on edge function error", async () => {
     mockInvoke.mockResolvedValueOnce({
       data: null,
       error: { message: "timeout" },
     });
 
-    await expect(parseEmailApi("email body")).rejects.toThrow("timeout");
+    const result = await parseEmailApi("email body");
+    expect(result).toBeNull();
   });
 
   it("returns null when Zod validation fails", async () => {

--- a/apps/mobile/__tests__/email-capture/parse-email-service.test.ts
+++ b/apps/mobile/__tests__/email-capture/parse-email-service.test.ts
@@ -125,7 +125,7 @@ describe("createParseEmailService", () => {
     });
   });
 
-  it("throws when the parse-email function rejects the authenticated request", async () => {
+  it("returns null when the parse-email function rejects the authenticated request", async () => {
     const captureWarning = vi.fn();
     const mockInvoke = vi.fn().mockResolvedValue({
       data: { success: false, error: "invalid_auth" },
@@ -134,6 +134,36 @@ describe("createParseEmailService", () => {
 
     const service = createParseEmailService({
       validCategoryIds: ["food"],
+      supabase: {
+        getSupabase: () =>
+          ({
+            functions: { invoke: mockInvoke },
+          }) as never,
+      },
+      telemetry: {
+        captureError: vi.fn(),
+        captureWarning,
+        capturePipelineEvent: vi.fn(),
+      },
+    });
+
+    await expect(service.parseEmail("Compra por $50,000")).resolves.toBeNull();
+    expect(captureWarning).toHaveBeenCalledWith("parse_email_api_failed", {
+      errorMessage: "Invalid JWT",
+      hasData: true,
+    });
+  });
+
+  it("throws on parse-email failure when configured for retryable pipeline parsing", async () => {
+    const captureWarning = vi.fn();
+    const mockInvoke = vi.fn().mockResolvedValue({
+      data: { success: false, error: "invalid_auth" },
+      error: { message: "Invalid JWT" },
+    });
+
+    const service = createParseEmailService({
+      validCategoryIds: ["food"],
+      throwOnApiFailure: true,
       supabase: {
         getSupabase: () =>
           ({

--- a/apps/mobile/__tests__/email-capture/retry-integration.test.ts
+++ b/apps/mobile/__tests__/email-capture/retry-integration.test.ts
@@ -29,6 +29,7 @@ import type { IsoDateTime, ProcessedEmailId, TransactionId } from "@/shared/type
 const mockParseEmailApi = vi.fn();
 vi.mock("@/features/email-capture/services/parse-email-api", () => ({
   parseEmailApi: (...args: unknown[]) => mockParseEmailApi(...args),
+  retryableParseEmailApi: (...args: unknown[]) => mockParseEmailApi(...args),
 }));
 
 vi.mock("@/shared/lib/sentry", () => ({

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -512,9 +512,10 @@ describe("email capture boundary", () => {
         accounts: [makeAccount()],
       });
 
-      await runFetchAndProcess();
+      const result = await runFetchAndProcess();
 
       expect(mockAdapter.fetchEmails).not.toHaveBeenCalled();
+      expect(result).toEqual({ status: "skipped" });
     });
 
     it("continues processing other accounts when one fails", async () => {
@@ -563,7 +564,12 @@ describe("email capture boundary", () => {
 
       const result = await runFetchAndProcess();
 
-      expect(result).toEqual({ savedCount: 2, needsReviewCount: 1, failedCount: 0 });
+      expect(result).toEqual({
+        status: "completed",
+        savedCount: 2,
+        needsReviewCount: 1,
+        failedCount: 0,
+      });
     });
 
     it("sets phase to processing when showing progress", async () => {
@@ -614,6 +620,31 @@ describe("email capture boundary", () => {
 
       expect(updateLastFetchedAt).not.toHaveBeenCalled();
       expect(useEmailCaptureStore.getState().accounts[0]?.lastFetchedAt).toBeNull();
+    });
+
+    it("advances lastFetchedAt for accounts whose own emails process successfully", async () => {
+      setAccounts([
+        makeAccount(),
+        makeAccount({
+          id: "ea-2" as EmailAccountId,
+          provider: "outlook",
+          email: "test@outlook.com",
+        }),
+      ]);
+      mockAdapter.fetchEmails
+        .mockResolvedValueOnce([makeRawEmail({ externalId: "ext-1" })])
+        .mockResolvedValueOnce([makeRawEmail({ externalId: "ext-2", provider: "outlook" })]);
+      mockProcessResult({ failed: 1 });
+      mockProcessResult({ saved: 1 });
+      mockEmptyReviewLoads();
+
+      await runFetchAndProcess();
+
+      expect(updateLastFetchedAt).toHaveBeenCalledTimes(1);
+      expect(updateLastFetchedAt).toHaveBeenCalledWith(mockDb, "ea-2", expect.any(String));
+      const [failedAccount, savedAccount] = useEmailCaptureStore.getState().accounts;
+      expect(failedAccount?.lastFetchedAt).toBeNull();
+      expect(savedAccount?.lastFetchedAt).not.toBeNull();
     });
 
     it("auto-clears phase after 2s timeout when phase is complete", async () => {

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -167,6 +167,14 @@ type ProcessSummary = {
   needsReview: number;
 };
 
+type ProgressSnapshot = {
+  total: number;
+  completed: number;
+  saved: number;
+  failed: number;
+  needsReview: number;
+};
+
 const DEFAULT_ACCOUNT: TestEmailAccount = {
   id: "ea-1" as EmailAccountId,
   userId: mockUserId as UserId,
@@ -515,7 +523,7 @@ describe("email capture boundary", () => {
       const result = await runFetchAndProcess();
 
       expect(mockAdapter.fetchEmails).not.toHaveBeenCalled();
-      expect(result).toEqual({ status: "skipped" });
+      expect(result).toEqual({ status: "skipped", reason: "already_fetching" });
     });
 
     it("continues processing other accounts when one fails", async () => {
@@ -645,6 +653,40 @@ describe("email capture boundary", () => {
       const [failedAccount, savedAccount] = useEmailCaptureStore.getState().accounts;
       expect(failedAccount?.lastFetchedAt).toBeNull();
       expect(savedAccount?.lastFetchedAt).not.toBeNull();
+    });
+
+    it("reports whole-sync progress across per-account processing", async () => {
+      setAccounts([
+        makeAccount(),
+        makeAccount({
+          id: "ea-2" as EmailAccountId,
+          provider: "outlook",
+          email: "test@outlook.com",
+        }),
+      ]);
+      mockAdapter.fetchEmails
+        .mockResolvedValueOnce([makeRawEmail({ externalId: "ext-1" })])
+        .mockResolvedValueOnce([makeRawEmail({ externalId: "ext-2", provider: "outlook" })]);
+      const progressSnapshots: ProgressSnapshot[] = [];
+      vi.mocked(processEmails)
+        .mockImplementationOnce(async (_db, _uid, _emails, onProgress) => {
+          onProgress?.({ total: 1, completed: 1, saved: 1, failed: 0, needsReview: 0 });
+          progressSnapshots.push(useEmailCaptureStore.getState().progress!);
+          return { ...EMPTY_PROCESS_SUMMARY, saved: 1 };
+        })
+        .mockImplementationOnce(async (_db, _uid, _emails, onProgress) => {
+          onProgress?.({ total: 1, completed: 1, saved: 1, failed: 0, needsReview: 0 });
+          progressSnapshots.push(useEmailCaptureStore.getState().progress!);
+          return { ...EMPTY_PROCESS_SUMMARY, saved: 1 };
+        });
+      mockEmptyReviewLoads();
+
+      await runFetchAndProcess();
+
+      expect(progressSnapshots).toEqual([
+        expect.objectContaining({ total: 2, completed: 1, saved: 1 }),
+        expect.objectContaining({ total: 2, completed: 2, saved: 2 }),
+      ]);
     });
 
     it("auto-clears phase after 2s timeout when phase is complete", async () => {

--- a/apps/mobile/__tests__/error-handling/pipeline-save-error.test.ts
+++ b/apps/mobile/__tests__/error-handling/pipeline-save-error.test.ts
@@ -90,6 +90,7 @@ vi.mock("@/features/email-capture/lib/merchant-rules", () => ({
 
 vi.mock("@/features/email-capture/services/parse-email-api", () => ({
   parseEmailApi: (...args: unknown[]) => mockParseEmailApi(...args),
+  retryableParseEmailApi: (...args: unknown[]) => mockParseEmailApi(...args),
 }));
 
 const mockGenerateId = vi.fn();

--- a/apps/mobile/features/email-capture/services/create-parse-email-service.ts
+++ b/apps/mobile/features/email-capture/services/create-parse-email-service.ts
@@ -47,6 +47,7 @@ type CreateParseEmailServiceDeps = {
   readonly validCategoryIds: readonly string[];
   readonly supabase?: AppSupabase;
   readonly telemetry?: AppTelemetry;
+  readonly throwOnApiFailure?: boolean;
 };
 
 const AUTHORIZATION_HEADER = "Authorization";
@@ -73,14 +74,17 @@ function invokeParseEmailFunctionEffect<Response>(body: string, mode: ParseMode)
 
 function logParseApiFailureEffect(
   warningPrefix: "parse_email" | "parse_notification",
-  response: ParseFunctionResult<ParseEmailResponse>
+  response: ParseFunctionResult<ParseEmailResponse>,
+  throwOnApiFailure: boolean
 ) {
   return Effect.zipRight(
     captureWarningEffect(`${warningPrefix}_api_failed`, {
       errorMessage: response.error?.message ?? "unknown",
       hasData: response.data != null,
     }),
-    Effect.fail(new Error(response.error?.message ?? "parse-email request failed"))
+    throwOnApiFailure
+      ? Effect.fail(new Error(response.error?.message ?? "parse-email request failed"))
+      : Effect.succeed(null)
   );
 }
 
@@ -118,10 +122,11 @@ function validateParsedTransactionEffect(
 function handleParseTransactionResponseEffect(
   warningPrefix: "parse_email" | "parse_notification",
   response: ParseFunctionResult<ParseEmailResponse>,
-  validCategoryIds: readonly string[]
+  validCategoryIds: readonly string[],
+  throwOnApiFailure: boolean
 ) {
   if (response.error != null || !response.data?.success) {
-    return logParseApiFailureEffect(warningPrefix, response);
+    return logParseApiFailureEffect(warningPrefix, response, throwOnApiFailure);
   }
 
   return validateParsedTransactionEffect(warningPrefix, response.data.data, validCategoryIds);
@@ -143,24 +148,32 @@ function parseApiResponseEffect(
   input: {
     readonly warningPrefix: "parse_email" | "parse_notification";
     readonly validCategoryIds: readonly string[];
+    readonly throwOnApiFailure: boolean;
   },
   response: ParseFunctionResult<ParseEmailResponse>
 ) {
   return handleParseTransactionResponseEffect(
     input.warningPrefix,
     response,
-    input.validCategoryIds
+    input.validCategoryIds,
+    input.throwOnApiFailure
   );
 }
 
-function parseTransactionEffect(input: ParseTransactionInput) {
+function parseTransactionEffect(
+  input: ParseTransactionInput & { readonly throwOnApiFailure: boolean }
+) {
   const request = Effect.catchAll(
     invokeParseEmailFunctionEffect<ParseEmailResponse>(input.body, input.mode),
     (error) =>
-      Effect.zipRight(logParseExceptionEffect(input.warningPrefix, error), Effect.fail(error))
+      input.throwOnApiFailure
+        ? Effect.zipRight(logParseExceptionEffect(input.warningPrefix, error), Effect.fail(error))
+        : Effect.zipRight(logParseExceptionEffect(input.warningPrefix, error), Effect.succeed(null))
   );
 
-  return Effect.flatMap(request, (response) => parseApiResponseEffect(input, response));
+  return Effect.flatMap(request, (response) =>
+    response === null ? Effect.succeed(null) : parseApiResponseEffect(input, response)
+  );
 }
 
 function logClassifyApiFailureEffect(response: ParseFunctionResult<ClassifyResponse>) {
@@ -201,6 +214,7 @@ export function createParseEmailService({
   validCategoryIds,
   supabase,
   telemetry,
+  throwOnApiFailure = false,
 }: CreateParseEmailServiceDeps): ParseEmailService {
   const supabaseRuntime = bindAppSupabase(supabase);
   const telemetryRuntime = bindAppTelemetry(telemetry);
@@ -216,6 +230,7 @@ export function createParseEmailService({
           mode: "full_parse",
           warningPrefix: "parse_email",
           validCategoryIds,
+          throwOnApiFailure,
         })
       ),
     parseNotification: (sanitizedText) =>
@@ -225,6 +240,7 @@ export function createParseEmailService({
           mode: "parse_notification",
           warningPrefix: "parse_notification",
           validCategoryIds,
+          throwOnApiFailure,
         })
       ),
   };

--- a/apps/mobile/features/email-capture/services/email-capture-fetch-service.ts
+++ b/apps/mobile/features/email-capture/services/email-capture-fetch-service.ts
@@ -31,6 +31,10 @@ export type EmailAccountFetchResult = {
   readonly fetchOk: boolean;
 };
 
+export type ProcessedEmailAccountFetchResult = EmailAccountFetchResult & {
+  readonly processingResult: PipelineResult;
+};
+
 export type EmailCaptureFetchSummary = {
   readonly fetchResults: readonly EmailAccountFetchResult[];
   readonly allEmails: readonly RawEmail[];
@@ -61,8 +65,7 @@ type FetchEmailAccountCommand = {
 
 type PersistFetchedAccountsCommand = {
   readonly db: AnyDb;
-  readonly fetchResults: readonly EmailAccountFetchResult[];
-  readonly processingResult: PipelineResult;
+  readonly fetchResults: readonly ProcessedEmailAccountFetchResult[];
 };
 
 const createEmptyFetchResult = (account: EmailAccountRow): EmailAccountFetchResult => ({
@@ -86,9 +89,23 @@ const createFetchSummary = (
   };
 };
 
-const getSuccessfulFetches = (
-  fetchResults: readonly EmailAccountFetchResult[]
-): readonly EmailAccountFetchResult[] => fetchResults.filter((result) => result.fetchOk);
+const getSuccessfulProcessedFetches = (
+  fetchResults: readonly ProcessedEmailAccountFetchResult[]
+): readonly ProcessedEmailAccountFetchResult[] =>
+  fetchResults.filter((result) => result.fetchOk && result.processingResult.failed === 0);
+
+export const aggregatePipelineResults = (results: readonly PipelineResult[]): PipelineResult =>
+  results.reduce(
+    (total, result) => ({
+      filtered: total.filtered + result.filtered,
+      skippedDuplicate: total.skippedDuplicate + result.skippedDuplicate,
+      skippedCrossSource: total.skippedCrossSource + result.skippedCrossSource,
+      saved: total.saved + result.saved,
+      failed: total.failed + result.failed,
+      needsReview: total.needsReview + result.needsReview,
+    }),
+    EMPTY_PIPELINE_RESULT
+  );
 
 const isSupportedEmailProvider = (provider: string): provider is EmailProvider =>
   provider === "gmail" || provider === "outlook";
@@ -154,6 +171,7 @@ export async function ingestFetchedEmails(input: {
   readonly userId: UserId;
   readonly emails: readonly RawEmail[];
   readonly onProgress?: ProgressCallback;
+  readonly runRetries?: boolean;
 }): Promise<PipelineResult> {
   const captureIngestion = createCaptureIngestionPort(input.db, {
     processEmails,
@@ -170,10 +188,12 @@ export async function ingestFetchedEmails(input: {
         })) as PipelineResult)
       : EMPTY_PIPELINE_RESULT;
 
-  await captureIngestion.ingest({
-    kind: "email_retry",
-    userId: input.userId,
-  });
+  if (input.runRetries !== false) {
+    await captureIngestion.ingest({
+      kind: "email_retry",
+      userId: input.userId,
+    });
+  }
 
   return processingResult;
 }
@@ -181,8 +201,7 @@ export async function ingestFetchedEmails(input: {
 export async function persistFetchedAccounts(
   command: PersistFetchedAccountsCommand
 ): Promise<PersistedFetchedAccounts> {
-  const successfulFetches =
-    command.processingResult.failed === 0 ? getSuccessfulFetches(command.fetchResults) : [];
+  const successfulFetches = getSuccessfulProcessedFetches(command.fetchResults);
   const fetchedAt = toIsoDateTime(new Date());
 
   await Promise.all(

--- a/apps/mobile/features/email-capture/services/email-pipeline.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline.ts
@@ -28,12 +28,12 @@ import {
   type ProgressCallback,
   type RetryResult,
 } from "./create-email-pipeline-service";
-import { parseEmailApi } from "./parse-email-api";
+import { retryableParseEmailApi } from "./parse-email-api";
 
 export type { PipelineResult, ProcessEmails, ProcessRetries, ProgressCallback, RetryResult };
 
 const emailPipeline = createEmailPipelineService({
-  parseEmailApi,
+  parseEmailApi: retryableParseEmailApi,
   lookupMerchantRule,
   findDuplicateTransaction,
   getProcessedExternalIds,

--- a/apps/mobile/features/email-capture/services/parse-email-api.ts
+++ b/apps/mobile/features/email-capture/services/parse-email-api.ts
@@ -1,5 +1,5 @@
 import type { LlmParsedTransaction } from "./llm-parser";
-import { liveParseEmailService } from "./parse-email-service";
+import { liveParseEmailService, retryableParseEmailService } from "./parse-email-service";
 
 type RedactionRule = {
   pattern: RegExp;
@@ -43,3 +43,8 @@ export const classifyMerchantApi = async (merchant: string): Promise<string> =>
 
 export const parseEmailApi = async (emailBody: string): Promise<LlmParsedTransaction | null> =>
   liveParseEmailService.parseEmail(sanitizeEmailBody(emailBody));
+
+export const retryableParseEmailApi = async (
+  emailBody: string
+): Promise<LlmParsedTransaction | null> =>
+  retryableParseEmailService.parseEmail(sanitizeEmailBody(emailBody));

--- a/apps/mobile/features/email-capture/services/parse-email-service.ts
+++ b/apps/mobile/features/email-capture/services/parse-email-service.ts
@@ -4,3 +4,8 @@ import { createParseEmailService } from "./create-parse-email-service";
 export const liveParseEmailService = createParseEmailService({
   validCategoryIds: CATEGORY_IDS,
 });
+
+export const retryableParseEmailService = createParseEmailService({
+  validCategoryIds: CATEGORY_IDS,
+  throwOnApiFailure: true,
+});

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -53,7 +53,7 @@ export type EmailCaptureFetchOutcome =
       readonly needsReviewCount: number;
       readonly failedCount: number;
     }
-  | { readonly status: "skipped" };
+  | { readonly status: "skipped"; readonly reason: "already_fetching" | "missing_context" };
 
 const EMPTY_FETCH_OUTCOME: EmailCaptureFetchOutcome = {
   status: "completed",
@@ -62,7 +62,15 @@ const EMPTY_FETCH_OUTCOME: EmailCaptureFetchOutcome = {
   failedCount: 0,
 };
 
-const SKIPPED_FETCH_OUTCOME: EmailCaptureFetchOutcome = { status: "skipped" };
+const alreadyFetchingOutcome: EmailCaptureFetchOutcome = {
+  status: "skipped",
+  reason: "already_fetching",
+};
+
+const missingContextOutcome: EmailCaptureFetchOutcome = {
+  status: "skipped",
+  reason: "missing_context",
+};
 
 export { useEmailCaptureStore };
 
@@ -195,11 +203,11 @@ export async function fetchAndProcessEmails(
   const fetchStart = beginEmailCaptureFetchRun(userId);
   if (fetchStart.kind === "missing_context") {
     warnFetchMissingContext(userId);
-    return SKIPPED_FETCH_OUTCOME;
+    return missingContextOutcome;
   }
   if (fetchStart.kind === "already_fetching") {
     captureWarning("email_capture_fetch_already_running");
-    return SKIPPED_FETCH_OUTCOME;
+    return alreadyFetchingOutcome;
   }
 
   const run = fetchStart.run;
@@ -226,11 +234,26 @@ export async function fetchAndProcessEmails(
         const processed = await processedPromise;
         if (!fetchResult.fetchOk) return processed;
 
+        const previousResult = aggregatePipelineResults(
+          processed.map((result) => result.processingResult)
+        );
+        const completedBefore = processed.reduce(
+          (completed, result) => completed + result.rawEmails.length,
+          0
+        );
+
         const processingResult = await ingestFetchedEmails({
           db,
           userId,
           emails: fetchResult.rawEmails,
-          onProgress,
+          onProgress: (progress) =>
+            onProgress({
+              total: summary.allEmails.length,
+              completed: completedBefore + progress.completed,
+              saved: previousResult.saved + progress.saved,
+              failed: previousResult.failed + progress.failed,
+              needsReview: previousResult.needsReview + progress.needsReview,
+            }),
           runRetries: false,
         });
 

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -13,10 +13,12 @@ import {
 import type { EmailProvider } from "./schema";
 import { getAdapter } from "./services/email-adapter";
 import {
+  aggregatePipelineResults,
   createEmailFetchClientIds,
   fetchEmailAccountBatch,
   ingestFetchedEmails,
   loadEmailCaptureQueues,
+  type ProcessedEmailAccountFetchResult,
   persistFetchedAccounts,
 } from "./services/email-capture-fetch-service";
 import {
@@ -44,17 +46,23 @@ export { confirmReviewedEmail } from "./store/reviewed-email";
 
 const noopRefreshTransactions: RefreshTransactions = () => undefined;
 
-export type EmailCaptureFetchOutcome = {
-  readonly savedCount: number;
-  readonly needsReviewCount: number;
-  readonly failedCount: number;
-};
+export type EmailCaptureFetchOutcome =
+  | {
+      readonly status: "completed";
+      readonly savedCount: number;
+      readonly needsReviewCount: number;
+      readonly failedCount: number;
+    }
+  | { readonly status: "skipped" };
 
 const EMPTY_FETCH_OUTCOME: EmailCaptureFetchOutcome = {
+  status: "completed",
   savedCount: 0,
   needsReviewCount: 0,
   failedCount: 0,
 };
+
+const SKIPPED_FETCH_OUTCOME: EmailCaptureFetchOutcome = { status: "skipped" };
 
 export { useEmailCaptureStore };
 
@@ -187,11 +195,11 @@ export async function fetchAndProcessEmails(
   const fetchStart = beginEmailCaptureFetchRun(userId);
   if (fetchStart.kind === "missing_context") {
     warnFetchMissingContext(userId);
-    return EMPTY_FETCH_OUTCOME;
+    return SKIPPED_FETCH_OUTCOME;
   }
   if (fetchStart.kind === "already_fetching") {
     captureWarning("email_capture_fetch_already_running");
-    return EMPTY_FETCH_OUTCOME;
+    return SKIPPED_FETCH_OUTCOME;
   }
 
   const run = fetchStart.run;
@@ -212,26 +220,42 @@ export async function fetchAndProcessEmails(
       showProgress: summary.showProgress,
       emailCount: summary.allEmails.length,
     });
-    const processingResult = await ingestFetchedEmails({
-      db,
-      userId,
-      emails: summary.allEmails,
-      onProgress: createEmailCaptureFetchProgressHandler(run, refreshTransactions),
-    });
+    const onProgress = createEmailCaptureFetchProgressHandler(run, refreshTransactions);
+    const processedFetchResults = await summary.fetchResults.reduce(
+      async (processedPromise, fetchResult) => {
+        const processed = await processedPromise;
+        if (!fetchResult.fetchOk) return processed;
+
+        const processingResult = await ingestFetchedEmails({
+          db,
+          userId,
+          emails: fetchResult.rawEmails,
+          onProgress,
+          runRetries: false,
+        });
+
+        return [...processed, { ...fetchResult, processingResult }];
+      },
+      Promise.resolve([] as ProcessedEmailAccountFetchResult[])
+    );
+    await ingestFetchedEmails({ db, userId, emails: [] });
+    const processingResult = aggregatePipelineResults(
+      processedFetchResults.map((result) => result.processingResult)
+    );
 
     await applyEmailCaptureFetchOutcome({
       run,
       showProgress: summary.showProgress,
       persistedAccounts: await persistFetchedAccounts({
         db,
-        fetchResults: summary.fetchResults,
-        processingResult,
+        fetchResults: processedFetchResults,
       }),
       queues: await loadEmailCaptureQueues(db),
       refreshTransactions,
     });
 
     return {
+      status: "completed",
       savedCount: processingResult.saved,
       needsReviewCount: processingResult.needsReview,
       failedCount: processingResult.failed,

--- a/apps/mobile/features/onboarding/components/SyncProgressStep.tsx
+++ b/apps/mobile/features/onboarding/components/SyncProgressStep.tsx
@@ -54,6 +54,7 @@ export function SyncProgressStep() {
           () => refreshTransactions(db, userId)
         );
         if (!isMounted) return;
+        if (outcome.status !== "completed") return;
         setSyncOutcome({
           savedCount: outcome.savedCount,
           hasAccountSuggestions:

--- a/apps/mobile/features/onboarding/components/SyncProgressStep.tsx
+++ b/apps/mobile/features/onboarding/components/SyncProgressStep.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { createAccountSuggestionService } from "@/features/account-suggestions/public";
 import { useOptionalUserId } from "@/features/auth/public";
@@ -25,6 +25,7 @@ export function SyncProgressStep() {
 
   const accounts = useEmailCaptureStore((s) => s.accounts);
   const progress = useEmailCaptureStore((s) => s.progress);
+  const isFetching = useEmailCaptureStore((s) => s.isFetching);
   const [syncOutcome, setSyncOutcome] = useState<{
     readonly savedCount: number;
     readonly hasAccountSuggestions: boolean;
@@ -39,8 +40,7 @@ export function SyncProgressStep() {
   const fetchStarted = useRef(false);
   const suggestionService = useMemo(() => createAccountSuggestionService(), []);
 
-  // Start fetch on mount if we have accounts
-  useMountEffect(() => {
+  const startSync = useCallback(() => {
     let isMounted = true;
     if (accounts.length > 0 && !fetchStarted.current && db && userId) {
       fetchStarted.current = true;
@@ -54,7 +54,12 @@ export function SyncProgressStep() {
           () => refreshTransactions(db, userId)
         );
         if (!isMounted) return;
-        if (outcome.status !== "completed") return;
+        if (outcome.status !== "completed") {
+          if (outcome.reason === "already_fetching") {
+            fetchStarted.current = false;
+          }
+          return;
+        }
         setSyncOutcome({
           savedCount: outcome.savedCount,
           hasAccountSuggestions:
@@ -72,7 +77,20 @@ export function SyncProgressStep() {
     return () => {
       isMounted = false;
     };
+  }, [accounts.length, db, suggestionService, userId]);
+
+  // Start fetch on mount if we have accounts.
+  useMountEffect(() => {
+    const cleanup = startSync();
+    return cleanup;
   });
+
+  useEffect(() => {
+    if (accounts.length === 0 || isFetching || fetchStarted.current || syncOutcome !== null) {
+      return undefined;
+    }
+    return startSync();
+  }, [accounts.length, isFetching, startSync, syncOutcome]);
 
   const livePercent = progress
     ? progress.total > 0

--- a/apps/mobile/features/onboarding/components/SyncProgressStep.tsx
+++ b/apps/mobile/features/onboarding/components/SyncProgressStep.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { createAccountSuggestionService } from "@/features/account-suggestions/public";
 import { useOptionalUserId } from "@/features/auth/public";
@@ -25,7 +25,6 @@ export function SyncProgressStep() {
 
   const accounts = useEmailCaptureStore((s) => s.accounts);
   const progress = useEmailCaptureStore((s) => s.progress);
-  const isFetching = useEmailCaptureStore((s) => s.isFetching);
   const [syncOutcome, setSyncOutcome] = useState<{
     readonly savedCount: number;
     readonly hasAccountSuggestions: boolean;
@@ -40,35 +39,58 @@ export function SyncProgressStep() {
   const fetchStarted = useRef(false);
   const suggestionService = useMemo(() => createAccountSuggestionService(), []);
 
-  const startSync = useCallback(() => {
+  const startSync = () => {
     let isMounted = true;
+    let resolveIdle: ((value: boolean) => void) | null = null;
+    let unsubscribeIdle: (() => void) | null = null;
+
+    const clearIdleWait = (shouldRetry: boolean) => {
+      unsubscribeIdle?.();
+      unsubscribeIdle = null;
+      resolveIdle?.(shouldRetry);
+      resolveIdle = null;
+    };
+
+    const waitForFetchIdle = () => {
+      if (!useEmailCaptureStore.getState().isFetching) return Promise.resolve(isMounted);
+
+      return new Promise<boolean>((resolve) => {
+        resolveIdle = resolve;
+        unsubscribeIdle = useEmailCaptureStore.subscribe((state) => {
+          if (state.isFetching) return;
+          clearIdleWait(isMounted);
+        });
+      });
+    };
+
     if (accounts.length > 0 && !fetchStarted.current && db && userId) {
       fetchStarted.current = true;
       trackOnboardingEvent("email_sync_start", { accountCount: accounts.length });
       void (async () => {
-        const outcome = await fetchAndProcessEmails(
-          db,
-          userId,
-          getGmailClientId(),
-          getOutlookClientId(),
-          () => refreshTransactions(db, userId)
-        );
-        if (!isMounted) return;
-        if (outcome.status !== "completed") {
-          if (outcome.reason === "already_fetching") {
-            fetchStarted.current = false;
+        while (isMounted) {
+          const outcome = await fetchAndProcessEmails(
+            db,
+            userId,
+            getGmailClientId(),
+            getOutlookClientId(),
+            () => refreshTransactions(db, userId)
+          );
+          if (!isMounted) return;
+          if (outcome.status === "completed") {
+            setSyncOutcome({
+              savedCount: outcome.savedCount,
+              hasAccountSuggestions:
+                suggestionService.listSuggestions({
+                  db,
+                  userId,
+                  limit: 2,
+                }).length > 0,
+            });
+            return;
           }
-          return;
+
+          if (outcome.reason !== "already_fetching" || !(await waitForFetchIdle())) return;
         }
-        setSyncOutcome({
-          savedCount: outcome.savedCount,
-          hasAccountSuggestions:
-            suggestionService.listSuggestions({
-              db,
-              userId,
-              limit: 2,
-            }).length > 0,
-        });
       })();
     } else if (accounts.length === 0) {
       logOnboardingEvent("email_sync_no_accounts");
@@ -76,21 +98,15 @@ export function SyncProgressStep() {
 
     return () => {
       isMounted = false;
+      clearIdleWait(false);
     };
-  }, [accounts.length, db, suggestionService, userId]);
+  };
 
   // Start fetch on mount if we have accounts.
   useMountEffect(() => {
     const cleanup = startSync();
     return cleanup;
   });
-
-  useEffect(() => {
-    if (accounts.length === 0 || isFetching || fetchStarted.current || syncOutcome !== null) {
-      return undefined;
-    }
-    return startSync();
-  }, [accounts.length, isFetching, startSync, syncOutcome]);
 
   const livePercent = progress
     ? progress.total > 0


### PR DESCRIPTION
- Graceful public parser

- Account-scoped fetch state

- Onboarding skip guard

- Local checks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened mobile email sync with a fail‑safe public parser, per‑account processing, accurate whole‑sync progress, and mount‑scoped auto‑retry in onboarding. Prevents crashes, reports correct totals, and only advances fetch times for accounts without failures.

- **Bug Fixes**
  - `parseEmailApi` now returns null on edge errors; added `retryableParseEmailApi` that throws to trigger pipeline retries, and switched the pipeline to use it.
  - Parser service supports `throwOnApiFailure`; `retryableParseEmailService` enables it.
  - Process emails per account, aggregate progress across accounts, and advance `lastFetchedAt` only for accounts with zero failures; run a single final retry after all accounts (no per‑account retries).
  - Fetch returns `{ status: "skipped" }` with reasons (`missing_context` | `already_fetching`); onboarding `SyncProgressStep` ignores skipped outcomes and retries while mounted when a prior run was in flight.

<sup>Written for commit 55de63d55aa7bec2108b86445b9b4f17738f7748. Summary will update on new commits. <a href="https://cubic.dev/pr/B4rz99/fidy/pull/371?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

