### PR TITLE
docs(readme): describe product

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,17 @@ Fidy is designed for people who want to:
 
 ## Features
 
-- Digital transaction capture from supported payment and notification surfaces.
-- Local-first ledger for transactions, transfers, accounts, budgets, goals, and financial derivations.
-- Capture evidence interpretation for turning raw signals into reviewable financial records.
-- AI-assisted transaction interpretation and personal finance guidance.
-- Private recovery through encrypted backups instead of plaintext financial sync.
-- Mobile-first flows for everyday budgeting, goal tracking, and financial review.
+- **A clear money home**: See balances, recent activity, spending trends, and items that need attention from one dashboard.
+- **Fast transaction tracking**: Add expenses, income, and transfers manually, or let Fidy capture digital transactions where supported.
+- **Account organization**: Track cash, bank accounts, wallets, and credit cards, including account details that help Fidy place future transactions correctly.
+- **Budget control**: Set monthly spending limits, copy budgets forward, and get alerts when a category is close to or over budget.
+- **Savings and debt goals**: Create goals, record contributions, follow progress, and see simple recommendations for staying on pace.
+- **Spending insights**: Review income, expenses, category breakdowns, and period-over-period changes across weekly, monthly, quarterly, and yearly views.
+- **AI finance chat**: Ask Fidy questions about spending, trends, transactions, and next steps in plain language.
+- **Review queues for accuracy**: Confirm ambiguous captures, choose the right account owner, and correct transactions before they affect the wrong place.
+- **Search and categorization**: Find transactions by text, date, amount, category, or type, and customize categories to match how you think about spending.
+- **Notifications and weekly summaries**: Get budget alerts, goal milestone updates, spending alerts, and private weekly money summaries.
+- **Private backup**: Recover financial records through encrypted backups without turning Fidy servers into a readable copy of the ledger.
 
 ## Stack
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,25 @@ Fidy is designed for people who want to:
 - **Recovery should not require plaintext sync.** Remote recovery uses Encrypted Backups instead of storing readable financial records on Fidy servers.
 - **Cloud AI is task-scoped.** When remote AI processing is needed, Fidy sends the minimum financial context needed for that task.
 
+## Features
+
+- Digital transaction capture from supported payment and notification surfaces.
+- Local-first ledger for transactions, transfers, accounts, budgets, goals, and financial derivations.
+- Capture evidence interpretation for turning raw signals into reviewable financial records.
+- AI-assisted transaction interpretation and personal finance guidance.
+- Private recovery through encrypted backups instead of plaintext financial sync.
+- Mobile-first flows for everyday budgeting, goal tracking, and financial review.
+
+## Stack
+
+- **Mobile app**: Expo, React Native, Expo Router, React 19.
+- **Local data**: Expo SQLite, Drizzle ORM, branded TypeScript domain types.
+- **State and data fetching**: Zustand, TanStack Query, Effect.
+- **Backend services**: Supabase Auth, Supabase Edge Functions, scoped remote APIs.
+- **Styling and UI**: NativeWind, Tailwind CSS, Expo UI, React Native vector icons.
+- **Observability and analytics**: Sentry and PostHog.
+- **Tooling**: Bun workspaces, TypeScript, Vitest, Oxlint, Oxfmt, dependency-cruiser.
+
 ## What Is In This Repo
 
 This is the Fidy monorepo. It contains the mobile app, landing site, shared packages, Supabase functions, and project automation.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,42 @@
 # Fidy
 
-Monorepo for the Fidy mobile app, landing site, shared packages, and Supabase functions.
+Fidy is a fintech app for improving personal finances by reducing manual transaction tracking and making everyday financial decisions easier to understand.
 
