### PR TITLE
test(mobile): type search mocks

### DIFF
--- a/apps/mobile/__tests__/search/repository.test.ts
+++ b/apps/mobile/__tests__/search/repository.test.ts
@@ -1,22 +1,25 @@
-// biome-ignore-all lint/suspicious/noExplicitAny: mock db needs flexible typing
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AnyDb } from "@/shared/db/client";
 import { requireUserId } from "@/shared/types/assertions";
 import type { SearchFilters } from "../../features/search/lib/types";
 import { EMPTY_FILTERS } from "../../features/search/lib/types";
 
-const _mockRun = vi.fn();
-const mockAll = vi.fn().mockReturnValue([]);
-const mockGet = vi.fn().mockReturnValue(null);
-const mockSelect = vi.fn().mockReturnThis();
-const mockFrom = vi.fn().mockReturnThis();
-const mockWhere = vi.fn().mockReturnThis();
-const mockOrderBy = vi.fn().mockReturnThis();
-const mockLimit = vi.fn().mockReturnThis();
-const mockOffset = vi.fn().mockReturnThis();
+type SearchRow = { readonly id: string; readonly description: string; readonly amount: number };
+type AggregateRow = { readonly count: number; readonly total: number };
+
+const _mockRun = vi.fn<() => void>();
+const mockAll = vi.fn<() => SearchRow[]>().mockReturnValue([]);
+const mockGet = vi.fn<() => AggregateRow | null>().mockReturnValue(null);
+const mockSelect = vi.fn<(fields?: unknown) => unknown>();
+const mockFrom = vi.fn<(table?: unknown) => unknown>();
+const mockWhere = vi.fn<(condition?: unknown) => unknown>();
+const mockOrderBy = vi.fn<(...columns: unknown[]) => unknown>();
+const mockLimit = vi.fn<(limit: number) => unknown>();
+const mockOffset = vi.fn<(offset: number) => unknown>();
 
 const mockDb = {
   select: mockSelect,
-} as any;
+} as unknown as AnyDb;
 const USER_ID = requireUserId("user-1");
 
 const withFilters = (overrides: Partial<SearchFilters>): SearchFilters => ({

--- a/apps/mobile/__tests__/search/store.test.ts
+++ b/apps/mobile/__tests__/search/store.test.ts
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/suspicious/noExplicitAny: search store tests use flexible mock rows
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { EMPTY_FILTERS } from "@/features/search/public";
 import {
@@ -7,25 +6,33 @@ import {
   updateSearchQuery,
   useSearchStore,
 } from "@/features/search/store";
+import type { StoredTransaction } from "@/features/transactions/query.public";
+import type { AnyDb } from "@/shared/db/client";
 import { requireUserId } from "@/shared/types/assertions";
 
-const mockSearchTransactionsPaginated = vi.fn();
-const mockSearchTransactionsAggregate = vi.fn();
-const mockToStoredTransaction = vi.fn((row: any) => ({
-  ...row,
-  converted: true,
-}));
+type SearchRow = ReturnType<typeof makeRow>;
+type SearchSummary = { readonly count: number; readonly total: number };
+
+const mockSearchTransactionsPaginated = vi.fn<(...args: unknown[]) => SearchRow[]>();
+const mockSearchTransactionsAggregate = vi.fn<(...args: unknown[]) => SearchSummary>();
+const mockToStoredTransaction = vi.fn<(row: SearchRow) => StoredTransaction & { converted: true }>(
+  (row) =>
+    ({
+      ...row,
+      converted: true,
+    }) as unknown as StoredTransaction & { converted: true }
+);
 
 vi.mock("@/features/search/lib/repository", () => ({
-  searchTransactionsPaginated: (...args: any[]) => mockSearchTransactionsPaginated(...args),
-  searchTransactionsAggregate: (...args: any[]) => mockSearchTransactionsAggregate(...args),
+  searchTransactionsPaginated: (...args: unknown[]) => mockSearchTransactionsPaginated(...args),
+  searchTransactionsAggregate: (...args: unknown[]) => mockSearchTransactionsAggregate(...args),
 }));
 
 vi.mock("@/features/transactions/query.public", () => ({
-  toStoredTransaction: (row: any) => mockToStoredTransaction(row),
+  toStoredTransaction: (row: SearchRow) => mockToStoredTransaction(row),
 }));
 
-const mockDb = {} as any;
+const mockDb = {} as unknown as AnyDb;
 const USER_ID = requireUserId("user-1");
 
 const makeRow = (id: string) => ({
@@ -77,7 +84,7 @@ describe("search store boundary", () => {
 
   it("loads the next page through the explicit boundary", () => {
     useSearchStore.setState({
-      results: [makeRow("tx-1")] as any,
+      results: [mockToStoredTransaction(makeRow("tx-1"))],
       offset: 1,
       hasMore: true,
     });
@@ -93,7 +100,7 @@ describe("search store boundary", () => {
       offset: 1,
     });
     expect(useSearchStore.getState().results).toEqual([
-      makeRow("tx-1"),
+      mockToStoredTransaction(makeRow("tx-1")),
       expect.objectContaining({ id: "tx-2" }),
       expect.objectContaining({ id: "tx-3" }),
     ]);


### PR DESCRIPTION
## Summary
- Type search repository/store test mocks for strict OXC `vitest/require-mock-type-parameters` coverage.
- Remove loose `any` casts from search test mock DB and row setup.

## Checks
- `bunx oxlint --config .oxlintrc.strict.json apps/mobile/__tests__/search/repository.test.ts apps/mobile/__tests__/search/store.test.ts`
- `bun run --cwd apps/mobile --shell=bun vitest run __tests__/search/repository.test.ts __tests__/search/store.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- pre-push hooks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Type-safe search test mocks for the mobile app to satisfy `vitest/require-mock-type-parameters` and remove loose casts, with no runtime changes.

- **Refactors**
  - Typed repository/store mocks with `SearchRow`, aggregate/summary types, and `AnyDb`.
  - Replaced `any` with `unknown`, added explicit `vi.fn` generics, and typed `vi.mock` wrappers; removed `biome-ignore` comments.
  - Updated store tests to build `results` via `toStoredTransaction` and typed its mock to return `StoredTransaction`; adjusted assertions.

<sup>Written for commit 465b3d48df5c140b28755259b95a2626252dd70a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

