### PR TITLE
fix(mobile): respect safe areas

### DIFF
--- a/apps/mobile/app/(tabs)/(finance)/index.tsx
+++ b/apps/mobile/app/(tabs)/(finance)/index.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/features/calendar";
 import { useGoalStore } from "@/features/goals/hooks.public";
 import { GoalsListScreen } from "@/features/goals/ui.public";
+import { TAB_BAR_CLEARANCE } from "@/shared/components";
 import { Plus } from "@/shared/components/icons";
 import { Platform, Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
@@ -190,6 +191,7 @@ const styles = StyleSheet.create({
   calendarPanel: {
     flex: 1,
     paddingHorizontal: 16,
+    paddingBottom: TAB_BAR_CLEARANCE,
   },
   calendarGridWrap: {
     flex: 1,

--- a/apps/mobile/app/(tabs)/add.tsx
+++ b/apps/mobile/app/(tabs)/add.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from "expo-router";
+import { TAB_BAR_CLEARANCE } from "@/shared/components";
 import { ArrowLeftRight, type LucideIcon, Plus } from "@/shared/components/icons";
-import { Pressable, Text, View } from "@/shared/components/rn";
+import { Pressable, ScrollView, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 
 function AddEntryCard({
@@ -126,12 +127,19 @@ export default function AddEntryChooserScreen() {
   const accentGreenLight = useThemeColor("accentGreenLight");
 
   return (
-    <View
+    <ScrollView
+      contentInsetAdjustmentBehavior="automatic"
+      showsVerticalScrollIndicator={false}
       style={{
         flex: 1,
         backgroundColor: peachLight,
+      }}
+      contentContainerStyle={{
+        flexGrow: 1,
         justifyContent: "center",
         paddingHorizontal: 16,
+        paddingTop: 16,
+        paddingBottom: TAB_BAR_CLEARANCE + 16,
       }}
     >
       <View
@@ -224,6 +232,6 @@ export default function AddEntryChooserScreen() {
           </Text>
         </View>
       </View>
-    </View>
+    </ScrollView>
   );
 }

--- a/apps/mobile/app/auto-suggest-budgets.tsx
+++ b/apps/mobile/app/auto-suggest-budgets.tsx
@@ -1,4 +1,5 @@
 import { useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useOptionalUserId } from "@/features/auth/hooks.public";
 import {
   acceptBudgetSuggestions,
@@ -29,6 +30,7 @@ import {
 export default function AutoSuggestBudgetsScreen() {
   const { back } = useRouter();
   const { t, locale } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
   const userId = useOptionalUserId();
   const db = userId ? tryGetDb(userId) : null;
 
@@ -73,7 +75,8 @@ export default function AutoSuggestBudgetsScreen() {
     >
       <ScrollView
         style={[styles.container, { backgroundColor: cardBg }]}
-        contentContainerStyle={styles.scrollContent}
+        contentContainerStyle={[styles.scrollContent, { paddingBottom: bottom + 24 }]}
+        contentInsetAdjustmentBehavior="automatic"
         keyboardShouldPersistTaps="handled"
       >
         <Text style={[styles.title, { color: primaryColor }]}>

--- a/apps/mobile/app/connected-accounts.tsx
+++ b/apps/mobile/app/connected-accounts.tsx
@@ -1,5 +1,6 @@
 import { formatDistanceToNow } from "date-fns";
 import { useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Animated from "react-native-reanimated";
 import { useOptionalUserId } from "@/features/auth";
 import { ApplePaySetupCard, NotificationSetupCard } from "@/features/capture-sources";
@@ -20,6 +21,7 @@ import { getDateFnsLocale } from "@/shared/i18n";
 export default function ConnectedAccountsScreen() {
   const { back } = useRouter();
   const { t } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
   const userId = useOptionalUserId();
   const db = userId ? tryGetDb(userId) : null;
   const accounts = useEmailCaptureStore((s) => s.accounts);
@@ -32,7 +34,7 @@ export default function ConnectedAccountsScreen() {
     <ScreenLayout title={t("connectedAccounts.title")} variant="sub" onBack={() => back()}>
       <ScrollView
         contentInsetAdjustmentBehavior="automatic"
-        contentContainerStyle={{ paddingBottom: 40 }}
+        contentContainerStyle={{ paddingBottom: bottom + 40 }}
         className="flex-1 px-4"
       >
         <View style={{ gap: 24 }}>

--- a/apps/mobile/app/day-detail.tsx
+++ b/apps/mobile/app/day-detail.tsx
@@ -1,5 +1,6 @@
 import { format } from "date-fns";
 import { useLocalSearchParams, useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useOptionalUserId } from "@/features/auth";
 import {
   type BillPayment,
@@ -22,6 +23,7 @@ export default function DayDetailScreen() {
   const { date } = useLocalSearchParams<{ date: string }>();
   const router = useRouter();
   const { t, locale } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
   const bills = useCalendarStore((s) => s.bills);
   const payments = useCalendarStore((s) => s.payments);
   const userId = useOptionalUserId();
@@ -74,7 +76,8 @@ export default function DayDetailScreen() {
   return (
     <ScrollView
       style={[styles.container, { backgroundColor: cardBg }]}
-      contentContainerStyle={styles.content}
+      contentContainerStyle={[styles.content, { paddingBottom: bottom + 24 }]}
+      contentInsetAdjustmentBehavior="automatic"
     >
       <Text style={[styles.title, { color: primaryColor }]}>
         {format(dateObj, "EEEE, PP", { locale: getDateFnsLocale(locale) })}

--- a/apps/mobile/app/enable-notifications.tsx
+++ b/apps/mobile/app/enable-notifications.tsx
@@ -2,6 +2,7 @@ import * as Notifications from "expo-notifications";
 import { useRouter } from "expo-router";
 import * as SecureStore from "expo-secure-store";
 import { useState } from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useOptionalUserId } from "@/features/auth/hooks.public";
 import { PRE_PERMISSION_KEY, registerPushToken } from "@/features/notifications/hooks.public";
 import { Bell } from "@/shared/components/icons";
@@ -12,6 +13,7 @@ import { captureError } from "@/shared/lib";
 export default function EnableNotificationsSheet() {
   const { t } = useTranslation();
   const router = useRouter();
+  const { bottom } = useSafeAreaInsets();
   const userId = useOptionalUserId();
   const accentGreen = useThemeColor("accentGreen");
   const borderColor = useThemeColor("borderSubtle");
@@ -44,7 +46,13 @@ export default function EnableNotificationsSheet() {
   return (
     <ScrollView
       className="flex-1 bg-card dark:bg-card-dark"
-      contentContainerStyle={{ padding: 24, alignItems: "center", gap: 16 }}
+      contentContainerStyle={{
+        padding: 24,
+        paddingBottom: bottom + 24,
+        alignItems: "center",
+        gap: 16,
+      }}
+      contentInsetAdjustmentBehavior="automatic"
     >
       <View
         style={{

--- a/apps/mobile/app/failed-emails.tsx
+++ b/apps/mobile/app/failed-emails.tsx
@@ -2,6 +2,7 @@ import { FlashList } from "@shopify/flash-list";
 import { format } from "date-fns";
 import { useRouter } from "expo-router";
 import { useCallback } from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useOptionalUserId } from "@/features/auth";
 import {
   dismissFailedEmail,
@@ -20,6 +21,7 @@ const ItemSeparator = () => <View style={{ height: 10 }} />;
 export default function FailedEmailsScreen() {
   const { back, push } = useRouter();
   const { t } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
   const userId = useOptionalUserId();
   const db = userId ? tryGetDb(userId) : null;
   const failedEmails = useEmailCaptureStore((s) => s.failedEmails);
@@ -50,7 +52,7 @@ export default function FailedEmailsScreen() {
         keyExtractor={(item) => item.id}
         contentInsetAdjustmentBehavior="automatic"
         contentContainerStyle={{
-          paddingBottom: 40,
+          paddingBottom: bottom + 40,
           paddingHorizontal: 16,
         }}
         ItemSeparatorComponent={ItemSeparator}

--- a/apps/mobile/features/account-suggestions/components/AccountSuggestionReviewScreen.tsx
+++ b/apps/mobile/features/account-suggestions/components/AccountSuggestionReviewScreen.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from "expo-router";
 import { useMemo } from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useOptionalUserId } from "@/features/auth/public";
 import { ScreenLayout } from "@/shared/components";
 import { ScrollView, StyleSheet, Text, View } from "@/shared/components/rn";
@@ -13,6 +14,7 @@ import { AccountSuggestionCard } from "./AccountSuggestionCard";
 export function AccountSuggestionReviewScreen() {
   const router = useRouter();
   const { t } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
   const userId = useOptionalUserId();
   const db = userId ? tryGetDb(userId) : null;
   const { suggestions, hasLoadedSuggestions, reloadSuggestions } = useAccountSuggestions({
@@ -62,7 +64,7 @@ export function AccountSuggestionReviewScreen() {
     >
       <ScrollView
         contentInsetAdjustmentBehavior="automatic"
-        contentContainerStyle={styles.content}
+        contentContainerStyle={[styles.content, { paddingBottom: bottom + 32 }]}
         showsVerticalScrollIndicator={false}
       >
         <Text style={[styles.subtitle, { color: secondary }]}>

--- a/apps/mobile/features/account-suggestions/components/CreateSuggestedAccountScreen.tsx
+++ b/apps/mobile/features/account-suggestions/components/CreateSuggestedAccountScreen.tsx
@@ -1,5 +1,6 @@
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useMemo, useState } from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useOptionalUserId } from "@/features/auth/public";
 import type { FinancialAccountKind } from "@/features/financial-accounts/public";
 import { useOnboardingStore } from "@/features/onboarding/store";
@@ -33,6 +34,7 @@ function ResolvedCreateSuggestedAccountForm({
 }) {
   const { back } = useRouter();
   const { t } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
   const onboardingStep = useOnboardingStore((state) => state.step);
   const nextStep = useOnboardingStore((state) => state.nextStep);
   const service = useMemo(() => createAccountSuggestionService(), []);
@@ -82,7 +84,7 @@ function ResolvedCreateSuggestedAccountForm({
     <ScreenLayout title={t("accountSuggestions.create.title")} variant="sub" onBack={back}>
       <ScrollView
         contentInsetAdjustmentBehavior="automatic"
-        contentContainerStyle={styles.scrollContent}
+        contentContainerStyle={[styles.scrollContent, { paddingBottom: bottom + 32 }]}
         keyboardShouldPersistTaps="handled"
       >
         <Text style={[styles.subtitle, { color: secondary }]}>

--- a/apps/mobile/features/account-suggestions/components/LinkSuggestedAccountScreen.tsx
+++ b/apps/mobile/features/account-suggestions/components/LinkSuggestedAccountScreen.tsx
@@ -1,5 +1,6 @@
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useMemo } from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useOptionalUserId } from "@/features/auth/public";
 import { getFinancialAccountsForUser } from "@/features/financial-accounts/public";
 import { useOnboardingStore } from "@/features/onboarding/store";
@@ -51,6 +52,7 @@ export default function LinkSuggestedAccountScreen() {
   const { back } = useRouter();
   const { fingerprint } = useLocalSearchParams<{ fingerprint?: string }>();
   const { t } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
   const userId = useOptionalUserId();
   const db = userId ? tryGetDb(userId) : null;
   const onboardingStep = useOnboardingStore((state) => state.step);
@@ -107,7 +109,10 @@ export default function LinkSuggestedAccountScreen() {
 
   return (
     <ScreenLayout title={t("accountSuggestions.link.title")} variant="sub" onBack={back}>
-      <ScrollView contentInsetAdjustmentBehavior="automatic" contentContainerStyle={styles.content}>
+      <ScrollView
+        contentInsetAdjustmentBehavior="automatic"
+        contentContainerStyle={[styles.content, { paddingBottom: bottom + 32 }]}
+      >
         <Text style={[styles.subtitle, { color: secondary }]}>
           {t("accountSuggestions.link.subtitle")}
         </Text>

--- a/apps/mobile/features/account-suggestions/components/OnboardingAccountReviewStep.tsx
+++ b/apps/mobile/features/account-suggestions/components/OnboardingAccountReviewStep.tsx
@@ -3,7 +3,7 @@ import { useRef, useState } from "react";
 import { useOptionalUserId } from "@/features/auth/public";
 import { trackOnboardingEvent } from "@/features/onboarding/lib/telemetry";
 import { useOnboardingStore } from "@/features/onboarding/store";
-import { Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { useAccountSuggestions } from "../hooks/use-account-suggestions";
@@ -35,7 +35,12 @@ export function OnboardingAccountReviewStep() {
 
   return (
     <View style={styles.container}>
-      <View style={styles.content}>
+      <ScrollView
+        style={styles.scrollArea}
+        contentContainerStyle={styles.content}
+        contentInsetAdjustmentBehavior="automatic"
+        showsVerticalScrollIndicator={false}
+      >
         <Text style={[styles.eyebrow, { color: accentGreen }]}>
           {t("accountSuggestions.onboarding.eyebrow")}
         </Text>
@@ -106,7 +111,7 @@ export function OnboardingAccountReviewStep() {
             />
           ))}
         </View>
-      </View>
+      </ScrollView>
 
       <Pressable
         style={[styles.continueButton, { backgroundColor: accentGreen }]}
@@ -136,6 +141,9 @@ const styles = StyleSheet.create({
   },
   content: {
     gap: 12,
+  },
+  scrollArea: {
+    flex: 1,
   },
   eyebrow: {
     fontFamily: "Poppins_700Bold",

--- a/apps/mobile/features/ai-chat/components/StarterSuggestions.tsx
+++ b/apps/mobile/features/ai-chat/components/StarterSuggestions.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { Sparkles } from "@/shared/components/icons";
-import { Pressable, Text, View } from "@/shared/components/rn";
+import { Pressable, ScrollView, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 
 type StarterSuggestionsProps = {
@@ -23,14 +23,17 @@ export function StarterSuggestions({ onSelect }: StarterSuggestionsProps) {
   );
 
   return (
-    <View
-      style={{
-        flex: 1,
+    <ScrollView
+      contentContainerStyle={{
+        flexGrow: 1,
         alignItems: "center",
         justifyContent: "center",
         paddingHorizontal: 32,
+        paddingVertical: 24,
         gap: 24,
       }}
+      contentInsetAdjustmentBehavior="automatic"
+      showsVerticalScrollIndicator={false}
     >
       <View style={{ alignItems: "center", gap: 8 }}>
         <View
@@ -74,6 +77,6 @@ export function StarterSuggestions({ onSelect }: StarterSuggestionsProps) {
           </Pressable>
         ))}
       </View>
-    </View>
+    </ScrollView>
   );
 }

--- a/apps/mobile/features/analytics/components/AnalyticsScreen.tsx
+++ b/apps/mobile/features/analytics/components/AnalyticsScreen.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback } from "react";
 import { useOptionalUserId } from "@/features/auth/public";
+import { TAB_BAR_CLEARANCE } from "@/shared/components";
 import type { ViewStyle } from "@/shared/components/rn";
 import { Pressable, ScrollView, StyleSheet, Text, View } from "@/shared/components/rn";
 import { getDb } from "@/shared/db";
@@ -12,6 +13,7 @@ import { IncomeExpenseCard } from "./IncomeExpenseCard";
 import { PeriodDeltaCard } from "./PeriodDeltaCard";
 
 const PERIODS: readonly AnalyticsPeriod[] = ["W", "M", "Q", "Y"];
+const ANALYTICS_CONTENT_PADDING = 16;
 
 type PeriodSelectorProps = {
   readonly activePeriod: AnalyticsPeriod;
@@ -86,7 +88,11 @@ export function AnalyticsScreen() {
   return (
     <ScrollView
       style={[styles.scrollView, scrollBg]}
-      contentContainerStyle={styles.contentContainer}
+      contentContainerStyle={[
+        styles.contentContainer,
+        { paddingBottom: ANALYTICS_CONTENT_PADDING + TAB_BAR_CLEARANCE },
+      ]}
+      contentInsetAdjustmentBehavior="automatic"
       showsVerticalScrollIndicator={false}
     >
       <PeriodSelector activePeriod={period} onSelect={handleSelectPeriod} />
@@ -111,7 +117,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   contentContainer: {
-    padding: 16,
+    padding: ANALYTICS_CONTENT_PADDING,
     gap: 16,
   },
   selectorContainer: {

--- a/apps/mobile/features/budget/components/create-budget/CreateBudgetFormContent.tsx
+++ b/apps/mobile/features/budget/components/create-budget/CreateBudgetFormContent.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Animated from "react-native-reanimated";
 import { CategoryPill } from "@/features/transactions/display.public";
 import { CATEGORIES, type CategoryId } from "@/shared/categories";
@@ -54,6 +55,7 @@ export function CreateBudgetFormContent({
   setCategory,
 }: CreateBudgetFormContentProps) {
   const { t, locale } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
   const { cursorStyle } = useBlinkingCursor();
   const accentGreen = useThemeColor("accentGreen");
   const accentRed = useThemeColor("accentRed");
@@ -77,7 +79,8 @@ export function CreateBudgetFormContent({
   return (
     <ScrollView
       style={[styles.container, { backgroundColor: cardBg }]}
-      contentContainerStyle={styles.scrollContent}
+      contentContainerStyle={[styles.scrollContent, { paddingBottom: bottom + 24 }]}
+      contentInsetAdjustmentBehavior="automatic"
     >
       <Text style={[styles.title, { color: primaryColor }]}>
         {isEdit ? t("budgets.edit.title") : t("budgets.create.title")}

--- a/apps/mobile/features/calendar/components/add-bill/AddBillFormContent.tsx
+++ b/apps/mobile/features/calendar/components/add-bill/AddBillFormContent.tsx
@@ -1,4 +1,5 @@
 import DateTimePicker from "@react-native-community/datetimepicker";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { CATEGORIES, type CategoryId } from "@/shared/categories";
 import {
   KeyboardAvoidingView,
@@ -50,6 +51,7 @@ export function AddBillFormContent({
   startDate,
 }: AddBillFormContentProps) {
   const { t, locale } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
   const accentGreen = useThemeColor("accentGreen");
   const borderColor = useThemeColor("borderSubtle");
   const cardBg = useThemeColor("card");
@@ -64,7 +66,8 @@ export function AddBillFormContent({
     >
       <ScrollView
         style={[styles.container, { backgroundColor: cardBg }]}
-        contentContainerStyle={styles.content}
+        contentContainerStyle={[styles.content, { paddingBottom: bottom + 24 }]}
+        contentInsetAdjustmentBehavior="automatic"
         keyboardShouldPersistTaps="handled"
       >
         <Text style={[styles.title, { color: primaryColor }]}>

--- a/apps/mobile/features/categories/components/CategoriesScreen.tsx
+++ b/apps/mobile/features/categories/components/CategoriesScreen.tsx
@@ -75,6 +75,7 @@ export function CategoriesScreen() {
       <ScrollView
         className="flex-1"
         contentContainerStyle={styles.scrollContent}
+        contentInsetAdjustmentBehavior="automatic"
         showsVerticalScrollIndicator={false}
       >
         {/* Built-in categories */}

--- a/apps/mobile/features/categories/components/category-sheet/CreateCategorySheetContent.tsx
+++ b/apps/mobile/features/categories/components/category-sheet/CreateCategorySheetContent.tsx
@@ -1,4 +1,5 @@
 import { Keyboard } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Pressable, ScrollView, Text, TextInput, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { MAX_NAME_LENGTH } from "../../lib/constants";
@@ -21,6 +22,7 @@ export function CreateCategorySheetContent({
   trimmedName,
 }: CreateCategorySheetViewModel) {
   const { t } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
   const accentGreen = useThemeColor("accentGreen");
   const borderColor = useThemeColor("borderSubtle");
   const cardBg = useThemeColor("card");
@@ -32,7 +34,8 @@ export function CreateCategorySheetContent({
   return (
     <ScrollView
       style={[styles.container, { backgroundColor: pageBg }]}
-      contentContainerStyle={styles.scrollContent}
+      contentContainerStyle={[styles.scrollContent, { paddingBottom: bottom + 24 }]}
+      contentInsetAdjustmentBehavior="automatic"
       keyboardShouldPersistTaps="handled"
       keyboardDismissMode="interactive"
       automaticallyAdjustKeyboardInsets

--- a/apps/mobile/features/financial-accounts/components/FinancialAccountIdentifierSheet.tsx
+++ b/apps/mobile/features/financial-accounts/components/FinancialAccountIdentifierSheet.tsx
@@ -1,5 +1,6 @@
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useState } from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useOptionalUserId } from "@/features/auth/public";
 import { createFinancialAccountManagementService } from "@/features/financial-accounts/lib/management-service";
 import { parseFinancialAccountRouteParam } from "@/features/financial-accounts/lib/route-params";
@@ -17,6 +18,7 @@ export function FinancialAccountIdentifierSheet() {
   const { accountId: rawAccountId } = useLocalSearchParams<{ accountId?: string }>();
   const accountId = parseFinancialAccountRouteParam(rawAccountId);
   const { t } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
   const userId = useOptionalUserId();
   const db = userId ? tryGetDb(userId) : null;
   const primary = useThemeColor("primary");
@@ -78,7 +80,7 @@ export function FinancialAccountIdentifierSheet() {
     <ScreenLayout title={t("financialAccounts.identifierSheet.title")} variant="sub" onBack={back}>
       <ScrollView
         contentInsetAdjustmentBehavior="automatic"
-        contentContainerStyle={styles.content}
+        contentContainerStyle={[styles.content, { paddingBottom: bottom + 32 }]}
         keyboardShouldPersistTaps="handled"
       >
         <Text style={[styles.subtitle, { color: secondary }]}>

--- a/apps/mobile/features/financial-accounts/components/financial-account-details-screen/FinancialAccountDetailsScreenContent.tsx
+++ b/apps/mobile/features/financial-accounts/components/financial-account-details-screen/FinancialAccountDetailsScreenContent.tsx
@@ -1,3 +1,4 @@
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { ScreenLayout } from "@/shared/components";
 import { TriangleAlert } from "@/shared/components/icons";
 import { Pressable, ScrollView, Text, View } from "@/shared/components/rn";
@@ -30,6 +31,7 @@ export function FinancialAccountDetailsScreenContent({
   const secondary = useThemeColor("secondary");
   const accentRed = useThemeColor("accentRed");
   const accentGreen = useThemeColor("accentGreen");
+  const { bottom } = useSafeAreaInsets();
 
   if (!accountId || !details || !kind) {
     return (
@@ -55,7 +57,7 @@ export function FinancialAccountDetailsScreenContent({
     <ScreenLayout title={t("financialAccounts.detail.title")} variant="sub" onBack={onBack}>
       <ScrollView
         contentInsetAdjustmentBehavior="automatic"
-        contentContainerStyle={styles.content}
+        contentContainerStyle={[styles.content, { paddingBottom: bottom + 32 }]}
         showsVerticalScrollIndicator={false}
       >
         <FinancialAccountDetailsHero

--- a/apps/mobile/features/financial-accounts/components/financial-account-form/FinancialAccountFormBody.tsx
+++ b/apps/mobile/features/financial-accounts/components/financial-account-form/FinancialAccountFormBody.tsx
@@ -1,7 +1,8 @@
 import DateTimePicker from "@react-native-community/datetimepicker";
 import { format } from "date-fns";
-import { X } from "@/shared/components/icons";
 import { useState } from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { X } from "@/shared/components/icons";
 import {
   Keyboard,
   Platform,
@@ -35,6 +36,7 @@ export function FinancialAccountFormBody({
   readonly onManageIdentifiers: (() => void) | null;
 }) {
   const { t, locale } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
   const [datePickerFallback] = useState(() => new Date());
   const primary = useThemeColor("primary");
   const secondary = useThemeColor("secondary");
@@ -70,7 +72,7 @@ export function FinancialAccountFormBody({
   return (
     <ScrollView
       contentInsetAdjustmentBehavior="automatic"
-      contentContainerStyle={styles.content}
+      contentContainerStyle={[styles.content, { paddingBottom: bottom + 32 }]}
       keyboardShouldPersistTaps="handled"
       showsVerticalScrollIndicator={false}
     >

--- a/apps/mobile/features/financial-accounts/components/financial-accounts-screen/FinancialAccountsScreenContent.tsx
+++ b/apps/mobile/features/financial-accounts/components/financial-accounts-screen/FinancialAccountsScreenContent.tsx
@@ -1,3 +1,4 @@
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { ScreenLayout } from "@/shared/components";
 import { Plus } from "@/shared/components/icons";
 import { Pressable, ScrollView, Text, View } from "@/shared/components/rn";
@@ -23,13 +24,14 @@ export function FinancialAccountsScreenContent({
   const primary = useThemeColor("primary");
   const secondary = useThemeColor("secondary");
   const accentGreen = useThemeColor("accentGreen");
+  const { bottom } = useSafeAreaInsets();
   const hasItems = regularAccounts.length + creditCardAccounts.length > 0;
 
   return (
     <ScreenLayout title={t("financialAccounts.list.title")} variant="sub" onBack={onBack}>
       <ScrollView
         contentInsetAdjustmentBehavior="automatic"
-        contentContainerStyle={styles.content}
+        contentContainerStyle={[styles.content, { paddingBottom: bottom + 32 }]}
         showsVerticalScrollIndicator={false}
       >
         <Text style={[styles.subtitle, { color: secondary }]}>

--- a/apps/mobile/features/goals/components/AddPaymentSheet.tsx
+++ b/apps/mobile/features/goals/components/AddPaymentSheet.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from "expo-router";
 import { useCallback, useRef, useState } from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Animated from "react-native-reanimated";
 import { useOptionalUserId } from "@/features/auth/public";
 import { handleNumpadPress } from "@/features/transactions/display.public";
@@ -21,6 +22,7 @@ import { addContribution, useGoalStore } from "../store";
 export function AddPaymentSheet() {
   const { back } = useRouter();
   const { t } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
 
   const selectedGoalId = useGoalStore((s) => s.selectedGoalId);
   const userId = useOptionalUserId();
@@ -76,7 +78,8 @@ export function AddPaymentSheet() {
   return (
     <ScrollView
       style={[styles.container, { backgroundColor: cardBg }]}
-      contentContainerStyle={styles.scrollContent}
+      contentContainerStyle={[styles.scrollContent, { paddingBottom: bottom + 24 }]}
+      contentInsetAdjustmentBehavior="automatic"
       keyboardShouldPersistTaps="handled"
     >
       {/* Grab bar */}

--- a/apps/mobile/features/goals/components/goal-detail/GoalDetailContent.tsx
+++ b/apps/mobile/features/goals/components/goal-detail/GoalDetailContent.tsx
@@ -1,3 +1,4 @@
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { ScrollView, View } from "@/shared/components/rn";
 import { useThemeColor } from "@/shared/hooks";
 import type { GoalProjection, Milestone } from "../../lib/derive";
@@ -27,11 +28,12 @@ export function GoalDetailContent(props: {
   readonly targetAmount: number;
 }) {
   const pageBg = useThemeColor("page");
+  const { bottom } = useSafeAreaInsets();
 
   return (
     <View style={[styles.container, { backgroundColor: pageBg }]}>
       <ScrollView
-        contentContainerStyle={styles.scrollContent}
+        contentContainerStyle={[styles.scrollContent, { paddingBottom: bottom + 32 }]}
         showsVerticalScrollIndicator={false}
         contentInsetAdjustmentBehavior="automatic"
       >

--- a/apps/mobile/features/goals/components/goal-sheet/GoalSheetFrame.tsx
+++ b/apps/mobile/features/goals/components/goal-sheet/GoalSheetFrame.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { FidyNumpad } from "@/shared/components";
 import { ScrollView, Text, View } from "@/shared/components/rn";
 import { useThemeColor } from "@/shared/hooks";
@@ -20,11 +21,13 @@ export function GoalSheetFrame({
   const card = useThemeColor("card");
   const borderSubtle = useThemeColor("borderSubtle");
   const primary = useThemeColor("primary");
+  const { bottom } = useSafeAreaInsets();
 
   return (
     <ScrollView
       style={[styles.container, { backgroundColor: card }]}
-      contentContainerStyle={styles.scrollContent}
+      contentContainerStyle={[styles.scrollContent, { paddingBottom: bottom + 24 }]}
+      contentInsetAdjustmentBehavior="automatic"
       keyboardShouldPersistTaps="handled"
     >
       <View style={[styles.grabBar, { backgroundColor: borderSubtle }]} />

--- a/apps/mobile/features/qa/components/qa-tools/QaToolsContent.tsx
+++ b/apps/mobile/features/qa/components/qa-tools/QaToolsContent.tsx
@@ -1,3 +1,4 @@
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { ActivityIndicator, Pressable, ScrollView, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { FLAG_KEYS, QA_PROFILES, QA_TARGET_LABEL_KEYS, QA_TARGET_LIST } from "./QaTools.constants";
@@ -12,6 +13,7 @@ type QaToolsContentProps = {
 
 export function QaToolsContent({ qaTools }: QaToolsContentProps) {
   const { t } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
   const primary = useThemeColor("primary");
   const secondary = useThemeColor("secondary");
   const borderSubtle = useThemeColor("borderSubtle");
@@ -19,7 +21,10 @@ export function QaToolsContent({ qaTools }: QaToolsContentProps) {
   const accentGreen = useThemeColor("accentGreen");
 
   return (
-    <ScrollView contentContainerStyle={styles.scrollContent}>
+    <ScrollView
+      contentContainerStyle={[styles.scrollContent, { paddingBottom: bottom + 24 }]}
+      contentInsetAdjustmentBehavior="automatic"
+    >
       <View style={styles.statusBlock}>
         <Text style={[styles.subtitleText, { color: secondary }]}>{t("qaTools.subtitle")}</Text>
         <Text style={[styles.primaryValueText, { color: primary }]}>

--- a/apps/mobile/features/review-queues/components/AttributionQueueScreen.tsx
+++ b/apps/mobile/features/review-queues/components/AttributionQueueScreen.tsx
@@ -1,6 +1,7 @@
 import { FlashList } from "@shopify/flash-list";
 import { useRouter } from "expo-router";
 import { useState } from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useOptionalUserId } from "@/features/auth/public";
 import { refreshTransactions } from "@/features/transactions/store.public";
 import { ScreenLayout } from "@/shared/components";
@@ -104,6 +105,7 @@ function AttributionQueueCard({
 export function AttributionQueueScreen() {
   const router = useRouter();
   const { t } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
   const userId = useOptionalUserId();
   const db = userId ? tryGetDb(userId) : null;
   const { items, hasLoadedQueue, reloadQueue, service } = useAttributionReviewQueue({ db, userId });
@@ -148,7 +150,8 @@ export function AttributionQueueScreen() {
         <FlashList
           data={visibleItems}
           keyExtractor={(item) => item.transaction.id}
-          contentContainerStyle={styles.listContent}
+          contentContainerStyle={[styles.listContent, { paddingBottom: bottom + 28 }]}
+          contentInsetAdjustmentBehavior="automatic"
           ItemSeparatorComponent={() => <View style={{ height: 14 }} />}
           ListHeaderComponent={
             <SummaryCard

--- a/apps/mobile/features/review-queues/components/AttributionReviewScreen.tsx
+++ b/apps/mobile/features/review-queues/components/AttributionReviewScreen.tsx
@@ -1,11 +1,12 @@
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useMemo } from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useOptionalUserId } from "@/features/auth/public";
 import { readFinancialAccountKind } from "@/features/financial-accounts/lib/kind";
 import { refreshTransactions } from "@/features/transactions/store.public";
 import { ScreenLayout } from "@/shared/components";
 import { Info, TriangleAlert } from "@/shared/components/icons";
-import { StyleSheet, Text, View } from "@/shared/components/rn";
+import { ScrollView, StyleSheet, Text, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
 import { useAsyncGuard, useThemeColor, useTranslation } from "@/shared/hooks";
 import { formatSignedMoney, showErrorToast } from "@/shared/lib";
@@ -18,6 +19,7 @@ export function AttributionReviewScreen() {
   const router = useRouter();
   const { transactionId } = useLocalSearchParams<{ transactionId?: string }>();
   const { t } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
   const userId = useOptionalUserId();
   const db = userId ? tryGetDb(userId) : null;
   const { items, hasLoadedQueue, service } = useAttributionReviewQueue({ db, userId });
@@ -26,7 +28,7 @@ export function AttributionReviewScreen() {
     typeof transactionId === "string" && transactionId.trim().length > 0
       ? requireTransactionId(transactionId.trim())
       : null;
-  const item = useMemo(
+  const reviewItem = useMemo(
     () =>
       resolvedTransactionId
         ? (items.find((entry) => entry.transaction.id === resolvedTransactionId) ?? null)
@@ -37,7 +39,7 @@ export function AttributionReviewScreen() {
   const secondary = useThemeColor("secondary");
   const accentRed = useThemeColor("accentRed");
 
-  if (hasLoadedQueue && item == null) {
+  if (hasLoadedQueue && reviewItem == null) {
     return (
       <ScreenLayout
         title={t("attributionReview.reviewTitle")}
@@ -52,14 +54,14 @@ export function AttributionReviewScreen() {
     );
   }
 
-  if (!item) {
+  if (!reviewItem) {
     return null;
   }
 
-  const CurrentIcon = item.currentAccount
-    ? getFinancialAccountKindIcon(item.currentAccount.kind)
+  const CurrentIcon = reviewItem.currentAccount
+    ? getFinancialAccountKindIcon(reviewItem.currentAccount.kind)
     : TriangleAlert;
-  const SuggestedIcon = getFinancialAccountKindIcon(item.suggestedAccount.kind);
+  const SuggestedIcon = getFinancialAccountKindIcon(reviewItem.suggestedAccount.kind);
 
   const handleConfirm = () => {
     void guardedAction(async () => {
@@ -71,7 +73,7 @@ export function AttributionReviewScreen() {
         const result = service.confirmSuggestedOwner({
           db,
           userId,
-          transactionId: item.transaction.id,
+          transactionId: reviewItem.transaction.id,
         });
 
         if (!result.success) {
@@ -93,7 +95,11 @@ export function AttributionReviewScreen() {
       variant="sub"
       onBack={() => router.back()}
     >
-      <View style={styles.container}>
+      <ScrollView
+        contentContainerStyle={[styles.container, { paddingBottom: bottom + 28 }]}
+        contentInsetAdjustmentBehavior="automatic"
+        showsVerticalScrollIndicator={false}
+      >
         <SummaryCard
           icon={TriangleAlert}
           title={t("attributionReview.reviewPill")}
@@ -103,19 +109,21 @@ export function AttributionReviewScreen() {
 
         <View style={styles.headerCopy}>
           <Text style={[styles.title, { color: primary }]}>
-            {item.transaction.description || t("common.unknown")}
+            {reviewItem.transaction.description || t("common.unknown")}
           </Text>
           <Text style={[styles.amount, { color: accentRed }]}>
-            {formatSignedMoney(item.transaction.amount, item.transaction.type)}
+            {formatSignedMoney(reviewItem.transaction.amount, reviewItem.transaction.type)}
           </Text>
         </View>
 
         <DetailRow
           label={t("attributionReview.currentOwner")}
-          title={item.currentAccount?.name ?? t("common.unknown")}
+          title={reviewItem.currentAccount?.name ?? t("common.unknown")}
           subtitle={
-            item.currentAccount
-              ? t(`financialAccounts.kinds.${readFinancialAccountKind(item.currentAccount.kind)}`)
+            reviewItem.currentAccount
+              ? t(
+                  `financialAccounts.kinds.${readFinancialAccountKind(reviewItem.currentAccount.kind)}`
+                )
               : t("attributionReview.fallbackOwner")
           }
           icon={<CurrentIcon size={18} color={secondary} />}
@@ -123,8 +131,8 @@ export function AttributionReviewScreen() {
 
         <DetailRow
           label={t("attributionReview.suggestedOwner")}
-          title={item.suggestedAccount.name}
-          subtitle={item.evidenceLabel ?? t("attributionReview.suggestedByEvidence")}
+          title={reviewItem.suggestedAccount.name}
+          subtitle={reviewItem.evidenceLabel ?? t("attributionReview.suggestedByEvidence")}
           icon={<SuggestedIcon size={18} color={secondary} />}
           emphasis="green"
         />
@@ -140,7 +148,7 @@ export function AttributionReviewScreen() {
             onPress={() =>
               router.push({
                 pathname: "/create-financial-account",
-                params: { fingerprint: item.suggestion.fingerprint },
+                params: { fingerprint: reviewItem.suggestion.fingerprint },
               })
             }
             variant="outline"
@@ -160,16 +168,14 @@ export function AttributionReviewScreen() {
             {t("attributionReview.balanceHint")}
           </Text>
         </View>
-      </View>
+      </ScrollView>
     </ScreenLayout>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
     paddingHorizontal: 16,
-    paddingBottom: 28,
     gap: 16,
   },
   headerCopy: {

--- a/apps/mobile/features/review-queues/components/FinancialMeaningQueueScreen.tsx
+++ b/apps/mobile/features/review-queues/components/FinancialMeaningQueueScreen.tsx
@@ -2,6 +2,7 @@ import { FlashList } from "@shopify/flash-list";
 import { format } from "date-fns";
 import { useRouter } from "expo-router";
 import { useState } from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useOptionalUserId } from "@/features/auth/public";
 import {
   dismissFinancialMeaningReview,
@@ -104,6 +105,7 @@ function FinancialMeaningQueueCard({
 export function FinancialMeaningQueueScreen() {
   const router = useRouter();
   const { t } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
   const userId = useOptionalUserId();
   const db = userId ? tryGetDb(userId) : null;
   const { items, hasLoadedQueue, reloadQueue } = useFinancialMeaningReviewQueue({ db, userId });
@@ -144,7 +146,8 @@ export function FinancialMeaningQueueScreen() {
         <FlashList
           data={visibleItems}
           keyExtractor={(item) => item.processedEmail.id}
-          contentContainerStyle={styles.listContent}
+          contentContainerStyle={[styles.listContent, { paddingBottom: bottom + 28 }]}
+          contentInsetAdjustmentBehavior="automatic"
           ItemSeparatorComponent={() => <View style={{ height: 14 }} />}
           ListHeaderComponent={
             <SummaryCard

--- a/apps/mobile/features/review-queues/components/FinancialMeaningReviewScreen.tsx
+++ b/apps/mobile/features/review-queues/components/FinancialMeaningReviewScreen.tsx
@@ -1,6 +1,7 @@
 import { format } from "date-fns";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useMemo } from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useOptionalUserId } from "@/features/auth/public";
 import {
   dismissFinancialMeaningReview,
@@ -10,7 +11,7 @@ import {
 import { refreshTransactions } from "@/features/transactions/store.public";
 import { ScreenLayout } from "@/shared/components";
 import { ArrowLeftRight, TriangleAlert } from "@/shared/components/icons";
-import { StyleSheet, Text, View } from "@/shared/components/rn";
+import { ScrollView, StyleSheet, Text, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
 import { useAsyncGuard, useThemeColor, useTranslation } from "@/shared/hooks";
 import { getDateFnsLocale } from "@/shared/i18n";
@@ -23,6 +24,7 @@ export function FinancialMeaningReviewScreen() {
   const router = useRouter();
   const { processedEmailId } = useLocalSearchParams<{ processedEmailId?: string }>();
   const { t, locale } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
   const userId = useOptionalUserId();
   const db = userId ? tryGetDb(userId) : null;
   const { items, hasLoadedQueue } = useFinancialMeaningReviewQueue({ db, userId });
@@ -31,7 +33,7 @@ export function FinancialMeaningReviewScreen() {
     typeof processedEmailId === "string" && processedEmailId.trim().length > 0
       ? requireProcessedEmailId(processedEmailId.trim())
       : null;
-  const item = useMemo(
+  const reviewItem = useMemo(
     () =>
       resolvedProcessedEmailId
         ? (items.find((entry) => entry.processedEmail.id === resolvedProcessedEmailId) ?? null)
@@ -46,7 +48,7 @@ export function FinancialMeaningReviewScreen() {
   const accentRed = useThemeColor("accentRed");
   const accentGreen = useThemeColor("accentGreen");
 
-  if (hasLoadedQueue && item == null) {
+  if (hasLoadedQueue && reviewItem == null) {
     return (
       <ScreenLayout
         title={t("financialMeaningReview.reviewTitle")}
@@ -61,7 +63,7 @@ export function FinancialMeaningReviewScreen() {
     );
   }
 
-  if (!item) {
+  if (!reviewItem) {
     return null;
   }
 
@@ -72,7 +74,7 @@ export function FinancialMeaningReviewScreen() {
       }
 
       try {
-        await resolveFinancialMeaningReview(db, item.processedEmail.id);
+        await resolveFinancialMeaningReview(db, reviewItem.processedEmail.id);
         await loadNeedsReviewEmails(db, userId);
         await refreshTransactions(db, userId);
         router.replace("/needs-review");
@@ -89,7 +91,7 @@ export function FinancialMeaningReviewScreen() {
       }
 
       try {
-        await dismissFinancialMeaningReview(db, item.processedEmail.id);
+        await dismissFinancialMeaningReview(db, reviewItem.processedEmail.id);
         await loadNeedsReviewEmails(db, userId);
         await refreshTransactions(db, userId);
         router.replace("/needs-review");
@@ -105,7 +107,11 @@ export function FinancialMeaningReviewScreen() {
       variant="sub"
       onBack={() => router.back()}
     >
-      <View style={styles.container}>
+      <ScrollView
+        contentContainerStyle={[styles.container, { paddingBottom: bottom + 28 }]}
+        contentInsetAdjustmentBehavior="automatic"
+        showsVerticalScrollIndicator={false}
+      >
         <SummaryCard
           icon={TriangleAlert}
           title={t("financialMeaningReview.reviewPill")}
@@ -113,25 +119,27 @@ export function FinancialMeaningReviewScreen() {
         />
 
         <View style={[styles.card, { backgroundColor: card, borderColor: borderSubtle }]}>
-          <Text style={[styles.metaLabel, { color: tertiary }]}>{item.processedEmail.subject}</Text>
+          <Text style={[styles.metaLabel, { color: tertiary }]}>
+            {reviewItem.processedEmail.subject}
+          </Text>
           <View style={styles.titleRow}>
             <View style={styles.titleWrap}>
               <Text style={[styles.title, { color: primary }]}>
-                {item.transaction.description || t("common.unknown")}
+                {reviewItem.transaction.description || t("common.unknown")}
               </Text>
               <Text style={[styles.subtitle, { color: secondary }]}>
-                {format(item.transaction.date, "PP", { locale: getDateFnsLocale(locale) })}
+                {format(reviewItem.transaction.date, "PP", { locale: getDateFnsLocale(locale) })}
               </Text>
             </View>
             <Text
               style={[
                 styles.amount,
                 {
-                  color: item.transaction.type === "income" ? accentGreen : accentRed,
+                  color: reviewItem.transaction.type === "income" ? accentGreen : accentRed,
                 },
               ]}
             >
-              {formatSignedMoney(item.transaction.amount, item.transaction.type)}
+              {formatSignedMoney(reviewItem.transaction.amount, reviewItem.transaction.type)}
             </Text>
           </View>
 
@@ -162,8 +170,8 @@ export function FinancialMeaningReviewScreen() {
               router.push({
                 pathname: "/reclassify-transaction",
                 params: {
-                  transactionId: item.transaction.id,
-                  processedEmailId: item.processedEmail.id,
+                  transactionId: reviewItem.transaction.id,
+                  processedEmailId: reviewItem.processedEmail.id,
                 },
               } as never)
             }
@@ -184,16 +192,14 @@ export function FinancialMeaningReviewScreen() {
             {t("financialMeaningReview.transferExplanation")}
           </Text>
         </View>
-      </View>
+      </ScrollView>
     </ScreenLayout>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
     paddingHorizontal: 16,
-    paddingBottom: 28,
     gap: 16,
   },
   card: {

--- a/apps/mobile/features/search/components/search-screen/SearchResultsList.tsx
+++ b/apps/mobile/features/search/components/search-screen/SearchResultsList.tsx
@@ -78,6 +78,7 @@ export function SearchResultsList({
         hasActiveFilters(filters) ? <SearchEmptyState onClearFilters={handleClearAll} /> : undefined
       }
       showsVerticalScrollIndicator={false}
+      contentInsetAdjustmentBehavior="automatic"
       contentContainerStyle={{ paddingBottom: TAB_BAR_CLEARANCE }}
     />
   );

--- a/apps/mobile/features/settings/components/NotificationPreferencesScreen.tsx
+++ b/apps/mobile/features/settings/components/NotificationPreferencesScreen.tsx
@@ -1,4 +1,5 @@
 import { Stack, useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useOptionalUserId } from "@/features/auth/public";
 import { cancelWeeklyDigestNotification } from "@/features/notifications/schedule.public";
 import { ScreenLayout, SettingsSection } from "@/shared/components";
@@ -47,6 +48,7 @@ const PREFERENCE_TOGGLES: readonly PreferenceToggle[] = [
 export function NotificationPreferencesScreen() {
   const router = useRouter();
   const { t } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
 
   const userId = useOptionalUserId();
   const prefs = useSettingsStore((s) => s.notificationPreferences);
@@ -97,7 +99,7 @@ export function NotificationPreferencesScreen() {
         contentContainerStyle={{
           paddingHorizontal: 20,
           paddingTop: 16,
-          paddingBottom: 40,
+          paddingBottom: bottom + 40,
           gap: 24,
         }}
         contentInsetAdjustmentBehavior="automatic"

--- a/apps/mobile/features/settings/components/PrivateBackupScreen.tsx
+++ b/apps/mobile/features/settings/components/PrivateBackupScreen.tsx
@@ -1,6 +1,7 @@
 import { format } from "date-fns";
 import { useRouter } from "expo-router";
 import { useState } from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useOptionalUserId } from "@/features/auth/public";
 import {
   generateBackupRecoveryKey,
@@ -38,6 +39,7 @@ export function PrivateBackupScreen() {
   const router = useRouter();
   const userId = useOptionalUserId();
   const { t, locale } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
   const [confirmation, setConfirmation] = useState("");
   const [isSaving, setIsSaving] = useState(false);
   const privateBackup = useSettingsStore((s) => s.privateBackup);
@@ -121,9 +123,10 @@ export function PrivateBackupScreen() {
         contentContainerStyle={{
           paddingHorizontal: 20,
           paddingTop: 16,
-          paddingBottom: 40,
+          paddingBottom: bottom + 40,
           gap: 12,
         }}
+        contentInsetAdjustmentBehavior="automatic"
         showsVerticalScrollIndicator={false}
       >
         <StatusPill

--- a/apps/mobile/features/settings/components/ProfileScreen.tsx
+++ b/apps/mobile/features/settings/components/ProfileScreen.tsx
@@ -1,4 +1,5 @@
 import { useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useAuthIdentity, useAuthMode, useAuthStore } from "@/features/auth/public";
 import { LocalQaProfileTools } from "@/features/qa/routes.public";
 import { ScreenLayout } from "@/shared/components";
@@ -10,6 +11,7 @@ import { getUserInitials } from "../lib/settings-links";
 export function ProfileScreen() {
   const router = useRouter();
   const { t } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
 
   const { fullName, email } = useAuthIdentity();
   const authMode = useAuthMode();
@@ -43,8 +45,9 @@ export function ProfileScreen() {
         contentContainerStyle={{
           paddingHorizontal: 20,
           paddingTop: 32,
-          paddingBottom: 40,
+          paddingBottom: bottom + 40,
         }}
+        contentInsetAdjustmentBehavior="automatic"
       >
         {/* Avatar & Info */}
         <View className="items-center" style={{ gap: 12 }}>

--- a/apps/mobile/features/transfers/components/transfer-form/TransferFormContent.tsx
+++ b/apps/mobile/features/transfers/components/transfer-form/TransferFormContent.tsx
@@ -1,4 +1,5 @@
 import DateTimePicker from "@react-native-community/datetimepicker";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { TriangleAlert } from "@/shared/components/icons";
 import {
   KeyboardAvoidingView,
@@ -18,6 +19,7 @@ import type { useTransferForm } from "./useTransferForm";
 
 export function TransferFormContent(props: { readonly form: ReturnType<typeof useTransferForm> }) {
   const { t } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
   const primary = useThemeColor("primary");
   const secondary = useThemeColor("secondary");
   const tertiary = useThemeColor("tertiary");
@@ -32,7 +34,7 @@ export function TransferFormContent(props: { readonly form: ReturnType<typeof us
         contentInsetAdjustmentBehavior="automatic"
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
-        contentContainerStyle={styles.content}
+        contentContainerStyle={[styles.content, { paddingBottom: bottom + 28 }]}
       >
         <Text style={[styles.subtitle, { color: secondary }]}>{props.form.subtitle}</Text>
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Respect mobile safe areas and tab bar clearance across the app to prevent content from being hidden behind notches, home indicators, and the bottom tab bar. Adds consistent bottom padding and automatic inset handling on scrollable screens.

- **Bug Fixes**
  - Applied `useSafeAreaInsets()` and `paddingBottom: bottom + N` to `ScrollView` and `FlashList` content containers.
  - Enabled `contentInsetAdjustmentBehavior="automatic"` on lists and scroll views for safe-area aware scrolling.
  - Used `TAB_BAR_CLEARANCE` for tabbed screens like Finance, `AnalyticsScreen`, and `SearchResultsList`.
  - Switched several static `View` layouts to `ScrollView` (e.g., Add Entry chooser, StarterSuggestions, onboarding account review, attribution/meaning review) to ensure proper scrolling and keyboard handling.

<sup>Written for commit 4afc10b7900ef22e8186e9a5f356842f9029fa31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

