### PR TITLE
feat(mobile): record transactions

### DIFF
--- a/apps/mobile/__tests__/local-ledger/record-transaction.test.ts
+++ b/apps/mobile/__tests__/local-ledger/record-transaction.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "vitest";
+import {
+  type LocalLedgerEntryId,
+  recordTransaction,
+  type RecordTransactionPorts,
+} from "@/local-ledger/public";
+import type {
+  CategoryId,
+  CopAmount,
+  FinancialAccountId,
+  IsoDate,
+  UserId,
+} from "@/shared/types/branded";
+
+const validCommand = {
+  userId: "user-1" as UserId,
+  type: "expense" as const,
+  amount: 12_000 as CopAmount,
+  accountId: "account-1" as FinancialAccountId,
+  accountAttributionState: "confirmed" as const,
+  categoryId: "food" as CategoryId,
+  occurredOn: "2026-05-11" as IsoDate,
+  description: "Lunch",
+  counterpartyName: "Cafe",
+  source: "manual" as const,
+};
+
+const createPorts = (overrides: Partial<RecordTransactionPorts> = {}): RecordTransactionPorts => ({
+  commit: async (transaction) => ({ ok: true, transaction }),
+  canUseAccount: async () => true,
+  canUseCategory: async () => true,
+  today: () => "2026-05-11" as IsoDate,
+  generateEntryId: () => "entry-1" as LocalLedgerEntryId,
+  ...overrides,
+});
+
+describe("RecordTransaction", () => {
+  test("rejects transactions dated after the injected local ledger today", async () => {
+    const result = await recordTransaction({
+      command: {
+        ...validCommand,
+        occurredOn: "2026-05-12" as IsoDate,
+      },
+      ports: createPorts({
+        commit: async (transaction) => {
+          void transaction;
+          throw new Error("commit should not run");
+        },
+      }),
+    });
+
+    expect(result).toEqual({ ok: false, code: "future-dated-transaction" });
+  });
+
+  test("rejects transactions without an account", async () => {
+    const result = await recordTransaction({
+      command: { ...validCommand, accountId: null },
+      ports: createPorts(),
+    });
+
+    expect(result).toEqual({ ok: false, code: "missing-account" });
+  });
+
+  test("rejects transactions without a positive amount", async () => {
+    const result = await recordTransaction({
+      command: { ...validCommand, amount: 0 as CopAmount },
+      ports: createPorts(),
+    });
+
+    expect(result).toEqual({ ok: false, code: "non-positive-amount" });
+  });
+
+  test("rejects accounts the user cannot use", async () => {
+    const result = await recordTransaction({
+      command: validCommand,
+      ports: createPorts({ canUseAccount: async () => false }),
+    });
+
+    expect(result).toEqual({ ok: false, code: "account-not-usable" });
+  });
+
+  test("rejects transactions without a category", async () => {
+    const result = await recordTransaction({
+      command: { ...validCommand, categoryId: null },
+      ports: createPorts(),
+    });
+
+    expect(result).toEqual({ ok: false, code: "missing-category" });
+  });
+
+  test("rejects categories the user cannot use", async () => {
+    const result = await recordTransaction({
+      command: validCommand,
+      ports: createPorts({ canUseCategory: async () => false }),
+    });
+
+    expect(result).toEqual({ ok: false, code: "category-not-usable" });
+  });
+
+  test("rejects manual source transactions with unresolved account attribution", async () => {
+    const result = await recordTransaction({
+      command: { ...validCommand, accountAttributionState: "unresolved" },
+      ports: createPorts(),
+    });
+
+    expect(result).toEqual({ ok: false, code: "manual-source-requires-resolved-account" });
+  });
+
+  test("records an accepted transaction with normalized note and counterparty text", async () => {
+    const longCounterparty = `  ${"Counterparty ".repeat(30)}  `;
+    const result = await recordTransaction({
+      command: {
+        ...validCommand,
+        description: "  User note  ",
+        counterpartyName: longCounterparty,
+        source: "automated",
+        accountAttributionState: "unresolved",
+      },
+      ports: createPorts(),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.transaction).toMatchObject({
+      id: "entry-1",
+      userId: "user-1",
+      description: "User note",
+      counterpartyName: "Counterparty ".repeat(30).slice(0, 200),
+      source: "automated",
+      accountAttributionState: "unresolved",
+    });
+    expect(result.events).toEqual([
+      { type: "local-ledger.transaction-recorded", transactionId: "entry-1" },
+    ]);
+  });
+
+  test("returns a commit-time policy rejection without a recorded event", async () => {
+    const result = await recordTransaction({
+      command: validCommand,
+      ports: createPorts({ commit: async () => ({ ok: false, code: "account-not-usable" }) }),
+    });
+
+    expect(result).toEqual({ ok: false, code: "account-not-usable" });
+  });
+});

--- a/apps/mobile/local-ledger/public.ts
+++ b/apps/mobile/local-ledger/public.ts
@@ -1,4 +1,5 @@
 export type {
+  FinancialAccountId,
   LocalLedgerCommandId,
   LocalLedgerDomainEvent,
   LocalLedgerEntry,
@@ -7,7 +8,6 @@ export type {
   LocalLedgerSourceId,
   LocalLedgerTransfer,
   LocalLedgerTransferSide,
-  FinancialAccountId,
   TransferId,
   UserId,
 } from "./domain/public";
@@ -18,6 +18,16 @@ export type {
 } from "./use-cases/intake.public";
 export {
   createRecordTransfer,
+  recordTransaction,
+  type RecordTransactionAccepted,
+  type RecordTransactionAccountAttributionState,
+  type RecordTransactionCommand,
+  type RecordTransactionEvent,
+  type RecordTransactionInput,
+  type RecordTransactionPorts,
+  type RecordTransactionRejectCode,
+  type RecordTransactionResult,
+  type RecordTransactionSource,
   type RecordTransfer,
   type RecordTransferCommand,
   type RecordTransferDependencies,
@@ -28,6 +38,6 @@ export {
 } from "./use-cases/write.public";
 export type {
   LocalLedgerEntryRepository,
-  LocalLedgerTransferRepository,
   LocalLedgerTransferRecordResult,
+  LocalLedgerTransferRepository,
 } from "./ports/public";

--- a/apps/mobile/local-ledger/use-cases/write.public.ts
+++ b/apps/mobile/local-ledger/use-cases/write.public.ts
@@ -1,8 +1,15 @@
-import type { CopAmount, IsoDate, IsoDateTime } from "@/shared/types/branded";
+import type {
+  CategoryId,
+  CopAmount,
+  FinancialAccountId,
+  IsoDate,
+  IsoDateTime,
+} from "@/shared/types/branded";
 import type {
   LocalLedgerCommandId,
   LocalLedgerDomainEvent,
   LocalLedgerEntry,
+  LocalLedgerEntryId,
   LocalLedgerTransfer,
   LocalLedgerTransferSide,
   TransferId,
@@ -88,3 +95,175 @@ async function recordValidatedTransfer(
     events: [transferRecordedEvent(recordResult.transfer, command.now)],
   };
 }
+
+export type RecordTransactionSource = "manual" | "automated";
+
+export type RecordTransactionAccountAttributionState = "confirmed" | "inferred" | "unresolved";
+
+export type RecordTransactionCommand = {
+  readonly userId: UserId;
+  readonly type: "expense" | "income";
+  readonly amount: CopAmount;
+  readonly accountId: FinancialAccountId | null;
+  readonly accountAttributionState: RecordTransactionAccountAttributionState;
+  readonly categoryId: CategoryId | null;
+  readonly occurredOn: IsoDate;
+  readonly description: string | null;
+  readonly counterpartyName: string | null;
+  readonly source: RecordTransactionSource;
+};
+
+export type RecordTransactionAccepted = {
+  readonly id: LocalLedgerEntryId;
+  readonly userId: UserId;
+  readonly type: RecordTransactionCommand["type"];
+  readonly amount: CopAmount;
+  readonly accountId: FinancialAccountId;
+  readonly accountAttributionState: RecordTransactionAccountAttributionState;
+  readonly categoryId: CategoryId;
+  readonly occurredOn: IsoDate;
+  readonly description: string;
+  readonly counterpartyName: string;
+  readonly source: RecordTransactionSource;
+};
+
+export type RecordTransactionEvent = {
+  readonly type: "local-ledger.transaction-recorded";
+  readonly transactionId: LocalLedgerEntryId;
+};
+
+export type RecordTransactionRejectCode =
+  | "future-dated-transaction"
+  | "non-positive-amount"
+  | "missing-account"
+  | "account-not-usable"
+  | "missing-category"
+  | "category-not-usable"
+  | "manual-source-requires-resolved-account";
+
+export type RecordTransactionResult =
+  | {
+      readonly ok: true;
+      readonly transaction: RecordTransactionAccepted;
+      readonly events: readonly RecordTransactionEvent[];
+    }
+  | { readonly ok: false; readonly code: RecordTransactionRejectCode };
+
+export type RecordTransactionCommitResult =
+  | { readonly ok: true; readonly transaction: RecordTransactionAccepted }
+  | { readonly ok: false; readonly code: "account-not-usable" | "category-not-usable" };
+
+export type RecordTransactionPorts = {
+  readonly commit: (
+    transaction: RecordTransactionAccepted
+  ) => Promise<RecordTransactionCommitResult>;
+  readonly canUseAccount: (input: {
+    readonly userId: UserId;
+    readonly accountId: FinancialAccountId;
+  }) => Promise<boolean>;
+  readonly canUseCategory: (input: {
+    readonly userId: UserId;
+    readonly categoryId: CategoryId;
+  }) => Promise<boolean>;
+  readonly today: () => IsoDate;
+  readonly generateEntryId: () => LocalLedgerEntryId;
+};
+
+export type RecordTransactionInput = {
+  readonly command: RecordTransactionCommand;
+  readonly ports: RecordTransactionPorts;
+};
+
+const MAX_TEXT_LENGTH = 200;
+
+const normalizeText = (value: string | null): string =>
+  (value ?? "").trim().slice(0, MAX_TEXT_LENGTH);
+
+const isFutureDated = (occurredOn: IsoDate, today: IsoDate): boolean => occurredOn > today;
+
+const toEvent = (transaction: RecordTransactionAccepted): RecordTransactionEvent => ({
+  type: "local-ledger.transaction-recorded",
+  transactionId: transaction.id,
+});
+
+const rejectTransaction = (code: RecordTransactionRejectCode): RecordTransactionResult => ({
+  ok: false,
+  code,
+});
+
+const getCommandRejectCode = (
+  command: RecordTransactionCommand,
+  today: IsoDate
+): RecordTransactionRejectCode | null =>
+  isFutureDated(command.occurredOn, today)
+    ? "future-dated-transaction"
+    : command.amount <= 0
+      ? "non-positive-amount"
+      : command.accountId === null
+        ? "missing-account"
+        : command.categoryId === null
+          ? "missing-category"
+          : command.source === "manual" && command.accountAttributionState === "unresolved"
+            ? "manual-source-requires-resolved-account"
+            : null;
+
+const getPolicyRejectCode = async (
+  command: RecordTransactionCommand & {
+    readonly accountId: FinancialAccountId;
+    readonly categoryId: CategoryId;
+  },
+  ports: RecordTransactionPorts
+): Promise<RecordTransactionRejectCode | null> =>
+  !(await ports.canUseAccount({ userId: command.userId, accountId: command.accountId }))
+    ? "account-not-usable"
+    : !(await ports.canUseCategory({ userId: command.userId, categoryId: command.categoryId }))
+      ? "category-not-usable"
+      : null;
+
+const toAcceptedTransaction = (
+  command: RecordTransactionCommand & {
+    readonly accountId: FinancialAccountId;
+    readonly categoryId: CategoryId;
+  },
+  id: LocalLedgerEntryId
+): RecordTransactionAccepted => ({
+  id,
+  userId: command.userId,
+  type: command.type,
+  amount: command.amount,
+  accountId: command.accountId,
+  accountAttributionState: command.accountAttributionState,
+  categoryId: command.categoryId,
+  occurredOn: command.occurredOn,
+  description: normalizeText(command.description),
+  counterpartyName: normalizeText(command.counterpartyName),
+  source: command.source,
+});
+
+const toSuccess = (transaction: RecordTransactionAccepted): RecordTransactionResult => ({
+  ok: true,
+  transaction,
+  events: [toEvent(transaction)],
+});
+
+const toCommitResult = (result: RecordTransactionCommitResult): RecordTransactionResult =>
+  result.ok ? toSuccess(result.transaction) : result;
+
+export const recordTransaction = async ({
+  command,
+  ports,
+}: RecordTransactionInput): Promise<RecordTransactionResult> => {
+  const commandRejectCode = getCommandRejectCode(command, ports.today());
+  if (commandRejectCode !== null) return rejectTransaction(commandRejectCode);
+
+  const acceptedCommand = command as RecordTransactionCommand & {
+    readonly accountId: FinancialAccountId;
+    readonly categoryId: CategoryId;
+  };
+  const policyRejectCode = await getPolicyRejectCode(acceptedCommand, ports);
+  if (policyRejectCode !== null) return rejectTransaction(policyRejectCode);
+
+  return toCommitResult(
+    await ports.commit(toAcceptedTransaction(acceptedCommand, ports.generateEntryId()))
+  );
+};


### PR DESCRIPTION
- add local ledger use case

- cover policy rejections

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `recordTransaction` use case to the mobile local ledger to record expenses/income with validations, policy checks, and event emission, and exposes it via the public API. Implements core requirements for issue-415 with tests for acceptance, normalization, and policy rejections.

- **New Features**
  - New `recordTransaction` flow with types, result/events, and reject codes; emits `local-ledger.transaction-recorded` on success.
  - Validations: no future dates, positive amount required, require `accountId`/`categoryId`, and block manual entries with unresolved account attribution.
  - Policy checks via `canUseAccount`/`canUseCategory`; commit-time `account-not-usable`/`category-not-usable` rejections are returned without events.
  - Normalizes `description` and `counterpartyName` (trim, max 200 chars). Public API exports include the use case and related types; tests cover success and all reject paths.

<sup>Written for commit 0255e2d4c55ede52216cb118f44da00a2d0c2370. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

