### PR TITLE
fix(mobile): improve calendar layout

### DIFF
--- a/apps/mobile/__tests__/calendar/calendar-screen.test.ts
+++ b/apps/mobile/__tests__/calendar/calendar-screen.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+
+function readSource(relativePath: string) {
+  return readFileSync(resolve(__dirname, relativePath), "utf-8");
+}
+
+const billsCalendarSource = readSource("../../app/bills-calendar.tsx");
+const financeTabSource = readSource("../../app/(tabs)/(finance)/index.tsx");
+const gridSource = readSource("../../features/calendar/components/CalendarGrid.tsx");
+
+describe("calendar screen", () => {
+  test("calendar grid stretches rows to fill the available screen height", () => {
+    expect(gridSource).toContain("container: {\n    flex: 1");
+    expect(gridSource).toContain("weekRow: {\n    flex: 1");
+  });
+
+  test("standalone bills calendar exposes the add-bill route", () => {
+    expect(billsCalendarSource).toContain("rightActions");
+    expect(billsCalendarSource).toContain('push("/add-bill")');
+    expect(billsCalendarSource).toContain('accessibilityLabel={t("bills.addBill")}');
+  });
+
+  test("finance calendar tab exposes the add-bill route in the native header", () => {
+    expect(financeTabSource).toContain('activeTab === "calendar"');
+    expect(financeTabSource).toContain('push("/add-bill")');
+    expect(financeTabSource).toContain('accessibilityLabel={t("bills.addBill")}');
+  });
+
+  test("finance calendar leaves room for the native iOS tab bar", () => {
+    expect(financeTabSource).toContain("useSafeAreaInsets");
+    expect(financeTabSource).toContain(
+      'Platform.OS === "ios" ? insets.bottom + 72 : TAB_BAR_CLEARANCE'
+    );
+    expect(financeTabSource).toContain("{ paddingBottom: tabBarClearance }");
+  });
+
+  test("add-bill header actions use white plus icons", () => {
+    expect(billsCalendarSource).toContain("Colors.light.card");
+    expect(financeTabSource).toContain("Colors.light.card");
+  });
+});

--- a/apps/mobile/__tests__/shared/screen-layout.test.ts
+++ b/apps/mobile/__tests__/shared/screen-layout.test.ts
@@ -33,6 +33,10 @@ describe("ScreenLayout", () => {
     expect(source).toContain("ReactNode");
   });
 
+  test("passes rightActions to the native iOS header", () => {
+    expect(source).toContain("headerRight: () => rightActions");
+  });
+
   test("accepts onBack function prop", () => {
     expect(source).toMatch(/onBack\??\s*:\s*\(\)\s*=>\s*void/);
   });

--- a/apps/mobile/app/(tabs)/(finance)/index.tsx
+++ b/apps/mobile/app/(tabs)/(finance)/index.tsx
@@ -1,5 +1,6 @@
 import { Stack, useRouter } from "expo-router";
 import { useCallback, useMemo, useState } from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { AnalyticsScreen } from "@/features/analytics";
 import { useOptionalUserId } from "@/features/auth/hooks.public";
 import { BudgetListScreen } from "@/features/budget/ui.public";
