### PR TITLE
fix(lint): simplify nested conditionals

### DIFF
--- a/apps/mobile/features/account-suggestions/components/AccountSuggestionCard.tsx
+++ b/apps/mobile/features/account-suggestions/components/AccountSuggestionCard.tsx
@@ -31,6 +31,12 @@ function buildReasonKey(suggestion: AccountCreationSuggestion) {
   return "accountSuggestions.card.reasonLast4";
 }
 
+function getAccountIcon(kind: string) {
+  if (kind === "wallet" || kind === "cash") return Wallet;
+  if (kind === "credit_card") return CreditCard;
+  return Building2;
+}
+
 export function AccountSuggestionCard({
   suggestion,
   onCreate,
@@ -48,18 +54,13 @@ export function AccountSuggestionCard({
   const accentGreen = useThemeColor("accentGreen");
   const accentGreenLight = useThemeColor("accentGreenLight");
   const peachLight = useThemeColor("peachLight");
+  const AccountIcon = getAccountIcon(draft.kind);
 
   return (
     <View style={[styles.card, { backgroundColor: card, borderColor: borderSubtle }]}>
       <View style={styles.topRow}>
         <View style={[styles.iconWrap, { backgroundColor: accentGreenLight }]}>
-          {draft.kind === "wallet" || draft.kind === "cash" ? (
-            <Wallet size={20} color={accentGreen} />
-          ) : draft.kind === "credit_card" ? (
-            <CreditCard size={20} color={accentGreen} />
-          ) : (
-            <Building2 size={20} color={accentGreen} />
-          )}
+          <AccountIcon size={20} color={accentGreen} />
         </View>
         <View style={styles.textColumn}>
           <Text style={[styles.title, { color: primary }]}>{draft.name}</Text>

--- a/apps/mobile/features/ai-chat/store.ts
+++ b/apps/mobile/features/ai-chat/store.ts
@@ -26,6 +26,13 @@ function isActiveChatSession(userId: UserId, sessionId: number): boolean {
   return chatStoreSessionId === sessionId && useChatStore.getState().activeUserId === userId;
 }
 
+function getActionStatus(action: ChatAction | null): ActionStatus | null {
+  if (!action) return null;
+  if (action.type === "add") return "confirmed";
+  if (action.type === "delete") return "pending";
+  return null;
+}
+
 export function initializeChatSession(userId: UserId): void {
   chatStoreSessionId += 1;
   loadChatSessionsRequestId += 1;
@@ -183,13 +190,7 @@ export async function addAssistantChatMessage(
   const currentSessionId = useChatStore.getState().currentSessionId;
   if (!currentSessionId) throw new Error("No active session");
 
-  const actionStatus: ActionStatus | null = action
-    ? action.type === "add"
-      ? "confirmed"
-      : action.type === "delete"
-        ? "pending"
-        : null
-    : null;
+  const actionStatus = getActionStatus(action);
 
   const message: ChatMessage = {
     id: generateChatMessageId(),

--- a/apps/mobile/features/email-capture/services/email-capture-fetch-service.ts
+++ b/apps/mobile/features/email-capture/services/email-capture-fetch-service.ts
@@ -43,6 +43,12 @@ const FETCH_LOOKBACK_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
 
 type EmailFetchClientIds = Record<EmailProvider, string>;
 
+function getProcessEmailsForProfile(parseProfile: EmailCaptureParseProfile | undefined) {
+  if (parseProfile === "initial_sync") return processInitialSyncEmails;
+  if (parseProfile === "background") return processBackgroundEmails;
+  return processEmails;
+}
+
 export type EmailAccountFetchResult = {
   readonly account: EmailAccountRow;
   readonly rawEmails: readonly RawEmail[];
@@ -218,12 +224,7 @@ export async function ingestFetchedEmails(input: {
   readonly runRetries?: boolean;
   readonly parseProfile?: EmailCaptureParseProfile;
 }): Promise<PipelineResult> {
-  const processEmailsForProfile =
-    input.parseProfile === "initial_sync"
-      ? processInitialSyncEmails
-      : input.parseProfile === "background"
-        ? processBackgroundEmails
-        : processEmails;
+  const processEmailsForProfile = getProcessEmailsForProfile(input.parseProfile);
   const captureIngestion = createCaptureIngestionPort(input.db, {
     processEmails: processEmailsForProfile,
     processRetries,

--- a/apps/mobile/features/email-capture/services/email-capture-sync-policy.ts
+++ b/apps/mobile/features/email-capture/services/email-capture-sync-policy.ts
@@ -59,27 +59,22 @@ export const applyEmailCaptureCandidateLimit = <T extends EmailBatchLike>(
 
 export const resolveEmailCaptureSyncPolicy = (
   parseProfile: EmailCaptureParseProfile | undefined
-): EmailCaptureSyncPolicy =>
-  parseProfile === "background"
-    ? {
-        parseProfile,
-        advancesLastFetchedAt: false,
-        maxCandidateEmails: null,
-        runRetries: false,
-        showsProgress: false,
-      }
-    : parseProfile === "initial_sync"
-      ? {
-          parseProfile,
-          advancesLastFetchedAt: false,
-          maxCandidateEmails: null,
-          runRetries: false,
-          showsProgress: true,
-        }
-      : {
-          parseProfile: parseProfile ?? "foreground",
-          advancesLastFetchedAt: true,
-          maxCandidateEmails: null,
-          runRetries: true,
-          showsProgress: true,
-        };
+): EmailCaptureSyncPolicy => {
+  if (parseProfile === "background" || parseProfile === "initial_sync") {
+    return {
+      parseProfile,
+      advancesLastFetchedAt: false,
+      maxCandidateEmails: null,
+      runRetries: false,
+      showsProgress: parseProfile === "initial_sync",
+    };
+  }
+
+  return {
+    parseProfile: parseProfile ?? "foreground",
+    advancesLastFetchedAt: true,
+    maxCandidateEmails: null,
+    runRetries: true,
+    showsProgress: true,
+  };
+};

--- a/apps/mobile/features/financial-accounts/components/FinancialAccountFormScreen.tsx
+++ b/apps/mobile/features/financial-accounts/components/FinancialAccountFormScreen.tsx
@@ -92,6 +92,27 @@ export function FinancialAccountFormScreen() {
 
   const screenState = getFinancialAccountFormScreenState({ accountId, lookupStatus });
   const exitToAccountList = () => router.replace("/financial-accounts");
+  const onManageIdentifiers = accountId
+    ? () =>
+        router.push({
+          pathname: "/financial-account-identifier",
+          params: { accountId },
+        })
+    : null;
+  const formContent = (() => {
+    if (screenState === "loading") return <FinancialAccountFormLoadingState />;
+    if (screenState === "missing") {
+      return <FinancialAccountFormMissingState onExit={exitToAccountList} />;
+    }
+
+    return (
+      <FinancialAccountFormBody
+        key={accountId ?? "create"}
+        existingDetails={existingDetails}
+        onManageIdentifiers={onManageIdentifiers}
+      />
+    );
+  })();
 
   return (
     <ScreenLayout
@@ -101,25 +122,7 @@ export function FinancialAccountFormScreen() {
       variant="sub"
       onBack={screenState === "missing" ? exitToAccountList : () => router.back()}
     >
-      {screenState === "loading" ? (
-        <FinancialAccountFormLoadingState />
-      ) : screenState === "missing" ? (
-        <FinancialAccountFormMissingState onExit={exitToAccountList} />
-      ) : (
-        <FinancialAccountFormBody
-          key={accountId ?? "create"}
-          existingDetails={existingDetails}
-          onManageIdentifiers={
-            accountId
-              ? () =>
-                  router.push({
-                    pathname: "/financial-account-identifier",
-                    params: { accountId },
-                  })
-              : null
-          }
-        />
-      )}
+      {formContent}
     </ScreenLayout>
   );
 }

--- a/apps/mobile/features/goals/components/GoalCard.tsx
+++ b/apps/mobile/features/goals/components/GoalCard.tsx
@@ -39,29 +39,34 @@ function GoalCardInner({ goalWithProgress, onPress, onAddPayment }: GoalCardProp
       );
     }
     // Pace chip variants
-    const chipColor =
-      cardStatus.kind === "pace_ahead"
-        ? accentGreen
-        : cardStatus.kind === "pace_behind"
-          ? accentRed
-          : secondaryColor;
-    const chipLabel =
-      cardStatus.kind === "pace_ahead"
-        ? t("goals.card.paceAhead", { amount: formatMoney(cardStatus.amount) })
-        : cardStatus.kind === "pace_behind"
-          ? t("goals.card.paceBehind", { amount: formatMoney(cardStatus.amount) })
-          : t("goals.card.startSaving");
+    const chip = (() => {
+      if (cardStatus.kind === "pace_ahead") {
+        return {
+          color: accentGreen,
+          label: t("goals.card.paceAhead", { amount: formatMoney(cardStatus.amount) }),
+        };
+      }
+
+      if (cardStatus.kind === "pace_behind") {
+        return {
+          color: accentRed,
+          label: t("goals.card.paceBehind", { amount: formatMoney(cardStatus.amount) }),
+        };
+      }
+
+      return { color: secondaryColor, label: t("goals.card.startSaving") };
+    })();
     return (
       <View
         style={{
           paddingVertical: 3,
           paddingHorizontal: 8,
           borderRadius: 8,
-          backgroundColor: `${chipColor}26`,
+          backgroundColor: `${chip.color}26`,
         }}
       >
-        <Text style={{ fontFamily: "Poppins_600SemiBold", fontSize: 11, color: chipColor }}>
-          {chipLabel}
+        <Text style={{ fontFamily: "Poppins_600SemiBold", fontSize: 11, color: chip.color }}>
+          {chip.label}
         </Text>
       </View>
     );

--- a/apps/mobile/features/goals/lib/derive/pace.ts
+++ b/apps/mobile/features/goals/lib/derive/pace.ts
@@ -54,9 +54,12 @@ const getProgressStatus = (progress: GoalProgress): GoalCardStatus | null => {
   return null;
 };
 
-const getPaceStatus = (paceGuidance: GoalPaceGuidance): GoalCardStatus =>
-  paceGuidance.type === "pace_ahead"
-    ? { kind: "pace_ahead", amount: paceGuidance.amountAhead }
-    : paceGuidance.reason === "no_contributions"
-      ? { kind: "start_saving" }
-      : { kind: "pace_behind", amount: paceGuidance.amountBehind };
+const getPaceStatus = (paceGuidance: GoalPaceGuidance): GoalCardStatus => {
+  if (paceGuidance.type === "pace_ahead") {
+    return { kind: "pace_ahead", amount: paceGuidance.amountAhead };
+  }
+
+  if (paceGuidance.reason === "no_contributions") return { kind: "start_saving" };
+
+  return { kind: "pace_behind", amount: paceGuidance.amountBehind };
+};

--- a/apps/mobile/features/goals/lib/derive/projection.ts
+++ b/apps/mobile/features/goals/lib/derive/projection.ts
@@ -113,12 +113,11 @@ export function deriveGoalProgress(
   goal: { readonly targetAmount: number },
   currentAmount: number
 ): GoalProgress {
-  const percentComplete =
-    goal.targetAmount > 0
-      ? Math.round((currentAmount / goal.targetAmount) * 100)
-      : currentAmount > 0
-        ? 100
-        : 0;
+  const percentComplete = (() => {
+    if (goal.targetAmount > 0) return Math.round((currentAmount / goal.targetAmount) * 100);
+    if (currentAmount > 0) return 100;
+    return 0;
+  })();
 
   const remaining = goal.targetAmount - currentAmount;
   const isComplete = currentAmount >= goal.targetAmount;

--- a/apps/mobile/features/goals/lib/route-params.ts
+++ b/apps/mobile/features/goals/lib/route-params.ts
@@ -4,7 +4,9 @@ type GoalDetailRouteParams = {
 };
 
 function getFirstNonEmptyRouteParam(value: string | readonly string[] | undefined): string | null {
-  const values = Array.isArray(value) ? value : value === undefined ? [] : [value];
+  if (value === undefined) return null;
+
+  const values = Array.isArray(value) ? value : [value];
   const normalizedValues = values.map((entry) => entry.trim()).filter((entry) => entry.length > 0);
 
   return normalizedValues[0] ?? null;

--- a/apps/mobile/features/onboarding/components/SyncProgressStep.tsx
+++ b/apps/mobile/features/onboarding/components/SyncProgressStep.tsx
@@ -66,12 +66,12 @@ export function SyncProgressStep() {
     const getHasAccountSuggestions = () =>
       Boolean(
         db &&
-          userId &&
-          suggestionService.listSuggestions({
-            db,
-            userId,
-            limit: 2,
-          }).length > 0
+        userId &&
+        suggestionService.listSuggestions({
+          db,
+          userId,
+          limit: 2,
+        }).length > 0
       );
 
     const unlockSync = (input: {
@@ -228,11 +228,11 @@ export function SyncProgressStep() {
     const cleanup = startSync();
     return cleanup;
   });
-  const livePercent = progress
-    ? progress.total > 0
-      ? Math.round((progress.completed / progress.total) * 100)
-      : 0
-    : 0;
+  const livePercent = (() => {
+    if (!progress) return 0;
+    if (progress.total <= 0) return 0;
+    return Math.round((progress.completed / progress.total) * 100);
+  })();
 
   const importComplete = syncOutcome?.importComplete ?? false;
   const percent = importComplete ? 100 : livePercent;

--- a/apps/mobile/features/qa/lib/build-local-qa-seed.ts
+++ b/apps/mobile/features/qa/lib/build-local-qa-seed.ts
@@ -24,18 +24,17 @@ type LocalQaSeed = {
   readonly transfers: readonly TransferRow[];
 };
 
+function getDisplayName(profile: LocalQaProfile): string {
+  if (profile === "transfer-ready") return "Local QA Transfer Ready";
+  if (profile === "transfer-conflict") return "Local QA Transfer Conflict";
+  if (profile === "two-accounts") return "Local QA Two Accounts";
+  if (profile === "empty") return "Local QA Empty";
+  return "Local QA";
+}
+
 function getSessionForProfile(profile: LocalQaProfile): LocalQaSession {
   const userId = requireUserId(`qa-local-${profile}`);
-  const displayName =
-    profile === "transfer-ready"
-      ? "Local QA Transfer Ready"
-      : profile === "transfer-conflict"
-        ? "Local QA Transfer Conflict"
-        : profile === "two-accounts"
-          ? "Local QA Two Accounts"
-          : profile === "empty"
-            ? "Local QA Empty"
-            : "Local QA";
+  const displayName = getDisplayName(profile);
 
   return {
     userId,

--- a/apps/mobile/features/review-queues/components/shared.tsx
+++ b/apps/mobile/features/review-queues/components/shared.tsx
@@ -78,22 +78,16 @@ export function ActionButton({
   const accentGreen = useThemeColor("accentGreen");
   const peachLight = useThemeColor("peachLight");
 
-  const buttonStyle =
-    variant === "solid"
-      ? {
-          backgroundColor: accentGreen,
-          borderColor: accentGreen,
-        }
-      : variant === "outline"
-        ? {
-            backgroundColor: card,
-            borderColor: borderSubtle,
-          }
-        : {
-            backgroundColor: peachLight,
-            borderColor: peachLight,
-          };
-  const labelColor = variant === "solid" ? "#FFFFFF" : variant === "ghost" ? secondary : primary;
+  const buttonStyle = (() => {
+    if (variant === "solid") return { backgroundColor: accentGreen, borderColor: accentGreen };
+    if (variant === "outline") return { backgroundColor: card, borderColor: borderSubtle };
+    return { backgroundColor: peachLight, borderColor: peachLight };
+  })();
+  const labelColor = (() => {
+    if (variant === "solid") return "#FFFFFF";
+    if (variant === "ghost") return secondary;
+    return primary;
+  })();
 
   return (
     <Pressable

--- a/apps/mobile/features/search/lib/route-params.ts
+++ b/apps/mobile/features/search/lib/route-params.ts
@@ -6,7 +6,9 @@ type SearchRouteParams = {
 };
 
 function getFirstNonEmptyRouteParam(value: string | readonly string[] | undefined): string | null {
-  const values = Array.isArray(value) ? value : value === undefined ? [] : [value];
+  if (value === undefined) return null;
+
+  const values = Array.isArray(value) ? value : [value];
   const normalizedValues = values.map((entry) => entry.trim()).filter((entry) => entry.length > 0);
 
   return normalizedValues[0] ?? null;

--- a/apps/mobile/features/settings/components/PrivateBackupActionButton.tsx
+++ b/apps/mobile/features/settings/components/PrivateBackupActionButton.tsx
@@ -8,12 +8,11 @@ type BackupActionButtonProps = {
   readonly disabled?: boolean;
 };
 
-const getButtonTextClassName = (isPrimary: boolean, isDanger: boolean) =>
-  isPrimary
-    ? "font-poppins-semibold text-white"
-    : isDanger
-      ? "font-poppins-semibold text-accent-red dark:text-accent-red-dark"
-      : "font-poppins-semibold text-primary dark:text-primary-dark";
+const getButtonTextClassName = (isPrimary: boolean, isDanger: boolean) => {
+  if (isPrimary) return "font-poppins-semibold text-white";
+  if (isDanger) return "font-poppins-semibold text-accent-red dark:text-accent-red-dark";
+  return "font-poppins-semibold text-primary dark:text-primary-dark";
+};
 
 export function BackupActionButton({
   label,

--- a/apps/mobile/features/settings/components/PrivateBackupScreen.tsx
+++ b/apps/mobile/features/settings/components/PrivateBackupScreen.tsx
@@ -115,6 +115,21 @@ export function PrivateBackupScreen() {
   const isConfirmingKey = health.status === "recovery_key_not_confirmed";
   const isReady = health.status === "ready";
   const isFailed = health.status === "backup_failed";
+  const statusCopy = (() => {
+    if (isReady) {
+      return { title: t("privateBackup.readyTitle"), body: t("privateBackup.readyBody") };
+    }
+
+    if (isFailed) {
+      return { title: t("privateBackup.failedTitle"), body: t("privateBackup.failedBody") };
+    }
+
+    if (isConfirmingKey) {
+      return { title: t("privateBackup.confirmTitle"), body: t("privateBackup.confirmBody") };
+    }
+
+    return { title: t("privateBackup.notSetupTitle"), body: t("privateBackup.notSetupBody") };
+  })();
 
   return (
     <ScreenLayout variant="sub" title={t("privateBackup.title")} onBack={() => router.back()}>
@@ -136,24 +151,8 @@ export function PrivateBackupScreen() {
 
         <BackupStatusCard
           icon={isFailed ? RefreshCcw : Shield}
-          title={
-            isReady
-              ? t("privateBackup.readyTitle")
-              : isFailed
-                ? t("privateBackup.failedTitle")
-                : isConfirmingKey
-                  ? t("privateBackup.confirmTitle")
-                  : t("privateBackup.notSetupTitle")
-          }
-          body={
-            isReady
-              ? t("privateBackup.readyBody")
-              : isFailed
-                ? t("privateBackup.failedBody")
-                : isConfirmingKey
-                  ? t("privateBackup.confirmBody")
-                  : t("privateBackup.notSetupBody")
-          }
+          title={statusCopy.title}
+          body={statusCopy.body}
           tone={isFailed || isConfirmingKey ? "peach" : "green"}
         />
 

--- a/apps/mobile/features/transfers/components/transfer-form/TransferSideCard.tsx
+++ b/apps/mobile/features/transfers/components/transfer-form/TransferSideCard.tsx
@@ -9,6 +9,27 @@ import { getKindIcon } from "./TransferForm.helpers";
 import { styles } from "./TransferForm.styles";
 import type { AccountBalanceMap } from "./TransferForm.types";
 
+function getSideTitle(
+  side: TransferSide | null,
+  account: FinancialAccountRow | null | undefined,
+  t: ReturnType<typeof useTranslation>["t"]
+): string {
+  if (side == null) return t("transfers.chooseSide");
+  if (side.kind === "external") return t("transfers.outsideFidy");
+  return account?.name ?? t("common.unknown");
+}
+
+function getSideSubtitle(
+  side: TransferSide | null,
+  account: FinancialAccountRow | null | undefined,
+  t: ReturnType<typeof useTranslation>["t"]
+): string {
+  if (side == null) return t("transfers.chooseSideHint");
+  if (side.kind === "external") return t("transfers.outsideFidyDescription");
+  if (account) return t(`financialAccounts.kinds.${readFinancialAccountKind(account.kind)}`);
+  return t("common.unknown");
+}
+
 export function TransferSideCard(props: {
   readonly accounts: readonly FinancialAccountRow[];
   readonly balances: AccountBalanceMap;
@@ -30,24 +51,14 @@ export function TransferSideCard(props: {
   const peachLight = useThemeColor("peachLight");
   const accountId = props.side?.kind === "account" ? props.side.accountId : null;
   const account = accountId ? props.accounts.find((item) => item.id === accountId) : null;
-  const kind = account ? readFinancialAccountKind(account.kind) : null;
-  const Icon =
-    props.side?.kind === "external" ? ExternalLink : account ? getKindIcon(account.kind) : Landmark;
+  const Icon = (() => {
+    if (props.side?.kind === "external") return ExternalLink;
+    if (account) return getKindIcon(account.kind);
+    return Landmark;
+  })();
   const sideBalance = account ? (props.balances[account.id] ?? 0) : null;
-  const title =
-    props.side == null
-      ? t("transfers.chooseSide")
-      : props.side.kind === "external"
-        ? t("transfers.outsideFidy")
-        : (account?.name ?? t("common.unknown"));
-  const subtitle =
-    props.side == null
-      ? t("transfers.chooseSideHint")
-      : props.side.kind === "external"
-        ? t("transfers.outsideFidyDescription")
-        : account
-          ? t(`financialAccounts.kinds.${kind}`)
-          : t("common.unknown");
+  const title = getSideTitle(props.side, account, t);
+  const subtitle = getSideSubtitle(props.side, account, t);
 
   return (
     <View style={{ gap: 8 }}>

--- a/apps/mobile/features/transfers/lib/presentation.ts
+++ b/apps/mobile/features/transfers/lib/presentation.ts
@@ -25,14 +25,20 @@ export function getTransferActivityCopy(
 ) {
   const fromLabel = getTransferSideLabel(transfer.fromSide, accountNames, t);
   const toLabel = getTransferSideLabel(transfer.toSide, accountNames, t);
+  const title = (() => {
+    if (transfer.toSide.kind === "account") {
+      return t("transfers.activity.toAccount", { name: toLabel });
+    }
+
+    if (transfer.fromSide.kind === "account") {
+      return t("transfers.activity.fromAccount", { name: fromLabel });
+    }
+
+    return t("transfers.activity.generic");
+  })();
 
   return {
-    title:
-      transfer.toSide.kind === "account"
-        ? t("transfers.activity.toAccount", { name: toLabel })
-        : transfer.fromSide.kind === "account"
-          ? t("transfers.activity.fromAccount", { name: fromLabel })
-          : t("transfers.activity.generic"),
+    title,
     route: t("transfers.activity.route", { from: fromLabel, to: toLabel }),
   };
 }

--- a/apps/mobile/shared/components/PencilEntryField.tsx
+++ b/apps/mobile/shared/components/PencilEntryField.tsx
@@ -14,6 +14,20 @@ export type PencilEntryFieldProps = {
   readonly testID?: string;
 };
 
+function getToneColor(input: {
+  readonly primary: string;
+  readonly secondary: string;
+  readonly tertiary: string;
+  readonly value?: string;
+  readonly valueTone?: PencilEntryFieldProps["valueTone"];
+}): string {
+  if (input.valueTone === "primary") return input.primary;
+  if (input.valueTone === "secondary") return input.secondary;
+  if (input.valueTone === "tertiary") return input.tertiary;
+  if (input.value) return input.primary;
+  return input.tertiary;
+}
+
 export function PencilEntryField({
   children,
   icon: Icon,
@@ -28,16 +42,7 @@ export function PencilEntryField({
   const tertiary = useThemeColor("tertiary");
   const borderSubtle = useThemeColor("borderSubtle");
   const card = useThemeColor("card");
-  const toneColor =
-    valueTone === "primary"
-      ? primary
-      : valueTone === "secondary"
-        ? secondary
-        : valueTone === "tertiary"
-          ? tertiary
-          : value
-            ? primary
-            : tertiary;
+  const toneColor = getToneColor({ primary, secondary, tertiary, value, valueTone });
   const content = children ?? (
     <Text
       numberOfLines={1}

--- a/apps/mobile/shared/components/TransactionRow.tsx
+++ b/apps/mobile/shared/components/TransactionRow.tsx
@@ -16,6 +16,12 @@ type TransactionRowProps = {
   onDelete?: () => void;
 };
 
+function getAmountClassName(amountTone: NonNullable<TransactionRowProps["amountTone"]>): string {
+  if (amountTone === "positive") return "text-accent-green dark:text-accent-green-dark";
+  if (amountTone === "neutral") return "text-primary dark:text-primary-dark";
+  return "text-accent-red dark:text-accent-red-dark";
+}
+
 export function TransactionRow({
   icon,
   iconBgColor,
@@ -34,12 +40,7 @@ export function TransactionRow({
   const iconColor = iconColorOverride ?? defaultIconColor;
   const { t } = useTranslation();
   const resolvedAmountTone = amountTone ?? (isPositive ? "positive" : "negative");
-  const amountClassName =
-    resolvedAmountTone === "positive"
-      ? "text-accent-green dark:text-accent-green-dark"
-      : resolvedAmountTone === "neutral"
-        ? "text-primary dark:text-primary-dark"
-        : "text-accent-red dark:text-accent-red-dark";
+  const amountClassName = getAmountClassName(resolvedAmountTone);
 
   const handleLongPress = useCallback(() => {
     if (Platform.OS !== "ios") return;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Simplified nested conditionals across mobile features to satisfy lint rules and improve readability. No behavior changes expected.

- **Refactors**
  - Replaced nested ternaries with small helpers and early returns for icon/status/title/style selection in UI components (e.g., AccountSuggestionCard, GoalCard, Review queues, Settings, Transfers, PencilEntryField, TransactionRow).
  - Precomputed conditional JSX in `FinancialAccountFormScreen` and simplified progress calc in onboarding.
  - Centralized profile-based branching in email capture (`process*` selection and sync policy).
  - Clarified goal pace/projection math and unified route param parsing utilities.
  - Streamlined copy generation in transfers and QA seed profiles.

<sup>Written for commit b51db5abc1b7e757a2fb0fe3e0d8cfed0ebed0b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

