### PR TITLE
refactor(mobile): migrate date pickers

### DIFF
--- a/apps/mobile/__tests__/goals/goal-sheets.test.ts
+++ b/apps/mobile/__tests__/goals/goal-sheets.test.ts
@@ -39,7 +39,7 @@ test("keeps the edit-goal sheet wired to the shared form and delete flow", () =>
 test("keeps the shared goal-sheet cluster wired to the date picker and numpad flow", () => {
   expect(formSource).toContain("<GoalAmountField");
   expect(formSource).toContain("<GoalDateField");
-  expect(dateFieldSource).toContain("@react-native-community/datetimepicker");
+  expect(dateFieldSource).toContain("@expo/ui/community/datetime-picker");
   expect(formSource).toContain("<GoalTypeToggle");
   expect(formHookSource).toContain("handleNumpadPress");
   expect(formHookSource).toContain("setShowDatePicker(true)");

--- a/apps/mobile/__tests__/setup.ts
+++ b/apps/mobile/__tests__/setup.ts
@@ -266,8 +266,8 @@ vi.mock("expo-crypto", () => ({
   getRandomBytes: createMock(() => new Uint8Array(32)),
 }));
 
-// Mock @react-native-community/datetimepicker
-vi.mock("@react-native-community/datetimepicker", () => ({
+// Mock Expo UI DateTimePicker drop-in
+vi.mock("@expo/ui/community/datetime-picker", () => ({
   default: "DateTimePicker",
 }));
 

--- a/apps/mobile/__tests__/ui/date-picker-imports.test.ts
+++ b/apps/mobile/__tests__/ui/date-picker-imports.test.ts
@@ -1,0 +1,40 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const appRoot = resolve(__dirname, "../..");
+const sourceRoots = ["app", "features", "shared"] as const;
+
+function readSources(dir: string): readonly { readonly path: string; readonly source: string }[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return readSources(path);
+    if (!/\.(ts|tsx)$/.test(entry.name)) return [];
+    return [{ path: relative(appRoot, path), source: readFileSync(path, "utf-8") }];
+  });
+}
+
+describe("date picker imports", () => {
+  it("uses the Expo UI DateTimePicker drop-in instead of the community package", () => {
+    const sources = sourceRoots.flatMap((root) => readSources(resolve(appRoot, root)));
+    const communityImports = sources.filter(({ source }) =>
+      source.includes("@react-native-community/datetimepicker")
+    );
+
+    expect(communityImports).toEqual([]);
+    expect(
+      sources.some(({ source }) => source.includes("@expo/ui/community/datetime-picker"))
+    ).toBe(true);
+  });
+
+  it("uses Expo UI value and dismiss events instead of deprecated DateTimePicker onChange", () => {
+    const sources = sourceRoots.flatMap((root) => readSources(resolve(appRoot, root)));
+    const datePickerSources = sources.filter(({ source }) =>
+      source.includes("@expo/ui/community/datetime-picker")
+    );
+
+    expect(datePickerSources).not.toEqual([]);
+    expect(datePickerSources.filter(({ source }) => source.includes("onChange="))).toEqual([]);
+    expect(datePickerSources.every(({ source }) => source.includes("onValueChange="))).toBe(true);
+  });
+});

--- a/apps/mobile/features/calendar/components/add-bill/AddBillFormContent.tsx
+++ b/apps/mobile/features/calendar/components/add-bill/AddBillFormContent.tsx
@@ -1,4 +1,4 @@
-import DateTimePicker from "@react-native-community/datetimepicker";
+import DateTimePicker from "@expo/ui/community/datetime-picker";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { CATEGORIES, type CategoryId } from "@/shared/categories";
 import {
@@ -140,9 +140,7 @@ export function AddBillFormContent({
               value={startDate}
               mode="date"
               display="compact"
-              onChange={(_event, date) => {
-                if (date) onStartDateChange(date);
-              }}
+              onValueChange={(_event, date) => onStartDateChange(date)}
               style={styles.datePicker}
             />
           </View>

--- a/apps/mobile/features/financial-accounts/components/financial-account-form/FinancialAccountFormBody.tsx
+++ b/apps/mobile/features/financial-accounts/components/financial-account-form/FinancialAccountFormBody.tsx
@@ -1,4 +1,4 @@
-import DateTimePicker from "@react-native-community/datetimepicker";
+import DateTimePicker from "@expo/ui/community/datetime-picker";
 import { format } from "date-fns";
 import { useState } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -180,14 +180,13 @@ export function FinancialAccountFormBody({
               value={effectiveDate ?? datePickerFallback}
               mode="date"
               display={Platform.OS === "ios" ? "spinner" : "default"}
-              onChange={(_event, date) => {
+              onValueChange={(_event, date) => {
                 if (Platform.OS === "android") {
                   setShowDatePicker(false);
                 }
-                if (date) {
-                  setEffectiveDate(date);
-                }
+                setEffectiveDate(date);
               }}
+              onDismiss={() => setShowDatePicker(false)}
             />
           ) : null}
         </View>

--- a/apps/mobile/features/goals/components/goal-sheet/GoalDateField.tsx
+++ b/apps/mobile/features/goals/components/goal-sheet/GoalDateField.tsx
@@ -1,4 +1,4 @@
-import DateTimePicker from "@react-native-community/datetimepicker";
+import DateTimePicker from "@expo/ui/community/datetime-picker";
 import { Platform, Pressable, Text, View } from "@/shared/components/rn";
 import { useCurrentDate, useThemeColor, useTranslation } from "@/shared/hooks";
 import { getMinimumGoalDate } from "./GoalDateField.helpers";
@@ -63,7 +63,8 @@ export function GoalDateField({
           mode="date"
           display={Platform.OS === "ios" ? "inline" : "default"}
           minimumDate={minimumDate}
-          onChange={onChange}
+          onValueChange={onChange}
+          onDismiss={() => onChange({ type: "dismissed" })}
           accentColor={accentGreen}
         />
       ) : null}

--- a/apps/mobile/features/goals/components/goal-sheet/useGoalSheetForm.ts
+++ b/apps/mobile/features/goals/components/goal-sheet/useGoalSheetForm.ts
@@ -60,6 +60,7 @@ function useGoalSheetDates(initialTargetDate: Date | null) {
     }, []),
     handleDateChange: useCallback((_event: unknown, date?: Date) => {
       if (Platform.OS === "android") setShowDatePicker(false);
+      if (isDatePickerDismissed(_event)) return;
       if (date) setTargetDate(date);
     }, []),
     handleDateFieldPress: useCallback(() => {
@@ -70,6 +71,12 @@ function useGoalSheetDates(initialTargetDate: Date | null) {
     showDatePicker,
     targetDate,
   };
+}
+
+function isDatePickerDismissed(event: unknown) {
+  return (
+    typeof event === "object" && event !== null && "type" in event && event.type === "dismissed"
+  );
 }
 
 function useGoalSheetNumpad(

--- a/apps/mobile/features/transactions/components/PencilTransactionEntrySheets.tsx
+++ b/apps/mobile/features/transactions/components/PencilTransactionEntrySheets.tsx
@@ -1,4 +1,4 @@
-import DateTimePicker from "@react-native-community/datetimepicker";
+import DateTimePicker from "@expo/ui/community/datetime-picker";
 import type { ReactNode } from "react";
 import type { FinancialAccountRow } from "@/features/financial-accounts/public";
 import { Wallet } from "@/shared/components/icons";
@@ -184,10 +184,11 @@ export function TransactionDatePickerSheet(props: {
           mode="date"
           display={Platform.OS === "ios" ? "spinner" : "default"}
           maximumDate={maximumDate}
-          onChange={(_event, nextDate) => {
+          onValueChange={(_event, nextDate) => {
             if (Platform.OS !== "ios") props.onClose();
-            if (nextDate) props.onChange(nextDate);
+            props.onChange(nextDate);
           }}
+          onDismiss={props.onClose}
         />
         <Pressable
           style={{

--- a/apps/mobile/features/transfers/components/PencilTransferEntryContent.tsx
+++ b/apps/mobile/features/transfers/components/PencilTransferEntryContent.tsx
@@ -1,4 +1,4 @@
-import DateTimePicker from "@react-native-community/datetimepicker";
+import DateTimePicker from "@expo/ui/community/datetime-picker";
 import { useState } from "react";
 import { ArrowLeftRight, Calendar, Pencil, Tag } from "@/shared/components/icons";
 import {
@@ -130,7 +130,8 @@ export function usePencilTransferEntry(props: { readonly enabled?: boolean } = {
                 mode="date"
                 display={Platform.OS === "ios" ? "spinner" : "default"}
                 maximumDate={maximumDate}
-                onChange={form.handleDateChange}
+                onValueChange={form.handleDateChange}
+                onDismiss={() => form.handleDateChange({ type: "dismissed" })}
               />
               <Pressable
                 style={{

--- a/apps/mobile/features/transfers/components/TransferFormScreen.tsx
+++ b/apps/mobile/features/transfers/components/TransferFormScreen.tsx
@@ -1,4 +1,4 @@
-import DateTimePicker from "@react-native-community/datetimepicker";
+import DateTimePicker from "@expo/ui/community/datetime-picker";
 import { useRouter } from "expo-router";
 import { ScreenLayout } from "@/shared/components";
 import { useCurrentDate, useTranslation } from "@/shared/hooks";
@@ -39,7 +39,8 @@ export function TransferFormScreen(props: TransferFormScreenProps = {}) {
           mode="date"
           display="default"
           maximumDate={maximumDate}
-          onChange={form.handleDateChange}
+          onValueChange={form.handleDateChange}
+          onDismiss={() => form.handleDateChange({ type: "dismissed" })}
         />
       ) : null}
     </>

--- a/apps/mobile/features/transfers/components/transfer-form/TransferFormContent.tsx
+++ b/apps/mobile/features/transfers/components/transfer-form/TransferFormContent.tsx
@@ -1,4 +1,4 @@
-import DateTimePicker from "@react-native-community/datetimepicker";
+import DateTimePicker from "@expo/ui/community/datetime-picker";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { TriangleAlert } from "@/shared/components/icons";
 import {
@@ -96,7 +96,8 @@ export function TransferFormContent(props: { readonly form: ReturnType<typeof us
                 mode="date"
                 display="compact"
                 maximumDate={maximumDate}
-                onChange={props.form.handleDateChange}
+                onValueChange={props.form.handleDateChange}
+                onDismiss={() => props.form.handleDateChange({ type: "dismissed" })}
               />
             ) : (
               <Pressable

--- a/apps/mobile/features/transfers/components/transfer-form/useTransferFormActions.ts
+++ b/apps/mobile/features/transfers/components/transfer-form/useTransferFormActions.ts
@@ -78,6 +78,7 @@ export function useTransferFormActions(input: {
     handleDateChange: useCallback(
       (_event: unknown, nextDate?: Date) => {
         if (!input.isIos) input.setShowDatePicker(false);
+        if (isDatePickerDismissed(_event)) return;
         if (nextDate) input.setDate(clampDateToToday(nextDate));
       },
       [input]
@@ -106,4 +107,10 @@ export function useTransferFormActions(input: {
       ),
     isSaving,
   };
+}
+
+function isDatePickerDismissed(event: unknown) {
+  return (
+    typeof event === "object" && event !== null && "type" in event && event.type === "dismissed"
+  );
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -29,7 +29,6 @@
     "@fidy/schemas": "workspace:*",
     "@fidy/types": "workspace:*",
     "@fidy/utils": "workspace:*",
-    "@react-native-community/datetimepicker": "9.1.0",
     "@react-native-community/netinfo": "12.0.1",
     "@react-native-vector-icons/ionicons": "^13.1.1",
     "@react-native-vector-icons/material-icons": "^13.1.1",

--- a/bun.lock
+++ b/bun.lock
@@ -32,7 +32,6 @@
         "@fidy/schemas": "workspace:*",
         "@fidy/types": "workspace:*",
         "@fidy/utils": "workspace:*",
-        "@react-native-community/datetimepicker": "9.1.0",
         "@react-native-community/netinfo": "12.0.1",
         "@react-native-vector-icons/ionicons": "^13.1.1",
         "@react-native-vector-icons/material-icons": "^13.1.1",
@@ -58,7 +57,7 @@
         "expo-image": "~56.0.4",
         "expo-linking": "~56.0.4",
         "expo-localization": "~56.0.3",
-        "expo-navigation-bar": "^56.0.3",
+        "expo-navigation-bar": "~56.0.3",
         "expo-notifications": "~56.0.5",
         "expo-router": "~56.1.1",
         "expo-secure-store": "~56.0.3",
@@ -843,8 +842,6 @@
     "@radix-ui/react-use-escape-keydown": ["@radix-ui/react-use-escape-keydown@1.1.1", "", { "dependencies": { "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g=="],
 
     "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
-
-    "@react-native-community/datetimepicker": ["@react-native-community/datetimepicker@9.1.0", "", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "expo": ">=52.0.0", "react": "*", "react-native": "*", "react-native-windows": "*" }, "optionalPeers": ["expo", "react-native-windows"] }, "sha512-eadbnk+I2vxvW30iTAsm/qlCnMMAadkifIMYNEB2lzhxN/SvlKc7S2V4k5DyrwjdCbqdcMk3t9K6fnUMcAV34w=="],
 
     "@react-native-community/netinfo": ["@react-native-community/netinfo@12.0.1", "", { "peerDependencies": { "react": "*", "react-native": ">=0.59" } }, "sha512-P/3caXIvfYSJG8AWJVefukg+ZGRPs+M4Lp3pNJtgcTYoJxCjWrKQGNnCkj/Cz//zWa/avGed0i/wzm0T8vV2IQ=="],
 

--- a/docs/adr/0005-sdk-56-improvements-plan.md
+++ b/docs/adr/0005-sdk-56-improvements-plan.md
@@ -27,7 +27,7 @@ Expected benefit:
 
 ### 2. Spike Expo UI DateTimePicker replacement
 
-Status: one contained goal-date field migrated as a spike; broader migration remains gated on manual iOS/Android QA.
+Status: completed in PR 409; manual iOS/Android QA is still recommended for native picker presentation and dismissal behavior.
 
 SDK 56 introduces `@expo/ui/community/datetime-picker` as a drop-in replacement for `@react-native-community/datetimepicker`.
 
@@ -43,6 +43,13 @@ Expected benefit:
 - Fewer community native dependencies.
 - Better alignment with Expo-managed native primitives.
 - Lower upgrade risk for core financial forms.
+
+Migration result:
+
+- All DateTimePicker usage now imports from `@expo/ui/community/datetime-picker`.
+- The app uses Expo UI `onValueChange` and `onDismiss` instead of the deprecated community picker `onChange` API.
+- Android dismiss/cancel/backdrop behavior remains explicit so dismissed pickers do not commit dates.
+- `@react-native-community/datetimepicker` was removed once source imports were gone.
 
 ### 3. Add declarative Android NavigationBar handling
 
@@ -130,9 +137,33 @@ Measurement protocol:
 - Keep precompiled iOS Expo packages enabled by default; only opt out if native build logs show a concrete precompiled-module failure.
 - Do not claim Hermes V1 or Expo Modules runtime wins from JS-only tests; use device/simulator startup traces or build logs.
 
+### 7. Review Expo Widgets for the App Intents shortcut extension
+
+Status: reviewed after PR 409; no immediate `expo-widgets` migration is warranted.
+
+SDK 56 introduces `expo-widgets` for iOS home screen widgets and Live Activities built with Expo UI components.
+
+Tasks:
+
+- Compare Expo Widgets config plugin behavior against the existing `withFidyWidget` plugin.
+- Check whether Expo Widgets can replace the current empty WidgetKit target used only to host App Intents.
+- Check whether App Group `UserDefaults` queueing and the local Expo module bridge remain necessary.
+
+Expected benefit:
+
+- Avoids carrying custom native widget setup if Expo provides an equivalent managed primitive.
+
+Review result:
+
+- Fidy's `FidyWidgetBundle.swift` intentionally renders no useful widget UI; the target exists to host `QuickExpenseIntent` for Back Tap / Shortcuts discovery.
+- `expo-widgets` generates rendered WidgetKit and Live Activity surfaces from Expo UI components. Its documented API covers widget timelines, live activity lifecycle, push tokens, and widget interaction events, not defining App Intent parameters or an App Intents-only extension.
+- The current App Group `UserDefaults` bridge is still the handoff point between the App Intent extension and the local-first SQLite app. `expo-widgets` does not replace the pending transaction queue or `modules/expo-app-intents` reader/removal API.
+- Replacing the plugin now would likely add an unnecessary real widget target while losing the custom App Intent source files that power quick transaction capture.
+- Keep `withFidyWidget` and the local `expo-app-intents` module until Fidy designs an actual widget or Live Activity surface, or Expo documents first-class App Intents generation for shortcut-style intents.
+
 ## Deferred Work
 
-- Expo Widgets stable API review for the existing Fidy widget plugin.
+- Actual home screen widget or Live Activity design, if product value is clear.
 - Inline Expo Modules only if custom native code grows beyond config-plugin glue.
 - Expo UI broader component adoption after the DateTimePicker migration proves stable.
 - `expo/fetch` behavior review if OAuth/email/backup fetch flows show regressions.


### PR DESCRIPTION
- use expo ui date picker

- remove community date picker

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated all mobile date pickers to `@expo/ui/community/datetime-picker` for consistent behavior and simpler events. Removed the community picker and added tests to enforce the new API.

- **Refactors**
  - Replaced imports across AddBill, FinancialAccount, Goal, Transaction, and Transfer flows with `@expo/ui/community/datetime-picker`.
  - Switched from `onChange` to `onValueChange` and used `onDismiss`; ignore dismissed events and auto-close on Android while keeping iOS display modes.
  - Added tests/mocks (including a repo-wide import/event check) and updated ADR 0005 to mark the migration complete and document why `expo-widgets` doesn’t replace the App Intents extension.

- **Dependencies**
  - Removed `@react-native-community/datetimepicker` from `apps/mobile/package.json` and lockfile.

<sup>Written for commit 54c9793c859946c157e5ab477d04b700e1dbf4c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

