### PR TITLE
fix(mobile): uncap email sync

### DIFF
--- a/apps/mobile/__tests__/edge-functions/parse-email-source.test.ts
+++ b/apps/mobile/__tests__/edge-functions/parse-email-source.test.ts
@@ -20,7 +20,7 @@ describe("parse-email Edge Function source", () => {
   });
 
   it("does not trust client parse context for elevated rate limits", () => {
-    expect(parseEmailSource).toContain("const DEFAULT_RATE_LIMIT_PER_MINUTE = 20");
+    expect(parseEmailSource).toContain("const DEFAULT_RATE_LIMIT_PER_MINUTE = 300");
     expect(parseEmailSource).not.toContain("INITIAL_SYNC_RATE_LIMIT_PER_MINUTE");
     expect(parseEmailSource).not.toContain('parseContext === "initial_sync"');
     expect(parseEmailSource).not.toContain('"parse-email:initial-sync"');

--- a/apps/mobile/__tests__/edge-functions/parse-email-source.test.ts
+++ b/apps/mobile/__tests__/edge-functions/parse-email-source.test.ts
@@ -20,7 +20,7 @@ describe("parse-email Edge Function source", () => {
   });
 
   it("does not trust client parse context for elevated rate limits", () => {
-    expect(parseEmailSource).toContain("const DEFAULT_RATE_LIMIT_PER_MINUTE = 300");
+    expect(parseEmailSource).toContain("const DEFAULT_RATE_LIMIT_PER_MINUTE = 200");
     expect(parseEmailSource).not.toContain("INITIAL_SYNC_RATE_LIMIT_PER_MINUTE");
     expect(parseEmailSource).not.toContain('parseContext === "initial_sync"');
     expect(parseEmailSource).not.toContain('"parse-email:initial-sync"');

--- a/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
@@ -611,59 +611,47 @@ describe("email processing pipeline", () => {
     await processing;
   });
 
-  it("uses foreground policy with all parse starts and no fixed delay", async () => {
-    const events: string[] = [];
-    const pendingParses: Array<(result: ReturnType<typeof makeParsedEmailResult>) => void> = [];
+  async function expectSharedParseConcurrencyLimit(
+    processEmailsFn:
+      | typeof processEmails
+      | typeof processBackgroundEmails
+      | typeof processInitialSyncEmails
+  ) {
+    const parseStarts: string[] = [];
+    const pendingParses: Array<(result: null) => void> = [];
     mockParseEmailApi.mockImplementation(async (body: string) => {
-      events.push(`parse:${body}`);
+      parseStarts.push(`parse:${body}`);
       return new Promise((resolve) => pendingParses.push(resolve));
     });
 
-    const processing = processEmails(
+    const processing = processEmailsFn(
       mockDb,
       USER_ID,
-      Array.from({ length: 4 }, (_, index) =>
+      Array.from({ length: 16 }, (_, index) =>
         makeRawEmail({ externalId: `ext-${index + 1}`, body: `Compra ${index + 1}` })
       )
     );
 
-    await vi.waitFor(() => expect(events).toContain("parse:Compra 4"));
-    expect(events).toEqual([
-      "parse:Compra 1",
-      "parse:Compra 2",
-      "parse:Compra 3",
-      "parse:Compra 4",
-    ]);
+    await vi.waitFor(() => expect(parseStarts).toHaveLength(15));
+    expect(parseStarts).not.toContain("parse:Compra 16");
 
-    pendingParses.forEach((resolve, index) =>
-      resolve(makeParsedEmailResult({ description: `Compra ${index + 1}` }))
-    );
+    pendingParses[0]?.(null);
+    await vi.waitFor(() => expect(parseStarts).toContain("parse:Compra 16"));
+
+    pendingParses.slice(1).forEach((resolve) => resolve(null));
     await processing;
+  }
+
+  it("uses foreground policy with shared parse concurrency", async () => {
+    await expectSharedParseConcurrencyLimit(processEmails);
   });
 
-  it("uses background policy with all parse starts", async () => {
-    const events: string[] = [];
-    const pendingParses: Array<(result: ReturnType<typeof makeParsedEmailResult>) => void> = [];
-    mockParseEmailApi.mockImplementation(async (body: string) => {
-      events.push(`parse:${body}`);
-      return new Promise((resolve) => pendingParses.push(resolve));
-    });
+  it("uses background policy with shared parse concurrency", async () => {
+    await expectSharedParseConcurrencyLimit(processBackgroundEmails);
+  });
 
-    const processing = processBackgroundEmails(
-      mockDb,
-      USER_ID,
-      Array.from({ length: 3 }, (_, index) =>
-        makeRawEmail({ externalId: `ext-${index + 1}`, body: `Compra ${index + 1}` })
-      )
-    );
-
-    await vi.waitFor(() => expect(events).toContain("parse:Compra 3"));
-    expect(events).toEqual(["parse:Compra 1", "parse:Compra 2", "parse:Compra 3"]);
-
-    pendingParses[0]?.(makeParsedEmailResult({ description: "Compra 1" }));
-    pendingParses[1]?.(makeParsedEmailResult({ description: "Compra 2" }));
-    pendingParses[2]?.(makeParsedEmailResult({ description: "Compra 3" }));
-    await processing;
+  it("uses initial sync policy with shared parse concurrency", async () => {
+    await expectSharedParseConcurrencyLimit(processInitialSyncEmails);
   });
 
   it("does not bound background parsing after durable skips", async () => {

--- a/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
@@ -611,7 +611,7 @@ describe("email processing pipeline", () => {
     await processing;
   });
 
-  it("uses foreground policy with three concurrent parse starts and no fixed delay", async () => {
+  it("uses foreground policy with all parse starts and no fixed delay", async () => {
     const events: string[] = [];
     const pendingParses: Array<(result: ReturnType<typeof makeParsedEmailResult>) => void> = [];
     mockParseEmailApi.mockImplementation(async (body: string) => {
@@ -622,13 +622,18 @@ describe("email processing pipeline", () => {
     const processing = processEmails(
       mockDb,
       USER_ID,
-      Array.from({ length: 3 }, (_, index) =>
+      Array.from({ length: 4 }, (_, index) =>
         makeRawEmail({ externalId: `ext-${index + 1}`, body: `Compra ${index + 1}` })
       )
     );
 
-    await vi.waitFor(() => expect(events).toContain("parse:Compra 3"));
-    expect(events).toEqual(["parse:Compra 1", "parse:Compra 2", "parse:Compra 3"]);
+    await vi.waitFor(() => expect(events).toContain("parse:Compra 4"));
+    expect(events).toEqual([
+      "parse:Compra 1",
+      "parse:Compra 2",
+      "parse:Compra 3",
+      "parse:Compra 4",
+    ]);
 
     pendingParses.forEach((resolve, index) =>
       resolve(makeParsedEmailResult({ description: `Compra ${index + 1}` }))
@@ -636,7 +641,7 @@ describe("email processing pipeline", () => {
     await processing;
   });
 
-  it("uses background policy with two concurrent parse starts", async () => {
+  it("uses background policy with all parse starts", async () => {
     const events: string[] = [];
     const pendingParses: Array<(result: ReturnType<typeof makeParsedEmailResult>) => void> = [];
     mockParseEmailApi.mockImplementation(async (body: string) => {
@@ -652,19 +657,16 @@ describe("email processing pipeline", () => {
       )
     );
 
-    await vi.waitFor(() => expect(events).toContain("parse:Compra 2"));
-    expect(events).toEqual(["parse:Compra 1", "parse:Compra 2"]);
-
-    pendingParses[0]?.(makeParsedEmailResult({ description: "Compra 1" }));
     await vi.waitFor(() => expect(events).toContain("parse:Compra 3"));
     expect(events).toEqual(["parse:Compra 1", "parse:Compra 2", "parse:Compra 3"]);
 
+    pendingParses[0]?.(makeParsedEmailResult({ description: "Compra 1" }));
     pendingParses[1]?.(makeParsedEmailResult({ description: "Compra 2" }));
     pendingParses[2]?.(makeParsedEmailResult({ description: "Compra 3" }));
     await processing;
   });
 
-  it("bounds background parsing to ten unprocessed candidates after durable skips", async () => {
+  it("does not bound background parsing after durable skips", async () => {
     mockGetProcessedExternalIds.mockResolvedValueOnce(new Set(["ext-1", "ext-2"]));
     mockParseEmailApi.mockResolvedValue(makeParsedEmailResult());
 
@@ -676,10 +678,9 @@ describe("email processing pipeline", () => {
       )
     );
 
-    expect(mockParseEmailApi).toHaveBeenCalledTimes(10);
+    expect(mockParseEmailApi).toHaveBeenCalledTimes(12);
     expect(mockParseEmailApi).toHaveBeenCalledWith("Compra 3");
-    expect(mockParseEmailApi).toHaveBeenCalledWith("Compra 12");
-    expect(mockParseEmailApi).not.toHaveBeenCalledWith("Compra 13");
+    expect(mockParseEmailApi).toHaveBeenCalledWith("Compra 14");
   });
 
   it("serializes duplicate lookup and transaction insert under concurrent parsing", async () => {
@@ -747,7 +748,7 @@ describe("email processing pipeline", () => {
     );
   });
 
-  it("starts initial sync parsing two emails immediately", async () => {
+  it("starts all initial sync parses immediately", async () => {
     const events: string[] = [];
     const pendingParses: Array<(result: ReturnType<typeof makeParsedEmailResult>) => void> = [];
     mockParseEmailApi.mockImplementation(async (body: string) => {
@@ -763,16 +764,51 @@ describe("email processing pipeline", () => {
       )
     );
 
-    await vi.waitFor(() => expect(events).toContain("parse:Compra 2"));
-    expect(events).toEqual(["parse:Compra 1", "parse:Compra 2"]);
-
-    pendingParses[0]?.(makeParsedEmailResult({ description: "Compra 1" }));
     await vi.waitFor(() => expect(events).toContain("parse:Compra 3"));
     expect(events).toEqual(["parse:Compra 1", "parse:Compra 2", "parse:Compra 3"]);
 
+    pendingParses[0]?.(makeParsedEmailResult({ description: "Compra 1" }));
     pendingParses[1]?.(makeParsedEmailResult({ description: "Compra 2" }));
     pendingParses[2]?.(makeParsedEmailResult({ description: "Compra 3" }));
     await processing;
+  });
+
+  it("does not stop scheduling initial sync parses after the preview target is reached", async () => {
+    const events: string[] = [];
+    const pendingParses: Array<(result: ReturnType<typeof makeParsedEmailResult>) => void> = [];
+    mockParseEmailApi.mockImplementation(async (body: string) => {
+      events.push(`parse:${body}`);
+      return new Promise((resolve) => pendingParses.push(resolve));
+    });
+
+    const processing = processInitialSyncEmails(
+      mockDb,
+      USER_ID,
+      Array.from({ length: 6 }, (_, index) =>
+        makeRawEmail({ externalId: `ext-${index + 1}`, body: `Compra ${index + 1}` })
+      )
+    );
+
+    await vi.waitFor(() => expect(events).toContain("parse:Compra 6"));
+    expect(events).toEqual([
+      "parse:Compra 1",
+      "parse:Compra 2",
+      "parse:Compra 3",
+      "parse:Compra 4",
+      "parse:Compra 5",
+      "parse:Compra 6",
+    ]);
+
+    pendingParses[0]?.(makeParsedEmailResult({ description: "Compra 1" }));
+    pendingParses[1]?.(makeParsedEmailResult({ description: "Compra 2" }));
+    pendingParses[2]?.(makeParsedEmailResult({ description: "Compra 3" }));
+    pendingParses[3]?.(makeParsedEmailResult({ description: "Compra 4" }));
+    pendingParses[4]?.(makeParsedEmailResult({ description: "Compra 5" }));
+    pendingParses[5]?.(makeParsedEmailResult({ description: "Compra 6" }));
+
+    const result = await processing;
+
+    expect(result.saved).toBe(6);
   });
 
   it("passes the explicit initial-sync parse context to remote parsing", async () => {

--- a/apps/mobile/__tests__/email-capture/parse-email-service.test.ts
+++ b/apps/mobile/__tests__/email-capture/parse-email-service.test.ts
@@ -221,6 +221,44 @@ describe("createParseEmailService", () => {
     });
   });
 
+  it("surfaces parse-email rate limits from the Edge Function response", async () => {
+    const captureWarning = vi.fn();
+    const mockInvoke = vi.fn().mockResolvedValue({
+      data: null,
+      error: {
+        message: "Edge Function returned a non-2xx status code",
+        context: {
+          status: 429,
+          headers: { get: (header: string) => (header === "Retry-After" ? "41" : null) },
+        },
+      },
+    });
+
+    const service = createParseEmailService({
+      validCategoryIds: ["food"],
+      throwOnApiFailure: true,
+      supabase: {
+        getSupabase: () =>
+          ({
+            functions: { invoke: mockInvoke },
+          }) as never,
+      },
+      telemetry: {
+        captureError: vi.fn(),
+        captureWarning,
+        capturePipelineEvent: vi.fn(),
+      },
+    });
+
+    await expect(service.parseEmail("Compra por $50,000")).rejects.toThrow("rate_limited");
+    expect(captureWarning).toHaveBeenCalledWith("parse_email_api_failed", {
+      errorMessage: "rate_limited",
+      hasData: false,
+      httpStatus: 429,
+      retryAfterSeconds: 41,
+    });
+  });
+
   it("returns null and captures a warning when local notification validation rejects a candidate", async () => {
     const captureWarning = vi.fn();
     const mockInvoke = vi.fn().mockResolvedValue({

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -322,6 +322,39 @@ function getProcessedInitialSyncExternalIds(): string[] {
     .map((email) => email.externalId);
 }
 
+function getProcessedBackgroundExternalIds(): string[] {
+  return vi
+    .mocked(processBackgroundEmails)
+    .mock.calls.flatMap(([, , emails]) => emails)
+    .map((email) => email.externalId);
+}
+
+function setGmailAndOutlookAccounts() {
+  setAccounts([makeAccount(), makeAccount({ id: "ea-2" as EmailAccountId, provider: "outlook" })]);
+}
+
+function mockFetchedDatedEmails(input: {
+  readonly gmailCount: number;
+  readonly outlookCount: number;
+}) {
+  mockAdapter.fetchEmails
+    .mockResolvedValueOnce(
+      makeDatedEmails({ provider: "gmail", prefix: "gmail", hour: "10", count: input.gmailCount })
+    )
+    .mockResolvedValueOnce(
+      makeDatedEmails({
+        provider: "outlook",
+        prefix: "outlook",
+        hour: "11",
+        count: input.outlookCount,
+      })
+    );
+}
+
+function expectedNewestFirstIds(prefix: string, count: number): string[] {
+  return Array.from({ length: count }, (_, index) => `${prefix}-${count - index}`);
+}
+
 function runFetchAndProcess(gmailClientId = "g", outlookClientId = "o", refresh = mockRefresh) {
   return fetchAndProcessEmails(
     mockDb,
@@ -346,6 +379,18 @@ function runInitialSyncFetch() {
 describe("email capture boundary", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(processEmails).mockReset();
+    vi.mocked(processBackgroundEmails).mockReset();
+    vi.mocked(processInitialSyncEmails).mockReset();
+    vi.mocked(processRetries).mockReset();
+    vi.mocked(processEmails).mockResolvedValue({ ...EMPTY_PROCESS_SUMMARY });
+    vi.mocked(processBackgroundEmails).mockResolvedValue({ ...EMPTY_PROCESS_SUMMARY });
+    vi.mocked(processInitialSyncEmails).mockResolvedValue({ ...EMPTY_PROCESS_SUMMARY });
+    vi.mocked(processRetries).mockResolvedValue({
+      retried: 0,
+      succeeded: 0,
+      permanentlyFailed: 0,
+    });
     vi.mocked(insertEmailAccount).mockResolvedValue(true);
     mockEnsureBankSenders.mockResolvedValue([
       { bank: "Bancolombia", email: "notificaciones@bancolombia.com.co" },
@@ -779,7 +824,7 @@ describe("email capture boundary", () => {
       expect(processEmails).not.toHaveBeenCalled();
     });
 
-    it("uses the background parser profile and bounds email work per run when requested", async () => {
+    it("uses the background parser profile without bounding email work", async () => {
       setAccounts();
       const mockRawEmails = Array.from({ length: 12 }, (_, index) =>
         makeRawEmail({
@@ -790,7 +835,7 @@ describe("email capture boundary", () => {
       mockAdapter.fetchEmails.mockResolvedValueOnce(mockRawEmails);
       vi.mocked(processBackgroundEmails).mockResolvedValueOnce({
         ...EMPTY_PROCESS_SUMMARY,
-        saved: 10,
+        saved: 12,
       });
       mockEmptyReviewLoads();
 
@@ -806,7 +851,7 @@ describe("email capture boundary", () => {
       expect(processBackgroundEmails).toHaveBeenCalledWith(
         mockDb,
         mockUserId,
-        mockRawEmails.slice(-10).reverse(),
+        mockRawEmails.slice().reverse(),
         expect.any(Function)
       );
       expect(updateLastFetchedAt).not.toHaveBeenCalled();
@@ -815,27 +860,9 @@ describe("email capture boundary", () => {
       expect(processRetries).not.toHaveBeenCalled();
     });
 
-    it("applies the background work bound across all fetched accounts", async () => {
-      setAccounts([
-        makeAccount(),
-        makeAccount({ id: "ea-2" as EmailAccountId, provider: "outlook" }),
-      ]);
-      const gmailEmails = Array.from({ length: 8 }, (_, index) =>
-        makeRawEmail({
-          externalId: `gmail-${index + 1}`,
-          receivedAt: `2026-03-05T10:${String(index).padStart(2, "0")}:00Z`,
-        })
-      );
-      const outlookEmails = Array.from({ length: 8 }, (_, index) =>
-        makeRawEmail({
-          externalId: `outlook-${index + 1}`,
-          provider: "outlook",
-          receivedAt: `2026-03-05T11:${String(index).padStart(2, "0")}:00Z`,
-        })
-      );
-      mockAdapter.fetchEmails
-        .mockResolvedValueOnce(gmailEmails)
-        .mockResolvedValueOnce(outlookEmails);
+    it("processes all background work across all fetched accounts", async () => {
+      setGmailAndOutlookAccounts();
+      mockFetchedDatedEmails({ gmailCount: 8, outlookCount: 8 });
       vi.mocked(processBackgroundEmails)
         .mockResolvedValueOnce({ ...EMPTY_PROCESS_SUMMARY })
         .mockResolvedValueOnce({ ...EMPTY_PROCESS_SUMMARY });
@@ -850,25 +877,13 @@ describe("email capture boundary", () => {
         { parseProfile: "background" }
       );
 
-      const processedEmails = vi
-        .mocked(processBackgroundEmails)
-        .mock.calls.flatMap(([, , emails]) => emails);
-      expect(processedEmails).toHaveLength(10);
-      expect(processedEmails.map((email) => email.externalId)).toEqual([
-        "outlook-8",
-        "outlook-7",
-        "outlook-6",
-        "outlook-5",
-        "outlook-4",
-        "outlook-3",
-        "outlook-2",
-        "outlook-1",
-        "gmail-8",
-        "gmail-7",
+      expect(getProcessedBackgroundExternalIds()).toEqual([
+        ...expectedNewestFirstIds("outlook", 8),
+        ...expectedNewestFirstIds("gmail", 8),
       ]);
     });
 
-    it("bounds initial sync to newest candidates without advancing account cursors", async () => {
+    it("processes all initial sync candidates without advancing account cursors", async () => {
       setAccounts([
         makeAccount(),
         makeAccount({ id: "ea-2" as EmailAccountId, provider: "outlook" }),
@@ -908,6 +923,50 @@ describe("email capture boundary", () => {
         "gmail-7",
         "gmail-6",
         "gmail-5",
+        "gmail-4",
+        "gmail-3",
+        "gmail-2",
+        "gmail-1",
+      ]);
+      expect(updateLastFetchedAt).not.toHaveBeenCalled();
+    });
+
+    it("continues initial sync after enough transaction results are found", async () => {
+      setAccounts([
+        makeAccount(),
+        makeAccount({ id: "ea-2" as EmailAccountId, provider: "outlook" }),
+      ]);
+      mockAdapter.fetchEmails
+        .mockResolvedValueOnce(
+          makeDatedEmails({ provider: "gmail", prefix: "gmail", hour: "11", count: 4 })
+        )
+        .mockResolvedValueOnce(
+          makeDatedEmails({ provider: "outlook", prefix: "outlook", hour: "10", count: 4 })
+        );
+      vi.mocked(processInitialSyncEmails).mockResolvedValueOnce({
+        ...EMPTY_PROCESS_SUMMARY,
+        saved: 3,
+      });
+      mockEmptyReviewLoads();
+
+      const outcome = await runInitialSyncFetch();
+
+      expect(outcome).toEqual({
+        status: "completed",
+        savedCount: 3,
+        needsReviewCount: 0,
+        failedCount: 0,
+      });
+      expect(processInitialSyncEmails).toHaveBeenCalledTimes(2);
+      expect(getProcessedInitialSyncExternalIds()).toEqual([
+        "gmail-4",
+        "gmail-3",
+        "gmail-2",
+        "gmail-1",
+        "outlook-4",
+        "outlook-3",
+        "outlook-2",
+        "outlook-1",
       ]);
       expect(updateLastFetchedAt).not.toHaveBeenCalled();
     });
@@ -1040,22 +1099,38 @@ describe("email capture boundary", () => {
       ]);
     });
 
-    it("refreshes transactions after the first saved foreground email and after completion", async () => {
+    it("refreshes transactions as foreground email transactions are found and after completion", async () => {
       setAccounts();
       mockAdapter.fetchEmails.mockResolvedValueOnce([
         makeRawEmail({ externalId: "ext-1" }),
         makeRawEmail({ externalId: "ext-2" }),
+        makeRawEmail({ externalId: "ext-3" }),
       ]);
       vi.mocked(processEmails).mockImplementationOnce(async (_db, _uid, _emails, onProgress) => {
-        onProgress?.({ total: 2, completed: 1, saved: 1, failed: 0, needsReview: 0 });
-        onProgress?.({ total: 2, completed: 2, saved: 2, failed: 0, needsReview: 0 });
-        return { ...EMPTY_PROCESS_SUMMARY, saved: 2 };
+        onProgress?.({ total: 3, completed: 1, saved: 1, failed: 0, needsReview: 0 });
+        onProgress?.({ total: 3, completed: 2, saved: 1, failed: 0, needsReview: 1 });
+        onProgress?.({ total: 3, completed: 3, saved: 2, failed: 0, needsReview: 1 });
+        return { ...EMPTY_PROCESS_SUMMARY, saved: 2, needsReview: 1 };
       });
       mockEmptyReviewLoads();
 
       await runFetchAndProcess();
 
-      expect(mockRefresh).toHaveBeenCalledTimes(2);
+      expect(mockRefresh).toHaveBeenCalledTimes(4);
+    });
+
+    it("does not refresh transactions for filtered foreground email progress", async () => {
+      setAccounts();
+      mockAdapter.fetchEmails.mockResolvedValueOnce([makeRawEmail({ externalId: "ext-1" })]);
+      vi.mocked(processEmails).mockImplementationOnce(async (_db, _uid, _emails, onProgress) => {
+        onProgress?.({ total: 1, completed: 1, saved: 0, failed: 0, needsReview: 0 });
+        return { ...EMPTY_PROCESS_SUMMARY, filtered: 1 };
+      });
+      mockEmptyReviewLoads();
+
+      await runFetchAndProcess();
+
+      expect(mockRefresh).toHaveBeenCalledTimes(1);
     });
 
     it("auto-clears phase after 2s timeout when phase is complete", async () => {

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -1119,6 +1119,34 @@ describe("email capture boundary", () => {
       expect(mockRefresh).toHaveBeenCalledTimes(4);
     });
 
+    it("drops queued progress refreshes after the active fetch run changes", async () => {
+      const refreshGate = createDeferred<void>();
+      const processingGate = createDeferred<void>();
+      const slowRefresh = vi.fn().mockImplementationOnce(() => refreshGate.promise);
+      setAccounts();
+      mockAdapter.fetchEmails.mockResolvedValueOnce([
+        makeRawEmail({ externalId: "ext-1" }),
+        makeRawEmail({ externalId: "ext-2" }),
+      ]);
+      vi.mocked(processEmails).mockImplementationOnce(async (_db, _uid, _emails, onProgress) => {
+        onProgress?.({ total: 2, completed: 1, saved: 1, failed: 0, needsReview: 0 });
+        onProgress?.({ total: 2, completed: 2, saved: 2, failed: 0, needsReview: 0 });
+        await processingGate.promise;
+        return { ...EMPTY_PROCESS_SUMMARY, saved: 2 };
+      });
+      mockEmptyReviewLoads();
+
+      const fetchRun = runFetchAndProcess("g", "o", slowRefresh);
+      await vi.waitFor(() => expect(slowRefresh).toHaveBeenCalledTimes(1));
+
+      initializeEmailCaptureSession("user-2" as UserId);
+      refreshGate.resolve();
+      processingGate.resolve();
+      await fetchRun;
+
+      expect(slowRefresh).toHaveBeenCalledTimes(1);
+    });
+
     it("does not refresh transactions for filtered foreground email progress", async () => {
       setAccounts();
       mockAdapter.fetchEmails.mockResolvedValueOnce([makeRawEmail({ externalId: "ext-1" })]);

--- a/apps/mobile/features/email-capture/services/create-parse-email-service.ts
+++ b/apps/mobile/features/email-capture/services/create-parse-email-service.ts
@@ -16,6 +16,7 @@ import {
 } from "@/shared/effect/telemetry";
 import type { LlmParsedTransaction } from "./llm-parser";
 import { llmOutputSchema } from "./llm-parser";
+import { buildParseApiFailureDiagnostics } from "./parse-api-failure-diagnostics";
 
 type ParseMode = "classify" | "full_parse" | "parse_notification";
 export type ParseContext = "default" | "initial_sync";
@@ -24,6 +25,7 @@ type ParseFunctionResult<Response> = {
   readonly data?: Response | null;
   readonly error?: {
     readonly message?: string;
+    readonly context?: unknown;
   } | null;
 };
 
@@ -86,10 +88,6 @@ function invokeParseEmailFunctionEffect<Response>(
   );
 }
 
-function getParseApiErrorMessage(response: ParseFunctionResult<ParseEmailResponse>) {
-  return response.error?.message ?? response.data?.error ?? "unknown";
-}
-
 function createParseApiFailureResult(errorMessage: string, throwOnApiFailure: boolean) {
   return throwOnApiFailure
     ? Effect.fail(
@@ -103,20 +101,14 @@ function logParseApiFailureEffect(
   response: ParseFunctionResult<ParseEmailResponse>,
   throwOnApiFailure: boolean
 ) {
-  const errorMessage = getParseApiErrorMessage(response);
+  const diagnostics = buildParseApiFailureDiagnostics(response);
   if (typeof __DEV__ !== "undefined" && __DEV__) {
-    console.info(`[email-capture] ${warningPrefix}_api_failed`, {
-      errorMessage,
-      hasData: response.data != null,
-    });
+    console.info(`[email-capture] ${warningPrefix}_api_failed`, diagnostics);
   }
 
   return Effect.zipRight(
-    captureWarningEffect(`${warningPrefix}_api_failed`, {
-      errorMessage,
-      hasData: response.data != null,
-    }),
-    createParseApiFailureResult(errorMessage, throwOnApiFailure)
+    captureWarningEffect(`${warningPrefix}_api_failed`, diagnostics),
+    createParseApiFailureResult(diagnostics.errorMessage, throwOnApiFailure)
   );
 }
 

--- a/apps/mobile/features/email-capture/services/email-capture-store-runtime.ts
+++ b/apps/mobile/features/email-capture/services/email-capture-store-runtime.ts
@@ -119,9 +119,11 @@ const applyFetchProgress = (
   progressRuntime.lastRefreshedFoundCount = foundCount;
   progressRuntime.refreshGate = progressRuntime.refreshGate.then(
     async () => {
+      if (!isCurrentEmailCaptureFetchRun(progressRuntime.run)) return;
       await progressRuntime.refreshTransactions();
     },
     async () => {
+      if (!isCurrentEmailCaptureFetchRun(progressRuntime.run)) return;
       await progressRuntime.refreshTransactions();
     }
   );

--- a/apps/mobile/features/email-capture/services/email-capture-store-runtime.ts
+++ b/apps/mobile/features/email-capture/services/email-capture-store-runtime.ts
@@ -27,7 +27,8 @@ type FetchStartResult =
 type FetchProgressRuntime = {
   readonly run: EmailCaptureFetchRun;
   readonly refreshTransactions: RefreshTransactions;
-  hasRefreshedFirstSave: boolean;
+  lastRefreshedFoundCount: number;
+  refreshGate: Promise<void>;
 };
 
 export type EmailCaptureSession = {
@@ -113,9 +114,17 @@ const applyFetchProgress = (
   if (!isCurrentEmailCaptureFetchRun(progressRuntime.run)) return;
 
   getRuntime().setProgress(progress);
-  if (progress.saved === 0 || progressRuntime.hasRefreshedFirstSave) return;
-  progressRuntime.hasRefreshedFirstSave = true;
-  void progressRuntime.refreshTransactions();
+  const foundCount = progress.saved + progress.needsReview;
+  if (foundCount <= progressRuntime.lastRefreshedFoundCount) return;
+  progressRuntime.lastRefreshedFoundCount = foundCount;
+  progressRuntime.refreshGate = progressRuntime.refreshGate.then(
+    async () => {
+      await progressRuntime.refreshTransactions();
+    },
+    async () => {
+      await progressRuntime.refreshTransactions();
+    }
+  );
 };
 
 export function registerEmailCaptureStoreRuntime(nextRuntime: StoreRuntime): void {
@@ -187,7 +196,8 @@ export function createEmailCaptureFetchProgressHandler(
   const progressRuntime: FetchProgressRuntime = {
     run,
     refreshTransactions,
-    hasRefreshedFirstSave: false,
+    lastRefreshedFoundCount: 0,
+    refreshGate: Promise.resolve(),
   };
 
   return (progress) => applyFetchProgress(progressRuntime, progress);

--- a/apps/mobile/features/email-capture/services/email-capture-sync-policy.ts
+++ b/apps/mobile/features/email-capture/services/email-capture-sync-policy.ts
@@ -1,8 +1,5 @@
 import type { RawEmail } from "../schema";
 
-const BACKGROUND_MAX_CANDIDATE_EMAILS = 10;
-const INITIAL_SYNC_MAX_CANDIDATE_EMAILS = 20;
-
 export type EmailCaptureParseProfile = "foreground" | "background" | "initial_sync";
 
 export type EmailCaptureSyncPolicy = {
@@ -37,7 +34,12 @@ export const applyEmailCaptureCandidateLimit = <T extends EmailBatchLike>(
   fetchResults: readonly T[],
   maxCandidateEmails: number | null
 ): readonly T[] => {
-  if (maxCandidateEmails == null) return fetchResults;
+  if (maxCandidateEmails == null) {
+    return fetchResults.map((result) => ({
+      ...result,
+      rawEmails: sortNewestFirst(result.rawEmails),
+    }));
+  }
 
   const allowedExternalIds = new Set(
     sortNewestFirst(fetchResults.flatMap((result) => result.rawEmails))
@@ -60,7 +62,7 @@ export const resolveEmailCaptureSyncPolicy = (
     ? {
         parseProfile,
         advancesLastFetchedAt: false,
-        maxCandidateEmails: BACKGROUND_MAX_CANDIDATE_EMAILS,
+        maxCandidateEmails: null,
         runRetries: false,
         showsProgress: false,
       }
@@ -68,7 +70,7 @@ export const resolveEmailCaptureSyncPolicy = (
       ? {
           parseProfile,
           advancesLastFetchedAt: false,
-          maxCandidateEmails: INITIAL_SYNC_MAX_CANDIDATE_EMAILS,
+          maxCandidateEmails: null,
           runRetries: false,
           showsProgress: true,
         }

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-batch.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-batch.ts
@@ -104,7 +104,7 @@ async function runEmailWorker(input: {
   readonly queue: EmailQueue;
   readonly onOutcome: (outcome: IncomingEmailOutcome) => void;
 }): Promise<void> {
-  // FP exemption: the worker queue keeps parse-email calls serialized for Edge Function rate limits.
+  // FP exemption: workers share a queue so parse calls can run without artificial batching.
   while (true) {
     const email = getNextQueuedEmail(input.queue);
     if (!email) return;
@@ -119,15 +119,20 @@ async function runEmailWorkers(input: {
   readonly onOutcome: (outcome: IncomingEmailOutcome) => void;
 }) {
   const queue: EmailQueue = { emails: input.emails, nextIdx: 0 };
-  const workerCount = Math.min(
-    Math.max(1, input.context.runtime.parseRateLimit.concurrency),
-    input.emails.length
-  );
-  await Promise.all(
+  const concurrency = input.context.runtime.parseRateLimit.concurrency;
+  const workerCount =
+    concurrency == null
+      ? input.emails.length
+      : Math.min(Math.max(1, concurrency), input.emails.length);
+  const results = await Promise.allSettled(
     Array.from({ length: workerCount }, () =>
       runEmailWorker({ context: input.context, queue, onOutcome: input.onOutcome })
     )
   );
+  const rejection = results.find((result) => result.status === "rejected");
+  if (rejection?.status === "rejected") {
+    throw rejection.reason;
+  }
 }
 
 const createTimingAccumulator = (): EmailBatchTimingAccumulator => ({

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/internal-types.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/internal-types.ts
@@ -34,7 +34,7 @@ export type PipelineRuntime = {
   ) => Promise<A>;
   readonly parseRateLimit: {
     readonly delayMs: number;
-    readonly concurrency: number;
+    readonly concurrency: number | null;
     readonly sleep: (delayMs: number) => Promise<void>;
   };
   readonly maxCandidateEmails?: number;

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/public-types.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/public-types.ts
@@ -144,7 +144,7 @@ export type CreateEmailPipelineServiceDeps = {
   readonly telemetry?: AppTelemetry;
   readonly parseRateLimit?: {
     readonly delayMs?: number;
-    readonly concurrency?: number;
+    readonly concurrency?: number | null;
     readonly sleep?: (delayMs: number) => Promise<void>;
   };
   readonly maxCandidateEmails?: number;

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/runtime.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/runtime.ts
@@ -31,7 +31,7 @@ export const EmailPipelineDeps = makeAppService<CreateEmailPipelineServiceDeps>(
 );
 
 const DEFAULT_PARSE_RATE_LIMIT_DELAY_MS = 0;
-const DEFAULT_PARSE_RATE_LIMIT_CONCURRENCY = 3;
+const DEFAULT_PARSE_RATE_LIMIT_CONCURRENCY: number | null = null;
 
 const sleep = (delayMs: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, delayMs));

--- a/apps/mobile/features/email-capture/services/email-pipeline.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline.ts
@@ -33,12 +33,8 @@ import { retryableParseEmailApi } from "./parse-email-api";
 export type { PipelineResult, ProcessEmails, ProcessRetries, ProgressCallback, RetryResult };
 
 const FOREGROUND_PARSE_START_DELAY_MS = 0;
-const FOREGROUND_PARSE_CONCURRENCY = 3;
 const BACKGROUND_PARSE_START_DELAY_MS = 0;
-const BACKGROUND_PARSE_CONCURRENCY = 2;
-const BACKGROUND_MAX_CANDIDATE_EMAILS = 10;
 const INITIAL_SYNC_PARSE_START_DELAY_MS = 0;
-const INITIAL_SYNC_PARSE_CONCURRENCY = 2;
 
 const emailPipelineDeps = {
   parseEmailApi: retryableParseEmailApi,
@@ -64,7 +60,7 @@ const emailPipeline = createEmailPipelineService({
   ...emailPipelineDeps,
   parseRateLimit: {
     delayMs: FOREGROUND_PARSE_START_DELAY_MS,
-    concurrency: FOREGROUND_PARSE_CONCURRENCY,
+    concurrency: null,
   },
 });
 
@@ -72,9 +68,8 @@ const backgroundEmailPipeline = createEmailPipelineService({
   ...emailPipelineDeps,
   parseRateLimit: {
     delayMs: BACKGROUND_PARSE_START_DELAY_MS,
-    concurrency: BACKGROUND_PARSE_CONCURRENCY,
+    concurrency: null,
   },
-  maxCandidateEmails: BACKGROUND_MAX_CANDIDATE_EMAILS,
 });
 
 const initialSyncEmailPipeline = createEmailPipelineService({
@@ -82,7 +77,7 @@ const initialSyncEmailPipeline = createEmailPipelineService({
   parseContext: "initial_sync",
   parseRateLimit: {
     delayMs: INITIAL_SYNC_PARSE_START_DELAY_MS,
-    concurrency: INITIAL_SYNC_PARSE_CONCURRENCY,
+    concurrency: null,
   },
 });
 

--- a/apps/mobile/features/email-capture/services/email-pipeline.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline.ts
@@ -35,6 +35,7 @@ export type { PipelineResult, ProcessEmails, ProcessRetries, ProgressCallback, R
 const FOREGROUND_PARSE_START_DELAY_MS = 0;
 const BACKGROUND_PARSE_START_DELAY_MS = 0;
 const INITIAL_SYNC_PARSE_START_DELAY_MS = 0;
+const PARSE_CONCURRENCY = 15;
 
 const emailPipelineDeps = {
   parseEmailApi: retryableParseEmailApi,
@@ -60,7 +61,7 @@ const emailPipeline = createEmailPipelineService({
   ...emailPipelineDeps,
   parseRateLimit: {
     delayMs: FOREGROUND_PARSE_START_DELAY_MS,
-    concurrency: null,
+    concurrency: PARSE_CONCURRENCY,
   },
 });
 
@@ -68,7 +69,7 @@ const backgroundEmailPipeline = createEmailPipelineService({
   ...emailPipelineDeps,
   parseRateLimit: {
     delayMs: BACKGROUND_PARSE_START_DELAY_MS,
-    concurrency: null,
+    concurrency: PARSE_CONCURRENCY,
   },
 });
 
@@ -77,7 +78,7 @@ const initialSyncEmailPipeline = createEmailPipelineService({
   parseContext: "initial_sync",
   parseRateLimit: {
     delayMs: INITIAL_SYNC_PARSE_START_DELAY_MS,
-    concurrency: null,
+    concurrency: PARSE_CONCURRENCY,
   },
 });
 

--- a/apps/mobile/features/email-capture/services/parse-api-failure-diagnostics.ts
+++ b/apps/mobile/features/email-capture/services/parse-api-failure-diagnostics.ts
@@ -1,0 +1,45 @@
+type ParseApiFailureResponse = {
+  readonly data?: { readonly error?: string } | null;
+  readonly error?: {
+    readonly message?: string;
+    readonly context?: unknown;
+  } | null;
+};
+
+const RETRY_AFTER_HEADER = "Retry-After";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const getContext = (response: ParseApiFailureResponse): Record<string, unknown> | null =>
+  isRecord(response.error?.context) ? response.error.context : null;
+
+const readHttpStatus = (response: ParseApiFailureResponse): number | undefined => {
+  const status = getContext(response)?.status;
+  return typeof status === "number" ? status : undefined;
+};
+
+const readRetryAfterSeconds = (response: ParseApiFailureResponse): number | undefined => {
+  const headers = getContext(response)?.headers;
+  if (!isRecord(headers) || typeof headers.get !== "function") return undefined;
+  const value = headers.get.call(headers, RETRY_AFTER_HEADER);
+  if (typeof value !== "string") return undefined;
+  const seconds = Number.parseInt(value, 10);
+  return Number.isFinite(seconds) ? seconds : undefined;
+};
+
+const getParseApiErrorMessage = (response: ParseApiFailureResponse): string => {
+  if (readHttpStatus(response) === 429) return "rate_limited";
+  return response.error?.message ?? response.data?.error ?? "unknown";
+};
+
+export function buildParseApiFailureDiagnostics(response: ParseApiFailureResponse) {
+  const httpStatus = readHttpStatus(response);
+  const retryAfterSeconds = readRetryAfterSeconds(response);
+  return {
+    errorMessage: getParseApiErrorMessage(response),
+    hasData: response.data != null,
+    ...(httpStatus == null ? {} : { httpStatus }),
+    ...(retryAfterSeconds == null ? {} : { retryAfterSeconds }),
+  };
+}

--- a/supabase/functions/parse-email/index.ts
+++ b/supabase/functions/parse-email/index.ts
@@ -143,7 +143,7 @@ const supabase = createClient(
   Deno.env.get("SUPABASE_ANON_KEY") ?? ""
 );
 const LLM_SEED = 0;
-const DEFAULT_RATE_LIMIT_PER_MINUTE = 300;
+const DEFAULT_RATE_LIMIT_PER_MINUTE = 200;
 
 function getParseRateLimit() {
   return { key: "parse-email", limit: DEFAULT_RATE_LIMIT_PER_MINUTE };

--- a/supabase/functions/parse-email/index.ts
+++ b/supabase/functions/parse-email/index.ts
@@ -143,7 +143,7 @@ const supabase = createClient(
   Deno.env.get("SUPABASE_ANON_KEY") ?? ""
 );
 const LLM_SEED = 0;
-const DEFAULT_RATE_LIMIT_PER_MINUTE = 20;
+const DEFAULT_RATE_LIMIT_PER_MINUTE = 300;
 
 function getParseRateLimit() {
   return { key: "parse-email", limit: DEFAULT_RATE_LIMIT_PER_MINUTE };


### PR DESCRIPTION
- Remove onboarding and background caps

- Refresh home as transactions appear

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Uncapped mobile email sync: process all fetched emails newest-first across accounts without advancing cursors, and start parses immediately in all profiles with a shared concurrency of 15 while refreshing the home as transactions appear. The `parse-email` Edge Function default rate limit is raised to 200/min.

- **New Features**
  - Refreshes transactions as foreground parsing finds saved or needs-review items; ignores filtered progress and drops stale refreshes when a new run starts.
  - Surfaces `rate_limited` failures (HTTP 429) with `Retry-After` seconds from `parse-email`.

- **Refactors**
  - Removed background/initial candidate limits; process all fetched emails sorted newest-first; do not advance `lastFetchedAt`.
  - Share a 15-parallel parse concurrency across foreground/background/initial_sync; workers use a shared queue and propagate failures.

<sup>Written for commit b6c634d04b3f3a394f6d5e4e7f41cf3999c1246b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

