### PR TITLE
fix(mobile): route transfers to ledger

### DIFF
--- a/apps/mobile/__tests__/transfers/manual-transfer-local-ledger.test.ts
+++ b/apps/mobile/__tests__/transfers/manual-transfer-local-ledger.test.ts
@@ -1,0 +1,146 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: boundary test uses a focused Drizzle double
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { submitTransferForm } from "@/features/transfers/components/transfer-form/saveTransferForm";
+import { recordManualTransferWithLocalLedger } from "@/infrastructure/local-ledger/record-transfer";
+import type { FinancialAccountId, TransferId, UserId } from "@/shared/types/branded";
+
+const { refreshTransactionsMock } = vi.hoisted(() => ({
+  refreshTransactionsMock: vi.fn<(...args: any[]) => any>(),
+}));
+
+vi.mock("@/features/transactions/store.public", () => ({
+  refreshTransactions: refreshTransactionsMock,
+}));
+
+const USER_ID = "user-1" as UserId;
+const NOW = new Date("2026-04-18T10:00:00.000Z");
+const ACTIVE_ACCOUNT_ID = "fa-active" as FinancialAccountId;
+const CLOSED_ACCOUNT_ID = "fa-closed" as FinancialAccountId;
+
+function createDbDouble(accountLookupResults: readonly boolean[]) {
+  const insertedTransfers: unknown[] = [];
+  const lookups = [...accountLookupResults];
+  const transactionCalls: unknown[] = [];
+  const db = {
+    transaction: (callback: (tx: unknown) => unknown) => {
+      transactionCalls.push(callback);
+      return callback(db);
+    },
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => ({
+            all: () => (lookups.shift() ? [{ id: "usable-account" }] : []),
+          }),
+        }),
+      }),
+    }),
+    insert: () => ({
+      values: (row: unknown) => ({
+        run: () => {
+          insertedTransfers.push(row);
+        },
+      }),
+    }),
+  };
+
+  return { db, insertedTransfers, transactionCalls };
+}
+
+beforeEach(() => {
+  refreshTransactionsMock.mockReset();
+});
+
+describe("manual transfer Local Ledger writer", () => {
+  it("records a valid manual transfer through Local Ledger and inserts the transfer row", async () => {
+    const { db, insertedTransfers, transactionCalls } = createDbDouble([true]);
+
+    const result = await recordManualTransferWithLocalLedger({
+      db: db as any,
+      userId: USER_ID,
+      transferId: "tr-valid" as TransferId,
+      input: {
+        digits: "$450.000",
+        fromSide: { kind: "account", accountId: ACTIVE_ACCOUNT_ID },
+        toSide: { kind: "external", label: "Outside Fidy" },
+        description: "  Visa payment  ",
+        date: NOW,
+      },
+      now: NOW,
+    });
+
+    expect(result).toEqual({
+      success: true,
+      transfer: {
+        id: "tr-valid",
+        userId: USER_ID,
+        amount: 450000,
+        fromSide: { kind: "account", accountId: ACTIVE_ACCOUNT_ID },
+        toSide: { kind: "external", label: "Outside Fidy" },
+        description: "Visa payment",
+        date: "2026-04-18",
+        createdAt: "2026-04-18T10:00:00.000Z",
+        updatedAt: "2026-04-18T10:00:00.000Z",
+        deletedAt: null,
+      },
+    });
+    expect(insertedTransfers).toEqual([
+      {
+        id: "tr-valid",
+        userId: USER_ID,
+        amount: 450000,
+        fromAccountId: ACTIVE_ACCOUNT_ID,
+        toAccountId: null,
+        fromExternalLabel: null,
+        toExternalLabel: "Outside Fidy",
+        description: "Visa payment",
+        date: "2026-04-18",
+        createdAt: "2026-04-18T10:00:00.000Z",
+        updatedAt: "2026-04-18T10:00:00.000Z",
+        deletedAt: null,
+      },
+    ]);
+    expect(transactionCalls).toHaveLength(1);
+  });
+
+  it("rejects Local Ledger account usability failures before inserting a transfer", async () => {
+    const { db, insertedTransfers } = createDbDouble([true, false]);
+
+    const result = await recordManualTransferWithLocalLedger({
+      db: db as any,
+      userId: USER_ID,
+      transferId: "tr-closed-account" as TransferId,
+      input: {
+        digits: "450000",
+        fromSide: { kind: "account", accountId: ACTIVE_ACCOUNT_ID },
+        toSide: { kind: "account", accountId: CLOSED_ACCOUNT_ID },
+        description: "Move to closed savings",
+        date: NOW,
+      },
+      now: NOW,
+    });
+
+    expect(result).toEqual({ success: false, error: "accountNotUsable" });
+    expect(insertedTransfers).toEqual([]);
+  });
+
+  it("enforces Local Ledger validation through the full manual transfer form save path", async () => {
+    const { db, insertedTransfers } = createDbDouble([true]);
+
+    const result = await submitTransferForm({
+      date: new Date("2099-04-19T00:00:00.000Z"),
+      description: "Future transfer",
+      db: db as any,
+      digits: "450000",
+      fromSide: { kind: "account", accountId: ACTIVE_ACCOUNT_ID },
+      processedEmailId: null,
+      sourceTransaction: null,
+      toSide: { kind: "external", label: "Outside Fidy" },
+      userId: USER_ID,
+    });
+
+    expect(result).toEqual({ success: false, error: "futureDated" });
+    expect(insertedTransfers).toEqual([]);
+    expect(refreshTransactionsMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/__tests__/transfers/mutation-service.test.ts
+++ b/apps/mobile/__tests__/transfers/mutation-service.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { OUTSIDE_FIDY_LABEL } from "@/features/transfers/lib/build-transfer";
 import { createTransferMutationService } from "@/features/transfers/lib/mutation-service";
-import type { TransferRow } from "@/features/transfers/lib/repository";
 import type { AnyDb } from "@/shared/db";
 import type { FinancialAccountId, TransferId, UserId } from "@/shared/types/branded";
 
@@ -21,16 +20,16 @@ describe("transfer mutation service", () => {
   let currentUserId: UserId | null;
   let currentDb: AnyDb | null;
   let refresh: ServiceDeps["refresh"];
-  let saveTransferRow: ServiceDeps["saveTransferRow"];
+  let recordTransfer: ServiceDeps["recordTransfer"];
   let refreshMock: ReturnType<typeof vi.fn>;
-  let saveTransferRowMock: ReturnType<typeof vi.fn>;
+  let recordTransferMock: ReturnType<typeof vi.fn>;
 
   function createService() {
     return createTransferMutationService({
       getUserId: () => currentUserId,
       getDb: () => currentDb,
       refresh,
-      saveTransferRow,
+      recordTransfer,
       now: () => now,
       createId: () => "tr-new" as TransferId,
     });
@@ -40,9 +39,23 @@ describe("transfer mutation service", () => {
     currentUserId = "user-1" as UserId;
     currentDb = {} as AnyDb;
     refreshMock = vi.fn<(...args: any[]) => any>().mockResolvedValue(undefined);
-    saveTransferRowMock = vi.fn<(...args: any[]) => any>();
+    recordTransferMock = vi.fn<(...args: any[]) => any>().mockResolvedValue({
+      success: true,
+      transfer: {
+        id: "tr-new" as TransferId,
+        userId: "user-1" as UserId,
+        amount: 450000,
+        fromSide: validInput.fromSide,
+        toSide: validInput.toSide,
+        description: "Visa payment",
+        date: "2026-04-19",
+        createdAt: "2026-04-19T10:00:00.000Z",
+        updatedAt: "2026-04-19T10:00:00.000Z",
+        deletedAt: null,
+      },
+    });
     refresh = refreshMock as ServiceDeps["refresh"];
-    saveTransferRow = saveTransferRowMock as ServiceDeps["saveTransferRow"];
+    recordTransfer = recordTransferMock as ServiceDeps["recordTransfer"];
   });
 
   it("returns store-not-initialized when the user is unavailable", async () => {
@@ -55,7 +68,11 @@ describe("transfer mutation service", () => {
     });
   });
 
-  it("returns transfer validation failures directly", async () => {
+  it("delegates invalid transfer commands to the Local Ledger writer", async () => {
+    recordTransferMock.mockResolvedValueOnce({
+      success: false,
+      error: "distinctSidesRequired",
+    });
     const service = createService();
 
     await expect(
@@ -70,9 +87,11 @@ describe("transfer mutation service", () => {
       success: false,
       error: "distinctSidesRequired",
     });
+    expect(recordTransferMock).toHaveBeenCalledOnce();
+    expect(refreshMock).not.toHaveBeenCalled();
   });
 
-  it("saves a valid transfer row and refreshes the caller boundary", async () => {
+  it("records a valid transfer through the Local Ledger writer and refreshes the caller boundary", async () => {
     const service = createService();
 
     const result = await service.save(validInput);
@@ -85,20 +104,32 @@ describe("transfer mutation service", () => {
         amount: 450000 as never,
       }),
     });
-    expect(saveTransferRowMock).toHaveBeenCalledWith(
-      currentDb,
-      expect.objectContaining<Partial<TransferRow>>({
-        id: "tr-new" as TransferId,
-        amount: 450000 as never,
-        fromAccountId: "fa-checking" as FinancialAccountId,
-        toExternalLabel: OUTSIDE_FIDY_LABEL,
-      })
-    );
+    expect(recordTransferMock).toHaveBeenCalledWith({
+      db: currentDb,
+      userId: "user-1" as UserId,
+      transferId: "tr-new" as TransferId,
+      input: validInput,
+      now,
+    });
     expect(refreshMock).toHaveBeenCalledOnce();
   });
 
+  it("returns Local Ledger validation failures without refreshing", async () => {
+    recordTransferMock.mockResolvedValueOnce({
+      success: false,
+      error: "accountNotUsable",
+    });
+    const service = createService();
+
+    await expect(service.save(validInput)).resolves.toEqual({
+      success: false,
+      error: "accountNotUsable",
+    });
+    expect(refreshMock).not.toHaveBeenCalled();
+  });
+
   it("maps thrown persistence failures to a save error", async () => {
-    saveTransferRowMock.mockImplementation(() => {
+    recordTransferMock.mockImplementation(() => {
       throw new Error("db failed");
     });
     const service = createService();
@@ -122,7 +153,7 @@ describe("transfer mutation service", () => {
         id: "tr-new" as TransferId,
       }),
     });
-    expect(saveTransferRowMock).toHaveBeenCalledOnce();
+    expect(recordTransferMock).toHaveBeenCalledOnce();
     expect(refreshMock).toHaveBeenCalledOnce();
   });
 });

--- a/apps/mobile/features/transfers/components/transfer-form/TransferForm.helpers.ts
+++ b/apps/mobile/features/transfers/components/transfer-form/TransferForm.helpers.ts
@@ -34,8 +34,12 @@ type TransferFormCopy = Pick<
 >;
 
 const TRANSFER_ERROR_MESSAGE_KEYS = {
+  accountNotUsable: "transfers.errors.saveFailed",
   amountRequired: "transfers.errors.amountRequired",
+  amountNotPositive: "transfers.errors.amountRequired",
   distinctSidesRequired: "transfers.errors.distinctSidesRequired",
+  externalLabelRequired: "transfers.errors.saveFailed",
+  futureDated: "transfers.errors.saveFailed",
   saveFailed: "transfers.errors.saveFailed",
   storeNotInitialized: "transfers.errors.saveFailed",
   trackedAccountRequired: "transfers.errors.trackedAccountRequired",

--- a/apps/mobile/features/transfers/components/transfer-form/saveTransferForm.ts
+++ b/apps/mobile/features/transfers/components/transfer-form/saveTransferForm.ts
@@ -11,7 +11,7 @@ import type {
   ReclassifyTransactionAsTransferResult,
 } from "@/features/transfers/lib/reclassify-transaction-as-transfer";
 import { reclassifyTransactionAsTransfer } from "@/features/transfers/lib/reclassify-transaction-as-transfer";
-import { saveTransfer } from "@/features/transfers/lib/repository";
+import { recordManualTransferWithLocalLedger } from "@/infrastructure/local-ledger/record-transfer";
 import type { AnyDb } from "@/shared/db";
 import type { ProcessedEmailId, UserId } from "@/shared/types/branded";
 
@@ -50,7 +50,7 @@ async function saveNewTransfer(
     getDb: () => input.db,
     getUserId: () => input.userId,
     refresh: () => refreshTransactions(input.db, input.userId),
-    saveTransferRow: saveTransfer,
+    recordTransfer: recordManualTransferWithLocalLedger,
   }).save({
     digits: input.digits,
     fromSide: input.fromSide,

--- a/apps/mobile/features/transfers/lib/mutation-service.ts
+++ b/apps/mobile/features/transfers/lib/mutation-service.ts
@@ -1,14 +1,10 @@
+import type { LocalLedgerTransfer } from "@/local-ledger/public";
 import type { AnyDb } from "@/shared/db";
+import { parseIsoDate } from "@/shared/lib/format-date";
 import { generateTransferId } from "@/shared/lib/generate-id";
+import { captureError } from "@/shared/lib/sentry";
 import type { TransferId, UserId } from "@/shared/types/branded";
-import {
-  type BuildTransferInput,
-  buildTransfer,
-  type StoredTransfer,
-  type TransferBuildError,
-  toTransferRow,
-} from "./build-transfer";
-import type { TransferRow } from "./repository";
+import type { BuildTransferInput, StoredTransfer } from "./build-transfer";
 
 export type TransferFormInput = {
   readonly digits: BuildTransferInput["digits"];
@@ -18,7 +14,18 @@ export type TransferFormInput = {
   readonly date: BuildTransferInput["date"];
 };
 
-export type TransferMutationError = TransferBuildError | "storeNotInitialized" | "saveFailed";
+export type TransferMutationError =
+  | "amountRequired"
+  | "amountNotPositive"
+  | "distinctSidesRequired"
+  | "fromSideRequired"
+  | "toSideRequired"
+  | "trackedAccountRequired"
+  | "storeNotInitialized"
+  | "saveFailed"
+  | "accountNotUsable"
+  | "futureDated"
+  | "externalLabelRequired";
 
 export type TransferMutationResult =
   | { success: true; transfer: StoredTransfer }
@@ -28,16 +35,35 @@ type CreateTransferMutationServiceDeps = {
   readonly getDb: () => AnyDb | null;
   readonly getUserId: () => UserId | null;
   readonly refresh: () => Promise<void>;
-  readonly saveTransferRow: (db: AnyDb, row: TransferRow) => void;
+  readonly recordTransfer: (input: {
+    readonly db: AnyDb;
+    readonly userId: UserId;
+    readonly transferId: TransferId;
+    readonly input: TransferFormInput;
+    readonly now: Date;
+  }) => Promise<
+    | { success: true; transfer: LocalLedgerTransfer }
+    | { success: false; error: TransferMutationError }
+  >;
   readonly now?: () => Date;
   readonly createId?: () => TransferId;
 };
+
+function toStoredTransfer(transfer: LocalLedgerTransfer): StoredTransfer {
+  return {
+    ...transfer,
+    date: parseIsoDate(transfer.date),
+    createdAt: new Date(transfer.createdAt),
+    updatedAt: new Date(transfer.updatedAt),
+    deletedAt: transfer.deletedAt == null ? null : new Date(transfer.deletedAt),
+  };
+}
 
 export function createTransferMutationService({
   getDb,
   getUserId,
   refresh,
-  saveTransferRow,
+  recordTransfer,
   now = () => new Date(),
   createId = generateTransferId,
 }: CreateTransferMutationServiceDeps) {
@@ -50,21 +76,25 @@ export function createTransferMutationService({
         return { success: false, error: "storeNotInitialized" };
       }
 
-      const built = buildTransfer({
-        input,
-        userId,
-        id: createId(),
-        now: now(),
-      });
-      if (!built.success) {
-        return built;
-      }
+      const transferId = createId();
+      const currentTime = now();
 
+      let result:
+        | { success: true; transfer: LocalLedgerTransfer }
+        | { success: false; error: TransferMutationError };
       try {
-        saveTransferRow(db, toTransferRow(built.transfer));
-      } catch {
+        result = await recordTransfer({
+          db,
+          userId,
+          transferId,
+          input,
+          now: currentTime,
+        });
+      } catch (error) {
+        captureError(error);
         return { success: false, error: "saveFailed" };
       }
+      if (!result.success) return result;
 
       try {
         await refresh();
@@ -72,7 +102,7 @@ export function createTransferMutationService({
         // Keep the persisted transfer successful even if the caller refresh fails.
       }
 
-      return { success: true, transfer: built.transfer };
+      return { success: true, transfer: toStoredTransfer(result.transfer) };
     },
   };
 }

--- a/apps/mobile/infrastructure/local-ledger/record-transfer.ts
+++ b/apps/mobile/infrastructure/local-ledger/record-transfer.ts
@@ -1,0 +1,140 @@
+import { and, eq, isNull } from "drizzle-orm";
+import {
+  createRecordTransfer,
+  type LocalLedgerTransfer,
+  type RecordTransferRejectionReason,
+} from "@/local-ledger/public";
+import type { AnyDb } from "@/shared/db";
+import { financialAccounts, transfers } from "@/shared/db/schema";
+import { toIsoDate, toIsoDateTime } from "@/shared/lib/format-date";
+import { parseDigitsToAmount } from "@/shared/lib/format-money";
+import type { CopAmount, FinancialAccountId, TransferId, UserId } from "@/shared/types/branded";
+
+type ManualTransferInput = {
+  readonly digits: string;
+  readonly fromSide: LocalLedgerTransfer["fromSide"] | null;
+  readonly toSide: LocalLedgerTransfer["toSide"] | null;
+  readonly description: string;
+  readonly date: Date;
+};
+
+type RecordManualTransferInput = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly transferId: TransferId;
+  readonly input: ManualTransferInput;
+  readonly now: Date;
+};
+
+type RecordManualTransferResult =
+  | { readonly success: true; readonly transfer: LocalLedgerTransfer }
+  | {
+      readonly success: false;
+      readonly error: RecordManualTransferError;
+    };
+
+type RecordManualTransferError =
+  | "accountNotUsable"
+  | "amountNotPositive"
+  | "distinctSidesRequired"
+  | "externalLabelRequired"
+  | "fromSideRequired"
+  | "futureDated"
+  | "toSideRequired"
+  | "trackedAccountRequired";
+
+const rejectionErrorMap: Record<RecordTransferRejectionReason, RecordManualTransferError> = {
+  "account-not-usable": "accountNotUsable",
+  "amount-not-positive": "amountNotPositive",
+  "external-label-required": "externalLabelRequired",
+  "from-side-required": "fromSideRequired",
+  "future-dated": "futureDated",
+  "same-account": "distinctSidesRequired",
+  "to-side-required": "toSideRequired",
+  "tracked-account-required": "trackedAccountRequired",
+};
+
+function hasActiveFinancialAccount(db: AnyDb, userId: UserId, accountId: FinancialAccountId) {
+  const rows = db
+    .select({ id: financialAccounts.id })
+    .from(financialAccounts)
+    .where(
+      and(
+        eq(financialAccounts.id, accountId),
+        eq(financialAccounts.userId, userId),
+        isNull(financialAccounts.deletedAt)
+      )
+    )
+    .limit(1)
+    .all();
+  return rows.length > 0;
+}
+
+function toTransferRow(transfer: LocalLedgerTransfer): typeof transfers.$inferInsert {
+  return {
+    id: transfer.id,
+    userId: transfer.userId,
+    amount: transfer.amount,
+    fromAccountId: transfer.fromSide.kind === "account" ? transfer.fromSide.accountId : null,
+    toAccountId: transfer.toSide.kind === "account" ? transfer.toSide.accountId : null,
+    fromExternalLabel: transfer.fromSide.kind === "external" ? transfer.fromSide.label : null,
+    toExternalLabel: transfer.toSide.kind === "external" ? transfer.toSide.label : null,
+    description: transfer.description || null,
+    date: transfer.date,
+    createdAt: transfer.createdAt,
+    updatedAt: transfer.updatedAt,
+    deletedAt: transfer.deletedAt,
+  };
+}
+
+function insertTransfer(db: AnyDb, transfer: LocalLedgerTransfer) {
+  const row = toTransferRow(transfer);
+  db.insert(transfers).values(row).run();
+}
+
+export async function recordManualTransferWithLocalLedger({
+  db,
+  userId,
+  transferId,
+  input,
+  now,
+}: RecordManualTransferInput): Promise<RecordManualTransferResult> {
+  const normalizedDescription = input.description.trim();
+  const amount = parseDigitsToAmount(input.digits);
+
+  const recordTransfer = createRecordTransfer({
+    transfers: {
+      record: async (transfer) => {
+        return db.transaction((tx) => {
+          const accountSides = [transfer.fromSide, transfer.toSide].filter(
+            (side): side is Extract<LocalLedgerTransfer["fromSide"], { kind: "account" }> =>
+              side.kind === "account"
+          );
+          const canUseAccounts = accountSides.every((side) =>
+            hasActiveFinancialAccount(tx, userId, side.accountId)
+          );
+          if (!canUseAccounts) return { code: "account-not-usable" };
+
+          insertTransfer(tx, transfer);
+          return { code: "recorded", transfer };
+        });
+      },
+    },
+    today: () => toIsoDate(now),
+    userId,
+  });
+
+  const result = await recordTransfer({
+    transferId,
+    amount: amount as CopAmount,
+    fromSide: input.fromSide,
+    toSide: input.toSide,
+    description: normalizedDescription,
+    date: toIsoDate(input.date),
+    now: toIsoDateTime(now),
+  });
+
+  return result.code === "recorded"
+    ? { success: true, transfer: result.transfer }
+    : { success: false, error: rejectionErrorMap[result.reason] };
+}


### PR DESCRIPTION
- use Local Ledger writer

- preserve manual transfer behavior

- cover ledger validation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes manual transfer creation through the Local Ledger writer to enforce ledger-side validation while preserving current behavior. Supports Linear issue 419 for local ledger transfers.

- **Refactors**
  - Replaced `saveTransferRow` with ledger-backed `recordTransfer` in the mutation service; wired `recordManualTransferWithLocalLedger` in the form save flow.
  - Converted Local Ledger transfers to `StoredTransfer` (ISO date/time parsing) and refreshed only on success.
  - Wrapped persistence with `captureError`; writer uses DB transactions and active-account checks before insert.

- **New Features**
  - Enforced Local Ledger rules: usable accounts, distinct sides, non-future dates, positive amounts, required external labels.
  - Returned ledger validation errors without refreshing, including: `distinctSidesRequired`, `accountNotUsable`, `amountNotPositive`, `externalLabelRequired`, `futureDated`.
  - Added tests for the ledger writer, mutation service integration, and the form save path.

<sup>Written for commit 97a9dfa8471ac01744d78bc4ff8e5b1eb2b57068. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

