### PR TITLE
feat(mobile): reclassify transfers

### DIFF
--- a/apps/mobile/__tests__/transfers/reclassify-transaction-as-transfer.test.ts
+++ b/apps/mobile/__tests__/transfers/reclassify-transaction-as-transfer.test.ts
@@ -12,9 +12,17 @@ import {
   getProcessedEmailById,
   insertProcessedEmail,
 } from "@/features/email-capture/lib/repository";
-import { getTransactionById, insertTransaction } from "@/features/transactions/lib/repository";
+import {
+  getBalanceAggregate,
+  getSpendingByCategoryAggregate,
+  getTransactionById,
+  insertTransaction,
+} from "@/features/transactions/lib/repository";
+import { markTransactionSuperseded } from "@/features/transactions/transfer-reclassification.public";
 import { reclassifyTransactionAsTransfer } from "@/features/transfers/lib/reclassify-transaction-as-transfer";
+import { reclassifyTransactionsAsTransfer } from "@/features/transfers/lib/reclassify-transactions-as-transfer";
 import { getTransferById } from "@/features/transfers/lib/repository";
+import { financialAccounts } from "@/shared/db/schema";
 import type {
   CaptureEvidenceId,
   CategoryId,
@@ -33,6 +41,7 @@ let db: ReturnType<typeof drizzle>;
 
 const USER_ID = "user-1" as UserId;
 const ORIGINAL_TRANSACTION_ID = "tx-1" as TransactionId;
+const INCOMING_TRANSACTION_ID = "tx-2" as TransactionId;
 const TRANSFER_ID = "tr-1" as TransferId;
 const ACCOUNT_ID = "fa-1" as FinancialAccountId;
 const SAVINGS_ACCOUNT_ID = "fa-2" as FinancialAccountId;
@@ -48,6 +57,27 @@ beforeEach(() => {
 afterEach(() => {
   sqlite.close();
 });
+
+function insertFinancialAccount(
+  id: FinancialAccountId,
+  overrides: {
+    readonly userId?: UserId;
+    readonly deletedAt?: IsoDateTime | null;
+  } = {}
+) {
+  db.insert(financialAccounts)
+    .values({
+      id,
+      userId: overrides.userId ?? USER_ID,
+      name: id,
+      kind: "checking",
+      isDefault: false,
+      createdAt: ORIGINAL_CREATED_AT,
+      updatedAt: ORIGINAL_CREATED_AT,
+      deletedAt: overrides.deletedAt ?? null,
+    })
+    .run();
+}
 
 function insertOriginalTransactionRecord() {
   insertTransaction(db as any, {
@@ -66,6 +96,30 @@ function insertOriginalTransactionRecord() {
     supersededAt: null,
     source: "automated",
   });
+}
+
+function insertIncomingTransactionRecord() {
+  insertTransaction(db as any, {
+    id: INCOMING_TRANSACTION_ID,
+    userId: USER_ID,
+    type: "income",
+    amount: 350000 as CopAmount,
+    categoryId: "income" as CategoryId,
+    description: "Transfer from checking",
+    date: "2026-04-18" as IsoDate,
+    accountId: SAVINGS_ACCOUNT_ID,
+    accountAttributionState: "confirmed",
+    createdAt: ORIGINAL_CREATED_AT,
+    updatedAt: ORIGINAL_CREATED_AT,
+    voidedAt: null,
+    supersededAt: null,
+    source: "automated",
+  });
+}
+
+function insertReclassificationAccounts() {
+  insertFinancialAccount(ACCOUNT_ID);
+  insertFinancialAccount(SAVINGS_ACCOUNT_ID);
 }
 
 function insertTransferEvidence() {
@@ -179,5 +233,268 @@ describe("reclassifyTransactionAsTransfer", () => {
     });
     expectCreatedTransferState();
     await expectProcessedEmailSucceeded();
+  });
+});
+
+describe("reclassifyTransactionsAsTransfer", () => {
+  it("creates one transfer and supersedes the matching outgoing and incoming transactions", () => {
+    insertReclassificationAccounts();
+    insertOriginalTransactionRecord();
+    insertIncomingTransactionRecord();
+
+    const result = reclassifyTransactionsAsTransfer(
+      db as any,
+      {
+        userId: USER_ID,
+        outgoingTransactionId: ORIGINAL_TRANSACTION_ID,
+        incomingTransactionId: INCOMING_TRANSACTION_ID,
+        description: "Move to savings",
+      },
+      {
+        now: () => new Date(NOW),
+        createId: () => TRANSFER_ID,
+      }
+    );
+
+    expect(result).toEqual({
+      success: true,
+      transfer: expect.objectContaining({
+        id: TRANSFER_ID,
+        amount: 350000,
+      }),
+    });
+    expect(getTransferById(db as any, TRANSFER_ID)).toMatchObject({
+      id: TRANSFER_ID,
+      userId: USER_ID,
+      amount: 350000,
+      fromAccountId: ACCOUNT_ID,
+      toAccountId: SAVINGS_ACCOUNT_ID,
+      description: "Move to savings",
+      date: "2026-04-18",
+    });
+    expect(getTransactionById(db as any, ORIGINAL_TRANSACTION_ID)).toMatchObject({
+      supersededAt: NOW,
+      supersededByTransferId: TRANSFER_ID,
+      voidedAt: null,
+      updatedAt: NOW,
+    });
+    expect(getTransactionById(db as any, INCOMING_TRANSACTION_ID)).toMatchObject({
+      supersededAt: NOW,
+      supersededByTransferId: TRANSFER_ID,
+      voidedAt: null,
+      updatedAt: NOW,
+    });
+    expect(getBalanceAggregate(db as any, USER_ID)).toBe(0);
+    expect(getSpendingByCategoryAggregate(db as any, USER_ID, "2026-04" as any)).toEqual([]);
+  });
+
+  it("rolls back the transfer and supersession links when the atomic commit fails", () => {
+    insertReclassificationAccounts();
+    insertOriginalTransactionRecord();
+    insertIncomingTransactionRecord();
+
+    expect(() =>
+      reclassifyTransactionsAsTransfer(
+        db as any,
+        {
+          userId: USER_ID,
+          outgoingTransactionId: ORIGINAL_TRANSACTION_ID,
+          incomingTransactionId: INCOMING_TRANSACTION_ID,
+          description: "Move to savings",
+        },
+        {
+          now: () => new Date(NOW),
+          createId: () => TRANSFER_ID,
+          saveTransactionRow: (tx, input) => {
+            if (input.id === INCOMING_TRANSACTION_ID) {
+              throw new Error("failed to supersede incoming transaction");
+            }
+            return markTransactionSuperseded(tx, input);
+          },
+        }
+      )
+    ).toThrow("failed to supersede incoming transaction");
+
+    expect(getTransferById(db as any, TRANSFER_ID)).toBeNull();
+    expect(getTransactionById(db as any, ORIGINAL_TRANSACTION_ID)).toMatchObject({
+      supersededAt: null,
+      supersededByTransferId: null,
+      updatedAt: ORIGINAL_CREATED_AT,
+    });
+    expect(getTransactionById(db as any, INCOMING_TRANSACTION_ID)).toMatchObject({
+      supersededAt: null,
+      supersededByTransferId: null,
+      updatedAt: ORIGINAL_CREATED_AT,
+    });
+  });
+
+  it("rejects transactions that do not both belong to the user", () => {
+    insertOriginalTransactionRecord();
+    insertTransaction(db as any, {
+      id: INCOMING_TRANSACTION_ID,
+      userId: "other-user" as UserId,
+      type: "income",
+      amount: 350000 as CopAmount,
+      categoryId: "income" as CategoryId,
+      description: "Transfer from checking",
+      date: "2026-04-18" as IsoDate,
+      accountId: SAVINGS_ACCOUNT_ID,
+      accountAttributionState: "confirmed",
+      createdAt: ORIGINAL_CREATED_AT,
+      updatedAt: ORIGINAL_CREATED_AT,
+      voidedAt: null,
+      supersededAt: null,
+      source: "automated",
+    });
+
+    const result = reclassifyTransactionsAsTransfer(
+      db as any,
+      {
+        userId: USER_ID,
+        outgoingTransactionId: ORIGINAL_TRANSACTION_ID,
+        incomingTransactionId: INCOMING_TRANSACTION_ID,
+        description: "Move to savings",
+      },
+      {
+        now: () => new Date(NOW),
+        createId: () => TRANSFER_ID,
+      }
+    );
+
+    expect(result).toEqual({ success: false, error: "transactionsNotFound" });
+    expect(getTransferById(db as any, TRANSFER_ID)).toBeNull();
+    expect(getTransactionById(db as any, ORIGINAL_TRANSACTION_ID)).toMatchObject({
+      supersededAt: null,
+      supersededByTransferId: null,
+    });
+    expect(getTransactionById(db as any, INCOMING_TRANSACTION_ID)).toMatchObject({
+      supersededAt: null,
+      supersededByTransferId: null,
+    });
+  });
+
+  it("rejects same-amount transactions from different dates", () => {
+    insertReclassificationAccounts();
+    insertOriginalTransactionRecord();
+    insertIncomingTransactionRecord();
+    insertTransaction(db as any, {
+      id: "tx-3" as TransactionId,
+      userId: USER_ID,
+      type: "income",
+      amount: 350000 as CopAmount,
+      categoryId: "income" as CategoryId,
+      description: "Transfer from checking",
+      date: "2026-04-19" as IsoDate,
+      accountId: SAVINGS_ACCOUNT_ID,
+      accountAttributionState: "confirmed",
+      createdAt: ORIGINAL_CREATED_AT,
+      updatedAt: ORIGINAL_CREATED_AT,
+      voidedAt: null,
+      supersededAt: null,
+      source: "automated",
+    });
+
+    const result = reclassifyTransactionsAsTransfer(
+      db as any,
+      {
+        userId: USER_ID,
+        outgoingTransactionId: ORIGINAL_TRANSACTION_ID,
+        incomingTransactionId: "tx-3" as TransactionId,
+        description: "Move to savings",
+      },
+      {
+        now: () => new Date(NOW),
+        createId: () => TRANSFER_ID,
+      }
+    );
+
+    expect(result).toEqual({ success: false, error: "transactionsNotReclassifiable" });
+    expect(getTransferById(db as any, TRANSFER_ID)).toBeNull();
+    expect(getTransactionById(db as any, ORIGINAL_TRANSACTION_ID)).toMatchObject({
+      supersededAt: null,
+      supersededByTransferId: null,
+    });
+    expect(getTransactionById(db as any, "tx-3" as TransactionId)).toMatchObject({
+      supersededAt: null,
+      supersededByTransferId: null,
+    });
+  });
+
+  it("rejects transactions with unresolved account attribution", () => {
+    insertReclassificationAccounts();
+    insertOriginalTransactionRecord();
+    insertTransaction(db as any, {
+      id: INCOMING_TRANSACTION_ID,
+      userId: USER_ID,
+      type: "income",
+      amount: 350000 as CopAmount,
+      categoryId: "income" as CategoryId,
+      description: "Transfer from checking",
+      date: "2026-04-18" as IsoDate,
+      accountId: SAVINGS_ACCOUNT_ID,
+      accountAttributionState: "unresolved",
+      createdAt: ORIGINAL_CREATED_AT,
+      updatedAt: ORIGINAL_CREATED_AT,
+      voidedAt: null,
+      supersededAt: null,
+      source: "automated",
+    });
+
+    const result = reclassifyTransactionsAsTransfer(
+      db as any,
+      {
+        userId: USER_ID,
+        outgoingTransactionId: ORIGINAL_TRANSACTION_ID,
+        incomingTransactionId: INCOMING_TRANSACTION_ID,
+        description: "Move to savings",
+      },
+      {
+        now: () => new Date(NOW),
+        createId: () => TRANSFER_ID,
+      }
+    );
+
+    expect(result).toEqual({ success: false, error: "transactionsNotReclassifiable" });
+    expect(getTransferById(db as any, TRANSFER_ID)).toBeNull();
+    expect(getTransactionById(db as any, ORIGINAL_TRANSACTION_ID)).toMatchObject({
+      supersededAt: null,
+      supersededByTransferId: null,
+    });
+    expect(getTransactionById(db as any, INCOMING_TRANSACTION_ID)).toMatchObject({
+      supersededAt: null,
+      supersededByTransferId: null,
+    });
+  });
+
+  it("rejects transactions whose accounts are not active accounts for the user", () => {
+    insertFinancialAccount(ACCOUNT_ID);
+    insertFinancialAccount(SAVINGS_ACCOUNT_ID, { userId: "other-user" as UserId });
+    insertOriginalTransactionRecord();
+    insertIncomingTransactionRecord();
+
+    const result = reclassifyTransactionsAsTransfer(
+      db as any,
+      {
+        userId: USER_ID,
+        outgoingTransactionId: ORIGINAL_TRANSACTION_ID,
+        incomingTransactionId: INCOMING_TRANSACTION_ID,
+        description: "Move to savings",
+      },
+      {
+        now: () => new Date(NOW),
+        createId: () => TRANSFER_ID,
+      }
+    );
+
+    expect(result).toEqual({ success: false, error: "transactionsNotReclassifiable" });
+    expect(getTransferById(db as any, TRANSFER_ID)).toBeNull();
+    expect(getTransactionById(db as any, ORIGINAL_TRANSACTION_ID)).toMatchObject({
+      supersededAt: null,
+      supersededByTransferId: null,
+    });
+    expect(getTransactionById(db as any, INCOMING_TRANSACTION_ID)).toMatchObject({
+      supersededAt: null,
+      supersededByTransferId: null,
+    });
   });
 });

--- a/apps/mobile/features/transfers/lib/reclassify-transactions-as-transfer.ts
+++ b/apps/mobile/features/transfers/lib/reclassify-transactions-as-transfer.ts
@@ -1,0 +1,176 @@
+import { and, eq, inArray, isNull } from "drizzle-orm";
+import {
+  getTransactionById,
+  markTransactionSuperseded,
+} from "@/features/transactions/transfer-reclassification.public";
+import type { AnyDb } from "@/shared/db";
+import { financialAccounts } from "@/shared/db/schema";
+import { parseIsoDate, toIsoDateTime } from "@/shared/lib/format-date";
+import { generateTransferId } from "@/shared/lib.public";
+import type {
+  FinancialAccountId,
+  IsoDateTime,
+  TransactionId,
+  TransferId,
+  UserId,
+} from "@/shared/types/branded";
+import {
+  buildTransfer,
+  type StoredTransfer,
+  type TransferBuildError,
+  toTransferRow,
+} from "./build-transfer";
+import type { TransferRow } from "./repository";
+import { saveTransfer } from "./repository";
+
+type ReclassifyTransactionsAsTransferInput = {
+  readonly userId: UserId;
+  readonly outgoingTransactionId: TransactionId;
+  readonly incomingTransactionId: TransactionId;
+  readonly description: string;
+};
+
+type ReclassifyTransactionsAsTransferDeps = {
+  readonly now?: () => Date;
+  readonly createId?: () => TransferId;
+  readonly saveTransferRow?: (db: Parameters<typeof saveTransfer>[0], row: TransferRow) => void;
+  readonly loadTransactionById?: typeof getTransactionById;
+  readonly saveTransactionRow?: typeof markTransactionSuperseded;
+  readonly canUseAccounts?: typeof canUseAccountsForReclassification;
+};
+
+export type ReclassifyTransactionsAsTransferError =
+  | TransferBuildError
+  | "transactionsNotFound"
+  | "transactionsNotReclassifiable";
+
+export type ReclassifyTransactionsAsTransferResult =
+  | { readonly success: true; readonly transfer: StoredTransfer }
+  | { readonly success: false; readonly error: ReclassifyTransactionsAsTransferError };
+
+function isActiveUserTransaction(
+  transaction: ReturnType<typeof getTransactionById>,
+  userId: UserId
+): transaction is NonNullable<ReturnType<typeof getTransactionById>> {
+  return (
+    transaction != null &&
+    transaction.userId === userId &&
+    transaction.voidedAt == null &&
+    transaction.supersededAt == null
+  );
+}
+
+const countActiveAccountsForReclassification = (
+  db: AnyDb,
+  userId: UserId,
+  accountIds: readonly [FinancialAccountId, FinancialAccountId]
+): number => {
+  return db
+    .select({ id: financialAccounts.id })
+    .from(financialAccounts)
+    .where(
+      and(
+        eq(financialAccounts.userId, userId),
+        inArray(financialAccounts.id, accountIds),
+        isNull(financialAccounts.deletedAt)
+      )
+    )
+    .all().length;
+};
+
+const canUseAccountsForReclassification = (
+  db: AnyDb,
+  userId: UserId,
+  accountIds: readonly [FinancialAccountId, FinancialAccountId]
+): boolean => {
+  return countActiveAccountsForReclassification(db, userId, accountIds) === accountIds.length;
+};
+
+function hasResolvedAccountAttribution(
+  transaction: NonNullable<ReturnType<typeof getTransactionById>>
+): boolean {
+  return transaction.accountAttributionState !== "unresolved";
+}
+
+export function reclassifyTransactionsAsTransfer(
+  db: Parameters<typeof saveTransfer>[0],
+  input: ReclassifyTransactionsAsTransferInput,
+  {
+    now = () => new Date(),
+    createId = generateTransferId,
+    saveTransferRow = saveTransfer,
+    loadTransactionById = getTransactionById,
+    saveTransactionRow = markTransactionSuperseded,
+    canUseAccounts = canUseAccountsForReclassification,
+  }: ReclassifyTransactionsAsTransferDeps = {}
+): ReclassifyTransactionsAsTransferResult {
+  const outgoing = loadTransactionById(db, input.outgoingTransactionId);
+  const incoming = loadTransactionById(db, input.incomingTransactionId);
+
+  if (
+    !isActiveUserTransaction(outgoing, input.userId) ||
+    !isActiveUserTransaction(incoming, input.userId)
+  ) {
+    return { success: false, error: "transactionsNotFound" };
+  }
+
+  if (
+    outgoing.id === incoming.id ||
+    outgoing.type !== "expense" ||
+    incoming.type !== "income" ||
+    outgoing.amount !== incoming.amount ||
+    outgoing.date !== incoming.date ||
+    !hasResolvedAccountAttribution(outgoing) ||
+    !hasResolvedAccountAttribution(incoming) ||
+    outgoing.accountId == null ||
+    incoming.accountId == null ||
+    outgoing.accountId === incoming.accountId
+  ) {
+    return { success: false, error: "transactionsNotReclassifiable" };
+  }
+
+  const accountIds = [outgoing.accountId, incoming.accountId] as const;
+  const nowDate = now();
+  const built = buildTransfer({
+    input: {
+      digits: String(outgoing.amount),
+      fromSide: { kind: "account", accountId: outgoing.accountId },
+      toSide: { kind: "account", accountId: incoming.accountId },
+      description: input.description,
+      date: parseIsoDate(outgoing.date),
+    },
+    userId: input.userId,
+    id: createId(),
+    now: nowDate,
+  });
+
+  if (!built.success) {
+    return built;
+  }
+
+  const updatedAt = toIsoDateTime(nowDate) as IsoDateTime;
+
+  const commitResult = db.transaction((tx) => {
+    if (!canUseAccounts(tx, input.userId, accountIds)) {
+      return { success: false, error: "transactionsNotReclassifiable" } as const;
+    }
+
+    saveTransferRow(tx, toTransferRow(built.transfer));
+    saveTransactionRow(tx, {
+      id: outgoing.id,
+      supersededAt: updatedAt,
+      supersededByTransferId: built.transfer.id,
+      updatedAt,
+    });
+    saveTransactionRow(tx, {
+      id: incoming.id,
+      supersededAt: updatedAt,
+      supersededByTransferId: built.transfer.id,
+      updatedAt,
+    });
+
+    return { success: true, transfer: built.transfer } as const;
+  });
+
+  return commitResult;
+}

--- a/apps/mobile/features/transfers/reclassification.public.ts
+++ b/apps/mobile/features/transfers/reclassification.public.ts
@@ -1,0 +1,10 @@
+export {
+  type ReclassifyTransactionAsTransferError,
+  type ReclassifyTransactionAsTransferResult,
+  reclassifyTransactionAsTransfer,
+} from "./lib/reclassify-transaction-as-transfer";
+export {
+  type ReclassifyTransactionsAsTransferError,
+  type ReclassifyTransactionsAsTransferResult,
+  reclassifyTransactionsAsTransfer,
+} from "./lib/reclassify-transactions-as-transfer";


### PR DESCRIPTION
- Add pair reclassification

- Preserve atomic rollback

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds atomic transfer reclassification for matched expense/income pairs, creating one transfer and superseding both in a single transaction. Keeps balances and spending unchanged and rolls back cleanly on failure (Linear #422).

- **New Features**
  - Added `reclassifyTransactionsAsTransfer` to turn an outgoing expense and incoming income into one `Transfer`.
  - Validates user ownership, same amount/date, opposite types, different accounts, active (non-deleted) accounts, and resolved account attribution; rechecks account activity at commit time.
  - Commits the transfer and supersessions atomically with rollback; exports `reclassifyTransactionAsTransfer` and `reclassifyTransactionsAsTransfer` via `features/transfers/reclassification.public.ts`; tests cover success, rollback, and aggregate invariants.

<sup>Written for commit 64d02a98d019a2bc480bbb1ea8569b47758ba1c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

