### PR TITLE
test(mobile): type small store mocks

### DIFF
--- a/apps/mobile/__tests__/analytics/store.test.ts
+++ b/apps/mobile/__tests__/analytics/store.test.ts
@@ -7,7 +7,7 @@ import {
 } from "@/features/analytics/store";
 import type { CategoryId, CopAmount, UserId } from "@/shared/types/branded";
 
-const mockLoadSnapshot = vi.fn();
+const mockLoadSnapshot = vi.fn<(...args: unknown[]) => Promise<unknown>>();
 
 vi.mock("@/features/analytics/services/create-analytics-service", () => ({
   createAnalyticsService: () => ({

--- a/apps/mobile/__tests__/onboarding/store.test.ts
+++ b/apps/mobile/__tests__/onboarding/store.test.ts
@@ -6,9 +6,9 @@ import type * as CheckOnboarding from "@/features/onboarding/lib/check-onboardin
 
 const { mockLogOnboardingEvent, mockMarkOnboardingComplete, mockTrackOnboardingEvent } = vi.hoisted(
   () => ({
-    mockLogOnboardingEvent: vi.fn(),
-    mockMarkOnboardingComplete: vi.fn(() => Promise.resolve()),
-    mockTrackOnboardingEvent: vi.fn(),
+    mockLogOnboardingEvent: vi.fn<(...args: unknown[]) => void>(),
+    mockMarkOnboardingComplete: vi.fn<() => Promise<void>>(() => Promise.resolve()),
+    mockTrackOnboardingEvent: vi.fn<(...args: unknown[]) => void>(),
   })
 );
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Typed `vi.fn` mocks in mobile analytics and onboarding store tests to improve type safety and satisfy lint rules. `mockLoadSnapshot` now returns `Promise<unknown>`, onboarding event mocks return `void`, and `mockMarkOnboardingComplete` returns `Promise<void>`.

<sup>Written for commit 79595a7fa16a0960cbee51f7981a46c8998a98ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

