### PR TITLE
chore(mobile): apply formatting

### DIFF
--- a/apps/mobile/__tests__/transactions/add-screen-source.test.ts
+++ b/apps/mobile/__tests__/transactions/add-screen-source.test.ts
@@ -135,6 +135,19 @@ test("Pencil transaction entry supports expense income transfer and calendar", (
   expect(transactionEntrySource).toContain("saveCurrentTransaction");
 });
 
+test("Pencil transaction entry confirms saves with a toast without leaving the add screen", () => {
+  expect(transactionEntrySource).toContain("showSuccessToast");
+  expect(transactionEntrySource).toContain('showSuccessToast(t("transactions.saved"), 1.6)');
+  expect(pencilTransferEntrySource).toContain('showSuccessToast(t("transfers.saved"), 1.6)');
+  expect(transactionEntrySource).not.toContain('navigate("/(tabs)"');
+  expect(pencilTransferEntrySource).not.toContain('navigate("/(tabs)"');
+});
+
+test("Pencil add screens do not allow future transaction dates", () => {
+  expect(transactionSheetsSource).toContain("maximumDate={new Date()}");
+  expect(pencilTransferEntrySource).toContain("maximumDate={new Date()}");
+});
+
 test("Pencil transfer entry supports transfer side pickers and calendar", () => {
   expect(transferEntrySource).toContain('activeTab="transfer"');
   expect(transferEntrySource).toContain("usePencilTransferEntry");

--- a/apps/mobile/__tests__/transfers/form-draft.test.ts
+++ b/apps/mobile/__tests__/transfers/form-draft.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import { resetSavedTransferDraft } from "@/features/transfers/components/transfer-form/resetTransferDraft";
+
+describe("transfer form draft", () => {
+  it("clears saved create-mode transfer fields so the Add tab cannot resubmit the same draft", () => {
+    const setters = {
+      setDate: vi.fn(),
+      setDescription: vi.fn(),
+      setDigits: vi.fn(),
+      setFromSide: vi.fn(),
+      setLastEditedSide: vi.fn(),
+      setPickerTarget: vi.fn(),
+      setShowDatePicker: vi.fn(),
+      setToSide: vi.fn(),
+    };
+
+    const defaultFromSide = { kind: "account", accountId: "account-1" as never } as const;
+
+    resetSavedTransferDraft(setters, defaultFromSide);
+
+    expect(setters.setDescription).toHaveBeenCalledWith("");
+    expect(setters.setDigits).toHaveBeenCalledWith("");
+    expect(setters.setFromSide).toHaveBeenCalledWith(defaultFromSide);
+    expect(setters.setToSide).toHaveBeenCalledWith(null);
+    expect(setters.setLastEditedSide).toHaveBeenCalledWith("to");
+    expect(setters.setPickerTarget).toHaveBeenCalledWith(null);
+    expect(setters.setShowDatePicker).toHaveBeenCalledWith(false);
+    expect(setters.setDate).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -28,7 +28,7 @@ import {
 } from "@/features/auth/hooks.public";
 import { isLocalQaAvailable, useQaDevtoolsRuntime } from "@/features/qa/hooks.public";
 import { QaStatusBanner } from "@/features/qa/ui.public";
-import { ErrorFallback } from "@/shared/components";
+import { AppToastHost, ErrorFallback } from "@/shared/components";
 import { Platform, useColorScheme } from "@/shared/components/rn";
 import { Colors } from "@/shared/constants/theme";
 import { type AnyDb, getDb } from "@/shared/db";
@@ -451,6 +451,7 @@ function RootLayout() {
           )}
         </QueryProvider>
       </SentryErrorBoundary>
+      <AppToastHost />
       <QaStatusBanner />
       <StatusBar style="auto" />
     </GestureHandlerRootView>

--- a/apps/mobile/app/edit-transaction.tsx
+++ b/apps/mobile/app/edit-transaction.tsx
@@ -1,5 +1,5 @@
 import * as Haptics from "expo-haptics";
-import { useLocalSearchParams, useRouter } from "expo-router";
+import { useLocalSearchParams, useNavigation, useRouter } from "expo-router";
 import { useState } from "react";
 import { useOptionalUserId } from "@/features/auth";
 import { getNeedsReviewEmailByTransactionId } from "@/features/email-capture";
@@ -15,20 +15,15 @@ import {
   TransactionForm,
   updateTransactionDirect,
 } from "@/features/transactions";
-import { InteractionManager } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
 import { useAsyncGuard, useMountEffect, useTranslation } from "@/shared/hooks";
-import { showErrorToast } from "@/shared/lib";
+import { clampDateToToday, showErrorToast, waitForNavigationTransition } from "@/shared/lib";
 import { requireTransactionId } from "@/shared/types/assertions";
 import type { CategoryId, FinancialAccountId, ProcessedEmailId } from "@/shared/types/branded";
 
-const afterDismiss = () =>
-  new Promise<void>((resolve) => {
-    InteractionManager.runAfterInteractions(() => resolve());
-  });
-
 export default function EditTransactionScreen() {
   const { transactionId: routeTransactionId } = useLocalSearchParams<{ transactionId?: string }>();
+  const navigation = useNavigation();
   const router = useRouter();
   const { t } = useTranslation();
   const userId = useOptionalUserId();
@@ -83,6 +78,12 @@ export default function EditTransactionScreen() {
 
   const { isBusy: isSaving, run: guardedSave } = useAsyncGuard();
 
+  const dismissAndWait = () => {
+    const pendingTransition = waitForNavigationTransition(navigation, { closing: true, fallbackMs: 2000 });
+    router.back();
+    return pendingTransition;
+  };
+
   const handleSave = () => {
     void guardedSave(async () => {
       if (transactionId == null || !db || !userId) {
@@ -90,8 +91,7 @@ export default function EditTransactionScreen() {
         return;
       }
       void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-      router.back();
-      await afterDismiss();
+      await dismissAndWait();
       try {
         const result = await updateTransactionDirect({
           db,
@@ -103,7 +103,7 @@ export default function EditTransactionScreen() {
             categoryId,
             accountId,
             description,
-            date,
+            date: clampDateToToday(date),
           },
         });
         if (!result.success) {
@@ -122,8 +122,7 @@ export default function EditTransactionScreen() {
         return;
       }
       void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-      router.back();
-      await afterDismiss();
+      await dismissAndWait();
       try {
         await deleteTransaction(db, userId, transactionId);
       } catch {

--- a/apps/mobile/app/edit-transaction.tsx
+++ b/apps/mobile/app/edit-transaction.tsx
@@ -79,7 +79,10 @@ export default function EditTransactionScreen() {
   const { isBusy: isSaving, run: guardedSave } = useAsyncGuard();
 
   const dismissAndWait = () => {
-    const pendingTransition = waitForNavigationTransition(navigation, { closing: true, fallbackMs: 2000 });
+    const pendingTransition = waitForNavigationTransition(navigation, {
+      closing: true,
+      fallbackMs: 2000,
+    });
     router.back();
     return pendingTransition;
   };

--- a/apps/mobile/features/search/components/search-screen/useSearchInitialization.ts
+++ b/apps/mobile/features/search/components/search-screen/useSearchInitialization.ts
@@ -46,7 +46,7 @@ export function useSearchInitialization(args: SearchInitializationArgs) {
     const handle = runAfterNavigationTransition(
       navigation,
       () => bootstrapSearch(args, inputRef as SearchInputRef, setReady),
-      { closing: false, fallbackMs: null }
+      { closing: false }
     );
 
     return () => {

--- a/apps/mobile/features/search/components/search-screen/useSearchInitialization.ts
+++ b/apps/mobile/features/search/components/search-screen/useSearchInitialization.ts
@@ -1,6 +1,8 @@
 import { useRef, useState } from "react";
-import { InteractionManager, type TextInput } from "@/shared/components/rn";
+import { useNavigation } from "expo-router";
+import type { TextInput } from "@/shared/components/rn";
 import { useMountEffect } from "@/shared/hooks";
+import { runAfterNavigationTransition } from "@/shared/lib";
 import type { SearchFilters } from "../../lib/types";
 import { executeSearch, updateSearchFilters } from "../../store";
 import type {
@@ -35,13 +37,16 @@ function bootstrapSearch(
 }
 
 export function useSearchInitialization(args: SearchInitializationArgs) {
+  const navigation = useNavigation();
   const [ready, setReady] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const inputRef = useRef<TextInput>(null);
 
   useMountEffect(() => {
-    const handle = InteractionManager.runAfterInteractions(() =>
-      bootstrapSearch(args, inputRef as SearchInputRef, setReady)
+    const handle = runAfterNavigationTransition(
+      navigation,
+      () => bootstrapSearch(args, inputRef as SearchInputRef, setReady),
+      { closing: false, fallbackMs: null }
     );
 
     return () => {

--- a/apps/mobile/features/settings/components/SettingsScreen.tsx
+++ b/apps/mobile/features/settings/components/SettingsScreen.tsx
@@ -84,9 +84,9 @@ export function SettingsScreen() {
         contentContainerStyle={{
           paddingHorizontal: 20,
           paddingTop: 16,
+          paddingBottom: TAB_BAR_CLEARANCE,
           gap: 24,
         }}
-        contentInset={{ bottom: TAB_BAR_CLEARANCE }}
         contentInsetAdjustmentBehavior="automatic"
         showsVerticalScrollIndicator={false}
       >
@@ -221,7 +221,6 @@ export function SettingsScreen() {
             isLast
           />
         </SettingsSection>
-        {Platform.OS === "android" ? <View style={{ height: TAB_BAR_CLEARANCE }} /> : null}
       </ScrollView>
     </ScreenLayout>
   );

--- a/apps/mobile/features/transactions/components/PencilTransactionEntryScreen.tsx
+++ b/apps/mobile/features/transactions/components/PencilTransactionEntryScreen.tsx
@@ -1,5 +1,4 @@
 import * as Haptics from "expo-haptics";
-import { useRouter } from "expo-router";
 import { useReducer } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { useOptionalUserId } from "@/features/auth/hooks.public";
@@ -20,7 +19,12 @@ import { View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
 import { useAsyncGuard, useSubscription, useTranslation } from "@/shared/hooks";
 import { getCategoryLabel, getDateFnsLocale } from "@/shared/i18n";
-import { captureError, formatInputDisplay, trackTransactionCreated } from "@/shared/lib";
+import {
+  captureError,
+  formatInputDisplay,
+  showSuccessToast,
+  trackTransactionCreated,
+} from "@/shared/lib";
 import { CATEGORIES } from "../lib/categories";
 import { getDateLabel } from "../lib/format-date";
 import { handleNumpadPress } from "../lib/handle-numpad-press";
@@ -48,7 +52,6 @@ export function PencilTransactionEntryScreen() {
     entryMode: "expense",
     sheet: null,
   });
-  const { navigate } = useRouter();
   const { t, locale } = useTranslation();
   const userId = useOptionalUserId();
   const db = userId ? tryGetDb(userId) : null;
@@ -125,7 +128,7 @@ export function PencilTransactionEntryScreen() {
       void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       trackTransactionCreated({ type, category: String(categoryId ?? ""), source: "manual" });
       resetForm();
-      navigate("/(tabs)" as never);
+      showSuccessToast(t("transactions.saved"), 1.6);
     });
   };
   const transactionFields = (

--- a/apps/mobile/features/transactions/components/PencilTransactionEntrySheets.tsx
+++ b/apps/mobile/features/transactions/components/PencilTransactionEntrySheets.tsx
@@ -20,7 +20,7 @@ function PickerSheetFrame({ children, onClose, testID, visible }: PickerSheetFra
   const modalBackdrop = useThemeColor("modalBackdrop");
 
   return (
-    <Modal visible={visible} transparent animationType="fade">
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
       <Pressable
         testID={testID}
         style={{ flex: 1, justifyContent: "flex-end", backgroundColor: `${modalBackdrop}40` }}
@@ -182,7 +182,9 @@ export function TransactionDatePickerSheet(props: {
           value={props.date}
           mode="date"
           display={Platform.OS === "ios" ? "spinner" : "default"}
+          maximumDate={new Date()}
           onChange={(_event, nextDate) => {
+            if (Platform.OS !== "ios") props.onClose();
             if (nextDate) props.onChange(nextDate);
           }}
         />

--- a/apps/mobile/features/transactions/store/form-input.ts
+++ b/apps/mobile/features/transactions/store/form-input.ts
@@ -1,3 +1,4 @@
+import { clampDateToToday } from "@/shared/lib";
 import type { TransactionFormInput } from "../lib/mutation-service";
 import type { TransactionState } from "./state";
 
@@ -13,6 +14,6 @@ export function toTransactionFormInput(state: TransactionFormState): Transaction
     categoryId: state.categoryId,
     accountId: state.accountId,
     description: state.description,
-    date: state.date,
+    date: clampDateToToday(state.date),
   };
 }

--- a/apps/mobile/features/transfers/components/PencilTransferEntryContent.tsx
+++ b/apps/mobile/features/transfers/components/PencilTransferEntryContent.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/shared/components/PencilEntryScaffold";
 import { Modal, Platform, Pressable, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
-import { formatInputDisplay } from "@/shared/lib";
+import { formatInputDisplay, showSuccessToast } from "@/shared/lib";
 import type { FinancialAccountRow } from "@/features/financial-accounts/public";
 import { handleNumpadPress } from "@/features/transactions/display.public";
 import type { TransferSide } from "../lib/build-transfer";
@@ -28,7 +28,10 @@ function getPencilTransferSideTitle(
 
 export function usePencilTransferEntry(props: { readonly enabled?: boolean } = {}) {
   const { t } = useTranslation();
-  const form = useTransferForm({ enabled: props.enabled ?? true });
+  const form = useTransferForm({
+    enabled: props.enabled ?? true,
+    onSuccessfulSave: () => showSuccessToast(t("transfers.saved"), 1.6),
+  });
   const [showCategoryPicker, setShowCategoryPicker] = useState(false);
   const primary = useThemeColor("primary");
   const secondary = useThemeColor("secondary");
@@ -125,6 +128,7 @@ export function usePencilTransferEntry(props: { readonly enabled?: boolean } = {
                 value={form.date}
                 mode="date"
                 display={Platform.OS === "ios" ? "spinner" : "default"}
+                maximumDate={new Date()}
                 onChange={form.handleDateChange}
               />
               <Pressable

--- a/apps/mobile/features/transfers/components/TransferFormScreen.tsx
+++ b/apps/mobile/features/transfers/components/TransferFormScreen.tsx
@@ -37,6 +37,7 @@ export function TransferFormScreen(props: TransferFormScreenProps = {}) {
           value={form.date}
           mode="date"
           display="default"
+          maximumDate={new Date()}
           onChange={form.handleDateChange}
         />
       ) : null}

--- a/apps/mobile/features/transfers/components/transfer-form/TransferForm.types.ts
+++ b/apps/mobile/features/transfers/components/transfer-form/TransferForm.types.ts
@@ -17,6 +17,7 @@ export type TransferFormScreenProps = {
   readonly initialDraftResolver?: (
     accounts: readonly FinancialAccountRow[]
   ) => TransferFormInitialDraft | null;
+  readonly onSuccessfulSave?: (destination: "needs-review" | "tabs") => Promise<void> | void;
 };
 
 export const TRANSFER_FORM_TEST_IDS = {

--- a/apps/mobile/features/transfers/components/transfer-form/TransferFormContent.tsx
+++ b/apps/mobile/features/transfers/components/transfer-form/TransferFormContent.tsx
@@ -94,6 +94,7 @@ export function TransferFormContent(props: { readonly form: ReturnType<typeof us
                 value={props.form.date}
                 mode="date"
                 display="compact"
+                maximumDate={new Date()}
                 onChange={props.form.handleDateChange}
               />
             ) : (

--- a/apps/mobile/features/transfers/components/transfer-form/resetTransferDraft.ts
+++ b/apps/mobile/features/transfers/components/transfer-form/resetTransferDraft.ts
@@ -1,0 +1,27 @@
+import type { TransferSide } from "@/features/transfers/lib/build-transfer";
+import type { PickerTarget } from "./TransferForm.types";
+
+type TransferDraftResetSetters = {
+  readonly setDate: (date: Date) => void;
+  readonly setDescription: (description: string) => void;
+  readonly setDigits: (digits: string) => void;
+  readonly setFromSide: (side: TransferSide | null) => void;
+  readonly setLastEditedSide: (target: PickerTarget) => void;
+  readonly setPickerTarget: (target: PickerTarget | null) => void;
+  readonly setShowDatePicker: (visible: boolean) => void;
+  readonly setToSide: (side: TransferSide | null) => void;
+};
+
+export function resetSavedTransferDraft(
+  setters: TransferDraftResetSetters,
+  defaultFromSide: TransferSide | null
+): void {
+  setters.setDate(new Date());
+  setters.setDescription("");
+  setters.setDigits("");
+  setters.setFromSide(defaultFromSide);
+  setters.setLastEditedSide("to");
+  setters.setPickerTarget(null);
+  setters.setShowDatePicker(false);
+  setters.setToSide(null);
+}

--- a/apps/mobile/features/transfers/components/transfer-form/useTransferForm.ts
+++ b/apps/mobile/features/transfers/components/transfer-form/useTransferForm.ts
@@ -56,9 +56,14 @@ function useTransferFormRouteContext() {
 
 function useTransferFormDerivedState(
   route: ReturnType<typeof useTransferFormRouteContext>,
+  props: TransferFormScreenProps,
   state: ReturnType<typeof useTransferFormState>
 ) {
   const isReclassification = state.sourceTransaction != null;
+  const defaultAccount = state.accounts.find((account) => account.isDefault) ?? state.accounts[0] ?? null;
+  const defaultFromSide = defaultAccount
+    ? ({ kind: "account", accountId: defaultAccount.id } as const)
+    : null;
   const presentationInput = {
     date: state.date,
     digits: state.digits,
@@ -70,14 +75,17 @@ function useTransferFormDerivedState(
   return {
     actions: useTransferFormActions({
       date: state.date,
+      defaultFromSide,
       description: state.description,
       db: route.db,
       digits: state.digits,
       fromSide: state.fromSide,
       isIos: route.isIos,
-      onSuccessfulSave: route.onSuccessfulSave,
+      onSuccessfulSave: props.onSuccessfulSave ?? route.onSuccessfulSave,
       processedEmailId: route.processedEmailId,
       setDate: state.setDate,
+      setDescription: state.setDescription,
+      setDigits: state.setDigits,
       setFromSide: state.setFromSide,
       setLastEditedSide: state.setLastEditedSide,
       setPickerTarget: state.setPickerTarget,
@@ -95,7 +103,7 @@ function useTransferFormDerivedState(
 export function useTransferForm(props: TransferFormScreenProps) {
   const state = useTransferFormState();
   const route = useTransferFormRouteContext();
-  const derived = useTransferFormDerivedState(route, state);
+  const derived = useTransferFormDerivedState(route, props, state);
 
   useHydrateTransferForm({
     db: route.db,

--- a/apps/mobile/features/transfers/components/transfer-form/useTransferForm.ts
+++ b/apps/mobile/features/transfers/components/transfer-form/useTransferForm.ts
@@ -60,7 +60,8 @@ function useTransferFormDerivedState(
   state: ReturnType<typeof useTransferFormState>
 ) {
   const isReclassification = state.sourceTransaction != null;
-  const defaultAccount = state.accounts.find((account) => account.isDefault) ?? state.accounts[0] ?? null;
+  const defaultAccount =
+    state.accounts.find((account) => account.isDefault) ?? state.accounts[0] ?? null;
   const defaultFromSide = defaultAccount
     ? ({ kind: "account", accountId: defaultAccount.id } as const)
     : null;

--- a/apps/mobile/features/transfers/components/transfer-form/useTransferFormActions.ts
+++ b/apps/mobile/features/transfers/components/transfer-form/useTransferFormActions.ts
@@ -3,13 +3,15 @@ import { useCallback } from "react";
 import type { StoredTransaction } from "@/features/transactions/query.public";
 import type { TransferSide } from "@/features/transfers/lib/build-transfer";
 import { useAsyncGuard, useTranslation } from "@/shared/hooks";
-import { showErrorToast } from "@/shared/lib";
+import { clampDateToToday, showErrorToast } from "@/shared/lib";
+import { resetSavedTransferDraft } from "./resetTransferDraft";
 import { submitTransferForm } from "./saveTransferForm";
 import { getTransferErrorMessageKey } from "./TransferForm.helpers";
 import type { PickerTarget } from "./TransferForm.types";
 
 async function saveTransferFormAction(input: {
   readonly date: Date;
+  readonly defaultFromSide: TransferSide | null;
   readonly description: string;
   readonly db: Parameters<typeof submitTransferForm>[0]["db"];
   readonly digits: string;
@@ -17,11 +19,12 @@ async function saveTransferFormAction(input: {
   readonly onError: (error: Parameters<typeof getTransferErrorMessageKey>[0]) => void;
   readonly onSuccessfulSave: (destination: "needs-review" | "tabs") => Promise<void> | void;
   readonly processedEmailId: Parameters<typeof submitTransferForm>[0]["processedEmailId"];
+  readonly resetDraft: (() => void) | null;
   readonly sourceTransaction: StoredTransaction | null;
   readonly toSide: TransferSide | null;
   readonly userId: Parameters<typeof submitTransferForm>[0]["userId"];
 }) {
-  const result = await submitTransferForm(input);
+  const result = await submitTransferForm({ ...input, date: clampDateToToday(input.date) });
 
   if (!result.success) {
     input.onError(result.error);
@@ -30,10 +33,12 @@ async function saveTransferFormAction(input: {
 
   void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
   await input.onSuccessfulSave(result.destination);
+  input.resetDraft?.();
 }
 
 export function useTransferFormActions(input: {
   readonly date: Date;
+  readonly defaultFromSide: TransferSide | null;
   readonly description: string;
   readonly db: Parameters<typeof submitTransferForm>[0]["db"];
   readonly digits: string;
@@ -42,6 +47,8 @@ export function useTransferFormActions(input: {
   readonly onSuccessfulSave: (destination: "needs-review" | "tabs") => Promise<void> | void;
   readonly processedEmailId: Parameters<typeof submitTransferForm>[0]["processedEmailId"];
   readonly setDate: (date: Date) => void;
+  readonly setDescription: (description: string) => void;
+  readonly setDigits: (digits: string) => void;
   readonly setFromSide: (
     side: TransferSide | null | ((current: TransferSide | null) => TransferSide | null)
   ) => void;
@@ -71,7 +78,7 @@ export function useTransferFormActions(input: {
     handleDateChange: useCallback(
       (_event: unknown, nextDate?: Date) => {
         if (!input.isIos) input.setShowDatePicker(false);
-        if (nextDate) input.setDate(nextDate);
+        if (nextDate) input.setDate(clampDateToToday(nextDate));
       },
       [input]
     ),
@@ -80,6 +87,7 @@ export function useTransferFormActions(input: {
       void guardedSave(() =>
         saveTransferFormAction({
           date: input.date,
+          defaultFromSide: input.defaultFromSide,
           description: input.description,
           db: input.db,
           digits: input.digits,
@@ -87,6 +95,10 @@ export function useTransferFormActions(input: {
           onError: (error) => showErrorToast(t(getTransferErrorMessageKey(error))),
           onSuccessfulSave: input.onSuccessfulSave,
           processedEmailId: input.processedEmailId,
+          resetDraft:
+            input.sourceTransaction == null
+              ? () => resetSavedTransferDraft(input, input.defaultFromSide)
+              : null,
           sourceTransaction: input.sourceTransaction,
           toSide: input.toSide,
           userId: input.userId,

--- a/apps/mobile/shared/components/AppToastHost.tsx
+++ b/apps/mobile/shared/components/AppToastHost.tsx
@@ -1,0 +1,110 @@
+import { useState } from "react";
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { CheckCircle } from "@/shared/components/icons";
+import { AccessibilityInfo, StyleSheet, Text, View } from "@/shared/components/rn";
+import { useSubscription, useThemeColor } from "@/shared/hooks";
+import { subscribeAppToasts } from "@/shared/lib";
+
+type AppToast = Parameters<Parameters<typeof subscribeAppToasts>[0]>[0];
+
+export function AppToastHost() {
+  const [toast, setToast] = useState<AppToast | null>(null);
+  const opacity = useSharedValue(0);
+  const translateY = useSharedValue(-80);
+  const { top } = useSafeAreaInsets();
+  const card = useThemeColor("card");
+  const primary = useThemeColor("primary");
+  const accentGreen = useThemeColor("accentGreen");
+  const onAccent = useThemeColor("onAccent");
+  const animatedToastStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    transform: [{ translateY: translateY.value }],
+  }));
+
+  useSubscription(() => subscribeAppToasts(setToast), []);
+  useSubscription(
+    () => {
+      if (!toast) return;
+      AccessibilityInfo.announceForAccessibility(toast.message);
+      opacity.value = 0;
+      translateY.value = -80;
+      opacity.value = withTiming(1, { duration: 140 });
+      translateY.value = withTiming(0, { duration: 220 });
+
+      const exitTimer = setTimeout(() => {
+        opacity.value = withTiming(0, { duration: 140 });
+        translateY.value = withTiming(-80, { duration: 180 });
+      }, toast.duration * 1000);
+      const clearTimer = setTimeout(() => setToast(null), toast.duration * 1000 + 190);
+      return () => {
+        clearTimeout(exitTimer);
+        clearTimeout(clearTimer);
+      };
+    },
+    [toast?.duration, toast?.id],
+    toast != null
+  );
+
+  if (!toast) return null;
+
+  return (
+    <View pointerEvents="box-none" style={StyleSheet.absoluteFill}>
+      <Animated.View
+        pointerEvents="none"
+        style={[
+          styles.toast,
+          {
+            top: top + 12,
+            backgroundColor: card,
+            borderColor: accentGreen,
+            shadowColor: primary,
+          },
+          animatedToastStyle,
+        ]}
+        accessibilityLiveRegion="polite"
+      >
+        <Text style={[styles.message, { color: primary }]} numberOfLines={2}>
+          {toast.message}
+        </Text>
+        <View style={[styles.icon, { backgroundColor: accentGreen }]}>
+          <CheckCircle size={16} color={onAccent} strokeWidth={2.5} />
+        </View>
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  icon: {
+    alignItems: "center",
+    borderRadius: 14,
+    height: 28,
+    justifyContent: "center",
+    width: 28,
+  },
+  message: {
+    flex: 1,
+    fontFamily: "Poppins_600SemiBold",
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  toast: {
+    alignItems: "center",
+    alignSelf: "center",
+    borderRadius: 18,
+    borderWidth: 1,
+    elevation: 8,
+    flexDirection: "row",
+    gap: 12,
+    maxWidth: 360,
+    minHeight: 52,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    position: "absolute",
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.16,
+    shadowRadius: 24,
+    width: "88%",
+  },
+});

--- a/apps/mobile/shared/components/index.ts
+++ b/apps/mobile/shared/components/index.ts
@@ -1,3 +1,4 @@
+export { AppToastHost } from "./AppToastHost";
 export { ComingSoonScreen } from "./ComingSoonScreen";
 export { ErrorFallback } from "./ErrorFallback";
 export { FidyLogo } from "./FidyLogo";

--- a/apps/mobile/shared/components/rn.ts
+++ b/apps/mobile/shared/components/rn.ts
@@ -10,12 +10,12 @@ export type {
 export {
   ActionSheetIOS,
   ActivityIndicator,
+  AccessibilityInfo,
   Alert,
   Appearance,
   AppState,
   FlatList,
   Image,
-  InteractionManager,
   Keyboard,
   KeyboardAvoidingView,
   Linking,

--- a/apps/mobile/shared/i18n/locales/en.ts
+++ b/apps/mobile/shared/i18n/locales/en.ts
@@ -103,6 +103,7 @@ const en = {
   transactions: {
     expense: "Expense",
     income: "Income",
+    saved: "Transaction saved",
     saveTransaction: "Save Transaction",
     descriptionOptional: "Description (optional)",
     noTransactionsYet: "No transactions yet",
@@ -134,6 +135,7 @@ const en = {
     chooseSide: "Choose side",
     chooseSideHint: "Choose an account or Outside Fidy",
     chooseDifferentSide: "Choose different side",
+    saved: "Transfer saved",
     save: "Record transfer",
     outsideFidy: "Outside Fidy",
     outsideFidyDescription: "Cash or another untracked side",

--- a/apps/mobile/shared/i18n/locales/es.ts
+++ b/apps/mobile/shared/i18n/locales/es.ts
@@ -106,6 +106,7 @@ const es = {
   transactions: {
     expense: "Gasto",
     income: "Ingreso",
+    saved: "Transacción guardada",
     saveTransaction: "Guardar Transacción",
     descriptionOptional: "Descripción (opcional)",
     noTransactionsYet: "Aún no hay transacciones",
@@ -138,6 +139,7 @@ const es = {
     chooseSide: "Elegir lado",
     chooseSideHint: "Elige una cuenta o Fuera de Fidy",
     chooseDifferentSide: "Elige otro lado",
+    saved: "Transferencia guardada",
     save: "Registrar transferencia",
     outsideFidy: "Fuera de Fidy",
     outsideFidyDescription: "Efectivo u otro lado no rastreado",

--- a/apps/mobile/shared/lib/date-constraints.ts
+++ b/apps/mobile/shared/lib/date-constraints.ts
@@ -1,0 +1,3 @@
+export function clampDateToToday(date: Date, today = new Date()): Date {
+  return date > today ? today : date;
+}

--- a/apps/mobile/shared/lib/index.ts
+++ b/apps/mobile/shared/lib/index.ts
@@ -74,4 +74,9 @@ export {
   setSentryUser,
   wrapWithSentry,
 } from "./sentry";
-export { handleRecoverableError, showErrorToast, showSuccessToast, subscribeAppToasts } from "./toast";
+export {
+  handleRecoverableError,
+  showErrorToast,
+  showSuccessToast,
+  subscribeAppToasts,
+} from "./toast";

--- a/apps/mobile/shared/lib/index.ts
+++ b/apps/mobile/shared/lib/index.ts
@@ -21,6 +21,7 @@ export {
 } from "./analytics";
 export type { CurrencyConfig } from "./currency";
 export { getActiveCurrency } from "./currency";
+export { clampDateToToday } from "./date-constraints";
 export {
   formatDateDisplay,
   parseIsoDate,
@@ -62,6 +63,7 @@ export {
   generateUserCategoryId,
   generateUserMemoryId,
 } from "./generate-id";
+export { runAfterNavigationTransition, waitForNavigationTransition } from "./navigation-transition";
 export { merchantsMatch, normalizeMerchant } from "./normalize-merchant";
 export {
   captureError,
@@ -72,4 +74,4 @@ export {
   setSentryUser,
   wrapWithSentry,
 } from "./sentry";
-export { handleRecoverableError, showErrorToast } from "./toast";
+export { handleRecoverableError, showErrorToast, showSuccessToast, subscribeAppToasts } from "./toast";

--- a/apps/mobile/shared/lib/navigation-transition.ts
+++ b/apps/mobile/shared/lib/navigation-transition.ts
@@ -1,0 +1,69 @@
+type TransitionEndNavigation = {
+  readonly addListener: (event: "transitionEnd", callback: (event: TransitionEndEvent) => void) => () => void;
+};
+
+type TransitionEndEvent = {
+  readonly data?: {
+    readonly closing?: boolean;
+  };
+};
+
+type NavigationTransitionOptions = {
+  readonly closing?: boolean;
+  readonly fallbackMs?: number | null;
+};
+
+function hasTransitionListener(navigation: unknown): navigation is TransitionEndNavigation {
+  return (
+    typeof navigation === "object" &&
+    navigation != null &&
+    "addListener" in navigation &&
+    typeof navigation.addListener === "function"
+  );
+}
+
+export function runAfterNavigationTransition(
+  navigation: unknown,
+  callback: () => void,
+  options: NavigationTransitionOptions = {}
+): { readonly cancel: () => void } {
+  const fallbackMs = options.fallbackMs === undefined ? 450 : options.fallbackMs;
+  let settled = false;
+  let fallback: ReturnType<typeof setTimeout> | null = null;
+  let unsubscribe: (() => void) | null = null;
+  const supportsTransitionEnd = hasTransitionListener(navigation);
+
+  const finish = () => {
+    if (settled) return;
+    settled = true;
+    if (fallback) clearTimeout(fallback);
+    unsubscribe?.();
+    callback();
+  };
+  if (supportsTransitionEnd) {
+    unsubscribe = navigation.addListener("transitionEnd", (event) => {
+      if (options.closing != null && event.data?.closing !== options.closing) return;
+      finish();
+    });
+  }
+  // Navigation events are preferred; fallback only prevents hanging if a platform skips the event.
+  if (fallbackMs != null) fallback = setTimeout(finish, fallbackMs);
+
+  return {
+    cancel: () => {
+      if (settled) return;
+      settled = true;
+      if (fallback) clearTimeout(fallback);
+      unsubscribe?.();
+    },
+  };
+}
+
+export function waitForNavigationTransition(
+  navigation: unknown,
+  options: NavigationTransitionOptions = {}
+): Promise<void> {
+  return new Promise((resolve) => {
+    runAfterNavigationTransition(navigation, resolve, options);
+  });
+}

--- a/apps/mobile/shared/lib/navigation-transition.ts
+++ b/apps/mobile/shared/lib/navigation-transition.ts
@@ -1,5 +1,8 @@
 type TransitionEndNavigation = {
-  readonly addListener: (event: "transitionEnd", callback: (event: TransitionEndEvent) => void) => () => void;
+  readonly addListener: (
+    event: "transitionEnd",
+    callback: (event: TransitionEndEvent) => void
+  ) => () => void;
 };
 
 type TransitionEndEvent = {

--- a/apps/mobile/shared/lib/toast.ts
+++ b/apps/mobile/shared/lib/toast.ts
@@ -1,8 +1,36 @@
 import * as burnt from "burnt";
 import { captureError } from "./sentry";
 
+type AppToastKind = "success";
+type AppToast = {
+  readonly id: number;
+  readonly duration: number;
+  readonly kind: AppToastKind;
+  readonly message: string;
+};
+
+type AppToastListener = (toast: AppToast) => void;
+
+const appToastListeners = new Set<AppToastListener>();
+let appToastId = 0;
+
+export function subscribeAppToasts(listener: AppToastListener): () => void {
+  appToastListeners.add(listener);
+  return () => appToastListeners.delete(listener);
+}
+
+function showAppToast(message: string, kind: AppToastKind, duration: number): void {
+  appToastId += 1;
+  const toast = { id: appToastId, duration, kind, message };
+  appToastListeners.forEach((listener) => listener(toast));
+}
+
 export function showErrorToast(message: string): void {
   burnt.toast({ title: message, preset: "error" });
+}
+
+export function showSuccessToast(message: string, duration?: number): void {
+  showAppToast(message, "success", duration ?? 5);
 }
 
 export function handleRecoverableError(message: string) {

--- a/dependency-policy.json
+++ b/dependency-policy.json
@@ -1,14 +1,44 @@
 {
   "deferredUpdates": [
     {
+      "name": "@supabase/supabase-js",
+      "until": "2026-06-01",
+      "reason": "Minor dependency update should land in a dedicated maintenance PR with Supabase auth/database smoke checks."
+    },
+    {
       "name": "@sentry/react-native",
       "until": "2026-06-01",
       "reason": "Major v8 migration needs a dedicated Sentry PR with config review, source map verification, and native QA."
     },
     {
+      "name": "dependency-cruiser",
+      "until": "2026-06-01",
+      "reason": "Minor dependency update should land in a dedicated tooling PR so architecture reports can be reviewed separately."
+    },
+    {
       "name": "eslint",
       "until": "2026-06-01",
       "reason": "ESLint 10 should wait for eslint-config-expo compatibility confirmation."
+    },
+    {
+      "name": "knip",
+      "until": "2026-06-01",
+      "reason": "Minor dependency update should land in a dedicated tooling PR so unused-code reports can be reviewed separately."
+    },
+    {
+      "name": "lucide-react-native",
+      "until": "2026-06-01",
+      "reason": "Minor dependency update should land in a dedicated UI dependency PR with icon rendering smoke checks."
+    },
+    {
+      "name": "oxlint",
+      "until": "2026-06-01",
+      "reason": "Minor dependency update should land in a dedicated tooling PR so lint output changes can be reviewed separately."
+    },
+    {
+      "name": "posthog-react-native",
+      "until": "2026-06-01",
+      "reason": "Minor dependency update should land in a dedicated analytics PR with event capture smoke checks."
     },
     {
       "name": "react-native",
@@ -29,6 +59,11 @@
       "name": "tailwindcss",
       "until": "2026-06-01",
       "reason": "Tailwind 4 requires NativeWind compatibility proof and a dedicated styling migration."
+    },
+    {
+      "name": "zod",
+      "until": "2026-06-01",
+      "reason": "Minor dependency update should land in a dedicated schema-validation PR with parser regression checks."
     }
   ]
 }

--- a/dependency-policy.json
+++ b/dependency-policy.json
@@ -1,44 +1,14 @@
 {
   "deferredUpdates": [
     {
-      "name": "@supabase/supabase-js",
-      "until": "2026-06-01",
-      "reason": "Minor dependency update should land in a dedicated maintenance PR with Supabase auth/database smoke checks."
-    },
-    {
       "name": "@sentry/react-native",
       "until": "2026-06-01",
       "reason": "Major v8 migration needs a dedicated Sentry PR with config review, source map verification, and native QA."
     },
     {
-      "name": "dependency-cruiser",
-      "until": "2026-06-01",
-      "reason": "Minor dependency update should land in a dedicated tooling PR so architecture reports can be reviewed separately."
-    },
-    {
       "name": "eslint",
       "until": "2026-06-01",
       "reason": "ESLint 10 should wait for eslint-config-expo compatibility confirmation."
-    },
-    {
-      "name": "knip",
-      "until": "2026-06-01",
-      "reason": "Minor dependency update should land in a dedicated tooling PR so unused-code reports can be reviewed separately."
-    },
-    {
-      "name": "lucide-react-native",
-      "until": "2026-06-01",
-      "reason": "Minor dependency update should land in a dedicated UI dependency PR with icon rendering smoke checks."
-    },
-    {
-      "name": "oxlint",
-      "until": "2026-06-01",
-      "reason": "Minor dependency update should land in a dedicated tooling PR so lint output changes can be reviewed separately."
-    },
-    {
-      "name": "posthog-react-native",
-      "until": "2026-06-01",
-      "reason": "Minor dependency update should land in a dedicated analytics PR with event capture smoke checks."
     },
     {
       "name": "react-native",
@@ -59,11 +29,6 @@
       "name": "tailwindcss",
       "until": "2026-06-01",
       "reason": "Tailwind 4 requires NativeWind compatibility proof and a dedicated styling migration."
-    },
-    {
-      "name": "zod",
-      "until": "2026-06-01",
-      "reason": "Minor dependency update should land in a dedicated schema-validation PR with parser regression checks."
     }
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an in-app toast system and shows success toasts after saving transactions and transfers, keeping users on the add screens. Clamps future dates to today and stabilizes navigation transitions for smoother search and edit flows.

- **New Features**
  - Introduced `AppToastHost` with `subscribeAppToasts` and `showSuccessToast`; mounted globally in `_layout`.
  - Pencil transaction and transfer saves now show a success toast instead of navigating away.
  - Added navigation transition helpers (`runAfterNavigationTransition`, `waitForNavigationTransition`) and used them in search init and edit-transaction flows.

- **Bug Fixes**
  - Disallow future dates: added `clampDateToToday` in save/field paths and `maximumDate={new Date()}` to all date pickers; Android picker closes on selection and sheets respond to back.
  - Prevent duplicate transfer submissions by resetting the saved draft after a successful create.
  - Restored search bootstrap fallback so initialization doesn’t hang when transition events aren’t emitted.
  - Adjusted Settings screen spacing using `paddingBottom` instead of `contentInset`/extra spacer view.
  - Added tests for toast behavior, date constraints, and transfer draft reset.

<sup>Written for commit 9c930a37f30db2d0420d0c6e488f991933a74bbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

