### PR TITLE
fix(mobile): route manual saves

### DIFF
--- a/apps/mobile/__tests__/local-ledger/manual-transaction-local-ledger.test.ts
+++ b/apps/mobile/__tests__/local-ledger/manual-transaction-local-ledger.test.ts
@@ -1,0 +1,106 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: boundary test uses a focused Drizzle double
+import { describe, expect, it } from "vitest";
+import { recordManualTransactionWithLocalLedger } from "@/infrastructure/local-ledger/record-transaction";
+import type { CategoryId, FinancialAccountId, TransactionId, UserId } from "@/shared/types/branded";
+
+const USER_ID = "user-1" as UserId;
+const ACCOUNT_ID = "fa-active" as FinancialAccountId;
+const TRANSACTION_ID = "tx-manual" as TransactionId;
+const NOW = new Date("2026-04-18T10:00:00.000Z");
+
+function createDbDouble(accountLookupResults: readonly boolean[]) {
+  const insertedTransactions: unknown[] = [];
+  const lookups = [...accountLookupResults];
+  const transactionCalls: unknown[] = [];
+  const db = {
+    transaction: (callback: (tx: unknown) => unknown) => {
+      transactionCalls.push(callback);
+      return callback(db);
+    },
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => ({
+            all: () => (lookups.shift() ? [{ id: "usable-account" }] : []),
+          }),
+        }),
+      }),
+    }),
+    insert: () => ({
+      values: (row: unknown) => ({
+        run: () => {
+          insertedTransactions.push(row);
+        },
+      }),
+    }),
+  };
+
+  return { db, insertedTransactions, transactionCalls };
+}
+
+describe("manual transaction Local Ledger writer", () => {
+  it("records a valid manual transaction through Local Ledger", async () => {
+    const { db, insertedTransactions, transactionCalls } = createDbDouble([true, true]);
+
+    const result = await recordManualTransactionWithLocalLedger({
+      db: db as any,
+      userId: USER_ID,
+      transactionId: TRANSACTION_ID,
+      input: {
+        type: "expense",
+        digits: "$45.200",
+        categoryId: "food" as CategoryId,
+        accountId: ACCOUNT_ID,
+        description: "  Groceries  ",
+        date: NOW,
+      },
+      now: NOW,
+    });
+
+    expect(result).toEqual({
+      success: true,
+      transaction: {
+        id: TRANSACTION_ID,
+        userId: USER_ID,
+        type: "expense",
+        amount: 45200,
+        accountId: ACCOUNT_ID,
+        accountAttributionState: "confirmed",
+        categoryId: "food",
+        description: "Groceries",
+        counterpartyName: null,
+        date: "2026-04-18",
+        createdAt: "2026-04-18T10:00:00.000Z",
+        updatedAt: "2026-04-18T10:00:00.000Z",
+        voidedAt: null,
+        supersededAt: null,
+        supersededByTransferId: null,
+        source: "manual",
+      },
+    });
+    expect(insertedTransactions).toHaveLength(1);
+    expect(transactionCalls).toHaveLength(1);
+  });
+
+  it("rechecks account usability inside the commit transaction before inserting", async () => {
+    const { db, insertedTransactions } = createDbDouble([true, false]);
+
+    const result = await recordManualTransactionWithLocalLedger({
+      db: db as any,
+      userId: USER_ID,
+      transactionId: TRANSACTION_ID,
+      input: {
+        type: "expense",
+        digits: "45200",
+        categoryId: "food" as CategoryId,
+        accountId: ACCOUNT_ID,
+        description: "Groceries",
+        date: NOW,
+      },
+      now: NOW,
+    });
+
+    expect(result).toEqual({ success: false, error: "accountNotUsable" });
+    expect(insertedTransactions).toEqual([]);
+  });
+});

