### PR TITLE
test(mobile): remove targeted any casts

### DIFF
--- a/apps/mobile/__tests__/budget/monitoring.test.ts
+++ b/apps/mobile/__tests__/budget/monitoring.test.ts
@@ -1,32 +1,36 @@
-// biome-ignore-all lint/suspicious/noExplicitAny: integration test uses a real SQLite DB
 import { resolve } from "node:path";
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { BudgetAlertState } from "@/features/budget/lib/monitoring";
+import type { BudgetAlertState, BudgetMonitoringPorts } from "@/features/budget/lib/monitoring";
 import { createBudgetMonitoringModule } from "@/features/budget/lib/monitoring";
 import { insertBudget } from "@/features/budget/lib/repository";
 import { insertTransaction } from "@/features/transactions/lib/repository";
+import type { AnyDb } from "@/shared/db";
 import type {
   BudgetId,
   CategoryId,
   CopAmount,
+  IsoDate,
   IsoDateTime,
   Month,
+  TransactionId,
   UserId,
 } from "@/shared/types/branded";
 
 let sqlite: InstanceType<typeof Database>;
 let db: ReturnType<typeof drizzle>;
 
+const testDb = () => db as unknown as AnyDb;
+
 const USER_ID = "user-1" as UserId;
 const CURRENT_MONTH = "2026-03" as Month;
 const CURRENT_DATE = new Date(2026, 3, 18);
 
-const mockScheduleBudgetAlert = vi.fn();
-const mockInsertNotification = vi.fn();
-const mockResolveCategoryLabel = vi.fn(
+const mockScheduleBudgetAlert = vi.fn<BudgetMonitoringPorts["scheduleBudgetAlert"]>();
+const mockInsertNotification = vi.fn<(...args: unknown[]) => unknown>();
+const mockResolveCategoryLabel = vi.fn<(categoryId: CategoryId, locale: string) => string>(
   (categoryId: CategoryId, locale: string) => `${locale}:${categoryId}`
 );
 
@@ -52,7 +56,7 @@ const insertBudgetRow = (
     month: Month;
   }> = {}
 ) =>
