### PR TITLE
fix(mobile): harden email capture sync

### DIFF
--- a/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
@@ -450,6 +450,21 @@ describe("email processing pipeline", () => {
     expect(mockSaveCaptureEvidenceRows).toHaveBeenCalledWith(mockDb, expect.any(Array));
   });
 
+  it("does not report saved when a bundled async write rejects", async () => {
+    const dbWithTransaction = {
+      transaction: vi.fn((operation: (tx: unknown) => unknown) => operation(mockDb)),
+    } as any;
+    mockParseEmailApi.mockResolvedValueOnce(makeParsedEmailResult());
+    mockInsertProcessedEmail.mockRejectedValueOnce(new Error("processed email insert failed"));
+
+    const result = await processEmails(dbWithTransaction, USER_ID, [makeRawEmail()]);
+
+    expect(result.saved).toBe(0);
+    expect(result.failed).toBe(1);
+    expect(result.pendingRetry).toBe(1);
+    expect(mockInsertMerchantRule).not.toHaveBeenCalled();
+  });
+
   it("uses the injected clock for persisted email timestamps and retry backoff", async () => {
     const fixedNow = requireIsoDateTime("2026-04-18T12:34:56.000Z");
     const service = createTestEmailPipelineService({

--- a/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RawEmail } from "@/features/email-capture/schema";
 import { createEmailPipelineService } from "@/features/email-capture/services/create-email-pipeline-service";
 import {
+  processBackgroundEmails,
   processEmails,
   processInitialSyncEmails,
   processRetries,
@@ -329,22 +330,77 @@ describe("email processing pipeline", () => {
         externalId: "ext-1",
         status: "skipped",
         failureReason: null,
+        subject: "",
+        rawBodyPreview: "",
       })
     );
-    expect(mockSaveCaptureEvidenceRows).toHaveBeenCalledWith(
-      mockDb,
-      expect.arrayContaining([
-        expect.objectContaining({
-          userId: USER_ID,
-          processedEmailId: expect.any(String),
-          processedCaptureId: null,
-          transactionId: null,
-          scope: "email:bancolombia:sender",
-          value: "notificaciones@bancolombia.com.co",
-        }),
-      ])
+    expect(mockSaveCaptureEvidenceRows).not.toHaveBeenCalled();
+    expect(mockBuildEmailCaptureEvidence).not.toHaveBeenCalled();
+  });
+
+  it("emits privacy-safe diagnostics for skipped emails and batch outcomes", async () => {
+    const capturePipelineEvent = vi.fn();
+    const service = createTestEmailPipelineService({
+      telemetry: {
+        captureError: vi.fn(),
+        captureWarning: vi.fn(),
+        capturePipelineEvent,
+      },
+    });
+    mockParseEmailApi.mockResolvedValueOnce(null);
+
+    await service.processEmails(mockDb, USER_ID, [makeRawEmail()]);
+
+    expect(capturePipelineEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        schema: "email_skipped_v1",
+        providerFamily: "gmail",
+        skipReason: "filtered",
+      })
     );
-    expectCaptureEvidenceBuiltFromEmailContent();
+    expect(capturePipelineEvent).toHaveBeenCalledWith({
+      source: "email",
+      schema: "email_pipeline_batch_v1",
+      batchSize: 1,
+      providerFamilyCount: 1,
+      providerFamilies: "gmail",
+      dedupedInBatch: 0,
+      skippedAlreadyProcessed: 0,
+      skippedCrossSource: 0,
+      skippedDuplicate: 0,
+      filtered: 1,
+      saved: 0,
+      failed: 0,
+      pendingRetry: 0,
+      needsReview: 0,
+    });
+    expect(JSON.stringify(capturePipelineEvent.mock.calls)).not.toContain("Compra aprobada");
+    expect(JSON.stringify(capturePipelineEvent.mock.calls)).not.toContain("50.000");
+    expect(JSON.stringify(capturePipelineEvent.mock.calls)).not.toContain(
+      "notificaciones@bancolombia.com.co"
+    );
+    expect(JSON.stringify(capturePipelineEvent.mock.calls)).not.toContain("bancolombia.com.co");
+  });
+
+  it("reports parser exceptions without exception messages", async () => {
+    const captureWarning = vi.fn();
+    const service = createTestEmailPipelineService({
+      telemetry: {
+        captureError: vi.fn(),
+        captureWarning,
+        capturePipelineEvent: vi.fn(),
+      },
+    });
+    mockParseEmailApi.mockRejectedValueOnce(new Error("Compra en Exito por $50.000"));
+
+    await service.processEmails(mockDb, USER_ID, [makeRawEmail()]);
+
+    expect(captureWarning).toHaveBeenCalledWith("email_parse_exception", {
+      provider: "gmail",
+      errorType: "Error",
+    });
+    expect(JSON.stringify(captureWarning.mock.calls)).not.toContain("Exito");
+    expect(JSON.stringify(captureWarning.mock.calls)).not.toContain("50.000");
   });
 
   it("saves transaction and caches merchant rule when LLM returns high confidence", async () => {
@@ -379,6 +435,21 @@ describe("email processing pipeline", () => {
     );
   });
 
+  it("persists a new transaction and its processed email in one database transaction", async () => {
+    const dbWithTransaction = {
+      transaction: vi.fn((operation: (tx: unknown) => unknown) => operation(mockDb)),
+    } as any;
+    mockParseEmailApi.mockResolvedValueOnce(makeParsedEmailResult());
+
+    const result = await processEmails(dbWithTransaction, USER_ID, [makeRawEmail()]);
+
+    expect(result.saved).toBe(1);
+    expect(dbWithTransaction.transaction).toHaveBeenCalledTimes(1);
+    expect(mockInsertTransaction).toHaveBeenCalledWith(mockDb, expect.any(Object));
+    expect(mockInsertProcessedEmail).toHaveBeenCalledWith(mockDb, expect.any(Object));
+    expect(mockSaveCaptureEvidenceRows).toHaveBeenCalledWith(mockDb, expect.any(Array));
+  });
+
   it("uses the injected clock for persisted email timestamps and retry backoff", async () => {
     const fixedNow = requireIsoDateTime("2026-04-18T12:34:56.000Z");
     const service = createTestEmailPipelineService({
@@ -406,6 +477,7 @@ describe("email processing pipeline", () => {
     const service = createTestEmailPipelineService({
       parseRateLimit: {
         delayMs: 3000,
+        concurrency: 1,
         sleep: async (delayMs: number) => {
           events.push(`sleep:${delayMs}`);
         },
@@ -464,6 +536,142 @@ describe("email processing pipeline", () => {
 
     resolveFirstParse(makeParsedEmailResult({ description: "Compra 1" }));
     await processing;
+  });
+
+  it("uses foreground policy with three concurrent parse starts and no fixed delay", async () => {
+    const events: string[] = [];
+    const pendingParses: Array<(result: ReturnType<typeof makeParsedEmailResult>) => void> = [];
+    mockParseEmailApi.mockImplementation(async (body: string) => {
+      events.push(`parse:${body}`);
+      return new Promise((resolve) => pendingParses.push(resolve));
+    });
+
+    const processing = processEmails(
+      mockDb,
+      USER_ID,
+      Array.from({ length: 3 }, (_, index) =>
+        makeRawEmail({ externalId: `ext-${index + 1}`, body: `Compra ${index + 1}` })
+      )
+    );
+
+    await vi.waitFor(() => expect(events).toContain("parse:Compra 3"));
+    expect(events).toEqual(["parse:Compra 1", "parse:Compra 2", "parse:Compra 3"]);
+
+    pendingParses.forEach((resolve, index) =>
+      resolve(makeParsedEmailResult({ description: `Compra ${index + 1}` }))
+    );
+    await processing;
+  });
+
+  it("uses background policy with two concurrent parse starts", async () => {
+    const events: string[] = [];
+    const pendingParses: Array<(result: ReturnType<typeof makeParsedEmailResult>) => void> = [];
+    mockParseEmailApi.mockImplementation(async (body: string) => {
+      events.push(`parse:${body}`);
+      return new Promise((resolve) => pendingParses.push(resolve));
+    });
+
+    const processing = processBackgroundEmails(
+      mockDb,
+      USER_ID,
+      Array.from({ length: 3 }, (_, index) =>
+        makeRawEmail({ externalId: `ext-${index + 1}`, body: `Compra ${index + 1}` })
+      )
+    );
+
+    await vi.waitFor(() => expect(events).toContain("parse:Compra 2"));
+    expect(events).toEqual(["parse:Compra 1", "parse:Compra 2"]);
+
+    pendingParses[0]?.(makeParsedEmailResult({ description: "Compra 1" }));
+    await vi.waitFor(() => expect(events).toContain("parse:Compra 3"));
+    expect(events).toEqual(["parse:Compra 1", "parse:Compra 2", "parse:Compra 3"]);
+
+    pendingParses[1]?.(makeParsedEmailResult({ description: "Compra 2" }));
+    pendingParses[2]?.(makeParsedEmailResult({ description: "Compra 3" }));
+    await processing;
+  });
+
+  it("bounds background parsing to ten unprocessed candidates after durable skips", async () => {
+    mockGetProcessedExternalIds.mockResolvedValueOnce(new Set(["ext-1", "ext-2"]));
+    mockParseEmailApi.mockResolvedValue(makeParsedEmailResult());
+
+    await processBackgroundEmails(
+      mockDb,
+      USER_ID,
+      Array.from({ length: 14 }, (_, index) =>
+        makeRawEmail({ externalId: `ext-${index + 1}`, body: `Compra ${index + 1}` })
+      )
+    );
+
+    expect(mockParseEmailApi).toHaveBeenCalledTimes(10);
+    expect(mockParseEmailApi).toHaveBeenCalledWith("Compra 3");
+    expect(mockParseEmailApi).toHaveBeenCalledWith("Compra 12");
+    expect(mockParseEmailApi).not.toHaveBeenCalledWith("Compra 13");
+  });
+
+  it("serializes duplicate lookup and transaction insert under concurrent parsing", async () => {
+    const persistedTransactions: Array<{
+      id: string;
+      amount: number;
+      date: string;
+      description: string;
+    }> = [];
+    let releaseFirstInsert!: () => void;
+    const firstInsertStarted = new Promise<void>((resolve) => {
+      mockInsertTransaction.mockImplementation(async (_db, row) => {
+        if (mockInsertTransaction.mock.calls.length === 1) {
+          resolve();
+          await new Promise<void>((release) => {
+            releaseFirstInsert = release;
+          });
+        }
+
+        persistedTransactions.push({
+          id: row.id,
+          amount: row.amount,
+          date: row.date,
+          description: row.description,
+        });
+      });
+    });
+    const service = createTestEmailPipelineService({
+      parseRateLimit: { delayMs: 0, concurrency: 2 },
+    });
+    mockParseEmailApi.mockResolvedValue(makeParsedEmailResult({ description: "Compra duplicada" }));
+    mockFindDuplicateTransaction.mockImplementation(async ({ amount, date, merchant }) => {
+      const existing = persistedTransactions.find(
+        (transaction) =>
+          transaction.amount === amount &&
+          transaction.date === date &&
+          transaction.description === merchant
+      );
+
+      return existing?.id ?? null;
+    });
+
+    const processing = service.processEmails(mockDb, USER_ID, [
+      makeRawEmail({ externalId: "ext-1", body: "Compra duplicada 1" }),
+      makeRawEmail({ externalId: "ext-2", body: "Compra duplicada 2" }),
+    ]);
+
+    await firstInsertStarted;
+    await Promise.resolve();
+    await Promise.resolve();
+    releaseFirstInsert();
+
+    const result = await processing;
+
+    expect(mockInsertTransaction).toHaveBeenCalledTimes(1);
+    expect(result.saved).toBe(1);
+    expect(result.skippedCrossSource).toBe(1);
+    expect(mockInsertProcessedEmail).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        externalId: "ext-2",
+        status: "skipped_duplicate",
+        transactionId: expect.stringMatching(/^tx-/),
+      })
+    );
   });
 
   it("keeps initial sync serialized until duplicate writes are atomic", async () => {
@@ -628,6 +836,7 @@ describe("email processing pipeline", () => {
     const result = await processEmails(mockDb, USER_ID, emails);
 
     expect(result.failed).toBe(1);
+    expect(result.pendingRetry).toBe(1);
     expect(result.saved).toBe(0);
     expect(mockInsertProcessedEmail).toHaveBeenCalledWith(
       mockDb,
@@ -651,6 +860,7 @@ describe("email processing pipeline", () => {
     const result = await processEmails(mockDb, USER_ID, emails);
 
     expect(result.failed).toBe(1);
+    expect(result.pendingRetry).toBe(1);
     expect(result.saved).toBe(0);
     expect(mockInsertTransaction).not.toHaveBeenCalled();
     expect(mockInsertProcessedEmail).toHaveBeenCalledWith(
@@ -674,6 +884,7 @@ describe("email processing pipeline", () => {
     const result = await processEmails(mockDb, USER_ID, emails);
 
     expect(result.failed).toBe(1);
+    expect(result.pendingRetry).toBe(1);
     expect(result.saved).toBe(0);
     expect(mockInsertProcessedEmail).toHaveBeenCalledWith(
       mockDb,
@@ -782,6 +993,7 @@ describe("email processing pipeline", () => {
       skippedCrossSource: 0,
       saved: 0,
       failed: 0,
+      pendingRetry: 0,
       needsReview: 0,
     });
   });

--- a/apps/mobile/__tests__/email-capture/email-telemetry.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-telemetry.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import type { RawEmail } from "@/features/email-capture/schema";
+import {
+  buildEmailPipelineBatchTelemetry,
+  buildSkippedEmailDiagnostics,
+} from "@/features/email-capture/services/email-pipeline-service/email-telemetry";
+
+const rawEmail: RawEmail = {
+  externalId: "gmail-raw-123",
+  from: "alerts@bank.example.com",
+  subject: "Compra aprobada en Exito por $50.000",
+  body: "Compra aprobada en Exito por $50.000 con tarjeta 1234. user@example.com",
+  receivedAt: "2026-03-05T10:00:00Z",
+  provider: "gmail",
+};
+
+describe("email pipeline telemetry", () => {
+  it("builds a structural batch event without email identifiers or content", () => {
+    const event = buildEmailPipelineBatchTelemetry({
+      rawEmails: [rawEmail],
+      dedupedInBatch: 0,
+      skippedAlreadyProcessed: 0,
+      result: {
+        filtered: 1,
+        skippedDuplicate: 0,
+        skippedCrossSource: 0,
+        saved: 0,
+        failed: 0,
+        pendingRetry: 0,
+        needsReview: 0,
+      },
+    });
+
+    expect(event).toEqual({
+      source: "email",
+      schema: "email_pipeline_batch_v1",
+      batchSize: 1,
+      providerFamilyCount: 1,
+      providerFamilies: "gmail",
+      dedupedInBatch: 0,
+      skippedAlreadyProcessed: 0,
+      skippedCrossSource: 0,
+      skippedDuplicate: 0,
+      filtered: 1,
+      saved: 0,
+      failed: 0,
+      pendingRetry: 0,
+      needsReview: 0,
+    });
+    expect(Object.keys(event).join(" ")).not.toMatch(/body|subject|email|merchant|amount/i);
+    expect(Object.values(event).join(" ")).not.toContain("Exito");
+    expect(Object.values(event).join(" ")).not.toContain("50.000");
+    expect(Object.values(event).join(" ")).not.toContain("user@example.com");
+  });
+
+  it("builds skipped-email diagnostics without sender or template identifiers", () => {
+    const diagnostics = buildSkippedEmailDiagnostics({ email: rawEmail, reason: "filtered" });
+
+    expect(diagnostics).toEqual({
+      source: "email",
+      schema: "email_skipped_v1",
+      providerFamily: "gmail",
+      skipReason: "filtered",
+      headerLengthBucket: "20_49",
+      contentLengthBucket: "50_99",
+      hasCurrencySymbol: true,
+      hasDigitRun: true,
+    });
+    expect(Object.keys(diagnostics).join(" ")).not.toMatch(
+      /body|subject|address|merchant|amount|sender|fingerprint/i
+    );
+    expect(Object.values(diagnostics).join(" ")).not.toContain("Exito");
+    expect(Object.values(diagnostics).join(" ")).not.toContain("50.000");
+    expect(Object.values(diagnostics).join(" ")).not.toContain("user@example.com");
+    expect(Object.values(diagnostics).join(" ")).not.toContain("alerts@");
+    expect(Object.values(diagnostics).join(" ")).not.toContain("bank.example.com");
+  });
+});

--- a/apps/mobile/__tests__/email-capture/fetch-service.test.ts
+++ b/apps/mobile/__tests__/email-capture/fetch-service.test.ts
@@ -3,7 +3,10 @@ import type { EmailAccountRow } from "@/features/email-capture/lib/repository";
 import {
   createEmailFetchClientIds,
   fetchEmailAccountBatch,
+  persistFetchedAccounts,
 } from "@/features/email-capture/services/email-capture-fetch-service";
+import type { AnyDb } from "@/shared/db";
+import { updateLastFetchedAt } from "@/features/email-capture/lib/repository";
 import type { EmailAccountId, IsoDateTime, UserId } from "@/shared/types/branded";
 
 const { mockFetchEmails, mockEnsureBankSenders } = vi.hoisted(() => ({
@@ -22,6 +25,7 @@ vi.mock("@/features/email-capture/lib/repository", () => ({
 }));
 
 vi.mock("@/features/email-capture/pipeline.public", () => ({
+  processBackgroundEmails: vi.fn(),
   processEmails: vi.fn(),
   processRetries: vi.fn(),
 }));
@@ -83,5 +87,91 @@ describe("fetchEmailAccountBatch", () => {
     expect(mockFetchEmails).toHaveBeenCalledWith("gmail-client", "2026-03-21T12:00:00.000Z", [
       "bank@example.com",
     ]);
+  });
+});
+
+describe("persistFetchedAccounts", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-20T12:00:00.000Z"));
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("advances lastFetchedAt when fetched emails are durably queued for retry", async () => {
+    const db = {} as AnyDb;
+    const account = makeAccount();
+
+    const result = await persistFetchedAccounts({
+      db,
+      fetchResults: [
+        {
+          account,
+          rawEmails: [
+            {
+              externalId: "ext-1",
+              from: "bank@example.com",
+              subject: "Compra aprobada",
+              body: "Compra por $50.000",
+              receivedAt: "2026-04-20T11:59:00.000Z",
+              provider: "gmail",
+            },
+          ],
+          fetchOk: true,
+          processingResult: {
+            filtered: 0,
+            skippedDuplicate: 0,
+            skippedCrossSource: 0,
+            saved: 0,
+            failed: 1,
+            pendingRetry: 1,
+            needsReview: 0,
+          },
+        },
+      ],
+    });
+
+    expect(updateLastFetchedAt).toHaveBeenCalledWith(db, account.id, "2026-04-20T12:00:00.000Z");
+    expect(result.updatedAccountIds.has(account.id)).toBe(true);
+  });
+
+  it("does not advance lastFetchedAt when fetched email failures are not durably accounted for", async () => {
+    const db = {} as AnyDb;
+    const account = makeAccount();
+
+    const result = await persistFetchedAccounts({
+      db,
+      fetchResults: [
+        {
+          account,
+          rawEmails: [
+            {
+              externalId: "ext-1",
+              from: "bank@example.com",
+              subject: "Compra aprobada",
+              body: "Compra por $50.000",
+              receivedAt: "2026-04-20T11:59:00.000Z",
+              provider: "gmail",
+            },
+          ],
+          fetchOk: true,
+          processingResult: {
+            filtered: 0,
+            skippedDuplicate: 0,
+            skippedCrossSource: 0,
+            saved: 0,
+            failed: 1,
+            pendingRetry: 0,
+            needsReview: 0,
+          },
+        },
+      ],
+    });
+
+    expect(updateLastFetchedAt).not.toHaveBeenCalled();
+    expect(result.updatedAccountIds.has(account.id)).toBe(false);
   });
 });

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -13,8 +13,10 @@ import {
 import { getAdapter } from "@/features/email-capture/services/email-adapter";
 import { summarizeFetchedEmailDiagnostics } from "@/features/email-capture/services/email-capture-fetch-service";
 import {
+  processBackgroundEmails,
   processEmails,
   processInitialSyncEmails,
+  processRetries,
 } from "@/features/email-capture/services/email-pipeline";
 import {
   confirmReviewedEmail,
@@ -70,12 +72,22 @@ vi.mock("@/features/email-capture/services/email-adapter", () => ({
 }));
 
 vi.mock("@/features/email-capture/services/email-pipeline", () => ({
+  processBackgroundEmails: vi.fn().mockResolvedValue({
+    filtered: 0,
+    skippedDuplicate: 0,
+    skippedCrossSource: 0,
+    saved: 0,
+    failed: 0,
+    pendingRetry: 0,
+    needsReview: 0,
+  }),
   processEmails: vi.fn().mockResolvedValue({
     filtered: 0,
     skippedDuplicate: 0,
     skippedCrossSource: 0,
     saved: 0,
     failed: 0,
+    pendingRetry: 0,
     needsReview: 0,
   }),
   processInitialSyncEmails: vi.fn().mockResolvedValue({
@@ -84,6 +96,7 @@ vi.mock("@/features/email-capture/services/email-pipeline", () => ({
     skippedCrossSource: 0,
     saved: 0,
     failed: 0,
+    pendingRetry: 0,
     needsReview: 0,
   }),
   processRetries: vi.fn().mockResolvedValue({
@@ -176,6 +189,7 @@ type ProcessSummary = {
   skippedCrossSource: number;
   saved: number;
   failed: number;
+  pendingRetry: number;
   needsReview: number;
 };
 
@@ -211,6 +225,7 @@ const EMPTY_PROCESS_SUMMARY: ProcessSummary = {
   skippedCrossSource: 0,
   saved: 0,
   failed: 0,
+  pendingRetry: 0,
   needsReview: 0,
 };
 
@@ -304,7 +319,7 @@ describe("email capture boundary", () => {
     expect(state.bannerDismissed).toBe(false);
   });
 
-  it("summarizes fetched email source families without email content", () => {
+  it("summarizes fetched email diagnostics without sender families or content", () => {
     expect(
       summarizeFetchedEmailDiagnostics([
         {
@@ -324,10 +339,6 @@ describe("email capture boundary", () => {
           provider: "gmail",
           fetchOk: true,
           emailCount: 3,
-          sourceFamilies: {
-            davibank: 1,
-            rappicard: 2,
-          },
         },
       ],
     });
@@ -633,6 +644,95 @@ describe("email capture boundary", () => {
       expect(processEmails).not.toHaveBeenCalled();
     });
 
+    it("uses the background parser profile and bounds email work per run when requested", async () => {
+      setAccounts();
+      const mockRawEmails = Array.from({ length: 12 }, (_, index) =>
+        makeRawEmail({
+          externalId: `ext-${index + 1}`,
+          receivedAt: `2026-03-05T10:${String(index).padStart(2, "0")}:00Z`,
+        })
+      );
+      mockAdapter.fetchEmails.mockResolvedValueOnce(mockRawEmails);
+      vi.mocked(processBackgroundEmails).mockResolvedValueOnce({
+        ...EMPTY_PROCESS_SUMMARY,
+        saved: 10,
+      });
+      mockEmptyReviewLoads();
+
+      await fetchAndProcessEmails(
+        mockDb,
+        mockUserId as UserId,
+        "gmail-client-id",
+        "outlook-client-id",
+        mockRefresh,
+        { parseProfile: "background" }
+      );
+
+      expect(processBackgroundEmails).toHaveBeenCalledWith(
+        mockDb,
+        mockUserId,
+        mockRawEmails.slice(-10).reverse(),
+        expect.any(Function)
+      );
+      expect(updateLastFetchedAt).not.toHaveBeenCalled();
+      expect(processEmails).not.toHaveBeenCalled();
+      expect(processInitialSyncEmails).not.toHaveBeenCalled();
+      expect(processRetries).not.toHaveBeenCalled();
+    });
+
+    it("applies the background work bound across all fetched accounts", async () => {
+      setAccounts([
+        makeAccount(),
+        makeAccount({ id: "ea-2" as EmailAccountId, provider: "outlook" }),
+      ]);
+      const gmailEmails = Array.from({ length: 8 }, (_, index) =>
+        makeRawEmail({
+          externalId: `gmail-${index + 1}`,
+          receivedAt: `2026-03-05T10:${String(index).padStart(2, "0")}:00Z`,
+        })
+      );
+      const outlookEmails = Array.from({ length: 8 }, (_, index) =>
+        makeRawEmail({
+          externalId: `outlook-${index + 1}`,
+          provider: "outlook",
+          receivedAt: `2026-03-05T11:${String(index).padStart(2, "0")}:00Z`,
+        })
+      );
+      mockAdapter.fetchEmails
+        .mockResolvedValueOnce(gmailEmails)
+        .mockResolvedValueOnce(outlookEmails);
+      vi.mocked(processBackgroundEmails)
+        .mockResolvedValueOnce({ ...EMPTY_PROCESS_SUMMARY })
+        .mockResolvedValueOnce({ ...EMPTY_PROCESS_SUMMARY });
+      mockEmptyReviewLoads();
+
+      await fetchAndProcessEmails(
+        mockDb,
+        mockUserId as UserId,
+        "gmail-client-id",
+        "outlook-client-id",
+        mockRefresh,
+        { parseProfile: "background" }
+      );
+
+      const processedEmails = vi
+        .mocked(processBackgroundEmails)
+        .mock.calls.flatMap(([, , emails]) => emails);
+      expect(processedEmails).toHaveLength(10);
+      expect(processedEmails.map((email) => email.externalId)).toEqual([
+        "outlook-8",
+        "outlook-7",
+        "outlook-6",
+        "outlook-5",
+        "outlook-4",
+        "outlook-3",
+        "outlook-2",
+        "outlook-1",
+        "gmail-8",
+        "gmail-7",
+      ]);
+    });
+
     it("returns the awaited processing outcome", async () => {
       setAccounts();
       mockAdapter.fetchEmails.mockResolvedValueOnce([makeRawEmail()]);
@@ -664,6 +764,7 @@ describe("email capture boundary", () => {
           skippedCrossSource: 0,
           saved: 1,
           failed: 0,
+          pendingRetry: 0,
           needsReview: 0,
         };
       });
@@ -687,19 +788,19 @@ describe("email capture boundary", () => {
       expect(updatedAccount.lastFetchedAt).not.toBeNull();
     });
 
-    it("does not advance lastFetchedAt when fetched emails fail processing", async () => {
+    it("advances lastFetchedAt when fetched emails are durably queued for retry", async () => {
       setAccounts();
       mockAdapter.fetchEmails.mockResolvedValueOnce([makeRawEmail()]);
-      mockProcessResult({ failed: 1 });
+      mockProcessResult({ failed: 1, pendingRetry: 1 });
       mockEmptyReviewLoads();
 
       await runFetchAndProcess();
 
-      expect(updateLastFetchedAt).not.toHaveBeenCalled();
-      expect(useEmailCaptureStore.getState().accounts[0]?.lastFetchedAt).toBeNull();
+      expect(updateLastFetchedAt).toHaveBeenCalledWith(mockDb, "ea-1", expect.any(String));
+      expect(useEmailCaptureStore.getState().accounts[0]?.lastFetchedAt).not.toBeNull();
     });
 
-    it("advances lastFetchedAt for accounts whose own emails process successfully", async () => {
+    it("advances lastFetchedAt for each account whose provider fetch and local processing is durable", async () => {
       setAccounts([
         makeAccount(),
         makeAccount({
@@ -711,16 +812,17 @@ describe("email capture boundary", () => {
       mockAdapter.fetchEmails
         .mockResolvedValueOnce([makeRawEmail({ externalId: "ext-1" })])
         .mockResolvedValueOnce([makeRawEmail({ externalId: "ext-2", provider: "outlook" })]);
-      mockProcessResult({ failed: 1 });
+      mockProcessResult({ failed: 1, pendingRetry: 1 });
       mockProcessResult({ saved: 1 });
       mockEmptyReviewLoads();
 
       await runFetchAndProcess();
 
-      expect(updateLastFetchedAt).toHaveBeenCalledTimes(1);
+      expect(updateLastFetchedAt).toHaveBeenCalledTimes(2);
+      expect(updateLastFetchedAt).toHaveBeenCalledWith(mockDb, "ea-1", expect.any(String));
       expect(updateLastFetchedAt).toHaveBeenCalledWith(mockDb, "ea-2", expect.any(String));
       const [failedAccount, savedAccount] = useEmailCaptureStore.getState().accounts;
-      expect(failedAccount?.lastFetchedAt).toBeNull();
+      expect(failedAccount?.lastFetchedAt).not.toBeNull();
       expect(savedAccount?.lastFetchedAt).not.toBeNull();
     });
 
@@ -756,6 +858,24 @@ describe("email capture boundary", () => {
         expect.objectContaining({ total: 2, completed: 1, saved: 1 }),
         expect.objectContaining({ total: 2, completed: 2, saved: 2 }),
       ]);
+    });
+
+    it("refreshes transactions after the first saved foreground email and after completion", async () => {
+      setAccounts();
+      mockAdapter.fetchEmails.mockResolvedValueOnce([
+        makeRawEmail({ externalId: "ext-1" }),
+        makeRawEmail({ externalId: "ext-2" }),
+      ]);
+      vi.mocked(processEmails).mockImplementationOnce(async (_db, _uid, _emails, onProgress) => {
+        onProgress?.({ total: 2, completed: 1, saved: 1, failed: 0, needsReview: 0 });
+        onProgress?.({ total: 2, completed: 2, saved: 2, failed: 0, needsReview: 0 });
+        return { ...EMPTY_PROCESS_SUMMARY, saved: 2 };
+      });
+      mockEmptyReviewLoads();
+
+      await runFetchAndProcess();
+
+      expect(mockRefresh).toHaveBeenCalledTimes(2);
     });
 
     it("auto-clears phase after 2s timeout when phase is complete", async () => {
@@ -824,6 +944,7 @@ describe("email capture boundary", () => {
           skippedCrossSource: 0,
           saved: 0,
           failed: 0,
+          pendingRetry: 0,
           needsReview: 0,
         };
       });

--- a/apps/mobile/features/background-fetch/task.ts
+++ b/apps/mobile/features/background-fetch/task.ts
@@ -25,7 +25,9 @@ TaskManager.defineTask(BACKGROUND_TASK_NAME, async () => {
     initializeEmailCaptureSession(userId);
     await loadEmailAccounts(db, userId);
 
-    await fetchAndProcessEmails(db, userId, getGmailClientId(), getOutlookClientId());
+    await fetchAndProcessEmails(db, userId, getGmailClientId(), getOutlookClientId(), undefined, {
+      parseProfile: "background",
+    });
     return BackgroundTask.BackgroundTaskResult.Success;
   } catch (error) {
     captureError(error);

--- a/apps/mobile/features/email-capture/pipeline.public.ts
+++ b/apps/mobile/features/email-capture/pipeline.public.ts
@@ -3,6 +3,7 @@ import type { UserId } from "@/shared/types/branded";
 import type { RawEmail } from "./schema";
 import type { PipelineResult, ProgressCallback, RetryResult } from "./services/email-pipeline";
 import {
+  processBackgroundEmails as processBackgroundEmailsInternal,
   processEmails as processEmailsInternal,
   processInitialSyncEmails as processInitialSyncEmailsInternal,
   processRetries as processRetriesInternal,
@@ -26,6 +27,9 @@ export type ProcessRetries = (db: AnyDb, userId: UserId) => Promise<RetryResult>
 
 export const processEmails: ProcessEmails = (db, userId, rawEmails, onProgress) =>
   processEmailsInternal(db, userId, rawEmails, onProgress);
+
+export const processBackgroundEmails: ProcessEmails = (db, userId, rawEmails, onProgress) =>
+  processBackgroundEmailsInternal(db, userId, rawEmails, onProgress);
 
 export const processInitialSyncEmails: ProcessEmails = (db, userId, rawEmails, onProgress) =>
   processInitialSyncEmailsInternal(db, userId, rawEmails, onProgress);

--- a/apps/mobile/features/email-capture/services/email-capture-fetch-service.ts
+++ b/apps/mobile/features/email-capture/services/email-capture-fetch-service.ts
@@ -7,10 +7,22 @@ import { isFirstFetchForAny, shouldShowProgress } from "../lib/progress-phases";
 import type { EmailAccountRow, ProcessedEmailRow } from "../lib/repository";
 import { getFailedEmails, getNeedsReviewEmails, updateLastFetchedAt } from "../lib/repository";
 import type { PipelineResult, ProgressCallback, RawEmail } from "../pipeline.public";
-import { processEmails, processInitialSyncEmails, processRetries } from "../pipeline.public";
+import {
+  processBackgroundEmails,
+  processEmails,
+  processInitialSyncEmails,
+  processRetries,
+} from "../pipeline.public";
 import { ensureBankSenders } from "../queries/bank-senders";
 import type { EmailProvider } from "../schema";
+import type { EmailCaptureParseProfile } from "./email-capture-sync-policy";
 import { getAdapter } from "./email-adapter";
+export {
+  applyEmailCaptureCandidateLimit,
+  type EmailCaptureParseProfile,
+  resolveEmailCaptureSyncPolicy,
+  sortFetchResultsByNewestEmail,
+} from "./email-capture-sync-policy";
 
 const EMPTY_RAW_EMAILS: RawEmail[] = [];
 const EMPTY_PIPELINE_RESULT: PipelineResult = {
@@ -19,6 +31,7 @@ const EMPTY_PIPELINE_RESULT: PipelineResult = {
   skippedCrossSource: 0,
   saved: 0,
   failed: 0,
+  pendingRetry: 0,
   needsReview: 0,
 };
 const FETCH_LOOKBACK_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
@@ -77,28 +90,6 @@ const createEmptyFetchResult = (account: EmailAccountRow): EmailAccountFetchResu
 const createFetchLookbackBoundary = (): string =>
   new Date(Date.now() - FETCH_LOOKBACK_WINDOW_MS).toISOString();
 
-const normalizeSourceFamily = (from: string): string => {
-  const domain = from.split("@").at(1)?.toLowerCase().trim() ?? "unknown";
-  return (
-    domain
-      .split(".")
-      .filter(Boolean)[0]
-      ?.replace(/[^a-z0-9]+/g, "_")
-      .replace(/^_+|_+$/g, "") || "unknown"
-  );
-};
-
-const countBySourceFamily = (emails: readonly RawEmail[]) =>
-  Object.fromEntries(
-    Array.from(
-      emails.reduce((counts, email) => {
-        const family = normalizeSourceFamily(email.from);
-        counts.set(family, (counts.get(family) ?? 0) + 1);
-        return counts;
-      }, new Map<string, number>())
-    ).sort(([left], [right]) => left.localeCompare(right))
-  );
-
 export const summarizeFetchedEmailDiagnostics = (
   fetchResults: readonly EmailAccountFetchResult[]
 ) => ({
@@ -107,7 +98,6 @@ export const summarizeFetchedEmailDiagnostics = (
     provider: result.account.provider,
     fetchOk: result.fetchOk,
     emailCount: result.rawEmails.length,
-    sourceFamilies: countBySourceFamily(result.rawEmails),
   })),
 });
 
@@ -129,10 +119,15 @@ const createFetchSummary = (
   };
 };
 
-const getSuccessfulProcessedFetches = (
+const getDurablyProcessedFetches = (
   fetchResults: readonly ProcessedEmailAccountFetchResult[]
 ): readonly ProcessedEmailAccountFetchResult[] =>
-  fetchResults.filter((result) => result.fetchOk && result.processingResult.failed === 0);
+  fetchResults.filter(
+    (result) =>
+      result.fetchOk &&
+      (result.processingResult.failed === 0 ||
+        result.processingResult.failed === result.processingResult.pendingRetry)
+  );
 
 export const aggregatePipelineResults = (results: readonly PipelineResult[]): PipelineResult =>
   results.reduce(
@@ -142,6 +137,7 @@ export const aggregatePipelineResults = (results: readonly PipelineResult[]): Pi
       skippedCrossSource: total.skippedCrossSource + result.skippedCrossSource,
       saved: total.saved + result.saved,
       failed: total.failed + result.failed,
+      pendingRetry: total.pendingRetry + result.pendingRetry,
       needsReview: total.needsReview + result.needsReview,
     }),
     EMPTY_PIPELINE_RESULT
@@ -177,7 +173,7 @@ async function fetchEmailsForAccount(
   } catch (error) {
     captureWarning("email_adapter_fetch_failed", {
       provider: command.account.provider,
-      errorType: error instanceof Error ? error.message : "unknown",
+      errorType: error instanceof Error ? error.name : "unknown",
     });
 
     return createEmptyFetchResult(command.account);
@@ -199,7 +195,12 @@ export async function fetchEmailAccountBatch(
   const minSince = createFetchLookbackBoundary();
   const fetchResults = await Promise.all(
     command.accounts.map((account) =>
-      fetchEmailsForAccount({ account, clientIds: command.clientIds, senderEmails, minSince })
+      fetchEmailsForAccount({
+        account,
+        clientIds: command.clientIds,
+        senderEmails,
+        minSince,
+      })
     )
   );
   logFetchedEmailDiagnostics(fetchResults);
@@ -213,10 +214,16 @@ export async function ingestFetchedEmails(input: {
   readonly emails: readonly RawEmail[];
   readonly onProgress?: ProgressCallback;
   readonly runRetries?: boolean;
-  readonly parseProfile?: "default" | "initial_sync";
+  readonly parseProfile?: EmailCaptureParseProfile;
 }): Promise<PipelineResult> {
+  const processEmailsForProfile =
+    input.parseProfile === "initial_sync"
+      ? processInitialSyncEmails
+      : input.parseProfile === "background"
+        ? processBackgroundEmails
+        : processEmails;
   const captureIngestion = createCaptureIngestionPort(input.db, {
-    processEmails: input.parseProfile === "initial_sync" ? processInitialSyncEmails : processEmails,
+    processEmails: processEmailsForProfile,
     processRetries,
   });
 
@@ -243,7 +250,7 @@ export async function ingestFetchedEmails(input: {
 export async function persistFetchedAccounts(
   command: PersistFetchedAccountsCommand
 ): Promise<PersistedFetchedAccounts> {
-  const successfulFetches = getSuccessfulProcessedFetches(command.fetchResults);
+  const successfulFetches = getDurablyProcessedFetches(command.fetchResults);
   const fetchedAt = toIsoDateTime(new Date());
 
   await Promise.all(

--- a/apps/mobile/features/email-capture/services/email-capture-store-runtime.ts
+++ b/apps/mobile/features/email-capture/services/email-capture-store-runtime.ts
@@ -27,7 +27,7 @@ type FetchStartResult =
 type FetchProgressRuntime = {
   readonly run: EmailCaptureFetchRun;
   readonly refreshTransactions: RefreshTransactions;
-  lastRefreshedSaved: number;
+  hasRefreshedFirstSave: boolean;
 };
 
 export type EmailCaptureSession = {
@@ -113,8 +113,8 @@ const applyFetchProgress = (
   if (!isCurrentEmailCaptureFetchRun(progressRuntime.run)) return;
 
   getRuntime().setProgress(progress);
-  if (progress.saved <= progressRuntime.lastRefreshedSaved) return;
-  progressRuntime.lastRefreshedSaved = progress.saved;
+  if (progress.saved === 0 || progressRuntime.hasRefreshedFirstSave) return;
+  progressRuntime.hasRefreshedFirstSave = true;
   void progressRuntime.refreshTransactions();
 };
 
@@ -187,7 +187,7 @@ export function createEmailCaptureFetchProgressHandler(
   const progressRuntime: FetchProgressRuntime = {
     run,
     refreshTransactions,
-    lastRefreshedSaved: 0,
+    hasRefreshedFirstSave: false,
   };
 
   return (progress) => applyFetchProgress(progressRuntime, progress);

--- a/apps/mobile/features/email-capture/services/email-capture-sync-policy.ts
+++ b/apps/mobile/features/email-capture/services/email-capture-sync-policy.ts
@@ -1,0 +1,72 @@
+import type { RawEmail } from "../schema";
+
+const BACKGROUND_MAX_CANDIDATE_EMAILS = 10;
+
+export type EmailCaptureParseProfile = "foreground" | "background" | "initial_sync";
+
+export type EmailCaptureSyncPolicy = {
+  readonly parseProfile: EmailCaptureParseProfile;
+  readonly advancesLastFetchedAt: boolean;
+  readonly maxCandidateEmails: number | null;
+  readonly runRetries: boolean;
+  readonly showsProgress: boolean;
+};
+
+type EmailBatchLike = {
+  readonly rawEmails: readonly RawEmail[];
+};
+
+const sortNewestFirst = (emails: readonly RawEmail[]): readonly RawEmail[] =>
+  [...emails].sort((left, right) => right.receivedAt.localeCompare(left.receivedAt));
+
+const newestReceivedAt = (result: EmailBatchLike) =>
+  result.rawEmails.reduce(
+    (newest, email) => (email.receivedAt > newest ? email.receivedAt : newest),
+    ""
+  );
+
+export const sortFetchResultsByNewestEmail = <T extends EmailBatchLike>(
+  fetchResults: readonly T[]
+): readonly T[] =>
+  [...fetchResults].sort((left, right) =>
+    newestReceivedAt(right).localeCompare(newestReceivedAt(left))
+  );
+
+export const applyEmailCaptureCandidateLimit = <T extends EmailBatchLike>(
+  fetchResults: readonly T[],
+  maxCandidateEmails: number | null
+): readonly T[] => {
+  if (maxCandidateEmails == null) return fetchResults;
+
+  const allowedExternalIds = new Set(
+    sortNewestFirst(fetchResults.flatMap((result) => result.rawEmails))
+      .slice(0, maxCandidateEmails)
+      .map((email) => email.externalId)
+  );
+
+  return fetchResults.map((result) => ({
+    ...result,
+    rawEmails: sortNewestFirst(result.rawEmails).filter((email) =>
+      allowedExternalIds.has(email.externalId)
+    ),
+  }));
+};
+
+export const resolveEmailCaptureSyncPolicy = (
+  parseProfile: EmailCaptureParseProfile | undefined
+): EmailCaptureSyncPolicy =>
+  parseProfile === "background"
+    ? {
+        parseProfile,
+        advancesLastFetchedAt: false,
+        maxCandidateEmails: BACKGROUND_MAX_CANDIDATE_EMAILS,
+        runRetries: false,
+        showsProgress: false,
+      }
+    : {
+        parseProfile: parseProfile ?? "foreground",
+        advancesLastFetchedAt: true,
+        maxCandidateEmails: null,
+        runRetries: true,
+        showsProgress: true,
+      };

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/email-telemetry.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/email-telemetry.ts
@@ -1,0 +1,61 @@
+import type { TelemetryContext } from "@/shared/effect/telemetry";
+import type { PipelineResult, RawEmail } from "./types";
+
+type BatchTelemetryInput = {
+  readonly rawEmails: readonly RawEmail[];
+  readonly dedupedInBatch: number;
+  readonly skippedAlreadyProcessed: number;
+  readonly result: PipelineResult;
+};
+
+type SkippedEmailDiagnosticsInput = {
+  readonly email: RawEmail;
+  readonly reason: "filtered" | "failed";
+};
+
+const lengthBucket = (value: string): string => {
+  if (value.length < 20) return "0_19";
+  if (value.length < 50) return "20_49";
+  if (value.length < 100) return "50_99";
+  if (value.length < 250) return "100_249";
+  if (value.length < 500) return "250_499";
+  return "500_plus";
+};
+
+export function buildEmailPipelineBatchTelemetry(input: BatchTelemetryInput): TelemetryContext {
+  const providerFamilies = Array.from(
+    new Set(input.rawEmails.map((email) => email.provider))
+  ).sort();
+
+  return {
+    source: "email",
+    schema: "email_pipeline_batch_v1",
+    batchSize: input.rawEmails.length,
+    providerFamilyCount: providerFamilies.length,
+    providerFamilies: providerFamilies.join(","),
+    dedupedInBatch: input.dedupedInBatch,
+    skippedAlreadyProcessed: input.skippedAlreadyProcessed,
+    skippedCrossSource: input.result.skippedCrossSource,
+    skippedDuplicate: input.result.skippedDuplicate,
+    filtered: input.result.filtered,
+    saved: input.result.saved,
+    failed: input.result.failed,
+    pendingRetry: input.result.pendingRetry,
+    needsReview: input.result.needsReview,
+  };
+}
+
+export function buildSkippedEmailDiagnostics(
+  input: SkippedEmailDiagnosticsInput
+): TelemetryContext {
+  return {
+    source: "email",
+    schema: "email_skipped_v1",
+    providerFamily: input.email.provider,
+    skipReason: input.reason,
+    headerLengthBucket: lengthBucket(input.email.subject),
+    contentLengthBucket: lengthBucket(input.email.body),
+    hasCurrencySymbol: /[$]/u.test(input.email.body),
+    hasDigitRun: /\d{2,}/u.test(input.email.body),
+  };
+}

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-batch.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-batch.ts
@@ -1,5 +1,6 @@
 import type { AnyDb } from "@/shared/db";
 import { capturePipelineEventEffect } from "@/shared/effect/telemetry";
+import { buildEmailPipelineBatchTelemetry } from "./email-telemetry";
 import { processIncomingEmail } from "./incoming-email";
 import { getProcessedExternalIdsEffect } from "./runtime";
 import {
@@ -32,14 +33,16 @@ async function createEmailBatchPlan(
     )
   );
   const toProcess = uniqueEmails.filter((email) => !processedIds.has(email.externalId));
+  const boundedToProcess =
+    runtime.maxCandidateEmails == null ? toProcess : toProcess.slice(0, runtime.maxCandidateEmails);
   const skippedAlreadyProcessed = uniqueEmails.length - toProcess.length;
 
   return {
-    toProcess,
+    toProcess: boundedToProcess,
     dedupedInBatch,
     skippedAlreadyProcessed,
     result: createPipelineResult(dedupedInBatch + skippedAlreadyProcessed),
-    total: toProcess.length,
+    total: boundedToProcess.length,
   };
 }
 
@@ -49,17 +52,14 @@ async function captureIncomingBatchEvent(
   batch: EmailBatchPlan
 ) {
   await runtime.runTelemetryEffect(
-    capturePipelineEventEffect({
-      source: "email",
-      batchSize: rawEmails.length,
-      uniqueProviders: new Set(rawEmails.map((email) => email.provider)).size,
-      dedupedInBatch: batch.dedupedInBatch,
-      skippedAlreadyProcessed: batch.skippedAlreadyProcessed,
-      skippedCrossSource: batch.result.skippedCrossSource,
-      saved: batch.result.saved,
-      failed: batch.result.failed,
-      needsReview: batch.result.needsReview,
-    })
+    capturePipelineEventEffect(
+      buildEmailPipelineBatchTelemetry({
+        rawEmails,
+        dedupedInBatch: batch.dedupedInBatch,
+        skippedAlreadyProcessed: batch.skippedAlreadyProcessed,
+        result: batch.result,
+      })
+    )
   );
 }
 
@@ -113,6 +113,7 @@ export async function processEmailBatch(runtime: PipelineRuntime, input: Process
     completed: 0,
     parseStarts: 0,
     parseStartGate: Promise.resolve(),
+    persistenceGate: Promise.resolve(),
   };
 
   reportEmailProgress(context);

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-email.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-email.ts
@@ -1,8 +1,13 @@
 import { currentIsoDateTimeEffect } from "@/shared/effect/clock";
-import { captureErrorEffect, captureWarningEffect } from "@/shared/effect/telemetry";
+import {
+  captureErrorEffect,
+  capturePipelineEventEffect,
+  captureWarningEffect,
+} from "@/shared/effect/telemetry";
 import { generateProcessedEmailId } from "@/shared/lib/generate-id";
 import { normalizeMerchant } from "@/shared/lib/normalize-merchant";
 import { assertIsoDateTime } from "@/shared/types/assertions";
+import { buildSkippedEmailDiagnostics } from "./email-telemetry";
 import {
   findDuplicateTransactionEffect,
   getProcessedExternalIdsEffect,
@@ -18,6 +23,7 @@ import {
   getPersistedCategoryId,
   incrementPipelineMetric,
   resolveEmailStatus,
+  runSerializedPersistence,
 } from "./shared";
 import { saveTransactionEffect } from "./transactions";
 import type {
@@ -45,7 +51,7 @@ async function parseIncomingEmail(
     await context.runtime.runTelemetryEffect(
       captureWarningEffect("email_parse_exception", {
         provider: email.provider,
-        errorType: error instanceof Error ? error.message : "unknown",
+        errorType: error instanceof Error ? error.name : "unknown",
       })
     );
     return { kind: "failed" };
@@ -81,12 +87,12 @@ async function persistPendingRetryIncomingEmail(
   context: EmailBatchContext,
   email: RawEmail,
   failureReason: string | null
-) {
+): Promise<boolean> {
   const processedIds = await context.runtime.runEmailEffect(
     getProcessedExternalIdsEffect(context.db, [email.externalId])
   );
   if (processedIds.has(email.externalId)) {
-    return;
+    return false;
   }
 
   const { createdAt, processedEmailId } = await createIncomingEmailPersistenceState(context, email);
@@ -108,6 +114,7 @@ async function persistPendingRetryIncomingEmail(
     transactionId: null,
     createdAt,
   });
+  return true;
 }
 
 async function persistSkippedIncomingEmail(
@@ -116,8 +123,9 @@ async function persistSkippedIncomingEmail(
   kind: Exclude<UnparsedIncomingEmailKind, "failed">
 ) {
   const { createdAt, processedEmailId } = await createIncomingEmailPersistenceState(context, email);
+  const metadataOnlyEmail = { ...email, subject: "", body: "" };
   const row = buildUnparsedProcessedEmailRow({
-    email,
+    email: metadataOnlyEmail,
     processedEmailId,
     createdAt,
     status: "skipped",
@@ -125,14 +133,10 @@ async function persistSkippedIncomingEmail(
     nextRetryAt: null,
   });
 
-  await persistIncomingEmailRecord({
-    context,
-    email,
-    row,
-    processedEmailId,
-    transactionId: null,
-    createdAt,
-  });
+  await context.runtime.runEmailEffect(insertProcessedEmailEffect(context.db, row));
+  await context.runtime.runTelemetryEffect(
+    capturePipelineEventEffect(buildSkippedEmailDiagnostics({ email, reason: kind }))
+  );
   incrementPipelineMetric(context.result, kind === "filtered" ? "filtered" : "failed");
 }
 
@@ -231,40 +235,51 @@ async function processParsedIncomingEmail(
   email: RawEmail,
   parsed: LlmParsedTransaction
 ) {
-  const duplicate = await lookupIncomingDuplicate(context, parsed);
-  if (duplicate.kind === "failed") {
-    await persistPendingRetryIncomingEmail(context, email, null);
-    incrementPipelineMetric(context.result, "failed");
-    return;
-  }
+  await runSerializedPersistence(context, async () => {
+    const duplicate = await lookupIncomingDuplicate(context, parsed);
+    if (duplicate.kind === "failed") {
+      const queuedRetry = await persistPendingRetryIncomingEmail(context, email, null);
+      incrementPipelineMetric(context.result, "failed");
+      if (queuedRetry) {
+        incrementPipelineMetric(context.result, "pendingRetry");
+      }
+      return;
+    }
 
-  if (duplicate.kind === "duplicate") {
-    await persistDuplicateIncomingEmail({
-      context,
-      email,
-      parsed,
-      transactionId: duplicate.transactionId,
-    });
-    return;
-  }
+    if (duplicate.kind === "duplicate") {
+      await persistDuplicateIncomingEmail({
+        context,
+        email,
+        parsed,
+        transactionId: duplicate.transactionId,
+      });
+      return;
+    }
 
-  const status = resolveEmailStatus(parsed.confidence);
-  const saved = await persistIncomingTransaction({ context, email, parsed, status });
-  if (!saved) {
-    await persistPendingRetryIncomingEmail(context, email, null);
-    incrementPipelineMetric(context.result, "failed");
-    return;
-  }
+    const status = resolveEmailStatus(parsed.confidence);
+    const saved = await persistIncomingTransaction({ context, email, parsed, status });
+    if (!saved) {
+      const queuedRetry = await persistPendingRetryIncomingEmail(context, email, null);
+      incrementPipelineMetric(context.result, "failed");
+      if (queuedRetry) {
+        incrementPipelineMetric(context.result, "pendingRetry");
+      }
+      return;
+    }
 
-  incrementPipelineMetric(context.result, status === "success" ? "saved" : "needsReview");
+    incrementPipelineMetric(context.result, status === "success" ? "saved" : "needsReview");
+  });
 }
 
 export async function processIncomingEmail(context: EmailBatchContext, email: RawEmail) {
   const parsed = await parseIncomingEmail(context, email);
   if (parsed.kind !== "parsed") {
     if (parsed.kind === "failed") {
-      await persistPendingRetryIncomingEmail(context, email, "parse_error");
+      const queuedRetry = await persistPendingRetryIncomingEmail(context, email, "parse_error");
       incrementPipelineMetric(context.result, "failed");
+      if (queuedRetry) {
+        incrementPipelineMetric(context.result, "pendingRetry");
+      }
       return;
     }
 

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/internal-types.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/internal-types.ts
@@ -36,6 +36,7 @@ export type PipelineRuntime = {
     readonly concurrency: number;
     readonly sleep: (delayMs: number) => Promise<void>;
   };
+  readonly maxCandidateEmails?: number;
 };
 
 export type CaptureEvidenceRowsInput = {
@@ -178,6 +179,7 @@ export type EmailBatchContext = {
   completed: number;
   parseStarts: number;
   parseStartGate: Promise<void>;
+  persistenceGate: Promise<void>;
 };
 
 export type RetryBatchContext = {
@@ -213,7 +215,13 @@ export type RetryDuplicateOutcome =
   | { readonly kind: "retry" };
 
 export type UnparsedIncomingEmailKind = Exclude<IncomingParseOutcome["kind"], "parsed">;
-export type EmailMetric = "filtered" | "skippedCrossSource" | "saved" | "failed" | "needsReview";
+export type EmailMetric =
+  | "filtered"
+  | "skippedCrossSource"
+  | "saved"
+  | "failed"
+  | "pendingRetry"
+  | "needsReview";
 
 export type UnparsedProcessedEmailRowInput = {
   readonly email: RawEmail;

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/public-types.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/public-types.ts
@@ -33,6 +33,7 @@ export type PipelineResult = {
   skippedCrossSource: number;
   saved: number;
   failed: number;
+  pendingRetry: number;
   needsReview: number;
 };
 
@@ -137,6 +138,7 @@ export type CreateEmailPipelineServiceDeps = {
     readonly concurrency?: number;
     readonly sleep?: (delayMs: number) => Promise<void>;
   };
+  readonly maxCandidateEmails?: number;
 };
 
 export type EmailPipelineService = {

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/runtime.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/runtime.ts
@@ -30,8 +30,8 @@ export const EmailPipelineDeps = makeAppService<CreateEmailPipelineServiceDeps>(
   "@/features/email-capture/EmailPipelineDeps"
 );
 
-const DEFAULT_PARSE_RATE_LIMIT_DELAY_MS = process.env.NODE_ENV === "test" ? 0 : 3000;
-const DEFAULT_PARSE_RATE_LIMIT_CONCURRENCY = 1;
+const DEFAULT_PARSE_RATE_LIMIT_DELAY_MS = 0;
+const DEFAULT_PARSE_RATE_LIMIT_CONCURRENCY = 3;
 
 const sleep = (delayMs: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, delayMs));
@@ -222,7 +222,7 @@ export function nextRetryAtEffect(retryCount: number) {
 }
 
 export function createPipelineRuntime(deps: CreateEmailPipelineServiceDeps): PipelineRuntime {
-  const { clock, telemetry, parseRateLimit, ...runtimeDeps } = deps;
+  const { clock, telemetry, parseRateLimit, maxCandidateEmails, ...runtimeDeps } = deps;
   const clockRuntime = bindAppClock(clock as AppClock | undefined);
   const telemetryRuntime = bindAppTelemetry(telemetry as AppTelemetry | undefined);
   const runtime = EmailPipelineDeps.bind(runtimeDeps);
@@ -237,5 +237,6 @@ export function createPipelineRuntime(deps: CreateEmailPipelineServiceDeps): Pip
       concurrency: parseRateLimit?.concurrency ?? DEFAULT_PARSE_RATE_LIMIT_CONCURRENCY,
       sleep: parseRateLimit?.sleep ?? sleep,
     },
+    maxCandidateEmails,
   };
 }

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/shared.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/shared.ts
@@ -63,6 +63,28 @@ export function getNextQueuedEmail(queue: EmailQueue) {
   return email ?? null;
 }
 
+export async function runSerializedPersistence<T>(
+  context: EmailBatchContext,
+  operation: () => Promise<T>
+): Promise<T> {
+  const previous = context.persistenceGate;
+  let releaseCurrent!: () => void;
+  const current = new Promise<void>((resolve) => {
+    releaseCurrent = resolve;
+  });
+  context.persistenceGate = previous.then(
+    () => current,
+    () => current
+  );
+
+  await previous;
+  try {
+    return await operation();
+  } finally {
+    releaseCurrent();
+  }
+}
+
 export function dedupeRawEmails(rawEmails: EmailQueue["emails"]) {
   return Array.from(new Map(rawEmails.map((email) => [email.externalId, email])).values());
 }
@@ -74,6 +96,7 @@ export function createPipelineResult(skippedDuplicate: number): PipelineResult {
     skippedCrossSource: 0,
     saved: 0,
     failed: 0,
+    pendingRetry: 0,
     needsReview: 0,
   };
 }

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/transactions.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/transactions.ts
@@ -6,7 +6,7 @@ import {
 import type { FinancialAccountRow } from "@/features/financial-accounts/public";
 import type { TransactionRow } from "@/features/transactions/lib/repository";
 import { currentIsoDateTimeEffect } from "@/shared/effect/clock";
-import { fromThunk } from "@/shared/effect/runtime";
+import { fromPromise, fromThunk } from "@/shared/effect/runtime";
 import { generateProcessedEmailId, generateTransactionId } from "@/shared/lib/generate-id";
 import { normalizeMerchant } from "@/shared/lib/normalize-merchant";
 import {
@@ -111,19 +111,19 @@ function persistTransactionBundleEffect(context: EmailTransactionContext) {
     };
     const evidenceRows = buildTransactionCaptureEvidenceRows(context, buildEmailCaptureEvidence);
 
-    yield* fromThunk(() => {
+    yield* fromPromise(async () => {
       if ("transaction" in context.db && typeof context.db.transaction === "function") {
-        context.db.transaction((tx) => {
-          insertTransaction(tx, transactionRow);
-          insertProcessedEmail(tx, processedEmailRow);
-          saveCaptureEvidenceRows(tx, evidenceRows);
+        await context.db.transaction(async (tx) => {
+          await insertTransaction(tx, transactionRow);
+          await insertProcessedEmail(tx, processedEmailRow);
+          await saveCaptureEvidenceRows(tx, evidenceRows);
         });
         return;
       }
 
-      insertTransaction(context.db, transactionRow);
-      insertProcessedEmail(context.db, processedEmailRow);
-      saveCaptureEvidenceRows(context.db, evidenceRows);
+      await insertTransaction(context.db, transactionRow);
+      await insertProcessedEmail(context.db, processedEmailRow);
+      await saveCaptureEvidenceRows(context.db, evidenceRows);
     });
   });
 }

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/transactions.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/transactions.ts
@@ -1,8 +1,12 @@
 import { Effect } from "effect";
+import {
+  type CaptureEvidenceRow,
+  materializeCaptureEvidenceRows,
+} from "@/features/capture-evidence/public";
 import type { FinancialAccountRow } from "@/features/financial-accounts/public";
 import type { TransactionRow } from "@/features/transactions/lib/repository";
 import { currentIsoDateTimeEffect } from "@/shared/effect/clock";
-import { fromPromise, fromThunk } from "@/shared/effect/runtime";
+import { fromThunk } from "@/shared/effect/runtime";
 import { generateProcessedEmailId, generateTransactionId } from "@/shared/lib/generate-id";
 import { normalizeMerchant } from "@/shared/lib/normalize-merchant";
 import {
@@ -16,7 +20,6 @@ import {
   EmailPipelineDeps,
   ensureDefaultFinancialAccountEffect,
   insertMerchantRuleEffect,
-  saveEmailCaptureEvidenceEffect,
 } from "./runtime";
 import {
   assertParsedTransaction,
@@ -32,6 +35,7 @@ import type {
   SaveRetryTransactionInput,
   SaveTransactionInput,
   TrackSavedTransactionInput,
+  CreateEmailPipelineServiceDeps,
 } from "./types";
 
 function buildTransactionRow(context: PersistedTransactionContext): TransactionRow {
@@ -58,24 +62,70 @@ function persistTransactionRecordEffect(context: PersistedTransactionContext) {
   });
 }
 
-function persistProcessedEmailEffect(context: EmailTransactionContext) {
-  const row = {
-    id: context.processedEmailId,
-    externalId: context.email.externalId,
-    provider: context.email.provider,
-    status: context.status,
-    failureReason: null,
-    subject: context.email.subject,
-    rawBodyPreview: context.email.body.slice(0, 500),
-    receivedAt: requireIsoDateTime(context.email.receivedAt),
-    transactionId: context.txId,
-    confidence: context.parsed.confidence,
-    createdAt: context.now,
-  };
-
-  return Effect.flatMap(EmailPipelineDeps.tag, ({ insertProcessedEmail }) =>
-    fromPromise(() => insertProcessedEmail(context.db, row))
+function buildTransactionCaptureEvidenceRows(
+  context: EmailTransactionContext,
+  buildEmailCaptureEvidence: CreateEmailPipelineServiceDeps["buildEmailCaptureEvidence"]
+): readonly CaptureEvidenceRow[] {
+  return materializeCaptureEvidenceRows(
+    buildEmailCaptureEvidence({
+      from: context.email.from,
+      body: context.email.body,
+      fromAccountHint: context.parsed.fromAccountHint,
+      toAccountHint: context.parsed.toAccountHint,
+      cardProductHint: context.parsed.cardProductHint,
+      accountTypeHint: context.parsed.accountTypeHint,
+      counterpartyHint: context.parsed.counterpartyHint,
+    }),
+    {
+      userId: context.userId,
+      transactionId: context.txId,
+      processedEmailId: context.processedEmailId,
+      processedCaptureId: null,
+      createdAt: context.now,
+      updatedAt: context.now,
+    }
   );
+}
+
+function persistTransactionBundleEffect(context: EmailTransactionContext) {
+  return Effect.gen(function* () {
+    const {
+      buildEmailCaptureEvidence,
+      insertProcessedEmail,
+      insertTransaction,
+      saveCaptureEvidenceRows,
+    } = yield* EmailPipelineDeps.tag;
+    const transactionRow = buildTransactionRow(context);
+    const processedEmailRow = {
+      id: context.processedEmailId,
+      externalId: context.email.externalId,
+      provider: context.email.provider,
+      status: context.status,
+      failureReason: null,
+      subject: context.email.subject,
+      rawBodyPreview: context.email.body.slice(0, 500),
+      receivedAt: requireIsoDateTime(context.email.receivedAt),
+      transactionId: context.txId,
+      confidence: context.parsed.confidence,
+      createdAt: context.now,
+    };
+    const evidenceRows = buildTransactionCaptureEvidenceRows(context, buildEmailCaptureEvidence);
+
+    yield* fromThunk(() => {
+      if ("transaction" in context.db && typeof context.db.transaction === "function") {
+        context.db.transaction((tx) => {
+          insertTransaction(tx, transactionRow);
+          insertProcessedEmail(tx, processedEmailRow);
+          saveCaptureEvidenceRows(tx, evidenceRows);
+        });
+        return;
+      }
+
+      insertTransaction(context.db, transactionRow);
+      insertProcessedEmail(context.db, processedEmailRow);
+      saveCaptureEvidenceRows(context.db, evidenceRows);
+    });
+  });
 }
 
 function trackSavedTransactionEffect(input: TrackSavedTransactionInput) {
@@ -182,22 +232,7 @@ function persistSuccessfulRetrySideEffectsEffect(context: RetryTransactionContex
 export function saveTransactionEffect(input: SaveTransactionInput) {
   return Effect.gen(function* () {
     const context = yield* createEmailTransactionContextEffect(input);
-    yield* persistTransactionRecordEffect(context);
-    yield* persistProcessedEmailEffect(context);
-    yield* saveEmailCaptureEvidenceEffect({
-      db: context.db,
-      userId: context.userId,
-      from: context.email.from,
-      body: context.email.body,
-      fromAccountHint: context.parsed.fromAccountHint,
-      toAccountHint: context.parsed.toAccountHint,
-      cardProductHint: context.parsed.cardProductHint,
-      accountTypeHint: context.parsed.accountTypeHint,
-      counterpartyHint: context.parsed.counterpartyHint,
-      processedEmailId: context.processedEmailId,
-      transactionId: context.txId,
-      now: context.now,
-    });
+    yield* persistTransactionBundleEffect(context);
     yield* trackSavedTransactionEffect({
       parsed: context.parsed,
       categoryId: context.categoryId,

--- a/apps/mobile/features/email-capture/services/email-pipeline.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline.ts
@@ -32,6 +32,11 @@ import { retryableParseEmailApi } from "./parse-email-api";
 
 export type { PipelineResult, ProcessEmails, ProcessRetries, ProgressCallback, RetryResult };
 
+const FOREGROUND_PARSE_START_DELAY_MS = 0;
+const FOREGROUND_PARSE_CONCURRENCY = 3;
+const BACKGROUND_PARSE_START_DELAY_MS = 0;
+const BACKGROUND_PARSE_CONCURRENCY = 2;
+const BACKGROUND_MAX_CANDIDATE_EMAILS = 10;
 const INITIAL_SYNC_PARSE_START_DELAY_MS = 1000;
 const INITIAL_SYNC_PARSE_CONCURRENCY = 1;
 
@@ -55,7 +60,22 @@ const emailPipelineDeps = {
   trackTransactionCreated,
 };
 
-const emailPipeline = createEmailPipelineService(emailPipelineDeps);
+const emailPipeline = createEmailPipelineService({
+  ...emailPipelineDeps,
+  parseRateLimit: {
+    delayMs: FOREGROUND_PARSE_START_DELAY_MS,
+    concurrency: FOREGROUND_PARSE_CONCURRENCY,
+  },
+});
+
+const backgroundEmailPipeline = createEmailPipelineService({
+  ...emailPipelineDeps,
+  parseRateLimit: {
+    delayMs: BACKGROUND_PARSE_START_DELAY_MS,
+    concurrency: BACKGROUND_PARSE_CONCURRENCY,
+  },
+  maxCandidateEmails: BACKGROUND_MAX_CANDIDATE_EMAILS,
+});
 
 const initialSyncEmailPipeline = createEmailPipelineService({
   ...emailPipelineDeps,
@@ -72,6 +92,13 @@ export const processEmails: ProcessEmails = (
   rawEmails: RawEmail[],
   onProgress?: ProgressCallback
 ) => emailPipeline.processEmails(db, userId, rawEmails, onProgress);
+
+export const processBackgroundEmails: ProcessEmails = (
+  db: AnyDb,
+  userId: UserId,
+  rawEmails: RawEmail[],
+  onProgress?: ProgressCallback
+) => backgroundEmailPipeline.processEmails(db, userId, rawEmails, onProgress);
 
 export const processInitialSyncEmails: ProcessEmails = (
   db: AnyDb,

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -13,13 +13,17 @@ import {
 import type { EmailProvider } from "./schema";
 import { getAdapter } from "./services/email-adapter";
 import {
+  applyEmailCaptureCandidateLimit,
   aggregatePipelineResults,
   createEmailFetchClientIds,
+  type EmailCaptureParseProfile,
   fetchEmailAccountBatch,
   ingestFetchedEmails,
   loadEmailCaptureQueues,
   type ProcessedEmailAccountFetchResult,
   persistFetchedAccounts,
+  resolveEmailCaptureSyncPolicy,
+  sortFetchResultsByNewestEmail,
 } from "./services/email-capture-fetch-service";
 import {
   applyEmailCaptureFetchSummary,
@@ -87,7 +91,6 @@ registerEmailCaptureStoreRuntime({
 export function initializeEmailCaptureSession(userId: UserId): void {
   initializeEmailCaptureStoreSession(userId);
 }
-
 export async function loadEmailAccounts(db: AnyDb, userId: UserId): Promise<void> {
   const request = beginEmailCaptureRequest("accounts", userId);
 
@@ -95,11 +98,8 @@ export async function loadEmailAccounts(db: AnyDb, userId: UserId): Promise<void
     const accounts = await getEmailAccounts(db, userId);
     if (!isCurrentEmailCaptureRequest(request)) return;
     useEmailCaptureStore.getState().setAccounts(accounts);
-  } catch {
-    // Keep existing state on account load failures.
-  }
+  } catch {}
 }
-
 export async function loadFailedEmails(db: AnyDb, userId: UserId): Promise<void> {
   const request = beginEmailCaptureRequest("failedEmails", userId);
 
@@ -107,11 +107,8 @@ export async function loadFailedEmails(db: AnyDb, userId: UserId): Promise<void>
     const failedEmails = await getFailedEmails(db);
     if (!isCurrentEmailCaptureRequest(request)) return;
     useEmailCaptureStore.getState().setFailedEmails(failedEmails);
-  } catch {
-    // Keep existing state on failed-email load failures.
-  }
+  } catch {}
 }
-
 export async function loadNeedsReviewEmails(db: AnyDb, userId: UserId): Promise<void> {
   const request = beginEmailCaptureRequest("needsReview", userId);
 
@@ -119,11 +116,8 @@ export async function loadNeedsReviewEmails(db: AnyDb, userId: UserId): Promise<
     const needsReviewEmails = await getNeedsReviewEmails(db);
     if (!isCurrentEmailCaptureRequest(request)) return;
     useEmailCaptureStore.getState().setNeedsReviewEmails(needsReviewEmails);
-  } catch {
-    // Keep existing state on needs-review load failures.
-  }
+  } catch {}
 }
-
 export async function dismissFailedEmail(
   db: AnyDb,
   userId: UserId,
@@ -139,7 +133,6 @@ export async function dismissFailedEmail(
   if (!isActiveEmailCaptureSession(session)) return;
   useEmailCaptureStore.getState().removeFailedEmail(processedEmailId);
 }
-
 export async function connectEmailAccount(
   db: AnyDb,
   userId: UserId,
@@ -170,7 +163,6 @@ export async function connectEmailAccount(
   if (!isActiveEmailCaptureSession(session)) return;
   useEmailCaptureStore.getState().appendAccount(row);
 }
-
 export async function disconnectEmailAccount(
   db: AnyDb,
   userId: UserId,
@@ -199,7 +191,7 @@ export async function fetchAndProcessEmails(
   gmailClientId: string,
   outlookClientId: string,
   refreshTransactions: RefreshTransactions = noopRefreshTransactions,
-  options: { readonly parseProfile?: "default" | "initial_sync" } = {}
+  options: { readonly parseProfile?: EmailCaptureParseProfile } = {}
 ): Promise<EmailCaptureFetchOutcome> {
   const fetchStart = beginEmailCaptureFetchRun(userId);
   if (fetchStart.kind === "missing_context") {
@@ -212,6 +204,7 @@ export async function fetchAndProcessEmails(
   }
 
   const run = fetchStart.run;
+  const syncPolicy = resolveEmailCaptureSyncPolicy(options.parseProfile);
 
   try {
     const accounts = useEmailCaptureStore.getState().accounts;
@@ -224,13 +217,19 @@ export async function fetchAndProcessEmails(
       accounts,
       clientIds: createEmailFetchClientIds(gmailClientId, outlookClientId),
     });
+    const fetchResults = applyEmailCaptureCandidateLimit(
+      summary.fetchResults,
+      syncPolicy.maxCandidateEmails
+    );
+    const allEmails = fetchResults.flatMap((result) => result.rawEmails);
+    const showProgress = syncPolicy.showsProgress && summary.showProgress;
     applyEmailCaptureFetchSummary({
       run,
-      showProgress: summary.showProgress,
-      emailCount: summary.allEmails.length,
+      showProgress,
+      emailCount: allEmails.length,
     });
     const onProgress = createEmailCaptureFetchProgressHandler(run, refreshTransactions);
-    const processedFetchResults = await summary.fetchResults.reduce(
+    const processedFetchResults = await sortFetchResultsByNewestEmail(fetchResults).reduce(
       async (processedPromise, fetchResult) => {
         const processed = await processedPromise;
         if (!fetchResult.fetchOk) return processed;
@@ -249,32 +248,36 @@ export async function fetchAndProcessEmails(
           emails: fetchResult.rawEmails,
           onProgress: (progress) =>
             onProgress({
-              total: summary.allEmails.length,
+              total: allEmails.length,
               completed: completedBefore + progress.completed,
               saved: previousResult.saved + progress.saved,
               failed: previousResult.failed + progress.failed,
               needsReview: previousResult.needsReview + progress.needsReview,
             }),
           runRetries: false,
-          parseProfile: options.parseProfile,
+          parseProfile: syncPolicy.parseProfile,
         });
 
         return [...processed, { ...fetchResult, processingResult }];
       },
       Promise.resolve([] as ProcessedEmailAccountFetchResult[])
     );
-    await ingestFetchedEmails({ db, userId, emails: [], parseProfile: options.parseProfile });
+    if (syncPolicy.runRetries) {
+      await ingestFetchedEmails({ db, userId, emails: [], parseProfile: syncPolicy.parseProfile });
+    }
     const processingResult = aggregatePipelineResults(
       processedFetchResults.map((result) => result.processingResult)
     );
 
     await applyEmailCaptureFetchOutcome({
       run,
-      showProgress: summary.showProgress,
-      persistedAccounts: await persistFetchedAccounts({
-        db,
-        fetchResults: processedFetchResults,
-      }),
+      showProgress,
+      persistedAccounts: syncPolicy.advancesLastFetchedAt
+        ? await persistFetchedAccounts({
+            db,
+            fetchResults: processedFetchResults,
+          })
+        : { fetchedAt: toIsoDateTime(new Date()), updatedAccountIds: new Set() },
       queues: await loadEmailCaptureQueues(db),
       refreshTransactions,
     });

--- a/apps/mobile/features/financial-accounts/components/financial-account-details-screen/FinancialAccountDetailsHero.tsx
+++ b/apps/mobile/features/financial-accounts/components/financial-account-details-screen/FinancialAccountDetailsHero.tsx
@@ -14,6 +14,8 @@ export function FinancialAccountDetailsHero({
   const { t } = useTranslation();
   const primary = useThemeColor("primary");
   const secondary = useThemeColor("secondary");
+  const card = useThemeColor("card");
+  const nav = useThemeColor("nav");
   const accentGreenLight = useThemeColor("accentGreenLight");
 
   return (
@@ -25,8 +27,8 @@ export function FinancialAccountDetailsHero({
         </View>
 
         {isDefault ? (
-          <View style={[styles.badge, { backgroundColor: "#FFFFFF" }]}>
-            <Text style={[styles.badgeText, { color: "#1F2933" }]}>
+          <View style={[styles.badge, { backgroundColor: card }]}>
+            <Text style={[styles.badgeText, { color: nav }]}>
               {t("financialAccounts.labels.default")}
             </Text>
           </View>

--- a/apps/mobile/features/search/components/CategoryFilter.tsx
+++ b/apps/mobile/features/search/components/CategoryFilter.tsx
@@ -22,6 +22,7 @@ const FilterPill = memo(
     onToggle: (categoryId: string) => void;
   }) => {
     const { locale } = useTranslation();
+    const card = useThemeColor("card");
     const peachLight = useThemeColor("peachLight");
 
     const handlePress = () => {
@@ -38,7 +39,7 @@ const FilterPill = memo(
         accessibilityState={{ selected: isSelected }}
         accessibilityLabel={getCategoryLabel(category, locale)}
       >
-        {isSelected ? <Check size={16} color="#FFFFFF" /> : <Text>{category.icon}</Text>}
+        {isSelected ? <Check size={16} color={card} /> : <Text>{category.icon}</Text>}
       </Pressable>
     );
   }

--- a/plans/email-capture-pipeline-reliability-prd.md
+++ b/plans/email-capture-pipeline-reliability-prd.md
@@ -1,0 +1,148 @@
+# Email Capture Pipeline Reliability and Latency
+
+## Problem
+
+Email-captured transactions can take 1-2 minutes to appear after opening the app, even when the bank email is already present. Some transaction emails may also be fetched but never become a visible transaction or review item, making the failure mode opaque to both users and developers.
+
+The current email pipeline is safe primarily because it is serialized. Normal parsing uses one worker with a fixed 3 second delay between parse starts, and account `lastFetchedAt` only advances when every processed email in the fetched batch succeeds. This can turn one bad email into repeated provider re-fetches of old emails. If concurrency is increased naively, the current shared mutable counters and separate duplicate-check-then-insert flow can create progress-order bugs or duplicate transaction races.
+
+## Proposal
+
+Refactor email capture so slow remote interpretation can run concurrently while transaction persistence remains atomic and deterministic.
+
+The target behavior is:
+
+- Initial onboarding sync stays conservative.
+- Normal foreground sync parses concurrently with no artificial fixed start delay.
+- Background sync uses moderate concurrency and bounded work.
+- Fetched emails are always persisted into a terminal or retryable local state before advancing provider `lastFetchedAt`.
+- Failed parse/save work retries from the local `processedEmails` queue instead of forcing repeated provider re-fetches.
+- Home updates as soon as a new transaction is saved.
+- Telemetry exposes timing and outcome reasons for diagnosing missing or delayed transactions.
+
+## Intended Users
+
+- Fidy users relying on email capture for near-real-time transaction registration.
+- Developers diagnosing missing transactions, slow email sync, parse failures, or duplicate transaction behavior.
+
+## User Stories
+
+- As a user, I want a bank email that already exists in my inbox to appear in Home quickly after opening the app, so I can trust my ledger is current.
+- As a user, I want emails that cannot be confidently turned into transactions to show up in the appropriate review or retry state, so transactions do not disappear silently.
+- As a developer, I want structured timing and outcome telemetry, so I can tell whether latency came from provider fetch, parsing, persistence, retries, or UI refresh.
+- As a developer, I want concurrent parsing without duplicate races, so we can improve latency without weakening ledger correctness.
+
+## Module Sketch
+
+- `features/email-capture/services/email-pipeline-service/incoming-batch.ts` - Split batch processing into concurrent parse work and serialized persistence work. Remove shared mutable result/progress counters from worker context. Return per-email outcomes and reduce them into the final batch result.
+- `features/email-capture/services/email-pipeline-service/incoming-email.ts` - Separate parse/interpret outcome from persistence outcome. Ensure every fetched email becomes `success`, `needs_review`, `skipped`, `skipped_duplicate`, `pending_retry`, or `failed`.
+- `features/email-capture/services/email-pipeline-service/transactions.ts` - Keep duplicate detection and transaction insertion in a serialized or transactional persistence section. Verify whether current DB constraints are sufficient; if not, add an atomic local write boundary or uniqueness guard appropriate for local-first data.
+- `features/email-capture/services/email-pipeline-service/runtime.ts` - Replace one global default parse throttle with profile-specific parse policies for initial sync, foreground sync, and background sync.
+- `features/email-capture/services/email-capture-fetch-service.ts` - Advance `lastFetchedAt` when provider fetch succeeds and every fetched email has been persisted into a retryable or terminal local state. Add optional max-email limits for background fetch.
+- `features/email-capture/store.ts` - Thread parse policy and work bounds through `fetchAndProcessEmails`. Keep foreground refresh behavior on first saved transaction and after completion.
+- `features/background-fetch/task.ts` - Use the background parse policy and bounded work. Ensure saved background transactions are visible on next foreground refresh without repeating provider work.
+- `features/email-capture/hooks/useEmailCapture.ts` - Use the foreground parse policy: higher concurrency, no fixed start delay.
+- `features/onboarding/components/SyncProgressStep.tsx` - Keep initial sync conservative and explicit via `parseProfile: "initial_sync"` or a clearer sync-mode option.
+- `shared/lib/sentry.ts` and email telemetry call sites - Add timing and outcome telemetry without plaintext financial data, merchant names, amounts, email content, or subject lines.
+
+## Implementation Plan
+
+1. Baseline current behavior with tests and telemetry gaps.
+
+- Add targeted tests documenting current foreground sync behavior, `lastFetchedAt` advancement rules, retry persistence, and duplicate handling.
+- Add a test that proves concurrency greater than one would be unsafe today if duplicate detection and insert are both parallel.
+- Identify existing `processedEmails` statuses used by review/retry screens and confirm which statuses are user-visible.
+
+2. Introduce explicit sync modes and parse policies.
+
+- Replace the loose `parseProfile` shape with a clearer sync mode if needed: `foreground`, `background`, `initial_sync`.
+- Define policy defaults: foreground parse concurrency `3`, delay `0`; background parse concurrency `2`, delay `0`, bounded candidate count; initial sync conservative, likely concurrency `1`, delay `1000` or existing behavior.
+- Keep these policies internal to email capture; do not expose UI configuration.
+
+3. Refactor batch processing into immutable per-email outcomes.
+
+- Make each email parse return a value describing parse result instead of mutating shared batch metrics.
+- Aggregate final `PipelineResult` with a pure reduce.
+- Report progress from completed outcome counts rather than shared `context.completed` mutation.
+
+4. Run remote parsing concurrently, but persist serially.
+
+- Allow parse calls to use policy concurrency.
+- Feed parsed outcomes into a single persistence lane so duplicate lookup and insert remain ordered.
+- Keep local writes deterministic and testable.
+
+5. Make fetched email state durable before advancing `lastFetchedAt`.
+
+- Ensure parse failures persist as `pending_retry` with retry metadata when retryable.
+- Ensure permanent failures persist as `failed` where appropriate.
+- Ensure filtered/skipped emails persist as `skipped` so they are not repeatedly fetched.
+- Update account `lastFetchedAt` after provider fetch success if all fetched emails reached local durable state, even when some are pending retry or failed.
+
+6. Add bounded background work.
+
+- Limit background runs to a small number of newest unprocessed candidate emails per provider account.
+- Keep background parsing moderate to respect OS execution limits and network/battery constraints.
+- Avoid progress UI assumptions in background mode.
+
+7. Improve Home refresh semantics.
+
+- Keep foreground `refreshTransactions` on first saved transaction.
+- Ensure completion refresh still happens after batch persistence.
+- Confirm that transactions saved in background appear immediately after the next foreground bootstrap/refresh without re-fetching old provider emails.
+
+8. Add diagnostic telemetry.
+
+- Capture fetch duration per provider family, fetched count, skipped already processed count, durable failed count, pending retry count, duplicate count, saved count, needs review count, time to first saved transaction, parse duration summary, and retry results.
+- Keep Sentry payloads structural only: no merchant names, amounts, subject lines, email bodies, account identifiers, or email addresses.
+
+9. Verify with tests and local QA.
+
+- Unit-test policy resolution, pure outcome aggregation, retry persistence, `lastFetchedAt` advancement, and duplicate-safe serialized persistence.
+- Integration-test foreground fetch with multiple emails where one fails and one succeeds.
+- Integration-test concurrency with two duplicate-like emails and assert only one transaction is saved.
+- Test background bounded work separately from foreground sync.
+
+## Security and Permissions
+
+- Do not log plaintext financial data, merchant names, amounts, email bodies, subjects, account numbers, card hints, or email addresses.
+- Continue using existing OAuth tokens and provider adapters; no new provider permissions are required.
+- Ensure telemetry uses counts, durations, statuses, and provider family only.
+- Background sync must respect authenticated session boundaries and local user database boundaries.
+
+## Testing
+
+- Direct unit tests for parse policy resolution and per-email outcome aggregation.
+- Direct unit tests for `lastFetchedAt` advancement with success, skipped, pending retry, failed, and mixed batches.
+- Direct unit tests for retry queue persistence when parse or save fails.
+- Integration tests for foreground sync refreshing Home after the first saved transaction.
+- Integration tests for concurrent parse plus serialized persistence to prevent duplicate transaction races.
+- Integration tests for background bounded work and no repeated provider re-fetch after durable local failure state.
+- Telemetry tests asserting structural fields are emitted and no PII fields are included.
+
+## Success Criteria
+
+- [ ] Normal foreground sync starts parsing without a fixed 3 second delay.
+- [ ] Normal foreground sync supports parse concurrency of 3 while preserving duplicate safety.
+- [ ] Background sync uses a separate bounded policy with moderate concurrency.
+- [ ] Initial sync remains conservative and does not burst historical LLM requests.
+- [ ] A single failed email no longer prevents provider `lastFetchedAt` from advancing after durable local state is recorded.
+- [ ] Failed parse/save work retries from local `processedEmails` instead of repeated provider re-fetches.
+- [ ] Home refreshes after the first saved foreground email transaction and after completion.
+- [ ] Duplicate-like emails processed under concurrent parsing save at most one transaction.
+- [ ] Telemetry reports fetch, parse, persistence, retry, and first-saved timing without PII.
+
+## Out of Scope
+
+- Adding push/webhook-based provider integrations for true real-time email events.
+- Changing bank sender discovery rules beyond telemetry needed to identify missed sender filters.
+- Redesigning the review UI, except for ensuring existing retry/review states are populated correctly.
+- Adding full-text search or remote plaintext financial storage.
+- Changing notification or Apple Pay capture pipelines unless shared deduplication logic must be hardened.
+
+## Open Questions
+
+Resolved decisions:
+
+- `skipped` emails should emit privacy-preserving structural diagnostics to Sentry. Do not log raw subject, body, amount, merchant, email address, account/card details, sender domains, deterministic fingerprints, or any free-text financial content. Use provider, skip reason, length buckets, and finite structural flags only.
+- Background sync should start with a max of 10 newest candidate emails per run, parse concurrency 2, and no fixed parse delay. Raise only if telemetry shows runs finish reliably and safely.
+- Foreground sync should not be capped initially. It should process fetched candidates newest-first with parse concurrency 3, no fixed parse delay, refresh Home after the first saved transaction, and rely on corrected `lastFetchedAt` behavior to prevent recurring stale backlogs.


### PR DESCRIPTION
- bound background parsing

- persist retry-safe fetch state

- remove PII from skip telemetry

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves mobile email capture reliability by awaiting bundled transaction writes and treating async failures as safe retries. Keeps fast concurrent parsing and bounded background work, and tightens telemetry privacy.

- **New Features**
  - Persist transaction + processed email + capture evidence atomically in one DB transaction and await completion.
  - Foreground parsing runs 3 concurrent starts with no delay; background uses 2 with a 10-email cap, applied newest-first across accounts.

- **Bug Fixes**
  - Catch async bundle failures: do not report saved; mark as `failed` and `pendingRetry`; skip merchant rule insert.
  - Remove PII from skipped and batch telemetry; report error types via `Error.name` instead of messages.
  - Prevent duplicate writes under concurrent parsing.
  - Replace hardcoded UI colors with theme values in `FinancialAccountDetailsHero` and `CategoryFilter`.

<sup>Written for commit c59900e4e9cce95c04cd7a4f027ef631bc37399d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