@@ -15,6 +16,7 @@ import { GoalsListScreen } from "@/features/goals/ui.public";
 import { TAB_BAR_CLEARANCE } from "@/shared/components";
 import { Plus } from "@/shared/components/icons";
 import { Platform, Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
+import { Colors } from "@/shared/constants/theme";
 import { tryGetDb } from "@/shared/db";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { captureError } from "@/shared/lib";
@@ -67,6 +69,8 @@ function FinanceCalendarPanel() {
   const payments = useCalendarStore((s) => s.payments);
   const userId = useOptionalUserId();
   const pageBg = useThemeColor("page");
+  const insets = useSafeAreaInsets();
+  const tabBarClearance = Platform.OS === "ios" ? insets.bottom + 72 : TAB_BAR_CLEARANCE;
 
   const handleNextMonth = useCallback(() => {
     if (!userId) return;
@@ -83,7 +87,13 @@ function FinanceCalendarPanel() {
   }, [userId]);
 
   return (
-    <View style={[styles.calendarPanel, { backgroundColor: pageBg }]}>
+    <View
+      style={[
+        styles.calendarPanel,
+        { backgroundColor: pageBg },
+        { paddingBottom: tabBarClearance },
+      ]}
+    >
       <MonthNavigator
         currentMonth={currentMonth}
         onPrev={handlePrevMonth}
@@ -106,6 +116,7 @@ function FinanceCalendarPanel() {
 
 function useHeaderRight(activeTab: FinanceTab) {
   const { push } = useRouter();
+  const { t } = useTranslation();
   const primaryColor = useThemeColor("primary");
   const accentGreen = useThemeColor("accentGreen");
   const goals = useGoalStore((s) => s.goals);
@@ -116,6 +127,20 @@ function useHeaderRight(activeTab: FinanceTab) {
         return (
           <Pressable onPress={() => push("/create-budget")} hitSlop={12}>
             <Plus size={24} color={primaryColor} />
+          </Pressable>
+        );
+      };
+    }
+    if (activeTab === "calendar") {
+      return function AddBillAction() {
+        return (
+          <Pressable
+            onPress={() => push("/add-bill")}
+            hitSlop={12}
+            accessibilityRole="button"
+            accessibilityLabel={t("bills.addBill")}
+          >
+            <Plus size={24} color={Colors.light.card} />
           </Pressable>
         );
       };
@@ -132,7 +157,7 @@ function useHeaderRight(activeTab: FinanceTab) {
     return function NoAction() {
       return null;
     };
-  }, [activeTab, goals.length, primaryColor, accentGreen, push]);
+  }, [activeTab, goals.length, primaryColor, accentGreen, push, t]);
 }
 
 export default function FinanceScreen() {
@@ -191,7 +216,6 @@ const styles = StyleSheet.create({
   calendarPanel: {
     flex: 1,
     paddingHorizontal: 16,
-    paddingBottom: TAB_BAR_CLEARANCE,
   },
   calendarGridWrap: {
     flex: 1,

--- a/apps/mobile/app/bills-calendar.tsx
+++ b/apps/mobile/app/bills-calendar.tsx
@@ -9,13 +9,15 @@ import {
   useCalendarStore,
 } from "@/features/calendar";
 import { ScreenLayout } from "@/shared/components";
-import { View } from "@/shared/components/rn";
+import { Plus } from "@/shared/components/icons";
+import { Pressable, View } from "@/shared/components/rn";
+import { Colors } from "@/shared/constants/theme";
 import { getDb } from "@/shared/db";
 import { useTranslation } from "@/shared/hooks";
 import { captureError } from "@/shared/lib";
 
 export default function BillsCalendarScreen() {
-  const router = useRouter();
+  const { back, push } = useRouter();
   const { t } = useTranslation();
   const currentMonth = useCalendarStore((s) => s.currentMonth);
   const bills = useCalendarStore((s) => s.bills);
@@ -33,7 +35,21 @@ export default function BillsCalendarScreen() {
   }, [userId]);
 
   return (
-    <ScreenLayout title={t("calendar.title")} variant="sub" onBack={() => router.back()}>
+    <ScreenLayout
+      title={t("calendar.title")}
+      variant="sub"
+      rightActions={
+        <Pressable
+          onPress={() => push("/add-bill")}
+          hitSlop={12}
+          accessibilityRole="button"
+          accessibilityLabel={t("bills.addBill")}
+        >
+          <Plus size={24} color={Colors.light.card} />
+        </Pressable>
+      }
+      onBack={() => back()}
+    >
       <View className="flex-1 px-4">
         <MonthNavigator
           currentMonth={currentMonth}
@@ -46,7 +62,7 @@ export default function BillsCalendarScreen() {
             bills={bills}
             payments={payments}
             onDayPress={(date) =>
-              router.push({ pathname: "/day-detail", params: { date: date.toISOString() } })
+              push({ pathname: "/day-detail", params: { date: date.toISOString() } })
             }
           />
         </View>

--- a/apps/mobile/features/calendar/components/CalendarGrid.tsx
+++ b/apps/mobile/features/calendar/components/CalendarGrid.tsx
@@ -109,6 +109,7 @@ export function CalendarGrid({ currentMonth, bills, payments, cellMinHeight, onD
 
 const styles = StyleSheet.create({
   container: {
+    flex: 1,
     borderRadius: 12,
     borderCurve: "continuous",
     borderWidth: 1,
@@ -127,6 +128,7 @@ const styles = StyleSheet.create({
     fontSize: 12,
   },
   weekRow: {
+    flex: 1,
     flexDirection: "row",
   },
 });

--- a/apps/mobile/shared/components/ScreenLayout.tsx
+++ b/apps/mobile/shared/components/ScreenLayout.tsx
@@ -33,6 +33,7 @@ export function ScreenLayout({
         <Stack.Screen
           options={{
             title,
+            headerRight: () => rightActions,
             ...(onBack != null && {
               headerLeft: () => (
                 <Pressable onPress={onBack} hitSlop={12}>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the calendar layout so the grid fills the screen and the finance calendar leaves room for the iOS tab bar. Adds an Add Bill header action to calendar screens and pipes `rightActions` into the native header.

- **Bug Fixes**
  - Calendar grid rows now stretch to fill available height.
  - Finance calendar uses safe-area bottom padding for the iOS tab bar.

- **New Features**
  - Add Bill header action on the finance calendar tab and the standalone bills calendar; routes to `/add-bill` with an accessible label and a white plus icon.
  - `ScreenLayout` now passes `rightActions` to `headerRight` in the native header.

<sup>Written for commit 62a67fdeefb1a54a1a78370de10e4a42d12a9d63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