-## Codex Quickstart
+The app is built around two product bets:
+
+- **Automated transaction capture**: Fidy interprets digital transaction signals from sources such as emails, notifications, wallets, and payment surfaces so users do not have to record every expense by hand.
+- **AI-assisted financial guidance**: Fidy can use task-scoped financial context to help users understand spending, budgets, goals, and next steps without turning their full financial history into a permanent cloud ledger.
+
+## Why Fidy Exists
+
+Most personal finance tools fail when recording transactions becomes a chore. Fidy aims to keep the user's financial record useful by making capture feel automatic, then turning that record into practical guidance.
+
+Fidy is designed for people who want to:
+
+- Keep a clearer record of their income, spending, accounts, budgets, and goals.
+- Reduce the time spent manually entering digital transactions.
+- Get help interpreting financial patterns and tradeoffs.
+- Keep sensitive financial data local-first, with cloud processing used only for explicit tasks.
+
+## Product Principles
+
+- **The phone is the source of truth.** Financial records live in the on-device Local Ledger.
+- **Capture should be explainable.** Transaction interpretation is based on Capture Evidence, not opaque guesses.
+- **AI should assist, not silently decide.** AI can propose interpretations or guidance, while deterministic validation owns final saves.
+- **Recovery should not require plaintext sync.** Remote recovery uses Encrypted Backups instead of storing readable financial records on Fidy servers.
+- **Cloud AI is task-scoped.** When remote AI processing is needed, Fidy sends the minimum financial context needed for that task.
+
+## What Is In This Repo
+
+This is the Fidy monorepo. It contains the mobile app, landing site, shared packages, Supabase functions, and project automation.
+
+- `apps/mobile`: Expo / React Native app.
+- `apps/landing`: Static landing site deployed to Vercel.
+- `packages/*`: Shared workspace packages consumed by the app.
+- `supabase/functions`: Edge Functions.
+- `docs/adr`: Architecture decisions for data privacy, capture evidence, recovery, and related product boundaries.
+
+## Development Quickstart
 
 1. Install dependencies with `bun install`.
 2. Copy `.env.local.template` to `.env.local` and fill the Expo public values you need.
@@ -11,30 +45,13 @@ Monorepo for the Fidy mobile app, landing site, shared packages, and Supabase fu
 Primary commands:
 
 - `bun run mobile` starts the Expo app.
+- `bun run mobile:ios` starts the Expo app on iOS.
+- `bun run mobile:android` starts the Expo app on Android.
 - `bun run landing` serves the static landing site.
-- `bun run lint` runs root Biome checks.
-- `bun run lint:complexity` runs the enforced Lizard gate (`CCN <= 5`, `NLOC <= 30`, `parameter_count <= 3`) against the checked-in zero-baseline ledger.
+- `bun run lint` runs root Oxlint checks.
 - `bun run lint:mobile` runs Expo ESLint for the mobile app.
-- `bun run analyze:complexity:strict` runs the strict Lizard scan, writes reports to `.context/reports/lizard/strict/`, and checks them against the checked-in baseline.
-- `bun run analyze:complexity:strict:update-ledger` rewrites the checked-in baseline ledger. In steady state this should remain zero and is maintenance-only.
+- `bun run lint:complexity` runs the enforced Lizard gate.
 - `bun run typecheck` builds shared packages and typechecks the workspace.
-- `bun run test` runs the mobile Vitest suite.
+- `bun run test` runs script and mobile test suites.
 - `bun run test:coverage` runs the mobile tests with coverage.
-- `bun run verify` runs lint, mobile lint, typecheck, and tests in the same order used locally.
-
-## Complexity Policy
-
-This repo treats function complexity as a design constraint, not just a lint metric. The target is `CCN <= 5`, `NLOC <= 30`, and `parameter_count <= 3` because smaller branching surfaces, shorter functions, and narrower interfaces reduce cognitive load, improve testability, and force orchestration code into deeper modules instead of growing monolithic workflow functions. The guardrail is architectural: do not "fix" the metric with shallow wrapper extraction or generic option bags. Refactors should reduce responsibility per function and improve boundary design. The checked-in ledger is now a zero baseline, so rewriting it is a rare maintenance operation rather than part of normal development.
-
-## Repo Layout
-
-- `apps/mobile`: Expo / React Native app.
-- `apps/landing`: Static landing site deployed to Vercel.
-- `packages/*`: Shared workspace packages consumed by the app.
-- `supabase/functions`: Edge Functions.
-
-## Agent Guidance
-
-- Architecture and code-style constraints live in [CLAUDE.md](./CLAUDE.md).
-- Codex-specific assistant hooks live in `.codex/settings.json` and `.ai-hooks/`.
-- Local knowledge stores and editor-specific agent folders are intentionally git-ignored.
+- `bun run verify` runs the full local verification pipeline.


### PR DESCRIPTION
- explain app purpose

- keep setup commands

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote the README to explain what Fidy is, why it exists, and who it’s for, adding two product bets (automated capture; assistive guidance), user outcomes, product principles, a clearer features list, and a fuller stack (state/data, styling, observability). Clarified repo contents with `docs/adr`, aligned features to current app modules, and updated the quickstart and commands (added `bun run mobile:ios`/`bun run mobile:android`, switched root lint to `Oxlint`, kept the `Lizard` gate, and noted tests cover script and mobile), and removed the complexity policy and agent guidance.

<sup>Written for commit d94d9d3738ac0957bcba356538526410a28eb402. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

