### PR TITLE
test(mobile): type categories mocks

### DIFF
--- a/apps/mobile/__tests__/categories/store.test.ts
+++ b/apps/mobile/__tests__/categories/store.test.ts
@@ -1,14 +1,17 @@
-// biome-ignore-all lint/suspicious/noExplicitAny: mock db needs flexible typing
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getUserCategoriesForUser, insertUserCategory } from "@/features/categories/lib/repository";
 import { CATEGORIES, CATEGORY_ROWS } from "@/features/transactions/lib/categories";
+import type { AnyDb } from "@/shared/db";
 import type { IsoDateTime, UserCategoryId, UserId } from "@/shared/types/branded";
+
+const GENERATED_CATEGORY_ID = "ucat-test-123" as UserCategoryId;
+const MOCK_NOW = "2026-03-21T12:00:00.000Z" as IsoDateTime;
 
 // Mock the repository
 vi.mock("@/features/categories/lib/repository", () => ({
-  getUserCategoriesForUser: vi.fn().mockReturnValue([]),
-  insertUserCategory: vi.fn(),
+  getUserCategoriesForUser: vi.fn<typeof getUserCategoriesForUser>().mockReturnValue([]),
+  insertUserCategory: vi.fn<typeof insertUserCategory>(),
 }));
 
 // Mock the icon-map
@@ -23,16 +26,16 @@ vi.mock("@/shared/lib", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/shared/lib")>();
   return {
     ...actual,
-    generateUserCategoryId: vi.fn().mockReturnValue("ucat-test-123"),
-    toIsoDateTime: vi.fn().mockReturnValue("2026-03-21T12:00:00.000Z"),
+    generateUserCategoryId: vi.fn<() => UserCategoryId>().mockReturnValue(GENERATED_CATEGORY_ID),
+    toIsoDateTime: vi.fn<() => IsoDateTime>().mockReturnValue(MOCK_NOW),
   };
 });
 
 const mockDb = {
-  insert: vi.fn(),
-  select: vi.fn(),
-  transaction: vi.fn((fn: (tx: any) => void) => fn(mockDb)),
-} as any;
+  insert: vi.fn<() => unknown>(),
+  select: vi.fn<() => unknown>(),
+  transaction: vi.fn<(fn: (tx: AnyDb) => void) => void>((fn) => fn(mockDb as unknown as AnyDb)),
+} as unknown as AnyDb;
 
 describe("useCategoriesStore", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- Type categories store test mocks for strict OXC `vitest/require-mock-type-parameters` coverage.
- Replace the loose mock DB `any` cast with the store boundary DB type.

## Checks
- `bunx oxlint --config .oxlintrc.strict.json apps/mobile/__tests__/categories/store.test.ts`
- `bun run --cwd apps/mobile --shell=bun vitest run __tests__/categories/store.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- pre-push hooks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Typed the categories store test mocks to satisfy strict `oxlint` rule `vitest/require-mock-type-parameters` and replace the loose `any` with the `AnyDb` boundary type.

- **Refactors**
  - Added explicit type params to `vitest` mocks for repository functions.
  - Typed util mocks to return `UserCategoryId` and `IsoDateTime`; introduced `GENERATED_CATEGORY_ID` and `MOCK_NOW`.
  - Replaced the mock DB with an `AnyDb`-typed object and a typed `transaction` callback.

<sup>Written for commit b79833bc57327f81c1def3a155f72a6796f57133. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