--- a/apps/mobile/__tests__/transactions/mutation-service.test.ts
+++ b/apps/mobile/__tests__/transactions/mutation-service.test.ts
@@ -54,11 +54,13 @@ describe("transaction mutation service", () => {
   let trackDeleted: ServiceDeps["trackDeleted"];
   let trackEdited: ServiceDeps["trackEdited"];
   let getTransactionById: ServiceDeps["getTransactionById"];
+  let recordManualTransaction: ServiceDeps["recordManualTransaction"];
   let refreshMock: ReturnType<typeof vi.fn>;
   let resetFormMock: ReturnType<typeof vi.fn>;
   let trackDeletedMock: ReturnType<typeof vi.fn>;
   let trackEditedMock: ReturnType<typeof vi.fn>;
   let getTransactionByIdMock: ReturnType<typeof vi.fn>;
+  let recordManualTransactionMock: ReturnType<typeof vi.fn>;
 
   function createService() {
     return createTransactionMutationService({
@@ -69,6 +71,7 @@ describe("transaction mutation service", () => {
       trackDeleted,
       trackEdited,
       getTransactionById,
+      recordManualTransaction,
       now: () => now,
       createId: () => "txn-1" as TransactionId,
     });
@@ -82,11 +85,33 @@ describe("transaction mutation service", () => {
     trackDeletedMock = vi.fn<(...args: any[]) => any>();
     trackEditedMock = vi.fn<(...args: any[]) => any>();
     getTransactionByIdMock = vi.fn<(...args: any[]) => any>().mockReturnValue(null);
+    recordManualTransactionMock = vi.fn<(...args: any[]) => any>().mockResolvedValue({
+      success: true,
+      transaction: {
+        id: "txn-1" as TransactionId,
+        userId: "user-1" as UserId,
+        type: "expense",
+        amount: 1200 as CopAmount,
+        categoryId: "food" as CategoryId,
+        description: "Lunch",
+        counterpartyName: "",
+        date: now,
+        createdAt: now,
+        updatedAt: now,
+        voidedAt: null,
+        accountId: "fa-default-user-1" as FinancialAccountId,
+        accountAttributionState: "confirmed",
+        supersededAt: null,
+        supersededByTransferId: null,
+        source: "manual",
+      },
+    });
     refresh = refreshMock as ServiceDeps["refresh"];
     resetForm = resetFormMock as ServiceDeps["resetForm"];
     trackDeleted = trackDeletedMock as ServiceDeps["trackDeleted"];
     trackEdited = trackEditedMock as ServiceDeps["trackEdited"];
     getTransactionById = getTransactionByIdMock as ServiceDeps["getTransactionById"];
+    recordManualTransaction = recordManualTransactionMock as ServiceDeps["recordManualTransaction"];
   });
 
   it("returns store-not-initialized when the user is unavailable", async () => {
@@ -99,35 +124,42 @@ describe("transaction mutation service", () => {
     });
   });
 
-  it("returns build validation failures directly", async () => {
-    const service = createService();
-    const result = await service.save({
-      ...input,
-      digits: "",
+  it("returns Local Ledger validation failures directly", async () => {
+    recordManualTransactionMock.mockResolvedValueOnce({
+      success: false,
+      error: "amountNotPositive",
     });
+    const service = createService();
+    const result = await service.save({ ...input, digits: "" });
 
-    expect(result.success).toBe(false);
-    if (result.success) return;
-    expect(result.error).toEqual(expect.any(String));
+    expect(result).toEqual({ success: false, error: "amountNotPositive" });
   });
 
-  it("maps failed insert commits to a save error", async () => {
-    currentCommit = vi.fn<(...args: any[]) => any>().mockResolvedValue({
+  it("maps failed manual Local Ledger writes to a save error", async () => {
+    recordManualTransactionMock.mockResolvedValueOnce({
       success: false,
-      error: "db failed",
+      error: "accountNotUsable",
     });
+    const service = createService();
+
+    await expect(service.save(input)).resolves.toEqual({
+      success: false,
+      error: "accountNotUsable",
+    });
+  });
+
+  it("maps manual Local Ledger writer exceptions to a save error", async () => {
+    recordManualTransactionMock.mockRejectedValueOnce(new Error("sqlite locked"));
     const service = createService();
 
     await expect(service.save(input)).resolves.toEqual({
       success: false,
       error: "Failed to save transaction",
     });
+    expect(refreshMock).not.toHaveBeenCalled();
   });
 
-  it("saves valid transactions through the write-through boundary", async () => {
-    currentCommit = vi
-      .fn<(...args: any[]) => any>()
-      .mockResolvedValue({ success: true, didMutate: true });
+  it("saves valid transactions through the Local Ledger writer", async () => {
     const service = createService();
 
     const result = await service.save(input);
@@ -142,23 +174,19 @@ describe("transaction mutation service", () => {
         accountId: "fa-default-user-1",
       }),
     });
-    expect(currentCommit).toHaveBeenCalledWith(
-      expect.objectContaining({
-        kind: "transaction.save",
-        mode: "insert",
-      })
-    );
+    expect(recordManualTransactionMock).toHaveBeenCalledWith({
+      userId: "user-1",
+      transactionId: "txn-1",
+      input,
+      now,
+    });
+    expect(currentCommit).not.toHaveBeenCalled();
     expect(refreshMock).toHaveBeenCalledOnce();
   });
 
-  it("treats missing or throwing commits as save/update failures", async () => {
+  it("treats throwing update commits as update failures", async () => {
     currentCommit = null;
     const service = createService();
-
-    await expect(service.save(input)).resolves.toEqual({
-      success: false,
-      error: "Store not initialized",
-    });
 
     currentCommit = vi.fn<(...args: any[]) => any>().mockRejectedValue(new Error("boom"));
     await expect(service.updateDirect("txn-9" as TransactionId, input)).resolves.toEqual({
@@ -323,11 +351,15 @@ describe("transaction mutation service", () => {
   });
 
   it("returns a validation failure when no owning account is selected", async () => {
+    recordManualTransactionMock.mockResolvedValueOnce({
+      success: false,
+      error: "missingAccount",
+    });
     const service = createService();
 
     await expect(service.save({ ...input, accountId: null })).resolves.toEqual({
       success: false,
-      error: "Account is required",
+      error: "missingAccount",
     });
     expect(currentCommit).not.toHaveBeenCalled();
     expect(refreshMock).not.toHaveBeenCalled();

--- a/apps/mobile/__tests__/transactions/store.test.ts
+++ b/apps/mobile/__tests__/transactions/store.test.ts
@@ -39,8 +39,26 @@ vi.mock("@/features/transactions/lib/repository", () => ({
   upsertTransaction: vi.fn<(...args: any[]) => any>(),
 }));
 
+const insertedTransactionRows: unknown[] = [];
+let canUseSelectedAccount = true;
 const mockDb = {
   transaction: vi.fn<(...args: any[]) => any>((fn: (tx: unknown) => unknown) => fn(mockDb)),
+  select: () => ({
+    from: () => ({
+      where: () => ({
+        limit: () => ({
+          all: () => (canUseSelectedAccount ? [{ id: "usable-row" }] : []),
+        }),
+      }),
+    }),
+  }),
+  insert: () => ({
+    values: (row: unknown) => ({
+      run: () => {
+        insertedTransactionRows.push(row);
+      },
+    }),
+  }),
 } as unknown as AnyDb;
 const mockUserId = "user-1" as UserId;
 
@@ -96,6 +114,8 @@ function makeRow(
 describe("transaction boundaries", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    insertedTransactionRows.length = 0;
+    canUseSelectedAccount = true;
     initializeTransactionSession(mockUserId);
     useTransactionStore.getState().setDefaultAccountId("fa-default-user-1" as FinancialAccountId);
   });
@@ -165,17 +185,30 @@ describe("transaction boundaries", () => {
     expect(result.success).toBe(true);
     if (!result.success) return;
     expect(result.transaction.amount).toBe(4520);
-    expect(insertTransaction).toHaveBeenCalledWith(
-      mockDb,
+    expect(insertTransaction).not.toHaveBeenCalled();
+    expect(insertedTransactionRows).toEqual([
       expect.objectContaining({
         amount: 4520,
         categoryId: "food",
         userId: mockUserId,
         updatedAt: expect.any(String),
-      })
-    );
+      }),
+    ]);
     expect(getTransactionsPaginated).toHaveBeenCalled();
     expect(getSpendingByCategoryAggregate).toHaveBeenCalled();
+  });
+
+  it("enforces Local Ledger validation for manual transaction saves", async () => {
+    canUseSelectedAccount = false;
+    useTransactionStore.getState().setDigits("4520");
+    useTransactionStore.getState().setCategoryId("food" as CategoryId);
+
+    const result = await saveCurrentTransaction(mockDb, mockUserId);
+
+    expect(result).toEqual({ success: false, error: "accountNotUsable" });
+    expect(insertTransaction).not.toHaveBeenCalled();
+    expect(insertedTransactionRows).toEqual([]);
+    expect(getTransactionsPaginated).not.toHaveBeenCalled();
   });
 
   it("defaults to the other category when saving without a selection", async () => {

--- a/apps/mobile/features/transactions/lib/mutation-service.ts
+++ b/apps/mobile/features/transactions/lib/mutation-service.ts
@@ -21,6 +21,12 @@ type CreateTransactionMutationServiceDeps = {
   getCommit: () => WriteThroughMutationModule["commit"] | null;
   getUserId: () => UserId | null;
   getTransactionById: (id: TransactionId) => StoredTransaction | null;
+  recordManualTransaction: (input: {
+    readonly userId: UserId;
+    readonly transactionId: TransactionId;
+    readonly input: TransactionFormInput;
+    readonly now: Date;
+  }) => Promise<TransactionMutationResult>;
   refresh: () => Promise<void>;
   resetForm: () => void;
   trackDeleted: () => void;
@@ -87,6 +93,30 @@ async function commitTransaction(
   }
 }
 
+async function recordManualTransaction(
+  deps: Pick<CreateTransactionMutationServiceDeps, "recordManualTransaction">,
+  input: {
+    readonly userId: UserId;
+    readonly transactionId: TransactionId;
+    readonly form: TransactionFormInput;
+    readonly now: Date;
+  }
+): Promise<TransactionMutationResult> {
+  try {
+    return await deps.recordManualTransaction({
+      userId: input.userId,
+      transactionId: input.transactionId,
+      input: input.form,
+      now: input.now,
+    });
+  } catch (error) {
+    captureWarning("transaction_manual_record_exception", {
+      errorType: errorType(error),
+    });
+    return fail("Failed to save transaction");
+  }
+}
+
 function buildMutationTransaction(input: BuildMutationTransactionInput) {
   if (!input.userId) {
     return fail("Store not initialized");
@@ -110,29 +140,23 @@ export function createTransactionMutationService(
 
   return {
     save: async (input) => {
-      const built = buildMutationTransaction({
-        form: input,
-        userId: deps.getUserId(),
-        transactionId: createId(),
-        now: now(),
-        existing: null,
-      });
-      if (!built.success) {
-        return built;
+      const userId = deps.getUserId();
+      if (!userId) {
+        return fail("Store not initialized");
       }
 
-      const committed = await commitTransaction(
-        deps.getCommit(),
-        "insert",
-        built.transaction,
-        "Failed to save transaction"
-      );
-      if (!committed.success) {
-        return committed;
+      const result = await recordManualTransaction(deps, {
+        userId,
+        transactionId: createId(),
+        form: input,
+        now: now(),
+      });
+      if (!result.success) {
+        return result;
       }
 
       await deps.refresh();
-      return { success: true, transaction: built.transaction };
+      return result;
     },
 
     update: async (id, input) => {

--- a/apps/mobile/features/transactions/store.ts
+++ b/apps/mobile/features/transactions/store.ts
@@ -1,15 +1,18 @@
 import { createWriteThroughMutationModule } from "@/mutations";
 import type { AnyDb } from "@/shared/db";
 import {
+  captureWarning,
   generateTransactionId,
   trackTransactionDeleted,
   trackTransactionEdited,
 } from "@/shared/lib";
+import { recordManualTransactionWithLocalLedger } from "@/infrastructure/local-ledger/record-transaction";
 import type { CategoryId, FinancialAccountId, TransactionId, UserId } from "@/shared/types/branded";
 import {
   createTransactionMutationService,
   type TransactionMutationResult,
 } from "./lib/mutation-service";
+import { toStoredTransaction } from "./lib/build-transaction";
 import type { StoredTransaction, TransactionType } from "./schema";
 import { createTransactionQueryService } from "./services/create-transaction-query-service";
 import { toTransactionFormInput } from "./store/form-input";
@@ -47,6 +50,9 @@ function isCurrentTransactionsRequest(
   return loadTransactionsRequestId === requestId && isActiveTransactionSession(userId, sessionId);
 }
 
+const getErrorType = (error: unknown): string =>
+  error instanceof Error ? error.name : typeof error;
+
 function createLiveTransactionMutationService(db: AnyDb, userId: UserId, sessionId: number) {
   const mutations = createWriteThroughMutationModule(db);
 
@@ -54,6 +60,18 @@ function createLiveTransactionMutationService(db: AnyDb, userId: UserId, session
     getCommit: () => mutations.commit,
     getUserId: () => userId,
     getTransactionById: (id) => getStoredTransactionById(db, userId, id),
+    recordManualTransaction: async (input) => {
+      const result = await recordManualTransactionWithLocalLedger({
+        db,
+        userId: input.userId,
+        transactionId: input.transactionId,
+        input: input.input,
+        now: input.now,
+      });
+      return result.success
+        ? { success: true, transaction: toStoredTransaction(result.transaction) }
+        : result;
+    },
     refresh: async () => {
       if (!isActiveTransactionSession(userId, sessionId)) return;
       await refreshTransactions(db, userId);
@@ -145,8 +163,10 @@ export async function refreshTransactions(db: AnyDb, userId: UserId): Promise<vo
     });
     if (!isCurrentTransactionsRequest(requestId, userId, sessionId)) return;
     useTransactionStore.getState().applyRefreshSnapshot(snapshot);
-  } catch {
-    // Refresh failed — keep existing state
+  } catch (error) {
+    captureWarning("transactions_refresh_failed", {
+      errorType: getErrorType(error),
+    });
   }
 }
 

--- a/apps/mobile/infrastructure/local-ledger/record-transaction.ts
+++ b/apps/mobile/infrastructure/local-ledger/record-transaction.ts
@@ -1,0 +1,154 @@
+import { and, eq, isNull } from "drizzle-orm";
+import {
+  recordTransaction,
+  type LocalLedgerEntryId,
+  type RecordTransactionAccepted,
+  type RecordTransactionRejectCode,
+} from "@/local-ledger/public";
+import { getBuiltInCategoryId, isValidCategoryId } from "@/shared/categories";
+import type { AnyDb } from "@/shared/db";
+import { financialAccounts, transactions, userCategories } from "@/shared/db/schema";
+import { parseDigitsToAmount, toIsoDate, toIsoDateTime } from "@/shared/lib";
+import type { CategoryId, FinancialAccountId, TransactionId, UserId } from "@/shared/types/branded";
+import { toTransactionStorageRow } from "./transaction-storage";
+
+type ManualTransactionInput = {
+  readonly type: "expense" | "income";
+  readonly digits: string;
+  readonly categoryId: CategoryId | null;
+  readonly accountId: FinancialAccountId | null;
+  readonly description: string;
+  readonly date: Date;
+};
+
+type RecordManualTransactionInput = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly transactionId: TransactionId;
+  readonly input: ManualTransactionInput;
+  readonly now: Date;
+};
+
+type CommitPolicyRejection = {
+  readonly ok: false;
+  readonly code: "account-not-usable" | "category-not-usable";
+};
+
+export type RecordManualTransactionResult =
+  | { readonly success: true; readonly transaction: typeof transactions.$inferInsert }
+  | { readonly success: false; readonly error: RecordManualTransactionError };
+
+export type RecordManualTransactionError =
+  | "accountNotUsable"
+  | "amountNotPositive"
+  | "categoryNotUsable"
+  | "futureDatedTransaction"
+  | "missingAccount"
+  | "missingCategory"
+  | "manualSourceRequiresResolvedAccount";
+
+const rejectionErrorMap: Record<RecordTransactionRejectCode, RecordManualTransactionError> = {
+  "account-not-usable": "accountNotUsable",
+  "category-not-usable": "categoryNotUsable",
+  "future-dated-transaction": "futureDatedTransaction",
+  "manual-source-requires-resolved-account": "manualSourceRequiresResolvedAccount",
+  "missing-account": "missingAccount",
+  "missing-category": "missingCategory",
+  "non-positive-amount": "amountNotPositive",
+};
+
+function hasActiveFinancialAccount(db: AnyDb, userId: UserId, accountId: FinancialAccountId) {
+  const rows = db
+    .select({ id: financialAccounts.id })
+    .from(financialAccounts)
+    .where(
+      and(
+        eq(financialAccounts.id, accountId),
+        eq(financialAccounts.userId, userId),
+        isNull(financialAccounts.deletedAt)
+      )
+    )
+    .limit(1)
+    .all();
+  return rows.length > 0;
+}
+
+function hasUsableCategory(db: AnyDb, userId: UserId, categoryId: CategoryId) {
+  if (isValidCategoryId(categoryId)) return true;
+
+  const rows = db
+    .select({ id: userCategories.id })
+    .from(userCategories)
+    .where(
+      and(
+        eq(userCategories.id, categoryId),
+        eq(userCategories.userId, userId),
+        isNull(userCategories.deletedAt)
+      )
+    )
+    .limit(1)
+    .all();
+  return rows.length > 0;
+}
+
+function getCommitPolicyRejection(
+  db: AnyDb,
+  transaction: RecordTransactionAccepted
+): CommitPolicyRejection | null {
+  if (!hasActiveFinancialAccount(db, transaction.userId, transaction.accountId)) {
+    return { ok: false, code: "account-not-usable" };
+  }
+
+  if (!hasUsableCategory(db, transaction.userId, transaction.categoryId)) {
+    return { ok: false, code: "category-not-usable" };
+  }
+
+  return null;
+}
+
+export async function recordManualTransactionWithLocalLedger({
+  db,
+  userId,
+  transactionId,
+  input,
+  now,
+}: RecordManualTransactionInput): Promise<RecordManualTransactionResult> {
+  const nowIso = toIsoDateTime(now);
+  const categoryId = input.categoryId ?? getBuiltInCategoryId("other");
+  const result = await recordTransaction({
+    command: {
+      userId,
+      type: input.type,
+      amount: parseDigitsToAmount(input.digits),
+      accountId: input.accountId,
+      accountAttributionState: "confirmed",
+      categoryId,
+      occurredOn: toIsoDate(input.date),
+      description: input.description,
+      counterpartyName: null,
+      source: "manual",
+    },
+    ports: {
+      canUseAccount: async ({ accountId }) => hasActiveFinancialAccount(db, userId, accountId),
+      canUseCategory: async ({ categoryId }) => hasUsableCategory(db, userId, categoryId),
+      commit: async (transaction) =>
+        db.transaction((tx) => {
+          const policyRejection = getCommitPolicyRejection(tx, transaction);
+          if (policyRejection) return policyRejection;
+
+          const row = toTransactionStorageRow({ transaction, now: nowIso });
+          tx.insert(transactions).values(row).run();
+          return { ok: true, transaction };
+        }),
+      generateEntryId: () => transactionId as string as LocalLedgerEntryId,
+      today: () => toIsoDate(now),
+    },
+  });
+
+  return result.ok
+    ? {
+        success: true,
+        transaction: toTransactionStorageRow({ transaction: result.transaction, now: nowIso }),
+      }
+    : { success: false, error: rejectionErrorMap[result.code] };
+}


### PR DESCRIPTION
- Local Ledger manual writes
- Save exception fallback
- Commit-time policy checks



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route manual transaction saves through the Local Ledger with commit-time policy checks and clearer error handling. This improves validation and prevents invalid inserts on mobile.

- **New Features**
  - Added a Local Ledger writer that validates input and rechecks account/category usability at commit.
  - Maps Local Ledger rejections to app errors (e.g., accountNotUsable, missingAccount, missingCategory, amountNotPositive, futureDatedTransaction).
  - Mutation service now uses the Local Ledger writer and refreshes state on success.

- **Bug Fixes**
  - Catches writer exceptions and returns "Failed to save transaction" without refreshing.
  - Prevents inserts when the selected account or category is not usable at commit time.
  - Adds tests for the manual writer, mutation service, and store boundary.

<sup>Written for commit b1a3ad29700461d9a648eb129525e53eed7c369d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