-  insertBudget(db as any, {
+  insertBudget(testDb(), {
     id: (overrides.id ?? "budget-1") as BudgetId,
     userId: USER_ID,
     categoryId: (overrides.categoryId ?? "food") as CategoryId,
@@ -72,14 +76,14 @@ const insertExpense = (
     month: Month;
   }> = {}
 ) =>
-  insertTransaction(db as any, {
-    id: (overrides.id ?? "tx-1") as any,
+  insertTransaction(testDb(), {
+    id: (overrides.id ?? "tx-1") as TransactionId,
     userId: USER_ID,
     type: "expense",
     amount: (overrides.amount ?? 85000) as CopAmount,
     categoryId: (overrides.categoryId ?? "food") as CategoryId,
     description: "merchant",
-    date: (overrides.date ?? `${overrides.month ?? CURRENT_MONTH}-10`) as any,
+    date: (overrides.date ?? `${overrides.month ?? CURRENT_MONTH}-10`) as IsoDate,
     createdAt: "2026-03-10T10:00:00.000Z" as IsoDateTime,
     updatedAt: "2026-03-10T10:00:00.000Z" as IsoDateTime,
     deletedAt: null,
@@ -105,7 +109,7 @@ async function refreshCurrentMonth(
   }
 ) {
   return module.refreshMonth({
-    db: db as any,
+    db: testDb(),
     userId: USER_ID,
     month: CURRENT_MONTH,
     ...(previous ? { previous } : {}),
@@ -342,7 +346,9 @@ describe("createBudgetMonitoringModule", () => {
   it("loads transaction aggregates from the transactions query public surface", async () => {
     vi.resetModules();
 
-    const getSpendingByCategoryAggregateMock = vi.fn(() => [
+    const getSpendingByCategoryAggregateMock = vi.fn<
+      () => { categoryId: CategoryId; total: CopAmount }[]
+    >(() => [
       {
         categoryId: "food" as CategoryId,
         total: 85000 as CopAmount,
@@ -351,7 +357,7 @@ describe("createBudgetMonitoringModule", () => {
 
     vi.doMock("@/features/transactions/query.public", () => ({
       getSpendingByCategoryAggregate: getSpendingByCategoryAggregateMock,
-      getSpendingByCategoryDateRangeAggregate: vi.fn(() => []),
+      getSpendingByCategoryDateRangeAggregate: vi.fn<() => unknown[]>(() => []),
     }));
     vi.doMock("@/features/transactions/lib/repository", () => ({
       getSpendingByCategoryAggregate: () => {
@@ -362,9 +368,8 @@ describe("createBudgetMonitoringModule", () => {
       },
     }));
 
-    const { createBudgetMonitoringModule: createBudgetMonitoringModuleFromPublic } = await import(
-      "@/features/budget/lib/monitoring"
-    );
+    const { createBudgetMonitoringModule: createBudgetMonitoringModuleFromPublic } =
+      await import("@/features/budget/lib/monitoring");
 
     insertBudgetRow();
 
@@ -377,7 +382,7 @@ describe("createBudgetMonitoringModule", () => {
     });
 
     const result = await module.refreshMonth({
-      db: db as any,
+      db: testDb(),
       userId: USER_ID,
       month: CURRENT_MONTH,
       previous: {
@@ -408,7 +413,7 @@ describe("createBudgetMonitoringModule", () => {
     });
 
     const suggestions = createMonitoringModule().loadAutoSuggestions({
-      db: db as any,
+      db: testDb(),
       userId: USER_ID,
       month: CURRENT_MONTH,
       existingCategoryIds: new Set(["food" as CategoryId]),
@@ -437,7 +442,7 @@ describe("createBudgetMonitoringModule", () => {
     });
 
     const suggestions = createMonitoringModule().loadAutoSuggestions({
-      db: db as any,
+      db: testDb(),
       userId: USER_ID,
       month: CURRENT_MONTH,
       existingCategoryIds: new Set(["food" as CategoryId]),

--- a/apps/mobile/__tests__/goals/repository.test.ts
+++ b/apps/mobile/__tests__/goals/repository.test.ts
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/suspicious/noExplicitAny: integration test uses a real SQLite DB
 import { resolve } from "node:path";
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -17,9 +16,12 @@ import {
   softDeleteGoal,
   updateGoal,
 } from "@/features/goals/public";
+import type { AnyDb } from "@/shared/db";
 
 let sqlite: InstanceType<typeof Database>;
 let db: ReturnType<typeof drizzle>;
+
+const testDb = () => db as unknown as AnyDb;
 
 const USER_ID = "user-1";
 const CREATED_AT = "2026-03-01T00:00:00.000Z";
@@ -45,7 +47,7 @@ const insertGoalRow = (
     targetDate: string | null;
   }> = {}
 ) =>
-  insertGoal(db as any, {
+  insertGoal(testDb(), {
     id: overrides.id ?? "goal-1",
     userId: overrides.userId ?? USER_ID,
     name: overrides.name ?? "Emergency fund",
@@ -70,7 +72,7 @@ const insertContributionRow = (
     date: string;
   }> = {}
 ) =>
-  insertContribution(db as any, {
+  insertContribution(testDb(), {
     id: overrides.id ?? "contribution-1",
     goalId: overrides.goalId ?? "goal-1",
     userId: overrides.userId ?? USER_ID,
@@ -135,25 +137,25 @@ describe("goals repository", () => {
 
     contributionSummaryRows.forEach(insertContributionRow);
 
-    expect(getGoalsForUser(db as any, USER_ID)).toHaveLength(2);
-    expect(getGoalById(db as any, "goal-1")).toMatchObject({
+    expect(getGoalsForUser(testDb(), USER_ID)).toHaveLength(2);
+    expect(getGoalById(testDb(), "goal-1")).toMatchObject({
       id: "goal-1",
       name: "Emergency fund",
     });
-    expect(getContributionById(db as any, "contribution-2")).toMatchObject({
+    expect(getContributionById(testDb(), "contribution-2")).toMatchObject({
       id: "contribution-2",
       goalId: "goal-1",
       amount: 150000,
     });
 
-    softDeleteContribution(db as any, "contribution-3", DELETED_AT);
+    softDeleteContribution(testDb(), "contribution-3", DELETED_AT);
 
-    expect(getContributionsForGoal(db as any, "goal-1").map(({ id }) => id)).toEqual([
+    expect(getContributionsForGoal(testDb(), "goal-1").map(({ id }) => id)).toEqual([
       "contribution-2",
       "contribution-1",
     ]);
-    expect(getGoalCurrentAmount(db as any, "goal-1")).toBe(250000);
-    expect(getContributionMonthCount(db as any, "goal-1")).toBe(2);
+    expect(getGoalCurrentAmount(testDb(), "goal-1")).toBe(250000);
+    expect(getContributionMonthCount(testDb(), "goal-1")).toBe(2);
   });
 
   it("applies partial goal updates without overwriting omitted fields", () => {
@@ -165,7 +167,7 @@ describe("goals repository", () => {
     });
 
     updateGoal({
-      db: db as any,
+      db: testDb(),
       id: "goal-1",
       data: {
         name: "Renovation fund",
@@ -176,7 +178,7 @@ describe("goals repository", () => {
       now: "2026-04-01T12:00:00.000Z",
     });
 
-    expect(getGoalById(db as any, "goal-1")).toMatchObject(updatedGoalExpectation);
+    expect(getGoalById(testDb(), "goal-1")).toMatchObject(updatedGoalExpectation);
   });
 
   it("soft deletes a goal so it disappears from active listings but remains queryable by id", () => {
@@ -189,10 +191,10 @@ describe("goals repository", () => {
       name: "Vacation",
     });
 
-    softDeleteGoal(db as any, "goal-1", DELETED_AT);
+    softDeleteGoal(testDb(), "goal-1", DELETED_AT);
 
-    expect(getGoalsForUser(db as any, USER_ID).map(({ id }) => id)).toEqual(["goal-2"]);
-    expect(getGoalById(db as any, "goal-1")).toMatchObject({
+    expect(getGoalsForUser(testDb(), USER_ID).map(({ id }) => id)).toEqual(["goal-2"]);
+    expect(getGoalById(testDb(), "goal-1")).toMatchObject({
       id: "goal-1",
       deletedAt: DELETED_AT,
       updatedAt: DELETED_AT,

--- a/apps/mobile/__tests__/setup.ts
+++ b/apps/mobile/__tests__/setup.ts
@@ -193,19 +193,13 @@ vi.mock("react-native-reanimated", () => {
     default: Animated,
     FadeIn: { duration: () => ({ duration: () => "FadeIn" }) },
     FadeOut: { duration: () => ({ duration: () => "FadeOut" }) },
-    // biome-ignore lint/suspicious/noExplicitAny: mock needs flexible typing
-    useAnimatedStyle: (fn: any) => fn(),
-    // biome-ignore lint/suspicious/noExplicitAny: mock needs flexible typing
-    useSharedValue: (init: any) => ({ value: init }),
-    // biome-ignore lint/suspicious/noExplicitAny: mock needs flexible typing
-    withTiming: (val: any) => val,
-    // biome-ignore lint/suspicious/noExplicitAny: mock needs flexible typing
-    withRepeat: (val: any) => val,
-    // biome-ignore lint/suspicious/noExplicitAny: mock needs flexible typing
-    withSequence: (...vals: any[]) => vals[0],
+    useAnimatedStyle: (fn: () => unknown) => fn(),
+    useSharedValue: (init: unknown) => ({ value: init }),
+    withTiming: <T>(val: T) => val,
+    withRepeat: <T>(val: T) => val,
+    withSequence: <T>(...vals: T[]) => vals[0],
     cancelAnimation: createMock(),
-    // biome-ignore lint/suspicious/noExplicitAny: mock needs flexible typing
-    runOnJS: (fn: any) => fn,
+    runOnJS: <T extends (...args: unknown[]) => unknown>(fn: T) => fn,
   };
 });
 


### PR DESCRIPTION
## Summary
- Remove `no-explicit-any` findings from goals repository and budget monitoring tests by using typed DB boundary helpers and branded IDs/dates.
- Replace loose Reanimated setup mock parameters with `unknown`/generic signatures.
- Type the budget monitoring mocks needed for the touched strict file to stay clean.

## Checks
- `bunx oxlint --config .oxlintrc.strict.json apps/mobile/__tests__/goals/repository.test.ts apps/mobile/__tests__/budget/monitoring.test.ts apps/mobile/__tests__/setup.ts`
- `bun run --cwd apps/mobile --shell=bun vitest run __tests__/goals/repository.test.ts __tests__/budget/monitoring.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- pre-push hooks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes targeted any casts in mobile tests by introducing typed DB helpers, branded IDs/dates, and stricter `react-native-reanimated` mocks. Improves type safety without changing test behavior.

- **Refactors**
  - Added `testDb()` to pass the drizzle instance as `AnyDb` from `@/shared/db`.
  - Replaced `any` with branded types (`BudgetId`, `TransactionId`, `IsoDate`, etc.) in budget/goals tests.
  - Typed `vi.fn` mocks with explicit signatures (e.g., `BudgetMonitoringPorts`, aggregate return shapes).
  - Updated `react-native-reanimated` mock to use `unknown` and generics for `useAnimatedStyle`, `useSharedValue`, `withTiming`, `withRepeat`, and `withSequence`; removed no-explicit-any ignores.

<sup>Written for commit 69eed98cf6047f0ee5ca41ee73d32f6262a9b35d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

