### PR TITLE
feat(mobile): add email sync telemetry

### DIFF
--- a/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
@@ -437,6 +437,30 @@ describe("email processing pipeline", () => {
     expect(JSON.stringify(capturePipelineEvent.mock.calls)).not.toContain("Exito");
   });
 
+  it("reports first-saved timing when the persisted transaction needs review", async () => {
+    const capturePipelineEvent = vi.fn();
+    const service = createTestEmailPipelineService({
+      telemetry: {
+        captureError: vi.fn(),
+        captureWarning: vi.fn(),
+        capturePipelineEvent,
+      },
+    });
+    mockParseEmailApi.mockResolvedValueOnce(makeParsedEmailResult({ confidence: 0.5 }));
+
+    await service.processEmails(mockDb, USER_ID, [makeRawEmail()]);
+
+    expect(capturePipelineEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        schema: "email_pipeline_batch_v1",
+        saved: 0,
+        needsReview: 1,
+        hasFirstSavedTransaction: true,
+        firstSavedLatencyMs: expect.any(Number),
+      })
+    );
+  });
+
   it("saves transaction and caches merchant rule when LLM returns high confidence", async () => {
     const emails = [makeRawEmail()];
     mockParseEmailApi.mockResolvedValueOnce(makeParsedEmailResult());

--- a/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
@@ -358,22 +358,30 @@ describe("email processing pipeline", () => {
         skipReason: "filtered",
       })
     );
-    expect(capturePipelineEvent).toHaveBeenCalledWith({
-      source: "email",
-      schema: "email_pipeline_batch_v1",
-      batchSize: 1,
-      providerFamilyCount: 1,
-      providerFamilies: "gmail",
-      dedupedInBatch: 0,
-      skippedAlreadyProcessed: 0,
-      skippedCrossSource: 0,
-      skippedDuplicate: 0,
-      filtered: 1,
-      saved: 0,
-      failed: 0,
-      pendingRetry: 0,
-      needsReview: 0,
-    });
+    expect(capturePipelineEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "email",
+        schema: "email_pipeline_batch_v1",
+        batchSize: 1,
+        providerFamilyCount: 1,
+        providerFamilies: "gmail",
+        dedupedInBatch: 0,
+        skippedAlreadyProcessed: 0,
+        skippedCrossSource: 0,
+        skippedDuplicate: 0,
+        filtered: 1,
+        saved: 0,
+        failed: 0,
+        pendingRetry: 0,
+        needsReview: 0,
+        batchDurationMs: expect.any(Number),
+        parseTotalDurationMs: expect.any(Number),
+        parseMaxDurationMs: expect.any(Number),
+        parseAverageDurationMs: expect.any(Number),
+        persistenceTotalDurationMs: expect.any(Number),
+        hasFirstSavedTransaction: false,
+      })
+    );
     expect(JSON.stringify(capturePipelineEvent.mock.calls)).not.toContain("Compra aprobada");
     expect(JSON.stringify(capturePipelineEvent.mock.calls)).not.toContain("50.000");
     expect(JSON.stringify(capturePipelineEvent.mock.calls)).not.toContain(
@@ -401,6 +409,32 @@ describe("email processing pipeline", () => {
     });
     expect(JSON.stringify(captureWarning.mock.calls)).not.toContain("Exito");
     expect(JSON.stringify(captureWarning.mock.calls)).not.toContain("50.000");
+  });
+
+  it("reports first-saved timing without transaction content", async () => {
+    const capturePipelineEvent = vi.fn();
+    const service = createTestEmailPipelineService({
+      telemetry: {
+        captureError: vi.fn(),
+        captureWarning: vi.fn(),
+        capturePipelineEvent,
+      },
+    });
+    mockParseEmailApi.mockResolvedValueOnce(makeParsedEmailResult());
+
+    await service.processEmails(mockDb, USER_ID, [makeRawEmail()]);
+
+    expect(capturePipelineEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        schema: "email_pipeline_batch_v1",
+        saved: 1,
+        hasFirstSavedTransaction: true,
+        firstSavedLatencyMs: expect.any(Number),
+      })
+    );
+    expect(JSON.stringify(capturePipelineEvent.mock.calls)).not.toContain("Compra aprobada");
+    expect(JSON.stringify(capturePipelineEvent.mock.calls)).not.toContain("50.000");
+    expect(JSON.stringify(capturePipelineEvent.mock.calls)).not.toContain("Exito");
   });
 
   it("saves transaction and caches merchant rule when LLM returns high confidence", async () => {
@@ -719,6 +753,16 @@ describe("email processing pipeline", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("passes the explicit initial-sync parse context to remote parsing", async () => {
+    mockParseEmailApi.mockResolvedValueOnce(makeParsedEmailResult());
+
+    await processInitialSyncEmails(mockDb, USER_ID, [makeRawEmail()]);
+
+    expect(mockParseEmailApi).toHaveBeenCalledWith("Su compra por $50.000 fue aprobada", {
+      parseContext: "initial_sync",
+    });
   });
 
   it("saves transaction as needs_review when LLM returns low confidence", async () => {

--- a/apps/mobile/__tests__/email-capture/email-telemetry.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-telemetry.test.ts
@@ -14,40 +14,60 @@ const rawEmail: RawEmail = {
   provider: "gmail",
 };
 
+const batchTiming = {
+  batchDurationMs: 42,
+  parseTotalDurationMs: 25,
+  parseMaxDurationMs: 20,
+  parseAverageDurationMs: 13,
+  persistenceTotalDurationMs: 12,
+  firstSavedLatencyMs: null,
+};
+
+const filteredPipelineResult = {
+  filtered: 1,
+  skippedDuplicate: 0,
+  skippedCrossSource: 0,
+  saved: 0,
+  failed: 0,
+  pendingRetry: 0,
+  needsReview: 0,
+  parseImprovementRequests: [],
+};
+
+const expectedBatchTelemetry = {
+  source: "email",
+  schema: "email_pipeline_batch_v1",
+  batchSize: 1,
+  providerFamilyCount: 1,
+  providerFamilies: "gmail",
+  dedupedInBatch: 0,
+  skippedAlreadyProcessed: 0,
+  skippedCrossSource: 0,
+  skippedDuplicate: 0,
+  filtered: 1,
+  batchDurationMs: 42,
+  parseTotalDurationMs: 25,
+  parseMaxDurationMs: 20,
+  parseAverageDurationMs: 13,
+  persistenceTotalDurationMs: 12,
+  hasFirstSavedTransaction: false,
+  saved: 0,
+  failed: 0,
+  pendingRetry: 0,
+  needsReview: 0,
+};
+
 describe("email pipeline telemetry", () => {
   it("builds a structural batch event without email identifiers or content", () => {
     const event = buildEmailPipelineBatchTelemetry({
       rawEmails: [rawEmail],
       dedupedInBatch: 0,
       skippedAlreadyProcessed: 0,
-      result: {
-        filtered: 1,
-        skippedDuplicate: 0,
-        skippedCrossSource: 0,
-        saved: 0,
-        failed: 0,
-        pendingRetry: 0,
-        needsReview: 0,
-        parseImprovementRequests: [],
-      },
+      timing: batchTiming,
+      result: filteredPipelineResult,
     });
 
-    expect(event).toEqual({
-      source: "email",
-      schema: "email_pipeline_batch_v1",
-      batchSize: 1,
-      providerFamilyCount: 1,
-      providerFamilies: "gmail",
-      dedupedInBatch: 0,
-      skippedAlreadyProcessed: 0,
-      skippedCrossSource: 0,
-      skippedDuplicate: 0,
-      filtered: 1,
-      saved: 0,
-      failed: 0,
-      pendingRetry: 0,
-      needsReview: 0,
-    });
+    expect(event).toEqual(expectedBatchTelemetry);
     expect(Object.keys(event).join(" ")).not.toMatch(/body|subject|email|merchant|amount/i);
     expect(Object.values(event).join(" ")).not.toContain("Exito");
     expect(Object.values(event).join(" ")).not.toContain("50.000");

--- a/apps/mobile/__tests__/email-capture/fetch-service.test.ts
+++ b/apps/mobile/__tests__/email-capture/fetch-service.test.ts
@@ -3,16 +3,21 @@ import type { EmailAccountRow } from "@/features/email-capture/lib/repository";
 import {
   createEmailFetchClientIds,
   fetchEmailAccountBatch,
+  ingestFetchedEmails,
   persistFetchedAccounts,
 } from "@/features/email-capture/services/email-capture-fetch-service";
+import { createCaptureIngestionPort } from "@/features/capture-sources/ingestion.public";
 import type { AnyDb } from "@/shared/db";
 import { updateLastFetchedAt } from "@/features/email-capture/lib/repository";
 import type { EmailAccountId, IsoDateTime, UserId } from "@/shared/types/branded";
 
-const { mockFetchEmails, mockEnsureBankSenders } = vi.hoisted(() => ({
-  mockFetchEmails: vi.fn(),
-  mockEnsureBankSenders: vi.fn(),
-}));
+const { mockFetchEmails, mockEnsureBankSenders, mockCapturePipelineEvent, mockCaptureWarning } =
+  vi.hoisted(() => ({
+    mockFetchEmails: vi.fn(),
+    mockEnsureBankSenders: vi.fn(),
+    mockCapturePipelineEvent: vi.fn(),
+    mockCaptureWarning: vi.fn(),
+  }));
 
 vi.mock("@/features/capture-sources/ingestion.public", () => ({
   createCaptureIngestionPort: vi.fn(),
@@ -43,6 +48,15 @@ vi.mock("@/features/email-capture/services/email-adapter", () => ({
 vi.mock("@/shared/query", () => ({
   queryClient: {},
 }));
+
+vi.mock("@/shared/lib", async () => {
+  const actual = await vi.importActual<typeof import("@/shared/lib")>("@/shared/lib");
+  return {
+    ...actual,
+    captureWarning: (...args: unknown[]) => mockCaptureWarning(...args),
+    capturePipelineEvent: (...args: unknown[]) => mockCapturePipelineEvent(...args),
+  };
+});
 
 const makeAccount = (overrides: Partial<EmailAccountRow> = {}): EmailAccountRow => ({
   id: "ea-1" as EmailAccountId,
@@ -88,6 +102,70 @@ describe("fetchEmailAccountBatch", () => {
       "bank@example.com",
     ]);
   });
+
+  it("emits privacy-safe fetch timing telemetry", async () => {
+    mockFetchEmails.mockResolvedValueOnce([
+      {
+        externalId: "ext-1",
+        from: "bank@example.com",
+        subject: "Compra aprobada en Exito por $50.000",
+        body: "Compra por $50.000 enviada a user@example.com",
+        receivedAt: "2026-04-20T11:59:00.000Z",
+        provider: "gmail",
+      },
+    ]);
+
+    await fetchEmailAccountBatch({
+      accounts: [makeAccount()],
+      clientIds: createEmailFetchClientIds("gmail-client", "outlook-client"),
+    });
+
+    expect(mockCapturePipelineEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "email",
+        schema: "email_fetch_batch_v1",
+        accountCount: 1,
+        successfulFetchCount: 1,
+        failedFetchCount: 0,
+        fetchedCount: 1,
+        providerFamilyCount: 1,
+        providerFamilies: "gmail",
+        fetchDurationMs: expect.any(Number),
+        maxProviderFetchDurationMs: expect.any(Number),
+      })
+    );
+    expect(JSON.stringify(mockCapturePipelineEvent.mock.calls)).not.toContain("Exito");
+    expect(JSON.stringify(mockCapturePipelineEvent.mock.calls)).not.toContain("50.000");
+    expect(JSON.stringify(mockCapturePipelineEvent.mock.calls)).not.toContain("user@example.com");
+    expect(JSON.stringify(mockCapturePipelineEvent.mock.calls)).not.toContain("bank@example.com");
+  });
+
+  it("keeps failed provider fetch duration privacy-safe", async () => {
+    mockFetchEmails.mockImplementationOnce(async () => {
+      vi.advanceTimersByTime(125);
+      throw new Error("provider timeout with Compra por $50.000");
+    });
+
+    await fetchEmailAccountBatch({
+      accounts: [makeAccount()],
+      clientIds: createEmailFetchClientIds("gmail-client", "outlook-client"),
+    });
+
+    expect(mockCaptureWarning).toHaveBeenCalledWith("email_adapter_fetch_failed", {
+      provider: "gmail",
+      errorType: "Error",
+      fetchDurationMs: 125,
+    });
+    expect(mockCapturePipelineEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        schema: "email_fetch_batch_v1",
+        successfulFetchCount: 0,
+        failedFetchCount: 1,
+        maxProviderFetchDurationMs: 125,
+      })
+    );
+    expect(JSON.stringify(mockCaptureWarning.mock.calls)).not.toContain("50.000");
+  });
 });
 
 describe("persistFetchedAccounts", () => {
@@ -121,6 +199,7 @@ describe("persistFetchedAccounts", () => {
             },
           ],
           fetchOk: true,
+          fetchDurationMs: 0,
           processingResult: {
             filtered: 0,
             skippedDuplicate: 0,
@@ -159,6 +238,7 @@ describe("persistFetchedAccounts", () => {
             },
           ],
           fetchOk: true,
+          fetchDurationMs: 0,
           processingResult: {
             filtered: 0,
             skippedDuplicate: 0,
@@ -175,5 +255,71 @@ describe("persistFetchedAccounts", () => {
 
     expect(updateLastFetchedAt).not.toHaveBeenCalled();
     expect(result.updatedAccountIds.has(account.id)).toBe(false);
+  });
+});
+
+describe("ingestFetchedEmails", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emits privacy-safe retry timing telemetry", async () => {
+    vi.mocked(createCaptureIngestionPort).mockReturnValue({
+      ingest: vi.fn(async (command: { kind: string }) =>
+        command.kind === "email_retry"
+          ? { retried: 2, succeeded: 1, permanentlyFailed: 1 }
+          : {
+              filtered: 0,
+              skippedDuplicate: 0,
+              skippedCrossSource: 0,
+              saved: 0,
+              failed: 0,
+              pendingRetry: 0,
+              needsReview: 0,
+              parseImprovementRequests: [],
+            }
+      ),
+    } as never);
+
+    await ingestFetchedEmails({
+      db: {} as AnyDb,
+      userId: "user-1" as UserId,
+      emails: [],
+      runRetries: true,
+    });
+
+    expect(mockCapturePipelineEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "email",
+        schema: "email_retry_batch_v1",
+        retried: 2,
+        succeeded: 1,
+        permanentlyFailed: 1,
+        retryDurationMs: expect.any(Number),
+      })
+    );
+  });
+
+  it("does not emit retry telemetry for no-op retry checks", async () => {
+    vi.mocked(createCaptureIngestionPort).mockReturnValue({
+      ingest: vi.fn(async () => ({ retried: 0, succeeded: 0, permanentlyFailed: 0 })),
+    } as never);
+
+    await ingestFetchedEmails({
+      db: {} as AnyDb,
+      userId: "user-1" as UserId,
+      emails: [],
+      runRetries: true,
+    });
+
+    expect(
+      mockCapturePipelineEvent.mock.calls.some(
+        ([event]) =>
+          typeof event === "object" &&
+          event !== null &&
+          "schema" in event &&
+          event.schema === "email_retry_batch_v1"
+      )
+    ).toBe(false);
   });
 });

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -344,6 +344,7 @@ describe("email capture boundary", () => {
         {
           account: makeAccount({ provider: "gmail" }) as never,
           fetchOk: true,
+          fetchDurationMs: 0,
           rawEmails: [
             makeRawEmail({ from: "notificaciones@rappicard.co" }) as never,
             makeRawEmail({ from: "alertas@rappicard.co" }) as never,

--- a/apps/mobile/features/email-capture/services/email-capture-dev-diagnostics.ts
+++ b/apps/mobile/features/email-capture/services/email-capture-dev-diagnostics.ts
@@ -1,0 +1,7 @@
+import type { TelemetryContext } from "@/shared/effect/telemetry";
+
+export function logEmailCaptureDevDiagnostic(name: string, context: TelemetryContext): void {
+  if (typeof __DEV__ === "undefined" || !__DEV__) return;
+
+  console.info(`[email-capture] ${name}`, context);
+}

--- a/apps/mobile/features/email-capture/services/email-capture-fetch-service.ts
+++ b/apps/mobile/features/email-capture/services/email-capture-fetch-service.ts
@@ -111,12 +111,6 @@ export const summarizeFetchedEmailDiagnostics = (
   })),
 });
 
-function logFetchedEmailDiagnostics(fetchResults: readonly EmailAccountFetchResult[]) {
-  if (typeof __DEV__ === "undefined" || !__DEV__) return;
-
-  console.info("[email-capture] fetch_batch", summarizeFetchedEmailDiagnostics(fetchResults));
-}
-
 const createFetchSummary = (
   accounts: readonly EmailAccountRow[],
   fetchResults: readonly EmailAccountFetchResult[]
@@ -208,7 +202,6 @@ export async function fetchEmailAccountBatch(
       })
     )
   );
-  logFetchedEmailDiagnostics(fetchResults);
   captureEmailFetchBatchTelemetry({
     fetchResults,
     fetchDurationMs: Date.now() - fetchStartedAt,

--- a/apps/mobile/features/email-capture/services/email-capture-fetch-service.ts
+++ b/apps/mobile/features/email-capture/services/email-capture-fetch-service.ts
@@ -6,7 +6,7 @@ import type { EmailAccountId, IsoDateTime, UserId } from "@/shared/types/branded
 import { isFirstFetchForAny, shouldShowProgress } from "../lib/progress-phases";
 import type { EmailAccountRow, ProcessedEmailRow } from "../lib/repository";
 import { getFailedEmails, getNeedsReviewEmails, updateLastFetchedAt } from "../lib/repository";
-import type { PipelineResult, ProgressCallback, RawEmail } from "../pipeline.public";
+import type { PipelineResult, ProgressCallback, RawEmail, RetryResult } from "../pipeline.public";
 import {
   processBackgroundEmails,
   processEmails,
@@ -16,6 +16,10 @@ import {
 import { ensureBankSenders } from "../queries/bank-senders";
 import type { EmailProvider } from "../schema";
 import type { EmailCaptureParseProfile } from "./email-capture-sync-policy";
+import {
+  captureEmailFetchBatchTelemetry,
+  captureEmailRetryBatchTelemetry,
+} from "./email-capture-fetch-telemetry";
 import { getAdapter } from "./email-adapter";
 export {
   applyEmailCaptureCandidateLimit,
@@ -43,6 +47,7 @@ export type EmailAccountFetchResult = {
   readonly account: EmailAccountRow;
   readonly rawEmails: readonly RawEmail[];
   readonly fetchOk: boolean;
+  readonly fetchDurationMs: number;
 };
 
 export type ProcessedEmailAccountFetchResult = EmailAccountFetchResult & {
@@ -82,10 +87,14 @@ type PersistFetchedAccountsCommand = {
   readonly fetchResults: readonly ProcessedEmailAccountFetchResult[];
 };
 
-const createEmptyFetchResult = (account: EmailAccountRow): EmailAccountFetchResult => ({
+const createEmptyFetchResult = (
+  account: EmailAccountRow,
+  fetchDurationMs = 0
+): EmailAccountFetchResult => ({
   account,
   rawEmails: EMPTY_RAW_EMAILS,
   fetchOk: false,
+  fetchDurationMs,
 });
 
 const createFetchLookbackBoundary = (): string =>
@@ -130,24 +139,6 @@ const getDurablyProcessedFetches = (
         result.processingResult.failed === result.processingResult.pendingRetry)
   );
 
-export const aggregatePipelineResults = (results: readonly PipelineResult[]): PipelineResult =>
-  results.reduce(
-    (total, result) => ({
-      filtered: total.filtered + result.filtered,
-      skippedDuplicate: total.skippedDuplicate + result.skippedDuplicate,
-      skippedCrossSource: total.skippedCrossSource + result.skippedCrossSource,
-      saved: total.saved + result.saved,
-      failed: total.failed + result.failed,
-      pendingRetry: total.pendingRetry + result.pendingRetry,
-      needsReview: total.needsReview + result.needsReview,
-      parseImprovementRequests: [
-        ...total.parseImprovementRequests,
-        ...result.parseImprovementRequests,
-      ],
-    }),
-    EMPTY_PIPELINE_RESULT
-  );
-
 const isSupportedEmailProvider = (provider: string): provider is EmailProvider =>
   provider === "gmail" || provider === "outlook";
 
@@ -166,6 +157,7 @@ async function fetchEmailsForAccount(
     return createEmptyFetchResult(command.account);
   }
 
+  const fetchStartedAt = Date.now();
   try {
     const provider = command.account.provider;
     const rawEmails = await getAdapter(provider).fetchEmails(
@@ -174,14 +166,21 @@ async function fetchEmailsForAccount(
       [...command.senderEmails]
     );
 
-    return { account: command.account, rawEmails, fetchOk: true };
+    return {
+      account: command.account,
+      rawEmails,
+      fetchOk: true,
+      fetchDurationMs: Date.now() - fetchStartedAt,
+    };
   } catch (error) {
+    const fetchDurationMs = Date.now() - fetchStartedAt;
     captureWarning("email_adapter_fetch_failed", {
       provider: command.account.provider,
       errorType: error instanceof Error ? error.name : "unknown",
+      fetchDurationMs,
     });
 
-    return createEmptyFetchResult(command.account);
+    return createEmptyFetchResult(command.account, fetchDurationMs);
   }
 }
 
@@ -196,6 +195,7 @@ export const createEmailFetchClientIds = (
 export async function fetchEmailAccountBatch(
   command: FetchEmailAccountsCommand
 ): Promise<EmailCaptureFetchSummary> {
+  const fetchStartedAt = Date.now();
   const senderEmails = await loadSenderEmails();
   const minSince = createFetchLookbackBoundary();
   const fetchResults = await Promise.all(
@@ -209,6 +209,10 @@ export async function fetchEmailAccountBatch(
     )
   );
   logFetchedEmailDiagnostics(fetchResults);
+  captureEmailFetchBatchTelemetry({
+    fetchResults,
+    fetchDurationMs: Date.now() - fetchStartedAt,
+  });
 
   return createFetchSummary(command.accounts, fetchResults);
 }
@@ -243,10 +247,17 @@ export async function ingestFetchedEmails(input: {
       : EMPTY_PIPELINE_RESULT;
 
   if (input.runRetries !== false) {
-    await captureIngestion.ingest({
+    const retryStartedAt = Date.now();
+    const retryResult = (await captureIngestion.ingest({
       kind: "email_retry",
       userId: input.userId,
-    });
+    })) as RetryResult;
+    if (retryResult.retried > 0 || retryResult.permanentlyFailed > 0) {
+      captureEmailRetryBatchTelemetry({
+        retryResult,
+        retryDurationMs: Date.now() - retryStartedAt,
+      });
+    }
   }
 
   return processingResult;

--- a/apps/mobile/features/email-capture/services/email-capture-fetch-telemetry.ts
+++ b/apps/mobile/features/email-capture/services/email-capture-fetch-telemetry.ts
@@ -1,5 +1,6 @@
 import { capturePipelineEvent } from "@/shared/lib";
 import type { RetryResult } from "../pipeline.public";
+import { logEmailCaptureDevDiagnostic } from "./email-capture-dev-diagnostics";
 
 type EmailFetchTelemetryResult = {
   readonly account: { readonly provider: string };
@@ -16,7 +17,7 @@ export function captureEmailFetchBatchTelemetry(input: {
   readonly fetchDurationMs: number;
 }) {
   const providerFamilies = providerFamiliesForResults(input.fetchResults);
-  capturePipelineEvent({
+  const event = {
     source: "email",
     schema: "email_fetch_batch_v1",
     accountCount: input.fetchResults.length,
@@ -30,19 +31,23 @@ export function captureEmailFetchBatchTelemetry(input: {
       0,
       ...input.fetchResults.map((result) => result.fetchDurationMs)
     ),
-  });
+  };
+  logEmailCaptureDevDiagnostic("fetch_batch", event);
+  capturePipelineEvent(event);
 }
 
 export function captureEmailRetryBatchTelemetry(input: {
   readonly retryResult: RetryResult;
   readonly retryDurationMs: number;
 }) {
-  capturePipelineEvent({
+  const event = {
     source: "email",
     schema: "email_retry_batch_v1",
     retried: input.retryResult.retried,
     succeeded: input.retryResult.succeeded,
     permanentlyFailed: input.retryResult.permanentlyFailed,
     retryDurationMs: input.retryDurationMs,
-  });
+  };
+  logEmailCaptureDevDiagnostic("retry_batch", event);
+  capturePipelineEvent(event);
 }

--- a/apps/mobile/features/email-capture/services/email-capture-fetch-telemetry.ts
+++ b/apps/mobile/features/email-capture/services/email-capture-fetch-telemetry.ts
@@ -1,0 +1,48 @@
+import { capturePipelineEvent } from "@/shared/lib";
+import type { RetryResult } from "../pipeline.public";
+
+type EmailFetchTelemetryResult = {
+  readonly account: { readonly provider: string };
+  readonly rawEmails: readonly unknown[];
+  readonly fetchOk: boolean;
+  readonly fetchDurationMs: number;
+};
+
+const providerFamiliesForResults = (fetchResults: readonly EmailFetchTelemetryResult[]): string[] =>
+  Array.from(new Set(fetchResults.map((result) => result.account.provider))).sort();
+
+export function captureEmailFetchBatchTelemetry(input: {
+  readonly fetchResults: readonly EmailFetchTelemetryResult[];
+  readonly fetchDurationMs: number;
+}) {
+  const providerFamilies = providerFamiliesForResults(input.fetchResults);
+  capturePipelineEvent({
+    source: "email",
+    schema: "email_fetch_batch_v1",
+    accountCount: input.fetchResults.length,
+    successfulFetchCount: input.fetchResults.filter((result) => result.fetchOk).length,
+    failedFetchCount: input.fetchResults.filter((result) => !result.fetchOk).length,
+    fetchedCount: input.fetchResults.reduce((count, result) => count + result.rawEmails.length, 0),
+    providerFamilyCount: providerFamilies.length,
+    providerFamilies: providerFamilies.join(","),
+    fetchDurationMs: input.fetchDurationMs,
+    maxProviderFetchDurationMs: Math.max(
+      0,
+      ...input.fetchResults.map((result) => result.fetchDurationMs)
+    ),
+  });
+}
+
+export function captureEmailRetryBatchTelemetry(input: {
+  readonly retryResult: RetryResult;
+  readonly retryDurationMs: number;
+}) {
+  capturePipelineEvent({
+    source: "email",
+    schema: "email_retry_batch_v1",
+    retried: input.retryResult.retried,
+    succeeded: input.retryResult.succeeded,
+    permanentlyFailed: input.retryResult.permanentlyFailed,
+    retryDurationMs: input.retryDurationMs,
+  });
+}

--- a/apps/mobile/features/email-capture/services/email-capture-result.ts
+++ b/apps/mobile/features/email-capture/services/email-capture-result.ts
@@ -1,0 +1,30 @@
+import type { PipelineResult } from "../pipeline.public";
+
+const EMPTY_PIPELINE_RESULT: PipelineResult = {
+  filtered: 0,
+  skippedDuplicate: 0,
+  skippedCrossSource: 0,
+  saved: 0,
+  failed: 0,
+  pendingRetry: 0,
+  needsReview: 0,
+  parseImprovementRequests: [],
+};
+
+export const aggregatePipelineResults = (results: readonly PipelineResult[]): PipelineResult =>
+  results.reduce(
+    (total, result) => ({
+      filtered: total.filtered + result.filtered,
+      skippedDuplicate: total.skippedDuplicate + result.skippedDuplicate,
+      skippedCrossSource: total.skippedCrossSource + result.skippedCrossSource,
+      saved: total.saved + result.saved,
+      failed: total.failed + result.failed,
+      pendingRetry: total.pendingRetry + result.pendingRetry,
+      needsReview: total.needsReview + result.needsReview,
+      parseImprovementRequests: [
+        ...total.parseImprovementRequests,
+        ...result.parseImprovementRequests,
+      ],
+    }),
+    EMPTY_PIPELINE_RESULT
+  );

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/email-telemetry.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/email-telemetry.ts
@@ -5,6 +5,14 @@ type BatchTelemetryInput = {
   readonly rawEmails: readonly RawEmail[];
   readonly dedupedInBatch: number;
   readonly skippedAlreadyProcessed: number;
+  readonly timing?: {
+    readonly batchDurationMs: number;
+    readonly parseTotalDurationMs: number;
+    readonly parseMaxDurationMs: number;
+    readonly parseAverageDurationMs: number;
+    readonly persistenceTotalDurationMs: number;
+    readonly firstSavedLatencyMs: number | null;
+  };
   readonly result: PipelineResult;
 };
 
@@ -38,6 +46,19 @@ export function buildEmailPipelineBatchTelemetry(input: BatchTelemetryInput): Te
     skippedCrossSource: input.result.skippedCrossSource,
     skippedDuplicate: input.result.skippedDuplicate,
     filtered: input.result.filtered,
+    ...(input.timing
+      ? {
+          batchDurationMs: input.timing.batchDurationMs,
+          parseTotalDurationMs: input.timing.parseTotalDurationMs,
+          parseMaxDurationMs: input.timing.parseMaxDurationMs,
+          parseAverageDurationMs: input.timing.parseAverageDurationMs,
+          persistenceTotalDurationMs: input.timing.persistenceTotalDurationMs,
+          hasFirstSavedTransaction: input.timing.firstSavedLatencyMs !== null,
+          ...(input.timing.firstSavedLatencyMs === null
+            ? {}
+            : { firstSavedLatencyMs: input.timing.firstSavedLatencyMs }),
+        }
+      : {}),
     saved: input.result.saved,
     failed: input.result.failed,
     pendingRetry: input.result.pendingRetry,

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-batch.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-batch.ts
@@ -30,6 +30,13 @@ type EmailBatchTiming = {
   readonly firstSavedLatencyMs: number | null;
 };
 
+type EmailBatchTimingAccumulator = {
+  readonly count: number;
+  readonly parseTotalDurationMs: number;
+  readonly parseMaxDurationMs: number;
+  readonly persistenceTotalDurationMs: number;
+};
+
 const nowMs = (): number => Date.now();
 
 async function createEmailBatchPlan(
@@ -122,27 +129,36 @@ async function runEmailWorkers(input: {
   );
 }
 
+const createTimingAccumulator = (): EmailBatchTimingAccumulator => ({
+  count: 0,
+  parseTotalDurationMs: 0,
+  parseMaxDurationMs: 0,
+  persistenceTotalDurationMs: 0,
+});
+
+const addOutcomeTiming = (
+  timing: EmailBatchTimingAccumulator,
+  outcome: IncomingEmailOutcome
+): EmailBatchTimingAccumulator => ({
+  count: timing.count + 1,
+  parseTotalDurationMs: timing.parseTotalDurationMs + outcome.parseDurationMs,
+  parseMaxDurationMs: Math.max(timing.parseMaxDurationMs, outcome.parseDurationMs),
+  persistenceTotalDurationMs: timing.persistenceTotalDurationMs + outcome.persistenceDurationMs,
+});
+
 const summarizeBatchTiming = (
-  outcomes: readonly IncomingEmailOutcome[],
+  timing: EmailBatchTimingAccumulator,
   batchDurationMs: number,
   firstSavedLatencyMs: number | null
-): EmailBatchTiming => {
-  const parseDurations = outcomes.map((outcome) => outcome.parseDurationMs);
-  const parseTotalDurationMs = parseDurations.reduce((total, duration) => total + duration, 0);
-
-  return {
-    batchDurationMs,
-    parseTotalDurationMs,
-    parseMaxDurationMs: Math.max(0, ...parseDurations),
-    parseAverageDurationMs:
-      parseDurations.length === 0 ? 0 : Math.round(parseTotalDurationMs / parseDurations.length),
-    persistenceTotalDurationMs: outcomes.reduce(
-      (total, outcome) => total + outcome.persistenceDurationMs,
-      0
-    ),
-    firstSavedLatencyMs,
-  };
-};
+): EmailBatchTiming => ({
+  batchDurationMs,
+  parseTotalDurationMs: timing.parseTotalDurationMs,
+  parseMaxDurationMs: timing.parseMaxDurationMs,
+  parseAverageDurationMs:
+    timing.count === 0 ? 0 : Math.round(timing.parseTotalDurationMs / timing.count),
+  persistenceTotalDurationMs: timing.persistenceTotalDurationMs,
+  firstSavedLatencyMs,
+});
 
 export async function processEmailBatch(runtime: PipelineRuntime, input: ProcessEmailsInput) {
   const batchStartedAt = nowMs();
@@ -155,9 +171,9 @@ export async function processEmailBatch(runtime: PipelineRuntime, input: Process
     parseStartGate: Promise.resolve(),
     persistenceGate: Promise.resolve(),
   };
-  const outcomes: IncomingEmailOutcome[] = [];
   let completed = 0;
   let firstSavedLatencyMs: number | null = null;
+  let timing = createTimingAccumulator();
   let progressResult = batch.result;
   const reportProgress = () => {
     input.onProgress?.(getProgressSnapshot(batch.total, completed, progressResult));
@@ -168,8 +184,8 @@ export async function processEmailBatch(runtime: PipelineRuntime, input: Process
     context,
     emails: batch.toProcess,
     onOutcome: (outcome) => {
-      outcomes.push(outcome);
       completed += 1;
+      timing = addOutcomeTiming(timing, outcome);
       if (firstSavedLatencyMs === null && outcome.savedTransaction) {
         firstSavedLatencyMs = nowMs() - batchStartedAt;
       }
@@ -183,7 +199,7 @@ export async function processEmailBatch(runtime: PipelineRuntime, input: Process
         rawEmails: input.rawEmails,
         batch,
         result: progressResult,
-        timing: summarizeBatchTiming(outcomes, nowMs() - batchStartedAt, firstSavedLatencyMs),
+        timing: summarizeBatchTiming(timing, nowMs() - batchStartedAt, firstSavedLatencyMs),
       })
     )
   );

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-batch.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-batch.ts
@@ -1,5 +1,6 @@
 import type { AnyDb } from "@/shared/db";
 import { capturePipelineEventEffect } from "@/shared/effect/telemetry";
+import { logEmailCaptureDevDiagnostic } from "../email-capture-dev-diagnostics";
 import { buildEmailPipelineBatchTelemetry } from "./email-telemetry";
 import { processIncomingEmail } from "./incoming-email";
 import { getProcessedExternalIdsEffect } from "./runtime";
@@ -193,15 +194,13 @@ export async function processEmailBatch(runtime: PipelineRuntime, input: Process
       reportProgress();
     },
   });
-  await runtime.runTelemetryEffect(
-    capturePipelineEventEffect(
-      buildIncomingBatchTelemetry({
-        rawEmails: input.rawEmails,
-        batch,
-        result: progressResult,
-        timing: summarizeBatchTiming(timing, nowMs() - batchStartedAt, firstSavedLatencyMs),
-      })
-    )
-  );
+  const telemetry = buildIncomingBatchTelemetry({
+    rawEmails: input.rawEmails,
+    batch,
+    result: progressResult,
+    timing: summarizeBatchTiming(timing, nowMs() - batchStartedAt, firstSavedLatencyMs),
+  });
+  logEmailCaptureDevDiagnostic("pipeline_batch", telemetry);
+  await runtime.runTelemetryEffect(capturePipelineEventEffect(telemetry));
   return progressResult;
 }

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-batch.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-batch.ts
@@ -4,20 +4,33 @@ import { buildEmailPipelineBatchTelemetry } from "./email-telemetry";
 import { processIncomingEmail } from "./incoming-email";
 import { getProcessedExternalIdsEffect } from "./runtime";
 import {
-  completeEmailStep,
   createPipelineResult,
   dedupeRawEmails,
   getNextQueuedEmail,
-  reportEmailProgress,
+  getProgressSnapshot,
+  mergePipelineResults,
 } from "./shared";
 import type {
   EmailBatchContext,
   EmailBatchPlan,
   EmailQueue,
+  IncomingEmailOutcome,
   PipelineRuntime,
+  PipelineResult,
   ProcessEmailsInput,
   RawEmail,
 } from "./types";
+
+type EmailBatchTiming = {
+  readonly batchDurationMs: number;
+  readonly parseTotalDurationMs: number;
+  readonly parseMaxDurationMs: number;
+  readonly parseAverageDurationMs: number;
+  readonly persistenceTotalDurationMs: number;
+  readonly firstSavedLatencyMs: number | null;
+};
+
+const nowMs = (): number => Date.now();
 
 async function createEmailBatchPlan(
   runtime: PipelineRuntime,
@@ -46,22 +59,19 @@ async function createEmailBatchPlan(
   };
 }
 
-async function captureIncomingBatchEvent(
-  runtime: PipelineRuntime,
-  rawEmails: RawEmail[],
-  batch: EmailBatchPlan
-) {
-  await runtime.runTelemetryEffect(
-    capturePipelineEventEffect(
-      buildEmailPipelineBatchTelemetry({
-        rawEmails,
-        dedupedInBatch: batch.dedupedInBatch,
-        skippedAlreadyProcessed: batch.skippedAlreadyProcessed,
-        result: batch.result,
-      })
-    )
-  );
-}
+const buildIncomingBatchTelemetry = (input: {
+  readonly rawEmails: RawEmail[];
+  readonly batch: EmailBatchPlan;
+  readonly result: PipelineResult;
+  readonly timing: EmailBatchTiming;
+}) =>
+  buildEmailPipelineBatchTelemetry({
+    rawEmails: input.rawEmails,
+    dedupedInBatch: input.batch.dedupedInBatch,
+    skippedAlreadyProcessed: input.batch.skippedAlreadyProcessed,
+    timing: input.timing,
+    result: input.result,
+  });
 
 async function waitForParseRateLimit(context: EmailBatchContext): Promise<void> {
   const delayMs = context.runtime.parseRateLimit.delayMs;
@@ -81,43 +91,101 @@ async function waitForParseRateLimit(context: EmailBatchContext): Promise<void> 
   await scheduledStart;
 }
 
-async function runEmailWorker(context: EmailBatchContext, queue: EmailQueue): Promise<void> {
+async function runEmailWorker(input: {
+  readonly context: EmailBatchContext;
+  readonly queue: EmailQueue;
+  readonly onOutcome: (outcome: IncomingEmailOutcome) => void;
+}): Promise<void> {
   // FP exemption: the worker queue keeps parse-email calls serialized for Edge Function rate limits.
   while (true) {
-    const email = getNextQueuedEmail(queue);
+    const email = getNextQueuedEmail(input.queue);
     if (!email) return;
-    await waitForParseRateLimit(context);
-    await processIncomingEmail(context, email);
-    completeEmailStep(context);
+    await waitForParseRateLimit(input.context);
+    input.onOutcome(await processIncomingEmail(input.context, email));
   }
 }
 
-async function runEmailWorkers(context: EmailBatchContext, emails: RawEmail[]) {
-  const queue: EmailQueue = { emails, nextIdx: 0 };
+async function runEmailWorkers(input: {
+  readonly context: EmailBatchContext;
+  readonly emails: RawEmail[];
+  readonly onOutcome: (outcome: IncomingEmailOutcome) => void;
+}) {
+  const queue: EmailQueue = { emails: input.emails, nextIdx: 0 };
   const workerCount = Math.min(
-    Math.max(1, context.runtime.parseRateLimit.concurrency),
-    emails.length
+    Math.max(1, input.context.runtime.parseRateLimit.concurrency),
+    input.emails.length
   );
-  await Promise.all(Array.from({ length: workerCount }, () => runEmailWorker(context, queue)));
+  await Promise.all(
+    Array.from({ length: workerCount }, () =>
+      runEmailWorker({ context: input.context, queue, onOutcome: input.onOutcome })
+    )
+  );
 }
 
+const summarizeBatchTiming = (
+  outcomes: readonly IncomingEmailOutcome[],
+  batchDurationMs: number,
+  firstSavedLatencyMs: number | null
+): EmailBatchTiming => {
+  const parseDurations = outcomes.map((outcome) => outcome.parseDurationMs);
+  const parseTotalDurationMs = parseDurations.reduce((total, duration) => total + duration, 0);
+
+  return {
+    batchDurationMs,
+    parseTotalDurationMs,
+    parseMaxDurationMs: Math.max(0, ...parseDurations),
+    parseAverageDurationMs:
+      parseDurations.length === 0 ? 0 : Math.round(parseTotalDurationMs / parseDurations.length),
+    persistenceTotalDurationMs: outcomes.reduce(
+      (total, outcome) => total + outcome.persistenceDurationMs,
+      0
+    ),
+    firstSavedLatencyMs,
+  };
+};
+
 export async function processEmailBatch(runtime: PipelineRuntime, input: ProcessEmailsInput) {
+  const batchStartedAt = nowMs();
   const batch = await createEmailBatchPlan(runtime, input.db, input.rawEmails);
   const context: EmailBatchContext = {
     runtime,
     db: input.db,
     userId: input.userId,
-    result: batch.result,
-    total: batch.total,
-    onProgress: input.onProgress,
-    completed: 0,
     parseStarts: 0,
     parseStartGate: Promise.resolve(),
     persistenceGate: Promise.resolve(),
   };
+  const outcomes: IncomingEmailOutcome[] = [];
+  let completed = 0;
+  let firstSavedLatencyMs: number | null = null;
+  let progressResult = batch.result;
+  const reportProgress = () => {
+    input.onProgress?.(getProgressSnapshot(batch.total, completed, progressResult));
+  };
 
-  reportEmailProgress(context);
-  await runEmailWorkers(context, batch.toProcess);
-  await captureIncomingBatchEvent(runtime, input.rawEmails, batch);
-  return batch.result;
+  reportProgress();
+  await runEmailWorkers({
+    context,
+    emails: batch.toProcess,
+    onOutcome: (outcome) => {
+      outcomes.push(outcome);
+      completed += 1;
+      if (firstSavedLatencyMs === null && outcome.savedTransaction) {
+        firstSavedLatencyMs = nowMs() - batchStartedAt;
+      }
+      progressResult = mergePipelineResults([progressResult, outcome.result]);
+      reportProgress();
+    },
+  });
+  await runtime.runTelemetryEffect(
+    capturePipelineEventEffect(
+      buildIncomingBatchTelemetry({
+        rawEmails: input.rawEmails,
+        batch,
+        result: progressResult,
+        timing: summarizeBatchTiming(outcomes, nowMs() - batchStartedAt, firstSavedLatencyMs),
+      })
+    )
+  );
+  return progressResult;
 }

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-email.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-email.ts
@@ -5,17 +5,15 @@ import {
   captureWarningEffect,
 } from "@/shared/effect/telemetry";
 import { generateProcessedEmailId } from "@/shared/lib/generate-id";
-import { normalizeMerchant } from "@/shared/lib/normalize-merchant";
 import { assertIsoDateTime } from "@/shared/types/assertions";
 import { buildSkippedEmailDiagnostics } from "./email-telemetry";
+import { cacheMerchantRule, lookupIncomingDuplicate } from "./incoming-parsed-helpers";
 import {
   appendFailedEmailParseImprovementRequest,
   appendNeedsReviewEmailParseImprovementRequest,
 } from "./parse-improvement";
 import {
-  findDuplicateTransactionEffect,
   getProcessedExternalIdsEffect,
-  insertMerchantRuleEffect,
   insertProcessedEmailEffect,
   nextRetryAtEffect,
   parseBodyEffect,
@@ -24,23 +22,27 @@ import {
 import {
   buildDuplicateProcessedEmailRow,
   buildUnparsedProcessedEmailRow,
-  getPersistedCategoryId,
-  incrementPipelineMetric,
+  createPipelineMetricResult,
+  mergePipelineResults,
   resolveEmailStatus,
   runSerializedPersistence,
 } from "./shared";
 import { saveTransactionEffect } from "./transactions";
 import type {
-  DuplicateLookupOutcome,
   EmailBatchContext,
   EmailSaveStatus,
+  IncomingEmailOutcome,
+  IncomingEmailPersistenceOutcome,
   IncomingEmailPersistenceInput,
   IncomingParseOutcome,
   LlmParsedTransaction,
+  PipelineResult,
   RawEmail,
   TransactionId,
   UnparsedIncomingEmailKind,
 } from "./types";
+
+const nowMs = (): number => Date.now();
 
 async function parseIncomingEmail(
   context: EmailBatchContext,
@@ -91,12 +93,12 @@ async function persistPendingRetryIncomingEmail(
   context: EmailBatchContext,
   email: RawEmail,
   failureReason: string | null
-): Promise<boolean> {
+): Promise<PipelineResult> {
   const processedIds = await context.runtime.runEmailEffect(
     getProcessedExternalIdsEffect(context.db, [email.externalId])
   );
   if (processedIds.has(email.externalId)) {
-    return false;
+    return createPipelineMetricResult("failed");
   }
 
   const { createdAt, processedEmailId } = await createIncomingEmailPersistenceState(context, email);
@@ -118,15 +120,20 @@ async function persistPendingRetryIncomingEmail(
     transactionId: null,
     createdAt,
   });
-  if (failureReason === "parse_error") appendFailedEmailParseImprovementRequest(context, email);
-  return true;
+  const result = mergePipelineResults([
+    createPipelineMetricResult("failed"),
+    createPipelineMetricResult("pendingRetry"),
+  ]);
+  return failureReason === "parse_error"
+    ? appendFailedEmailParseImprovementRequest(result, email)
+    : result;
 }
 
 async function persistSkippedIncomingEmail(
   context: EmailBatchContext,
   email: RawEmail,
   kind: Exclude<UnparsedIncomingEmailKind, "failed">
-) {
+): Promise<PipelineResult> {
   const { createdAt, processedEmailId } = await createIncomingEmailPersistenceState(context, email);
   const metadataOnlyEmail = { ...email, subject: "", body: "" };
   const row = buildUnparsedProcessedEmailRow({
@@ -142,22 +149,7 @@ async function persistSkippedIncomingEmail(
   await context.runtime.runTelemetryEffect(
     capturePipelineEventEffect(buildSkippedEmailDiagnostics({ email, reason: kind }))
   );
-  incrementPipelineMetric(context.result, kind === "filtered" ? "filtered" : "failed");
-}
-
-async function lookupIncomingDuplicate(
-  context: EmailBatchContext,
-  parsed: LlmParsedTransaction
-): Promise<DuplicateLookupOutcome> {
-  try {
-    const transactionId = await context.runtime.runEmailEffect(
-      findDuplicateTransactionEffect(context.db, context.userId, parsed)
-    );
-    return transactionId ? { kind: "duplicate", transactionId } : { kind: "new" };
-  } catch (error) {
-    await context.runtime.runTelemetryEffect(captureErrorEffect(error));
-    return { kind: "failed" };
-  }
+  return createPipelineMetricResult(kind === "filtered" ? "filtered" : "failed");
 }
 
 async function persistDuplicateIncomingEmail(input: {
@@ -186,27 +178,7 @@ async function persistDuplicateIncomingEmail(input: {
     transactionId: input.transactionId,
     createdAt,
   });
-  incrementPipelineMetric(input.context.result, "skippedCrossSource");
-}
-
-async function cacheMerchantRule(input: {
-  readonly context: EmailBatchContext;
-  readonly parsed: LlmParsedTransaction;
-}) {
-  try {
-    const createdAt = await input.context.runtime.runClockEffect(currentIsoDateTimeEffect);
-    await input.context.runtime.runEmailEffect(
-      insertMerchantRuleEffect({
-        db: input.context.db,
-        userId: input.context.userId,
-        merchantKey: normalizeMerchant(input.parsed.description),
-        categoryId: getPersistedCategoryId(input.parsed.categoryId),
-        createdAt,
-      })
-    );
-  } catch (error) {
-    await input.context.runtime.runTelemetryEffect(captureErrorEffect(error));
-  }
+  return createPipelineMetricResult("skippedCrossSource");
 }
 
 async function persistIncomingTransaction(input: {
@@ -239,61 +211,77 @@ async function processParsedIncomingEmail(
   context: EmailBatchContext,
   email: RawEmail,
   parsed: LlmParsedTransaction
-) {
-  await runSerializedPersistence(context, async () => {
+): Promise<IncomingEmailPersistenceOutcome> {
+  const persistenceStartedAt = nowMs();
+  const result = await runSerializedPersistence(context, async () => {
     const duplicate = await lookupIncomingDuplicate(context, parsed);
     if (duplicate.kind === "failed") {
-      const queuedRetry = await persistPendingRetryIncomingEmail(context, email, null);
-      incrementPipelineMetric(context.result, "failed");
-      if (queuedRetry) {
-        incrementPipelineMetric(context.result, "pendingRetry");
-      }
-      return;
+      return persistPendingRetryIncomingEmail(context, email, null);
     }
 
     if (duplicate.kind === "duplicate") {
-      await persistDuplicateIncomingEmail({
+      return persistDuplicateIncomingEmail({
         context,
         email,
         parsed,
         transactionId: duplicate.transactionId,
       });
-      return;
     }
 
     const status = resolveEmailStatus(parsed.confidence);
     const saved = await persistIncomingTransaction({ context, email, parsed, status });
     if (!saved) {
-      const queuedRetry = await persistPendingRetryIncomingEmail(context, email, null);
-      incrementPipelineMetric(context.result, "failed");
-      if (queuedRetry) {
-        incrementPipelineMetric(context.result, "pendingRetry");
-      }
-      return;
+      return persistPendingRetryIncomingEmail(context, email, null);
     }
 
-    incrementPipelineMetric(context.result, status === "success" ? "saved" : "needsReview");
+    const savedResult = createPipelineMetricResult(status === "success" ? "saved" : "needsReview");
     if (status === "needs_review") {
-      appendNeedsReviewEmailParseImprovementRequest(context, email, parsed.confidence);
+      return appendNeedsReviewEmailParseImprovementRequest(savedResult, email, parsed.confidence);
     }
+    return savedResult;
   });
+
+  return {
+    result,
+    persistenceDurationMs: nowMs() - persistenceStartedAt,
+    savedTransaction: result.saved > 0,
+  };
 }
 
-export async function processIncomingEmail(context: EmailBatchContext, email: RawEmail) {
+export async function processIncomingEmail(
+  context: EmailBatchContext,
+  email: RawEmail
+): Promise<IncomingEmailOutcome> {
+  const parseStartedAt = nowMs();
   const parsed = await parseIncomingEmail(context, email);
+  const parseDurationMs = nowMs() - parseStartedAt;
   if (parsed.kind !== "parsed") {
     if (parsed.kind === "failed") {
-      const queuedRetry = await persistPendingRetryIncomingEmail(context, email, "parse_error");
-      incrementPipelineMetric(context.result, "failed");
-      if (queuedRetry) {
-        incrementPipelineMetric(context.result, "pendingRetry");
-      }
-      return;
+      const persistenceStartedAt = nowMs();
+      const result = await persistPendingRetryIncomingEmail(context, email, "parse_error");
+      return {
+        result,
+        parseDurationMs,
+        persistenceDurationMs: nowMs() - persistenceStartedAt,
+        savedTransaction: false,
+      };
     }
 
-    await persistSkippedIncomingEmail(context, email, parsed.kind);
-    return;
+    const persistenceStartedAt = nowMs();
+    const result = await persistSkippedIncomingEmail(context, email, parsed.kind);
+    return {
+      result,
+      parseDurationMs,
+      persistenceDurationMs: nowMs() - persistenceStartedAt,
+      savedTransaction: false,
+    };
   }
 
-  await processParsedIncomingEmail(context, email, parsed.parsed);
+  const persistence = await processParsedIncomingEmail(context, email, parsed.parsed);
+  return {
+    result: persistence.result,
+    parseDurationMs,
+    persistenceDurationMs: persistence.persistenceDurationMs,
+    savedTransaction: persistence.savedTransaction,
+  };
 }

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-email.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-email.ts
@@ -6,6 +6,7 @@ import {
 } from "@/shared/effect/telemetry";
 import { generateProcessedEmailId } from "@/shared/lib/generate-id";
 import { assertIsoDateTime } from "@/shared/types/assertions";
+import { logEmailCaptureDevDiagnostic } from "../email-capture-dev-diagnostics";
 import { buildSkippedEmailDiagnostics } from "./email-telemetry";
 import { cacheMerchantRule, lookupIncomingDuplicate } from "./incoming-parsed-helpers";
 import {
@@ -146,9 +147,9 @@ async function persistSkippedIncomingEmail(
   });
 
   await context.runtime.runEmailEffect(insertProcessedEmailEffect(context.db, row));
-  await context.runtime.runTelemetryEffect(
-    capturePipelineEventEffect(buildSkippedEmailDiagnostics({ email, reason: kind }))
-  );
+  const diagnostics = buildSkippedEmailDiagnostics({ email, reason: kind });
+  logEmailCaptureDevDiagnostic("skipped_email", diagnostics);
+  await context.runtime.runTelemetryEffect(capturePipelineEventEffect(diagnostics));
   return createPipelineMetricResult(kind === "filtered" ? "filtered" : "failed");
 }
 

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-email.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-email.ts
@@ -244,7 +244,7 @@ async function processParsedIncomingEmail(
   return {
     result,
     persistenceDurationMs: nowMs() - persistenceStartedAt,
-    savedTransaction: result.saved > 0,
+    savedTransaction: result.saved > 0 || result.needsReview > 0,
   };
 }
 

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-parsed-helpers.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-parsed-helpers.ts
@@ -1,0 +1,41 @@
+import { currentIsoDateTimeEffect } from "@/shared/effect/clock";
+import { captureErrorEffect } from "@/shared/effect/telemetry";
+import { normalizeMerchant } from "@/shared/lib/normalize-merchant";
+import { findDuplicateTransactionEffect, insertMerchantRuleEffect } from "./runtime";
+import { getPersistedCategoryId } from "./shared";
+import type { DuplicateLookupOutcome, EmailBatchContext, LlmParsedTransaction } from "./types";
+
+export async function lookupIncomingDuplicate(
+  context: EmailBatchContext,
+  parsed: LlmParsedTransaction
+): Promise<DuplicateLookupOutcome> {
+  try {
+    const transactionId = await context.runtime.runEmailEffect(
+      findDuplicateTransactionEffect(context.db, context.userId, parsed)
+    );
+    return transactionId ? { kind: "duplicate", transactionId } : { kind: "new" };
+  } catch (error) {
+    await context.runtime.runTelemetryEffect(captureErrorEffect(error));
+    return { kind: "failed" };
+  }
+}
+
+export async function cacheMerchantRule(input: {
+  readonly context: EmailBatchContext;
+  readonly parsed: LlmParsedTransaction;
+}) {
+  try {
+    const createdAt = await input.context.runtime.runClockEffect(currentIsoDateTimeEffect);
+    await input.context.runtime.runEmailEffect(
+      insertMerchantRuleEffect({
+        db: input.context.db,
+        userId: input.context.userId,
+        merchantKey: normalizeMerchant(input.parsed.description),
+        categoryId: getPersistedCategoryId(input.parsed.categoryId),
+        createdAt,
+      })
+    );
+  } catch (error) {
+    await input.context.runtime.runTelemetryEffect(captureErrorEffect(error));
+  }
+}

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/internal-types.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/internal-types.ts
@@ -174,10 +174,6 @@ export type EmailBatchContext = {
   readonly runtime: PipelineRuntime;
   readonly db: AnyDb;
   readonly userId: UserId;
-  readonly result: PipelineResult;
-  readonly total: number;
-  readonly onProgress?: ProgressCallback;
-  completed: number;
   parseStarts: number;
   parseStartGate: Promise<void>;
   persistenceGate: Promise<void>;
@@ -199,6 +195,19 @@ export type IncomingParseOutcome =
   | { readonly kind: "parsed"; readonly parsed: LlmParsedTransaction }
   | { readonly kind: "filtered" }
   | { readonly kind: "failed" };
+
+export type IncomingEmailOutcome = {
+  readonly result: PipelineResult;
+  readonly parseDurationMs: number;
+  readonly persistenceDurationMs: number;
+  readonly savedTransaction: boolean;
+};
+
+export type IncomingEmailPersistenceOutcome = {
+  readonly result: PipelineResult;
+  readonly persistenceDurationMs: number;
+  readonly savedTransaction: boolean;
+};
 
 export type DuplicateLookupOutcome =
   | { readonly kind: "new" }

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/parse-improvement.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/parse-improvement.ts
@@ -1,16 +1,16 @@
 import { getTransactionSource } from "./shared";
-import type { EmailBatchContext, RawEmail } from "./types";
+import type { PipelineResult, RawEmail } from "./types";
 import { appendEmailParseImprovementRequest } from "./shared";
 
 const buildEmailParseImprovementRawText = (email: RawEmail): string =>
   [email.subject, email.body].filter((part) => part.trim().length > 0).join("\n\n");
 
 export function appendFailedEmailParseImprovementRequest(
-  context: EmailBatchContext,
+  result: PipelineResult,
   email: RawEmail
-) {
-  appendEmailParseImprovementRequest({
-    result: context.result,
+): PipelineResult {
+  return appendEmailParseImprovementRequest({
+    result,
     request: {
       rawText: buildEmailParseImprovementRawText(email),
       source: getTransactionSource(email.provider),
@@ -22,12 +22,12 @@ export function appendFailedEmailParseImprovementRequest(
 }
 
 export function appendNeedsReviewEmailParseImprovementRequest(
-  context: EmailBatchContext,
+  result: PipelineResult,
   email: RawEmail,
   confidence: number
-) {
-  appendEmailParseImprovementRequest({
-    result: context.result,
+): PipelineResult {
+  return appendEmailParseImprovementRequest({
+    result,
     request: {
       rawText: buildEmailParseImprovementRawText(email),
       source: getTransactionSource(email.provider),

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/shared.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/shared.ts
@@ -41,25 +41,38 @@ export function assertParsedTransaction(parsed: TrackSavedTransactionInput["pars
   assertIsoDate(parsed.date);
 }
 
-export function incrementPipelineMetric(result: PipelineResult, field: EmailMetric) {
-  result[field] += 1;
-}
+export const createPipelineMetricResult = (field: EmailMetric): PipelineResult => ({
+  ...createPipelineResult(0),
+  [field]: 1,
+});
 
-export function appendEmailParseImprovementRequest(input: AppendEmailParseImprovementRequestInput) {
-  input.result.parseImprovementRequests = [...input.result.parseImprovementRequests, input.request];
-}
+export const appendEmailParseImprovementRequest = (
+  input: AppendEmailParseImprovementRequestInput
+): PipelineResult => ({
+  ...input.result,
+  parseImprovementRequests: [...input.result.parseImprovementRequests, input.request],
+});
+
+export const mergePipelineResults = (results: readonly PipelineResult[]): PipelineResult =>
+  results.reduce(
+    (total, result) => ({
+      filtered: total.filtered + result.filtered,
+      skippedDuplicate: total.skippedDuplicate + result.skippedDuplicate,
+      skippedCrossSource: total.skippedCrossSource + result.skippedCrossSource,
+      saved: total.saved + result.saved,
+      failed: total.failed + result.failed,
+      pendingRetry: total.pendingRetry + result.pendingRetry,
+      needsReview: total.needsReview + result.needsReview,
+      parseImprovementRequests: [
+        ...total.parseImprovementRequests,
+        ...result.parseImprovementRequests,
+      ],
+    }),
+    createPipelineResult(0)
+  );
 
 export function incrementRetryMetric(result: RetryResult, field: keyof RetryResult) {
   result[field] += 1;
-}
-
-export function reportEmailProgress(context: EmailBatchContext) {
-  context.onProgress?.(getProgressSnapshot(context.total, context.completed, context.result));
-}
-
-export function completeEmailStep(context: EmailBatchContext) {
-  context.completed += 1;
-  reportEmailProgress(context);
 }
 
 export function getNextQueuedEmail(queue: EmailQueue) {

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/types.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/types.ts
@@ -11,6 +11,8 @@ export type {
   EmailQueue,
   EmailTransactionContext,
   IncomingEmailPersistenceInput,
+  IncomingEmailOutcome,
+  IncomingEmailPersistenceOutcome,
   IncomingParseOutcome,
   LinkCaptureEvidenceInput,
   MerchantRuleEffectInput,

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -10,7 +10,6 @@ import {
 import { shareEmailParseImprovementRequests } from "./services/email-parse-improvement-sharing";
 import {
   applyEmailCaptureCandidateLimit,
-  aggregatePipelineResults,
   createEmailFetchClientIds,
   type EmailCaptureParseProfile,
   fetchEmailAccountBatch,
@@ -21,6 +20,7 @@ import {
   resolveEmailCaptureSyncPolicy,
   sortFetchResultsByNewestEmail,
 } from "./services/email-capture-fetch-service";
+import { aggregatePipelineResults } from "./services/email-capture-result";
 import {
   applyEmailCaptureFetchSummary,
   beginEmailCaptureFetchRun,

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -8,6 +8,7 @@ import {
   getNeedsReviewEmails,
 } from "./lib/repository";
 import { shareEmailParseImprovementRequests } from "./services/email-parse-improvement-sharing";
+import { logEmailCaptureDevDiagnostic } from "./services/email-capture-dev-diagnostics";
 import {
   applyEmailCaptureCandidateLimit,
   createEmailFetchClientIds,
@@ -158,6 +159,16 @@ export async function fetchAndProcessEmails(
       captureWarning("email_capture_fetch_no_accounts");
       return EMPTY_FETCH_OUTCOME;
     }
+    logEmailCaptureDevDiagnostic("sync_policy", {
+      source: "email",
+      schema: "email_sync_policy_v1",
+      parseProfile: syncPolicy.parseProfile,
+      advancesLastFetchedAt: syncPolicy.advancesLastFetchedAt,
+      maxCandidateEmails: syncPolicy.maxCandidateEmails ?? "none",
+      runRetries: syncPolicy.runRetries,
+      showsProgress: syncPolicy.showsProgress,
+      accountCount: accounts.length,
+    });
 
     const summary = await fetchEmailAccountBatch({
       accounts,


### PR DESCRIPTION
- immutable email outcomes
- privacy-safe timing events
- full verify passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add privacy-safe telemetry for email sync across fetch, retry, and pipeline, including batch/parse/persistence timings and first-saved latency (counts review transactions), plus dev-only QA diagnostics for fetch/retry/pipeline/skipped email/sync policy without exposing email content.

- **New Features**
  - Emit `email_fetch_batch_v1` with account/provider counts, `fetchedCount`, and durations (`fetchDurationMs`, `maxProviderFetchDurationMs`); include `email_adapter_fetch_failed` warnings with `errorType` and `fetchDurationMs`.
  - Emit `email_retry_batch_v1` only when retries occur (`retried`/`succeeded`/`permanentlyFailed` + `retryDurationMs`).
  - Enhance `email_pipeline_batch_v1` with `batchDurationMs`, parse total/max/average, `persistenceTotalDurationMs`, and `hasFirstSavedTransaction` + `firstSavedLatencyMs` when the first saved or needs_review happens.
  - Pass explicit parseContext `"initial_sync"` to remote parsing.
  - Add dev-only diagnostics for `fetch_batch`, `retry_batch`, `pipeline_batch`, `skipped_email`, and `email_sync_policy` (structural fields only).

- **Refactors**
  - Introduce immutable per-email outcomes with `parseDurationMs`/`persistenceDurationMs`; merge results on the fly to avoid retaining outcomes; progress uses snapshots.
  - Move `aggregatePipelineResults` to `email-capture-result`; extract duplicate lookup and merchant rule caching helpers.
  - Make parse-improvement helpers pure (return updated `PipelineResult`); update tests to verify privacy and timing.

<sup>Written for commit a6acaeb796f04deb8f9e764a12444fb9459b701d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

