### PR TITLE
feat(mobile): add critical observability

### DIFF
--- a/apps/mobile/__tests__/capture-sources/widget-pipeline.test.ts
+++ b/apps/mobile/__tests__/capture-sources/widget-pipeline.test.ts
@@ -55,6 +55,7 @@ vi.mock("@/modules/expo-app-intents", () => ({
 vi.mock("@/shared/lib", () => ({
   captureError: vi.fn(),
   capturePipelineEvent: vi.fn(),
+  captureWarning: vi.fn(),
   generateProcessedCaptureId: () => mockGenerateProcessedCaptureId(),
   toIsoDate: (d: Date) => d.toISOString().slice(0, 10),
   toIsoDateTime: (d: Date) => d.toISOString(),

--- a/apps/mobile/__tests__/notifications/store.test.ts
+++ b/apps/mobile/__tests__/notifications/store.test.ts
@@ -19,6 +19,7 @@ vi.mock("@/features/notifications/repository", () => ({
 }));
 
 vi.mock("@/shared/lib", () => ({
+  captureWarning: vi.fn(),
   generateNotificationId: vi.fn(() => "notif-generated"),
   toIsoDateTime: vi.fn(() => "2026-04-12T10:00:00.000Z"),
 }));

--- a/apps/mobile/features/capture-sources/hooks/setup.ts
+++ b/apps/mobile/features/capture-sources/hooks/setup.ts
@@ -2,7 +2,12 @@ import { insertDetectedSmsEvent } from "@/features/capture-sources/lib/repositor
 import { processApplePayIntent } from "@/features/capture-sources/services/apple-pay-pipeline";
 import { processNotification } from "@/features/capture-sources/services/notification-pipeline";
 import type { AnyDb } from "@/shared/db";
-import { captureError, generateDetectedSmsEventId, toIsoDateTime } from "@/shared/lib";
+import {
+  captureError,
+  captureWarning,
+  generateDetectedSmsEventId,
+  toIsoDateTime,
+} from "@/shared/lib";
 import type { UserId } from "@/shared/types/branded";
 import { parseSmsDetectedAt } from "../lib/parse-sms-detected-at";
 import {
@@ -13,6 +18,8 @@ import {
 import { createCaptureIngestionPort } from "../services/capture-ingestion";
 
 const noop = () => undefined;
+
+const issueCount = (issues: readonly unknown[]): number => issues.length;
 
 // Dynamic import to avoid Android bundle crash — this module calls
 // requireNativeModule("ExpoAppIntents") which only exists on iOS.
@@ -27,7 +34,12 @@ export async function setupApplePayCapture(db: AnyDb, userId: UserId): Promise<(
 
   const subscription = mod.addLogTransactionListener((event) => {
     const parsed = applePayIntentDataSchema.safeParse(event);
-    if (!parsed.success) return;
+    if (!parsed.success) {
+      captureWarning("apple_pay_capture_invalid_payload", {
+        issueCount: issueCount(parsed.error.issues),
+      });
+      return;
+    }
 
     captureIngestion
       .ingest({
@@ -51,7 +63,12 @@ export async function setupSmsDetection(
 
   const subscription = mod.addDetectBankSmsListener((event) => {
     const parsed = smsDetectionDataSchema.safeParse(event);
-    if (!parsed.success) return;
+    if (!parsed.success) {
+      captureWarning("sms_detection_invalid_payload", {
+        issueCount: issueCount(parsed.error.issues),
+      });
+      return;
+    }
 
     const detectedAt = parseSmsDetectedAt(parsed.data.timestamp);
 
@@ -96,7 +113,12 @@ export async function setupNotificationCapture(
 
   const subscription = mod.addListener("onNotificationReceived", (event: unknown) => {
     const parsed = notificationDataSchema.safeParse(event);
-    if (!parsed.success) return;
+    if (!parsed.success) {
+      captureWarning("notification_capture_invalid_payload", {
+        issueCount: issueCount(parsed.error.issues),
+      });
+      return;
+    }
 
     captureIngestion
       .ingest({

--- a/apps/mobile/features/capture-sources/services/notification-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/notification-pipeline.ts
@@ -2,7 +2,7 @@ import { findMatchingFinancialAccountId } from "@/features/account-suggestions/p
 import { lookupMerchantRule } from "@/features/email-capture/merchant-rules.public";
 import { ensureDefaultFinancialAccount } from "@/features/financial-accounts/public";
 import type { AnyDb } from "@/shared/db";
-import { normalizeMerchant, toIsoDateTime } from "@/shared/lib";
+import { captureWarning, normalizeMerchant, toIsoDateTime } from "@/shared/lib";
 import { assertUserId } from "@/shared/types/assertions";
 import type { CategoryId } from "@/shared/types/branded";
 import { findDuplicateTransaction, isCaptureProcessed } from "../lib/dedup";
@@ -46,13 +46,22 @@ export async function processNotification(
 ): Promise<NotificationPipelineResult> {
   assertUserId(userId);
   const context = normalizeNotificationCommand({ db, userId, notification });
-  const parseStage = await parseNotificationStage(context);
 
-  if (parseStage.kind === "failed") {
-    return persistFailedNotification(parseStage.context);
+  try {
+    const parseStage = await parseNotificationStage(context);
+
+    if (parseStage.kind === "failed") {
+      return persistFailedNotification(parseStage.context);
+    }
+
+    return withFingerprintLock(parseStage.context, handleParsedNotification);
+  } catch (error) {
+    captureWarning("notification_pipeline_exception", {
+      bankSource: context.source,
+      errorType: error instanceof Error ? error.name : typeof error,
+    });
+    throw error;
   }
-
-  return withFingerprintLock(parseStage.context, handleParsedNotification);
 }
 
 async function parseNotificationStage(context: NotificationContext): Promise<ParseStageResult> {

--- a/apps/mobile/features/capture-sources/services/widget-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/widget-pipeline.ts
@@ -3,6 +3,7 @@ import type { AnyDb } from "@/shared/db";
 import {
   captureError,
   capturePipelineEvent,
+  captureWarning,
   generateProcessedCaptureId,
   toIsoDate,
   toIsoDateTime,
@@ -31,6 +32,8 @@ export type WidgetPipelineResult = {
   skippedDuplicate: number;
   errors: number;
 };
+
+const errorType = (error: unknown): string => (error instanceof Error ? error.name : typeof error);
 
 export async function processWidgetTransactions(
   db: AnyDb,
@@ -157,10 +160,18 @@ export async function processWidgetTransactions(
   }
 
   if (succeededEntryIds.length > 0) {
-    await removePendingTransactions(succeededEntryIds);
+    try {
+      await removePendingTransactions(succeededEntryIds);
+    } catch (error) {
+      captureWarning("widget_pending_cleanup_failed", {
+        succeeded: succeededEntryIds.length,
+        errorType: errorType(error),
+      });
+      throw error;
+    }
   }
 
-  capturePipelineEvent({ source: "widget", saved, skippedDuplicate });
+  capturePipelineEvent({ source: "widget", saved, skippedDuplicate, errors });
 
   return { saved, skippedDuplicate, errors };
 }

--- a/apps/mobile/features/capture-sources/store.ts
+++ b/apps/mobile/features/capture-sources/store.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { Platform } from "@/shared/components/rn";
 import type { AnyDb } from "@/shared/db";
-import { toIsoDateTime } from "@/shared/lib";
+import { captureWarning, toIsoDateTime } from "@/shared/lib";
 import type { UserId } from "@/shared/types/branded";
 import {
   getEnabledPackages,
@@ -49,6 +49,26 @@ export const useCaptureSourcesStore = create<CaptureSourcesState & CaptureSource
   })
 );
 
+const errorType = (error: unknown): string => (error instanceof Error ? error.name : typeof error);
+
+function reportHydrationFailures(results: readonly PromiseSettledResult<void>[]): void {
+  const operations = [
+    "load_config",
+    "check_permissions",
+    "refresh_status",
+    "refresh_sms_count",
+  ] as const;
+
+  results.forEach((result, index) => {
+    if (result.status === "rejected") {
+      captureWarning("capture_sources_hydration_failed", {
+        operation: operations[index] ?? "unknown",
+        errorType: errorType(result.reason),
+      });
+    }
+  });
+}
+
 async function loadCaptureSourceConfig(db: AnyDb, userId: UserId): Promise<void> {
   const enabledPackages = await getEnabledPackages(db, userId);
   useCaptureSourcesStore.getState().setEnabledPackages(enabledPackages);
@@ -83,12 +103,13 @@ function getUpdatedEnabledPackages(
 }
 
 export async function hydrateCaptureSources(db: AnyDb, userId: UserId): Promise<void> {
-  await Promise.allSettled([
+  const results = await Promise.allSettled([
     loadCaptureSourceConfig(db, userId),
     checkCaptureSourcePermissions(),
     refreshCaptureSourceStatus(db),
     refreshDetectedSmsCount(db, userId),
   ]);
+  reportHydrationFailures(results);
 }
 
 export async function toggleCaptureSourcePackage(

--- a/apps/mobile/features/notifications/store.ts
+++ b/apps/mobile/features/notifications/store.ts
@@ -2,13 +2,15 @@ import * as SecureStore from "expo-secure-store";
 import { create } from "zustand";
 import { createWriteThroughMutationModule } from "@/mutations";
 import type { AnyDb } from "@/shared/db";
-import { generateNotificationId, toIsoDateTime } from "@/shared/lib";
+import { captureWarning, generateNotificationId, toIsoDateTime } from "@/shared/lib";
 import { requireIsoDateTime } from "@/shared/types/assertions";
 import type { CategoryId, IsoDateTime, UserId } from "@/shared/types/branded";
 import type { NotificationType, StoredNotification } from "./lib/types";
 import { countNotificationsSince, getNotifications } from "./repository";
 
 const lastVisitedKey = (userId: UserId) => `notification_last_visited_${userId}`;
+
+const errorType = (error: unknown): string => (error instanceof Error ? error.name : typeof error);
 
 type InsertNotificationInput = {
   readonly type: NotificationType;
@@ -112,7 +114,10 @@ export async function initializeNotificationStore(db: AnyDb, userId: UserId): Pr
   try {
     const stored = await SecureStore.getItemAsync(lastVisitedKey(userId));
     lastVisitedAt = stored ? requireIsoDateTime(stored) : null;
-  } catch {
+  } catch (error) {
+    captureWarning("notification_store_last_visited_read_failed", {
+      errorType: errorType(error),
+    });
     // SecureStore may fail in tests — default to null
   }
 
@@ -131,7 +136,10 @@ export function loadNotificationsForUser(db: AnyDb, userId: UserId): void {
       return;
     }
     useNotificationStore.getState().setNotifications(rows as readonly StoredNotification[]);
-  } catch {
+  } catch (error) {
+    captureWarning("notification_store_load_failed", {
+      errorType: errorType(error),
+    });
     useNotificationStore.getState().setIsLoading(false);
   }
 }
@@ -146,6 +154,9 @@ export async function insertNotificationRecord(
   const result = await mutations.commit(createInsertNotificationCommand({ userId, input, now }));
 
   if (!result.success) {
+    captureWarning("notification_insert_failed", {
+      errorType: result.error ? "mutation_rejected" : "unknown",
+    });
     return false;
   }
 
@@ -154,7 +165,11 @@ export async function insertNotificationRecord(
 
 export function markNotificationsVisited(userId: UserId): void {
   const now = toIsoDateTime(new Date());
-  void SecureStore.setItemAsync(lastVisitedKey(userId), now).catch(() => undefined);
+  void SecureStore.setItemAsync(lastVisitedKey(userId), now).catch((error) => {
+    captureWarning("notification_store_last_visited_write_failed", {
+      errorType: errorType(error),
+    });
+  });
 
   if (isActiveNotificationUser(userId)) {
     useNotificationStore.getState().setNewCount(0);
@@ -170,7 +185,14 @@ export async function clearAllNotifications(db: AnyDb, userId: UserId): Promise<
     now,
   });
 
-  if (result.success && isActiveNotificationUser(userId)) {
+  if (!result.success) {
+    captureWarning("notification_clear_all_failed", {
+      errorType: result.error ? "mutation_rejected" : "unknown",
+    });
+    return;
+  }
+
+  if (isActiveNotificationUser(userId)) {
     useNotificationStore.getState().clearState();
   }
 }

--- a/apps/mobile/features/transactions/lib/mutation-service.ts
+++ b/apps/mobile/features/transactions/lib/mutation-service.ts
@@ -1,4 +1,4 @@
-import { generateTransactionId, toIsoDateTime } from "@/shared/lib";
+import { captureWarning, generateTransactionId, toIsoDateTime } from "@/shared/lib";
 import type { WriteThroughMutationModule } from "@/shared/mutations";
 import type { CategoryId, FinancialAccountId, TransactionId, UserId } from "@/shared/types/branded";
 import type { StoredTransaction, TransactionType } from "../schema";
@@ -49,6 +49,8 @@ export type TransactionMutationService = {
 
 const fail = (error: string): TransactionMutationResult => ({ success: false, error });
 
+const errorType = (error: unknown): string => (error instanceof Error ? error.name : typeof error);
+
 async function commitTransaction(
   commit: WriteThroughMutationModule["commit"] | null,
   mode: "insert" | "update",
@@ -56,6 +58,7 @@ async function commitTransaction(
   message: string
 ) {
   if (!commit) {
+    captureWarning("transaction_commit_unavailable", { mode });
     return fail("Store not initialized");
   }
 
@@ -66,8 +69,20 @@ async function commitTransaction(
       row: toTransactionRow(transaction),
     });
 
-    return result.success ? result : fail(message);
-  } catch {
+    if (!result.success) {
+      captureWarning("transaction_commit_failed", {
+        mode,
+        errorType: "mutation_rejected",
+      });
+      return fail(message);
+    }
+
+    return result;
+  } catch (error) {
+    captureWarning("transaction_commit_exception", {
+      mode,
+      errorType: errorType(error),
+    });
     return fail(message);
   }
 }
@@ -185,6 +200,9 @@ export function createTransactionMutationService(
         });
 
         if (!result.success) {
+          captureWarning("transaction_delete_failed", {
+            errorType: "mutation_rejected",
+          });
           throw new Error(result.error);
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds structured warning telemetry with `captureWarning` across mobile capture, notification, and transaction flows to surface invalid payloads, failed mutations, and cleanup/hydration errors without crashing. Also enriches widget pipeline events with error counts and updates tests.

- **New Features**
  - Warn on invalid payloads for Apple Pay, SMS detection, and notification capture (includes issue counts).
  - Catch and warn on notification pipeline exceptions and store read/write/load failures.
  - Report capture source hydration failures per operation; include error type.
  - Warn when transaction commits are unavailable, rejected, or throw; also on delete failures.
  - Widget pipeline now warns on pending cleanup failures and reports `errors` in `capturePipelineEvent`.
  - Tests updated to mock `captureWarning`.

<sup>Written for commit 90a044f8f087cd6c46ae17da089ac7a3fe364f21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

