### PR TITLE
test(mobile): type calendar mocks

### DIFF
--- a/apps/mobile/__tests__/calendar/schema.test.ts
+++ b/apps/mobile/__tests__/calendar/schema.test.ts
@@ -76,9 +76,7 @@ describe("createBillSchema", () => {
   test("strips id field from parsed output", () => {
     const result = createBillSchema.safeParse({ ...valid, id: "bill-1" });
     expect(result.success).toBe(true);
-    if (result.success) {
-      expect("id" in result.data).toBe(false);
-    }
+    expect(result.data).not.toHaveProperty("id");
   });
 
   test("rejects invalid frequency", () => {

--- a/apps/mobile/__tests__/calendar/store.test.ts
+++ b/apps/mobile/__tests__/calendar/store.test.ts
@@ -21,13 +21,13 @@ import type {
   UserId,
 } from "@/shared/types/branded";
 
-const mockLoadBills = vi.fn();
-const mockLoadPaymentsForMonth = vi.fn();
-const mockAddBill = vi.fn();
-const mockDeleteBill = vi.fn();
-const mockMarkBillPaid = vi.fn();
-const mockUnmarkBillPaid = vi.fn();
-const mockUpdateBill = vi.fn();
+const mockLoadBills = vi.fn<(...args: unknown[]) => Promise<unknown>>();
+const mockLoadPaymentsForMonth = vi.fn<(...args: unknown[]) => Promise<unknown>>();
+const mockAddBill = vi.fn<(...args: unknown[]) => Promise<unknown>>();
+const mockDeleteBill = vi.fn<(...args: unknown[]) => Promise<unknown>>();
+const mockMarkBillPaid = vi.fn<(...args: unknown[]) => Promise<unknown>>();
+const mockUnmarkBillPaid = vi.fn<(...args: unknown[]) => Promise<unknown>>();
+const mockUpdateBill = vi.fn<(...args: unknown[]) => Promise<unknown>>();
 
 vi.mock("@/features/calendar/services/create-calendar-query-service", () => ({
   createCalendarQueryService: () => ({
@@ -48,7 +48,7 @@ vi.mock("@/features/calendar/lib/bill-mutation-service", () => ({
 
 vi.mock("@/mutations", () => ({
   createWriteThroughMutationModule: () => ({
-    commit: vi.fn(),
+    commit: vi.fn<() => void>(),
   }),
 }));
 
@@ -112,18 +112,17 @@ describe("calendar store boundary", () => {
   });
 
   it("drops stale bill results after the active user changes", async () => {
-    const deferred =
-      createDeferred<
-        readonly {
-          id: BillId;
-          name: string;
-          amount: CopAmount;
-          frequency: "monthly";
-          categoryId: CategoryId;
-          startDate: Date;
-          isActive: boolean;
-        }[]
-      >();
+    const deferred = createDeferred<
+      readonly {
+        id: BillId;
+        name: string;
+        amount: CopAmount;
+        frequency: "monthly";
+        categoryId: CategoryId;
+        startDate: Date;
+        isActive: boolean;
+      }[]
+    >();
     mockLoadBills.mockReturnValueOnce(deferred.promise);
 
     initializeCalendarSession("user-1" as UserId);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Typed calendar test mocks to match async service APIs and cleaned up a schema test assertion for the missing id. This improves TypeScript safety and reduces brittle checks in mobile calendar tests.

- **Refactors**
  - Typed `vi.fn` mocks to return `Promise<unknown>` for calendar services and set `commit` as `() => void` in `@/mutations`.
  - Simplified schema test by asserting `result.data` does not have `id` using `not.toHaveProperty`.

<sup>Written for commit bfe9bdd99fecd03c14ef0516cb02a1923f5d1a03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

