### PR TITLE
test(mobile): type database mocks

### DIFF
--- a/apps/mobile/__tests__/db/client.test.ts
+++ b/apps/mobile/__tests__/db/client.test.ts
@@ -5,28 +5,34 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getDb, resetDb, resetDbForUser, tryGetDb } from "@/shared/db/client";
 
 vi.mock("expo-sqlite", () => ({
-  openDatabaseSync: vi.fn(() => ({ execSync: vi.fn(), closeSync: vi.fn() })),
-  deleteDatabaseAsync: vi.fn(() => Promise.resolve()),
+  openDatabaseSync: vi.fn<() => { execSync: () => void; closeSync: () => void }>(() => ({
+    execSync: vi.fn<() => void>(),
+    closeSync: vi.fn<() => void>(),
+  })),
+  deleteDatabaseAsync: vi.fn<() => Promise<void>>(() => Promise.resolve()),
 }));
 
 vi.mock("drizzle-orm/expo-sqlite", () => ({
-  drizzle: vi.fn((sqliteDb: unknown) => ({ _: "drizzle-instance", sqliteDb })),
+  drizzle: vi.fn<(sqliteDb: unknown) => { _: string; sqliteDb: unknown }>((sqliteDb) => ({
+    _: "drizzle-instance",
+    sqliteDb,
+  })),
 }));
 
 vi.mock("expo-secure-store", () => ({
-  getItem: vi.fn(),
-  setItem: vi.fn(),
-  deleteItemAsync: vi.fn(),
+  getItem: vi.fn<() => string | null>(),
+  setItem: vi.fn<() => void>(),
+  deleteItemAsync: vi.fn<() => Promise<void>>(),
 }));
 
 vi.mock("expo-crypto", () => ({
-  getRandomBytes: vi.fn(() => new Uint8Array(32)),
+  getRandomBytes: vi.fn<() => Uint8Array>(() => new Uint8Array(32)),
 }));
 
 vi.mock("@/shared/lib/sentry", () => ({
-  captureError: vi.fn(),
-  capturePipelineEvent: vi.fn(),
-  captureWarning: vi.fn(),
+  captureError: vi.fn<() => void>(),
+  capturePipelineEvent: vi.fn<() => void>(),
+  captureWarning: vi.fn<() => void>(),
 }));
 
 describe("getDb", () => {
@@ -71,10 +77,10 @@ describe("getDb", () => {
   });
 
   it("uses raw hex PRAGMA key syntax", () => {
-    const mockExecSync = vi.fn();
+    const mockExecSync = vi.fn<() => void>();
     vi.mocked(openDatabaseSync).mockReturnValueOnce({
       execSync: mockExecSync,
-      closeSync: vi.fn(),
+      closeSync: vi.fn<() => void>(),
     } as unknown as ReturnType<typeof openDatabaseSync>);
 
     getDb("user-123");
@@ -99,9 +105,9 @@ describe("getDb", () => {
   });
 
   it("resets and closes the connection on resetDb", () => {
-    const mockCloseSync = vi.fn();
+    const mockCloseSync = vi.fn<() => void>();
     vi.mocked(openDatabaseSync).mockReturnValueOnce({
-      execSync: vi.fn(),
+      execSync: vi.fn<() => void>(),
       closeSync: mockCloseSync,
     } as unknown as ReturnType<typeof openDatabaseSync>);
 
@@ -130,9 +136,9 @@ describe("getDb", () => {
   });
 
   it("auto-resets when called with a different userId", () => {
-    const mockCloseSync = vi.fn();
+    const mockCloseSync = vi.fn<() => void>();
     vi.mocked(openDatabaseSync).mockReturnValueOnce({
-      execSync: vi.fn(),
+      execSync: vi.fn<() => void>(),
       closeSync: mockCloseSync,
     } as unknown as ReturnType<typeof openDatabaseSync>);
 

--- a/apps/mobile/__tests__/lib/supabase.test.ts
+++ b/apps/mobile/__tests__/lib/supabase.test.ts
@@ -6,13 +6,15 @@ process.env.EXPO_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
 process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY = "test-anon-key";
 
 vi.mock("@supabase/supabase-js", () => ({
-  createClient: vi.fn(() => ({ auth: { getSession: vi.fn() } })),
+  createClient: vi.fn<() => { auth: { getSession: () => void } }>(() => ({
+    auth: { getSession: vi.fn<() => void>() },
+  })),
 }));
 
 vi.mock("expo-secure-store", () => ({
-  getItemAsync: vi.fn(),
-  setItemAsync: vi.fn(),
-  deleteItemAsync: vi.fn(),
+  getItemAsync: vi.fn<() => Promise<string | null>>(),
+  setItemAsync: vi.fn<() => Promise<void>>(),
+  deleteItemAsync: vi.fn<() => Promise<void>>(),
 }));
 
 describe("getSupabase", () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Typed the mobile test mocks for SQLite and Supabase to match real APIs and clear TS/lint warnings. This makes the mocks safer and easier to maintain.

- **Refactors**
  - Added explicit types to `expo-sqlite` mocks (`openDatabaseSync`, `deleteDatabaseAsync`, `execSync`, `closeSync`).
  - Typed `drizzle-orm/expo-sqlite` `drizzle` mock to return a shaped object.
  - Typed `expo-secure-store` and `expo-crypto` mocks in DB tests.
  - In Supabase tests, typed `@supabase/supabase-js` `createClient` and `auth.getSession`, plus async `expo-secure-store` methods.

<sup>Written for commit c4c7407397b8d79166e234704adbae9554d0d15b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

