### PR TITLE
feat(mobile): migrate email intake

### DIFF
--- a/apps/mobile/__tests__/backup/local-ledger-snapshot.test.ts
+++ b/apps/mobile/__tests__/backup/local-ledger-snapshot.test.ts
@@ -571,7 +571,7 @@ describe("local ledger backup snapshots", () => {
     });
   });
 
-  it("rejects legacy transaction rows with unsupported source values", () => {
+  it("normalizes legacy non-manual transaction source values as automated", () => {
     const legacyTransaction = {
       ...withoutKeys(transactionRow({ source: "email_gmail" }), [
         "counterpartyName",
@@ -581,15 +581,15 @@ describe("local ledger backup snapshots", () => {
       deletedAt: null,
     };
 
-    expect(() =>
-      validateBackupSnapshot(
-        validSnapshot({
-          userCategories: [userCategoryRow()],
-          financialAccounts: [rollbackAccountRow()],
-          transactions: [legacyTransaction],
-        })
-      )
-    ).toThrow("Malformed local ledger backup row: source is not supported");
+    const snapshot = validateBackupSnapshot(
+      validSnapshot({
+        userCategories: [userCategoryRow()],
+        financialAccounts: [rollbackAccountRow()],
+        transactions: [legacyTransaction],
+      })
+    );
+
+    expect(snapshot.data.transactions[0]).toEqual(expect.objectContaining({ source: "automated" }));
   });
 
   it("rejects duplicate primary IDs inside backed-up collections", () => {

--- a/apps/mobile/__tests__/capture-sources/dedup.test.ts
+++ b/apps/mobile/__tests__/capture-sources/dedup.test.ts
@@ -104,8 +104,10 @@ describe("findDuplicateTransaction", () => {
     mockWhere.mockResolvedValue([]);
   });
 
-  it("returns transaction ID when match found (same amount + date + normalized merchant)", async () => {
-    mockWhere.mockResolvedValueOnce([{ id: "tx-1", description: "Uber Eats" }]);
+  it("returns transaction ID when counterparty match found (same amount + date + normalized merchant)", async () => {
+    mockWhere.mockResolvedValueOnce([
+      { id: "tx-1", description: "Dinner with Ana", counterpartyName: "Uber Eats" },
+    ]);
 
     const { findDuplicateTransaction } = await import("@/features/capture-sources/lib/dedup");
     const result = await findDuplicateTransaction({
@@ -135,7 +137,9 @@ describe("findDuplicateTransaction", () => {
   });
 
   it("handles merchant normalization (case insensitive, trimmed)", async () => {
-    mockWhere.mockResolvedValueOnce([{ id: "tx-2", description: "  UBER   EATS  " }]);
+    mockWhere.mockResolvedValueOnce([
+      { id: "tx-2", description: "Lunch", counterpartyName: "  UBER   EATS  " },
+    ]);
 
     const { findDuplicateTransaction } = await import("@/features/capture-sources/lib/dedup");
     const result = await findDuplicateTransaction({
@@ -150,7 +154,9 @@ describe("findDuplicateTransaction", () => {
   });
 
   it("returns null when amount+date match but merchant differs", async () => {
-    mockWhere.mockResolvedValueOnce([{ id: "tx-3", description: "Starbucks" }]);
+    mockWhere.mockResolvedValueOnce([
+      { id: "tx-3", description: "Coffee", counterpartyName: "Starbucks" },
+    ]);
 
     const { findDuplicateTransaction } = await import("@/features/capture-sources/lib/dedup");
     const result = await findDuplicateTransaction({
@@ -165,7 +171,9 @@ describe("findDuplicateTransaction", () => {
   });
 
   it("matches when DB description contains the incoming merchant (substring)", async () => {
-    mockWhere.mockResolvedValueOnce([{ id: "tx-sub-1", description: "BOLD Natural Medical" }]);
+    mockWhere.mockResolvedValueOnce([
+      { id: "tx-sub-1", description: "Checkup", counterpartyName: "BOLD Natural Medical" },
+    ]);
 
     const { findDuplicateTransaction } = await import("@/features/capture-sources/lib/dedup");
     const result = await findDuplicateTransaction({
@@ -180,7 +188,9 @@ describe("findDuplicateTransaction", () => {
   });
 
   it("matches when incoming merchant contains the DB description (substring)", async () => {
-    mockWhere.mockResolvedValueOnce([{ id: "tx-sub-2", description: "HARISSA" }]);
+    mockWhere.mockResolvedValueOnce([
+      { id: "tx-sub-2", description: "Dinner", counterpartyName: "HARISSA" },
+    ]);
 
     const { findDuplicateTransaction } = await import("@/features/capture-sources/lib/dedup");
     const result = await findDuplicateTransaction({
@@ -195,7 +205,9 @@ describe("findDuplicateTransaction", () => {
   });
 
   it("does not substring-match when DB description is very short (< 3 chars)", async () => {
-    mockWhere.mockResolvedValueOnce([{ id: "tx-short", description: "AB" }]);
+    mockWhere.mockResolvedValueOnce([
+      { id: "tx-short", description: "Note", counterpartyName: "AB" },
+    ]);
 
     const { findDuplicateTransaction } = await import("@/features/capture-sources/lib/dedup");
     const result = await findDuplicateTransaction({
@@ -211,6 +223,54 @@ describe("findDuplicateTransaction", () => {
 
   it("handles null description in DB row without false match", async () => {
     mockWhere.mockResolvedValueOnce([{ id: "tx-null", description: null }]);
+
+    const { findDuplicateTransaction } = await import("@/features/capture-sources/lib/dedup");
+    const result = await findDuplicateTransaction({
+      db: mockDb,
+      userId: "user-1",
+      amount: 5000,
+      date: "2026-03-07",
+      merchant: "Uber Eats",
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null without querying when incoming merchant is empty", async () => {
+    const { findDuplicateTransaction } = await import("@/features/capture-sources/lib/dedup");
+    const result = await findDuplicateTransaction({
+      db: mockDb,
+      userId: "user-1",
+      amount: 5000,
+      date: "2026-03-07",
+      merchant: "   ",
+    });
+
+    expect(result).toBeNull();
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it("does not match amount and date when stored counterparty is empty", async () => {
+    mockWhere.mockResolvedValueOnce([
+      { id: "tx-empty-counterparty", description: null, counterpartyName: "   " },
+    ]);
+
+    const { findDuplicateTransaction } = await import("@/features/capture-sources/lib/dedup");
+    const result = await findDuplicateTransaction({
+      db: mockDb,
+      userId: "user-1",
+      amount: 5000,
+      date: "2026-03-07",
+      merchant: "Uber Eats",
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("does not match user-authored description when counterparty is missing", async () => {
+    mockWhere.mockResolvedValueOnce([
+      { id: "tx-description-only", description: "Uber Eats", counterpartyName: null },
+    ]);
 
     const { findDuplicateTransaction } = await import("@/features/capture-sources/lib/dedup");
     const result = await findDuplicateTransaction({

--- a/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
@@ -16,6 +16,9 @@ const mockGetProcessedExternalIds = vi
   .mockResolvedValue(new Set<string>());
 const mockInsertProcessedEmail = vi.fn<(...args: any[]) => any>();
 const mockInsertTransaction = vi.fn<(...args: any[]) => any>();
+const mockRecordTransaction = vi.fn<(...args: any[]) => any>();
+const mockCreateReviewCandidate = vi.fn<(...args: any[]) => any>();
+const mockWriteThroughCommit = vi.fn<(...args: any[]) => any>();
 const mockLookupMerchantRule = vi.fn<(...args: any[]) => any>().mockResolvedValue(null);
 const mockInsertMerchantRule = vi.fn<(...args: any[]) => any>();
 const mockParseEmailApi = vi.fn<(...args: any[]) => any>().mockResolvedValue(null);
@@ -76,6 +79,22 @@ vi.mock("@/features/capture-sources/lib/dedup", () => ({
   findDuplicateTransaction: (...args: unknown[]) => mockFindDuplicateTransaction(...args),
 }));
 
+vi.mock("@/local-ledger/public", () => ({
+  createReviewCandidateUseCase:
+    ({ commit }: { commit: (command: unknown) => Promise<unknown> }) =>
+    async (input: unknown) => {
+      await commit({ type: "test-review-candidate" });
+      return { success: true, candidate: input };
+    },
+  recordTransaction: (...args: unknown[]) => mockRecordTransaction(...args),
+}));
+
+vi.mock("@/mutations", () => ({
+  createWriteThroughMutationModule: (db: unknown) => ({
+    commit: (command: unknown) => mockWriteThroughCommit(db, command),
+  }),
+}));
+
 vi.mock("@/features/email-capture/lib/repository", () => ({
   getProcessedExternalIds: (...args: unknown[]) => mockGetProcessedExternalIds(...args),
   insertProcessedEmail: (...args: unknown[]) => mockInsertProcessedEmail(...args),
@@ -124,11 +143,18 @@ vi.mock("@/shared/lib/generate-id", () => ({
   generateId: (...args: unknown[]) => mockGenerateId(...args),
   generateTransactionId: () => mockGenerateId("tx"),
   generateProcessedEmailId: () => mockGenerateId("pe"),
+  generateCaptureEvidenceId: () => mockGenerateId("ce"),
+  generateProcessedSourceEventId: () => mockGenerateId("pse"),
+  generateReviewCandidateId: () => mockGenerateId("rc"),
+  generateReviewCandidateCaptureEvidenceId: () => mockGenerateId("rce"),
 }));
 
 const mockDb = {} as any;
 const USER_ID = requireUserId("user-1");
 let idCounter = 0;
+
+const normalizeLedgerText = (value: string | null | undefined) =>
+  (value ?? "").trim().slice(0, 200);
 
 function makeRawEmail(overrides: Partial<RawEmail> = {}): RawEmail {
   return {
@@ -166,6 +192,25 @@ function resetPipelineMocks() {
   mockGetProcessedExternalIds.mockResolvedValue(new Set<string>());
   mockInsertProcessedEmail.mockResolvedValue(undefined);
   mockInsertTransaction.mockResolvedValue(undefined);
+  mockRecordTransaction.mockImplementation(async ({ ports, command }) => {
+    const transaction = {
+      id: ports.generateEntryId(),
+      userId: command.userId,
+      type: command.type,
+      amount: command.amount,
+      accountId: command.accountId,
+      accountAttributionState: command.accountAttributionState,
+      categoryId: command.categoryId,
+      occurredOn: command.occurredOn,
+      description: normalizeLedgerText(command.description),
+      counterpartyName: normalizeLedgerText(command.counterpartyName),
+      source: command.source,
+    };
+    await ports.commit(transaction);
+    return { ok: true, transaction, events: [] };
+  });
+  mockCreateReviewCandidate.mockResolvedValue({ success: true });
+  mockWriteThroughCommit.mockResolvedValue(undefined);
   mockLookupMerchantRule.mockResolvedValue(null);
   mockInsertMerchantRule.mockResolvedValue(undefined);
   mockParseEmailApi.mockResolvedValue(null);
@@ -213,6 +258,8 @@ function createTestEmailPipelineService(overrides: Record<string, unknown> = {})
     saveCaptureEvidenceRows: mockSaveCaptureEvidenceRows,
     linkCaptureEvidenceToTransaction: mockLinkCaptureEvidenceToTransaction,
     insertTransaction: mockInsertTransaction,
+    recordTransaction: mockRecordTransaction,
+    createReviewCandidate: mockCreateReviewCandidate,
     insertMerchantRule: mockInsertMerchantRule,
     trackTransactionCreated: vi.fn<(...args: any[]) => any>(),
     ...overrides,
@@ -292,8 +339,7 @@ function expectProgressIncludesNeedsReview(
   expect(progressCalls[0]).toEqual(
     expect.objectContaining({ total: 2, completed: 0, saved: 0, failed: 0, needsReview: 0 })
   );
-  expect(progressCalls[1]?.needsReview).toBe(1);
-  expect(progressCalls[1]?.saved).toBe(0);
+  expect(progressCalls.some((progress) => progress.needsReview === 1)).toBe(true);
   expect(progressCalls.at(-1)?.needsReview).toBe(1);
   expect(progressCalls.at(-1)?.saved).toBe(1);
 }
@@ -467,7 +513,7 @@ describe("email processing pipeline", () => {
     const emails = [makeRawEmail()];
     const trackTransactionCreated = vi.fn<(...args: any[]) => any>();
     const service = createTestEmailPipelineService({ trackTransactionCreated });
-    mockParseEmailApi.mockResolvedValueOnce(makeParsedEmailResult());
+    mockParseEmailApi.mockResolvedValueOnce(makeParsedEmailResult({ counterpartyHint: "   " }));
 
     const result = await service.processEmails(mockDb, USER_ID, emails);
 
@@ -480,7 +526,9 @@ describe("email processing pipeline", () => {
       amount: 50000,
       accountId: "fa-default-user-1",
       accountAttributionState: "unresolved",
-      source: "email_gmail",
+      description: null,
+      counterpartyName: "Compra en Exito",
+      source: "automated",
     });
     expectProcessedEmailSaved({
       externalId: "ext-1",
@@ -494,6 +542,9 @@ describe("email processing pipeline", () => {
       "compra en exito",
       "other",
       expect.any(String)
+    );
+    expect(mockFindDuplicateTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({ merchant: "Compra en Exito" })
     );
     expect(trackTransactionCreated).toHaveBeenCalledWith({
       type: "expense",
@@ -575,6 +626,32 @@ describe("email processing pipeline", () => {
 
     expect(result.needsReview).toBe(1);
     expect(trackTransactionCreated).not.toHaveBeenCalled();
+  });
+
+  it("persists review candidates and processed email markers in one database transaction", async () => {
+    const txDb = { tx: true };
+    const dbWithTransaction = {
+      transaction: vi.fn<(...args: any[]) => any>((operation: (tx: unknown) => unknown) =>
+        operation(txDb)
+      ),
+    } as any;
+    mockParseEmailApi.mockResolvedValueOnce(makeParsedEmailResult({ confidence: 0.5 }));
+
+    const result = await processEmails(dbWithTransaction, USER_ID, [makeRawEmail()]);
+
+    expect(result.needsReview).toBe(1);
+    expect(dbWithTransaction.transaction).toHaveBeenCalledTimes(1);
+    expect(mockWriteThroughCommit).toHaveBeenCalledWith(
+      txDb,
+      expect.objectContaining({ type: "test-review-candidate" })
+    );
+    expect(mockInsertProcessedEmail).toHaveBeenCalledWith(
+      txDb,
+      expect.objectContaining({
+        externalId: "ext-1",
+        status: "needs_review",
+      })
+    );
   });
 
   it("does not report saved when a bundled async write rejects", async () => {
@@ -709,7 +786,9 @@ describe("email processing pipeline", () => {
     pendingParses[0]?.(null);
     await vi.waitFor(() => expect(parseStarts).toContain("parse:Compra 16"));
 
-    pendingParses.slice(1).forEach((resolve) => resolve(null));
+    pendingParses.slice(1).forEach((resolve) => {
+      resolve(null);
+    });
     await processing;
   }
 
@@ -747,7 +826,7 @@ describe("email processing pipeline", () => {
       id: string;
       amount: number;
       date: string;
-      description: string;
+      counterpartyName: string;
     }> = [];
     let releaseFirstInsert!: () => void;
     const firstInsertStarted = new Promise<void>((resolve) => {
@@ -763,7 +842,7 @@ describe("email processing pipeline", () => {
           id: row.id,
           amount: row.amount,
           date: row.date,
-          description: row.description,
+          counterpartyName: row.counterpartyName,
         });
       });
     });
@@ -776,7 +855,7 @@ describe("email processing pipeline", () => {
         (transaction) =>
           transaction.amount === amount &&
           transaction.date === date &&
-          transaction.description === merchant
+          transaction.counterpartyName === merchant
       );
 
       return existing?.id ?? null;
@@ -880,7 +959,7 @@ describe("email processing pipeline", () => {
     });
   });
 
-  it("saves transaction as needs_review when LLM returns low confidence", async () => {
+  it("creates a review candidate without committing a transaction when LLM returns low confidence", async () => {
     const emails = [makeRawEmail()];
     mockParseEmailApi.mockResolvedValueOnce({
       type: "expense",
@@ -891,17 +970,37 @@ describe("email processing pipeline", () => {
       confidence: 0.5,
     });
 
-    const result = await processEmails(mockDb, USER_ID, emails);
+    const result = await createTestEmailPipelineService().processEmails(mockDb, USER_ID, emails);
 
     expect(result.needsReview).toBe(1);
     expect(result.saved).toBe(0);
     expect(result.failed).toBe(0);
-    expect(mockInsertTransaction).toHaveBeenCalled();
+    expect(mockInsertTransaction).not.toHaveBeenCalled();
+    expect(mockRecordTransaction).not.toHaveBeenCalled();
+    expect(mockCreateReviewCandidate).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        source: expect.objectContaining({
+          sourceFamily: "email",
+          sourceId: "email_gmail",
+          sourceEventId: "ext-1",
+          status: "needs_review",
+        }),
+        candidate: expect.objectContaining({
+          candidateKind: "transaction",
+          status: "pending",
+          money: { amount: 50000, currency: "COP" },
+          description: null,
+          confidence: 0.5,
+        }),
+      })
+    );
     expect(mockInsertProcessedEmail).toHaveBeenCalledWith(
       mockDb,
       expect.objectContaining({
         externalId: "ext-1",
         status: "needs_review",
+        transactionId: null,
         confidence: 0.5,
       })
     );
@@ -916,6 +1015,37 @@ describe("email processing pipeline", () => {
         parseMethod: "llm",
       },
     ]);
+  });
+
+  it("uses the production email-pipeline review candidate adapter for low-confidence emails", async () => {
+    const emails = [makeRawEmail()];
+    mockParseEmailApi.mockResolvedValueOnce({
+      type: "expense",
+      amount: 50000,
+      categoryId: "other",
+      description: "Compra en Exito",
+      date: "2026-03-05",
+      confidence: 0.5,
+    });
+
+    const result = await processEmails(mockDb, USER_ID, emails);
+
+    expect(result.needsReview).toBe(1);
+    expect(mockWriteThroughCommit).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        type: "test-review-candidate",
+      })
+    );
+    expect(mockInsertProcessedEmail).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        externalId: "ext-1",
+        status: "needs_review",
+        transactionId: null,
+        confidence: 0.5,
+      })
+    );
   });
 
   it("uses typed LLM account hints as capture evidence for account suggestions", async () => {
@@ -941,6 +1071,7 @@ describe("email processing pipeline", () => {
       amount: 50000,
       categoryId: "other",
       description: "Compra en Exito",
+      counterpartyHint: "   ",
       date: "2026-03-05",
       confidence: 0.8,
     });
@@ -1008,7 +1139,26 @@ describe("email processing pipeline", () => {
     expect(result.saved).toBe(1);
     expect(mockInsertTransaction).toHaveBeenCalledWith(
       mockDb,
-      expect.objectContaining({ source: "email_outlook" })
+      expect.objectContaining({ source: "automated", counterpartyName: "Deposito" })
+    );
+  });
+
+  it("stores the local-ledger accepted counterparty value", async () => {
+    const longCounterparty = "Counterparty ".repeat(30);
+    mockParseEmailApi.mockResolvedValueOnce(
+      makeParsedEmailResult({
+        description: "Parser description",
+        counterpartyHint: longCounterparty,
+      })
+    );
+
+    await processEmails(mockDb, USER_ID, [makeRawEmail()]);
+
+    expect(mockInsertTransaction).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        counterpartyName: longCounterparty.trim().slice(0, 200),
+      })
     );
   });
 
@@ -1173,7 +1323,9 @@ describe("email processing pipeline", () => {
       needsReview: number;
     }[] = [];
 
-    await processEmails(mockDb, USER_ID, emails, (p) => progressCalls.push(p));
+    await createTestEmailPipelineService().processEmails(mockDb, USER_ID, emails, (p) =>
+      progressCalls.push(p)
+    );
 
     expectProgressIncludesNeedsReview(progressCalls);
   });
@@ -1250,6 +1402,24 @@ describe("processRetries", () => {
     mockMarkPermanentlyFailed.mockResolvedValue(undefined);
     mockMarkRetrySuccess.mockResolvedValue(undefined);
     mockInsertTransaction.mockResolvedValue(undefined);
+    mockRecordTransaction.mockImplementation(async ({ ports, command }) => {
+      const transaction = {
+        id: ports.generateEntryId(),
+        userId: command.userId,
+        type: command.type,
+        amount: command.amount,
+        accountId: command.accountId,
+        accountAttributionState: command.accountAttributionState,
+        categoryId: command.categoryId,
+        occurredOn: command.occurredOn,
+        description: command.description ?? "",
+        counterpartyName: normalizeLedgerText(command.counterpartyName),
+        source: command.source,
+      };
+      await ports.commit(transaction);
+      return { ok: true, transaction, events: [] };
+    });
+    mockCreateReviewCandidate.mockResolvedValue({ success: true });
     mockLookupMerchantRule.mockResolvedValue(null);
     mockInsertMerchantRule.mockResolvedValue(undefined);
     mockParseEmailApi.mockResolvedValue(null);
@@ -1277,7 +1447,8 @@ describe("processRetries", () => {
       type: "expense",
       amount: 50000,
       categoryId: "other",
-      description: "Compra en Exito",
+      description: "Compra con tarjeta terminada en 1234",
+      counterpartyHint: "Exito",
       date: "2026-03-05",
       confidence: 0.9,
     });
@@ -1299,7 +1470,7 @@ describe("processRetries", () => {
     expect(mockInsertMerchantRule).toHaveBeenCalledWith(
       mockDb,
       USER_ID,
-      "compra en exito",
+      "exito",
       "other",
       expect.any(String)
     );
@@ -1336,7 +1507,7 @@ describe("processRetries", () => {
     );
   });
 
-  it("marks as needs_review when confidence < 0.7 on retry", async () => {
+  it("creates a review candidate without a transaction when confidence < 0.7 on retry", async () => {
     const row = makePendingRetryRow();
     const trackTransactionCreated = vi.fn<(...args: any[]) => any>();
     const service = createTestEmailPipelineService({ trackTransactionCreated });
@@ -1352,15 +1523,35 @@ describe("processRetries", () => {
 
     await service.processRetries(mockDb, USER_ID);
 
+    expect(mockInsertTransaction).not.toHaveBeenCalled();
+    expect(mockCreateReviewCandidate).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        source: expect.objectContaining({
+          sourceFamily: "email",
+          sourceId: "email_gmail",
+          sourceEventId: "ext-retry-1",
+          status: "needs_review",
+        }),
+        candidate: expect.objectContaining({
+          candidateKind: "transaction",
+          status: "pending",
+          money: { amount: 50000, currency: "COP" },
+          description: null,
+          confidence: 0.5,
+        }),
+      })
+    );
     expect(mockMarkRetrySuccess).toHaveBeenCalledWith(
       expect.objectContaining({
         db: mockDb,
         id: "pe-retry-1",
         status: "needs_review",
-        transactionId: expect.stringMatching(/^tx-/),
+        transactionId: null,
         confidence: 0.5,
       })
     );
+    expect(mockLinkCaptureEvidenceToTransaction).not.toHaveBeenCalled();
     expect(mockInsertMerchantRule).not.toHaveBeenCalled();
     expect(trackTransactionCreated).not.toHaveBeenCalled();
   });

--- a/apps/mobile/features/backup/local-ledger-snapshot-legacy.ts
+++ b/apps/mobile/features/backup/local-ledger-snapshot-legacy.ts
@@ -1,3 +1,4 @@
+import { normalizeTransactionSource } from "@/shared/lib/transaction-source";
 import type { BackupSnapshot, LocalLedgerBackupSnapshotData } from "./local-ledger-snapshot";
 import type { BackupDataKey } from "./local-ledger-snapshot-row-shape";
 
@@ -54,5 +55,5 @@ const legacyTransactionTextDefaults = (row: TransactionRow) => ({
 
 const legacyTransactionStateDefaults = (row: TransactionRow, deletedAt: unknown) => ({
   voidedAt: (row.voidedAt ?? deletedAt ?? null) as TransactionRow["voidedAt"],
-  source: row.source ?? "manual",
+  source: normalizeTransactionSource(row.source),
 });

--- a/apps/mobile/features/capture-sources/lib/dedup.ts
+++ b/apps/mobile/features/capture-sources/lib/dedup.ts
@@ -51,10 +51,13 @@ export async function findDuplicateTransaction(
   assertCopAmount(input.amount);
   assertIsoDate(input.date);
   const normalized = normalizeMerchant(input.merchant);
+  if (normalized.length === 0) return null;
+
   const rows = await input.db
     .select({
       id: transactions.id,
       description: transactions.description,
+      counterpartyName: transactions.counterpartyName,
     })
     .from(transactions)
     .where(
@@ -66,8 +69,8 @@ export async function findDuplicateTransaction(
     );
 
   const match = rows.find((row) => {
-    const desc = normalizeMerchant(row.description ?? "");
-    return merchantsMatch(desc, normalized);
+    const desc = normalizeMerchant(row.counterpartyName ?? "");
+    return desc.length > 0 && merchantsMatch(desc, normalized);
   });
 
   return match?.id ?? null;

--- a/apps/mobile/features/email-capture/lib/repository.ts
+++ b/apps/mobile/features/email-capture/lib/repository.ts
@@ -27,7 +27,7 @@ type RetrySuccessInput = {
   readonly db: AnyDb;
   readonly id: ProcessedEmailId;
   readonly status: "success" | "needs_review";
-  readonly transactionId: TransactionId;
+  readonly transactionId: TransactionId | null;
   readonly confidence: number;
 };
 

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-parsed-helpers.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-parsed-helpers.ts
@@ -2,7 +2,7 @@ import { currentIsoDateTimeEffect } from "@/shared/effect/clock";
 import { captureErrorEffect } from "@/shared/effect/telemetry";
 import { normalizeMerchant } from "@/shared/lib/normalize-merchant";
 import { findDuplicateTransactionEffect, insertMerchantRuleEffect } from "./runtime";
-import { getPersistedCategoryId } from "./shared";
+import { getParsedCounterpartyName, getPersistedCategoryId } from "./shared";
 import type { DuplicateLookupOutcome, EmailBatchContext, LlmParsedTransaction } from "./types";
 
 export async function lookupIncomingDuplicate(
@@ -30,7 +30,7 @@ export async function cacheMerchantRule(input: {
       insertMerchantRuleEffect({
         db: input.context.db,
         userId: input.context.userId,
-        merchantKey: normalizeMerchant(input.parsed.description),
+        merchantKey: normalizeMerchant(getParsedCounterpartyName(input.parsed)),
         categoryId: getPersistedCategoryId(input.parsed.categoryId),
         createdAt,
       })

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/internal-types.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/internal-types.ts
@@ -96,7 +96,7 @@ export type RetrySuccessEffectInput = {
   readonly db: AnyDb;
   readonly id: ProcessedEmailId;
   readonly status: EmailSaveStatus;
-  readonly transactionId: TransactionId;
+  readonly transactionId: TransactionId | null;
   readonly confidence: number;
 };
 
@@ -258,7 +258,6 @@ export type DuplicateProcessedEmailRowInput = {
 export type TrackSavedTransactionInput = {
   readonly parsed: LlmParsedTransaction;
   readonly categoryId: CategoryId;
-  readonly status: EmailSaveStatus;
 };
 
 export type IncomingEmailPersistenceInput = {

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/public-types.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/public-types.ts
@@ -1,6 +1,11 @@
 import type { CaptureEvidenceRow, CaptureEvidenceSeed } from "@/features/capture-evidence/public";
 import type { FinancialAccountRow } from "@/features/financial-accounts/public";
 import type { TransactionRow } from "@/features/transactions/query.public";
+import type {
+  CreateReviewCandidateInput,
+  RecordTransactionInput,
+  RecordTransactionResult,
+} from "@/local-ledger/public";
 import type { AnyDb } from "@/shared/db";
 import type { AppClock } from "@/shared/effect/clock";
 import type { AppTelemetry } from "@/shared/effect/telemetry";
@@ -16,7 +21,6 @@ import type { RawEmail } from "../../schema";
 import type { ParseContext } from "../create-parse-email-service";
 import type { LlmParsedTransaction } from "../llm-parser";
 
-export type { ProcessedEmailRow } from "../../lib/repository";
 export type {
   CategoryId,
   IsoDateTime,
@@ -24,6 +28,7 @@ export type {
   TransactionId,
   UserId,
 } from "@/shared/types/branded";
+export type { ProcessedEmailRow } from "../../lib/repository";
 export type { RawEmail } from "../../schema";
 export type { LlmParsedTransaction } from "../llm-parser";
 
@@ -92,7 +97,7 @@ export type CreateEmailPipelineServiceDeps = {
     readonly db: AnyDb;
     readonly id: ProcessedEmailId;
     readonly status: "success" | "needs_review";
-    readonly transactionId: TransactionId;
+    readonly transactionId: TransactionId | null;
     readonly confidence: number;
   }) => Promise<void>;
   readonly updateProcessedEmailStatus: (input: {
@@ -128,6 +133,11 @@ export type CreateEmailPipelineServiceDeps = {
     options?: { now?: IsoDateTime }
   ) => FinancialAccountRow;
   readonly insertTransaction: (db: AnyDb, row: TransactionRow) => void | Promise<void>;
+  readonly recordTransaction?: (input: RecordTransactionInput) => Promise<RecordTransactionResult>;
+  readonly createReviewCandidate?: (
+    db: AnyDb,
+    input: CreateReviewCandidateInput
+  ) => Promise<{ readonly success: true } | { readonly success: false; readonly error: string }>;
   readonly insertMerchantRule: (
     db: AnyDb,
     userId: UserId,

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/retry.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/retry.ts
@@ -113,20 +113,22 @@ async function lookupRetryDuplicate(
 async function finalizeRetrySuccess(input: {
   readonly context: RetryBatchContext;
   readonly emailId: ProcessedEmailId;
-  readonly transactionId: TransactionId;
+  readonly transactionId: TransactionId | null;
   readonly status: EmailSaveStatus;
   readonly confidence: number;
 }) {
   const updatedAt = await input.context.runtime.runClockEffect(currentIsoDateTimeEffect);
 
-  await input.context.runtime.runEmailEffect(
-    linkCaptureEvidenceToTransactionEffect({
-      db: input.context.db,
-      processedEmailId: input.emailId,
-      transactionId: input.transactionId,
-      updatedAt,
-    })
-  );
+  if (input.transactionId !== null) {
+    await input.context.runtime.runEmailEffect(
+      linkCaptureEvidenceToTransactionEffect({
+        db: input.context.db,
+        processedEmailId: input.emailId,
+        transactionId: input.transactionId,
+        updatedAt,
+      })
+    );
+  }
   await input.context.runtime.runEmailEffect(
     markRetrySuccessEffect({
       db: input.context.db,

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/review-candidate.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/review-candidate.ts
@@ -1,0 +1,105 @@
+import { Effect } from "effect";
+import type {
+  CreateReviewCandidateInput,
+  LocalLedgerCaptureEvidence,
+  LocalLedgerCommandId,
+  LocalLedgerProcessedSourceEventId,
+  LocalLedgerReviewCandidateId,
+  LocalLedgerSourceId,
+} from "@/local-ledger/public";
+import { fromPromise } from "@/shared/effect/runtime";
+import {
+  generateCaptureEvidenceId,
+  generateId,
+  generateReviewCandidateCaptureEvidenceId,
+  generateReviewCandidateId,
+} from "@/shared/lib/generate-id";
+import { requireCopAmount, requireIsoDate, requireIsoDateTime } from "@/shared/types/assertions";
+import { EmailPipelineDeps } from "./runtime";
+import { getTransactionSource } from "./shared";
+import type { CreateEmailPipelineServiceDeps, EmailTransactionContext } from "./types";
+
+type ReviewCandidateContext = Pick<
+  EmailTransactionContext,
+  "db" | "userId" | "parsed" | "categoryId" | "now"
+> & {
+  readonly email: {
+    readonly externalId: string;
+    readonly provider: string;
+    readonly from?: string;
+    readonly body?: string | null;
+    readonly rawBody?: string | null;
+    readonly receivedAt: string;
+  };
+};
+
+const toReviewCandidateInput = (
+  context: ReviewCandidateContext,
+  evidenceSeeds: ReturnType<CreateEmailPipelineServiceDeps["buildEmailCaptureEvidence"]>
+): CreateReviewCandidateInput => ({
+  commandId: generateId("llc") as LocalLedgerCommandId,
+  userId: context.userId,
+  source: {
+    processedSourceEventId: generateId("pse") as LocalLedgerProcessedSourceEventId,
+    sourceFamily: "email",
+    sourceId: getTransactionSource(context.email.provider) as LocalLedgerSourceId,
+    sourceEventId: context.email.externalId,
+    receivedAt: requireIsoDateTime(context.email.receivedAt),
+    processedAt: context.now,
+    status: "needs_review",
+    failureReason: null,
+  },
+  candidate: {
+    id: generateReviewCandidateId() as unknown as LocalLedgerReviewCandidateId,
+    status: "pending",
+    candidateKind: "transaction",
+    occurredAt: requireIsoDate(context.parsed.date),
+    money: { amount: requireCopAmount(context.parsed.amount), currency: "COP" },
+    description: null,
+    confidence: context.parsed.confidence,
+  },
+  evidence: evidenceSeeds.map(
+    (seed): LocalLedgerCaptureEvidence => ({
+      id: generateCaptureEvidenceId(),
+      linkId: generateReviewCandidateCaptureEvidenceId(),
+      sourceFamily: seed.sourceFamily,
+      evidenceType: seed.evidenceType,
+      scope: seed.scope,
+      value: seed.value,
+    })
+  ),
+  now: context.now,
+});
+
+const buildEvidenceSeeds = (
+  context: ReviewCandidateContext,
+  buildEmailCaptureEvidence: CreateEmailPipelineServiceDeps["buildEmailCaptureEvidence"]
+) =>
+  buildEmailCaptureEvidence({
+    from: context.email.from ?? "",
+    body: context.email.body ?? context.email.rawBody ?? undefined,
+    fromAccountHint: context.parsed.fromAccountHint,
+    toAccountHint: context.parsed.toAccountHint,
+    cardProductHint: context.parsed.cardProductHint,
+    accountTypeHint: context.parsed.accountTypeHint,
+    counterpartyHint: context.parsed.counterpartyHint,
+  });
+
+export const commitReviewCandidate = async (
+  context: ReviewCandidateContext,
+  deps: CreateEmailPipelineServiceDeps
+) => {
+  if (!deps.createReviewCandidate) throw new Error("Review candidate intake is not configured");
+  const result = await deps.createReviewCandidate(
+    context.db,
+    toReviewCandidateInput(context, buildEvidenceSeeds(context, deps.buildEmailCaptureEvidence))
+  );
+  if (!result.success) throw new Error(result.error);
+};
+
+export function persistReviewCandidateEffect(context: ReviewCandidateContext) {
+  return Effect.gen(function* () {
+    const deps = yield* EmailPipelineDeps.tag;
+    yield* fromPromise(() => commitReviewCandidate(context, deps));
+  });
+}

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/runtime.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/runtime.ts
@@ -9,6 +9,7 @@ import { fromPromise, fromThunk, makeAppService } from "@/shared/effect/runtime"
 import { type AppTelemetry, bindAppTelemetry } from "@/shared/effect/telemetry";
 import { normalizeMerchant } from "@/shared/lib/normalize-merchant";
 import { computeNextRetryAt } from "../../lib/retry-backoff";
+import { getParsedCounterpartyName } from "./shared";
 import type {
   CaptureEvidenceRowsInput,
   CaptureEvidenceSaveInput,
@@ -44,7 +45,7 @@ export function parseBodyEffect(db: AnyDb, userId: UserId, body: string) {
     );
     if (!llmResult) return null;
 
-    const merchantKey = normalizeMerchant(llmResult.description);
+    const merchantKey = normalizeMerchant(getParsedCounterpartyName(llmResult));
     const cachedCategoryId = yield* fromPromise(() => lookupMerchantRule(db, userId, merchantKey));
 
     return cachedCategoryId
@@ -77,7 +78,7 @@ export function findDuplicateTransactionEffect(
         userId,
         amount: parsed.amount,
         date: parsed.date,
-        merchant: parsed.description,
+        merchant: getParsedCounterpartyName(parsed),
       })
     )
   );

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/shared.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/shared.ts
@@ -18,6 +18,14 @@ export function getTransactionSource(provider: string) {
   return provider === "gmail" ? "email_gmail" : "email_outlook";
 }
 
+export const getParsedCounterpartyName = (parsed: {
+  readonly description: string;
+  readonly counterpartyHint?: string;
+}) => {
+  const hint = parsed.counterpartyHint?.trim();
+  return hint && hint.length > 0 ? hint : parsed.description.trim();
+};
+
 export function getPersistedCategoryId(categoryId: string) {
   return isValidCategoryId(categoryId) ? categoryId : getBuiltInCategoryId("other");
 }

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/transaction-recording.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/transaction-recording.ts
@@ -1,0 +1,82 @@
+import { Effect } from "effect";
+import type { TransactionRow } from "@/features/transactions/lib/repository";
+import {
+  recordTransaction as defaultRecordTransaction,
+  type LocalLedgerEntryId,
+  type RecordTransactionAccepted,
+} from "@/local-ledger/public";
+import { fromPromise } from "@/shared/effect/runtime";
+import { requireCopAmount, requireIsoDate, requireTransactionId } from "@/shared/types/assertions";
+import { EmailPipelineDeps } from "./runtime";
+import { getParsedCounterpartyName } from "./shared";
+import type { CreateEmailPipelineServiceDeps, PersistedTransactionContext } from "./types";
+
+const buildTransactionRow = (
+  context: PersistedTransactionContext,
+  transaction: RecordTransactionAccepted
+): TransactionRow => ({
+  id: requireTransactionId(transaction.id),
+  userId: transaction.userId,
+  type: transaction.type,
+  amount: transaction.amount,
+  categoryId: transaction.categoryId,
+  description: transaction.description === "" ? null : transaction.description,
+  counterpartyName: transaction.counterpartyName === "" ? null : transaction.counterpartyName,
+  date: transaction.occurredOn,
+  accountId: transaction.accountId,
+  accountAttributionState: transaction.accountAttributionState,
+  source: transaction.source,
+  createdAt: context.now,
+  updatedAt: context.now,
+});
+
+export const recordTransactionToDb = async (
+  context: PersistedTransactionContext,
+  input: {
+    readonly insertTransaction: CreateEmailPipelineServiceDeps["insertTransaction"];
+    readonly recordTransaction: NonNullable<CreateEmailPipelineServiceDeps["recordTransaction"]>;
+    readonly db: PersistedTransactionContext["db"];
+  }
+) => {
+  const result = await input.recordTransaction({
+    command: {
+      userId: context.userId,
+      type: context.parsed.type,
+      amount: requireCopAmount(context.parsed.amount),
+      accountId: context.defaultAccount.id,
+      accountAttributionState: "unresolved",
+      categoryId: context.categoryId,
+      occurredOn: requireIsoDate(context.parsed.date),
+      description: null,
+      counterpartyName: getParsedCounterpartyName(context.parsed),
+      source: "automated",
+    },
+    ports: {
+      commit: async (transaction) => {
+        await input.insertTransaction(input.db, buildTransactionRow(context, transaction));
+        return { ok: true as const, transaction };
+      },
+      canUseAccount: async () => true,
+      canUseCategory: async () => true,
+      today: () => requireIsoDate(context.now.slice(0, 10)),
+      generateEntryId: () => context.txId as unknown as LocalLedgerEntryId,
+    },
+  });
+  if (!result.ok) throw new Error(`RecordTransaction rejected: ${result.code}`);
+};
+
+export function persistTransactionRecordEffect(context: PersistedTransactionContext) {
+  return Effect.gen(function* () {
+    const { insertTransaction, recordTransaction = defaultRecordTransaction } =
+      yield* EmailPipelineDeps.tag;
+    yield* fromPromise(() =>
+      recordTransactionToDb(context, {
+        insertTransaction,
+        recordTransaction,
+        db: context.db,
+      })
+    );
+  });
+}
+
+export { defaultRecordTransaction };

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/transactions.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/transactions.ts
@@ -4,18 +4,13 @@ import {
   materializeCaptureEvidenceRows,
 } from "@/features/capture-evidence/public";
 import type { FinancialAccountRow } from "@/features/financial-accounts/public";
-import type { TransactionRow } from "@/features/transactions/lib/repository";
 import { currentIsoDateTimeEffect } from "@/shared/effect/clock";
 import { fromPromise, fromThunk } from "@/shared/effect/runtime";
 import { generateProcessedEmailId, generateTransactionId } from "@/shared/lib/generate-id";
 import { normalizeMerchant } from "@/shared/lib/normalize-merchant";
-import {
-  assertIsoDateTime,
-  requireCopAmount,
-  requireIsoDate,
-  requireIsoDateTime,
-} from "@/shared/types/assertions";
+import { assertIsoDateTime, requireIsoDateTime } from "@/shared/types/assertions";
 import type { IsoDateTime } from "@/shared/types/branded";
+import { commitReviewCandidate, persistReviewCandidateEffect } from "./review-candidate";
 import {
   EmailPipelineDeps,
   ensureDefaultFinancialAccountEffect,
@@ -23,44 +18,25 @@ import {
 } from "./runtime";
 import {
   assertParsedTransaction,
+  getParsedCounterpartyName,
   getPersistedCategoryId,
   getTransactionSource,
   resolveEmailStatus,
 } from "./shared";
+import {
+  defaultRecordTransaction,
+  persistTransactionRecordEffect,
+  recordTransactionToDb,
+} from "./transaction-recording";
 import type {
-  EmailSaveStatus,
+  CreateEmailPipelineServiceDeps,
   EmailTransactionContext,
-  PersistedTransactionContext,
+  ProcessedEmailRow,
   RetryTransactionContext,
   SaveRetryTransactionInput,
   SaveTransactionInput,
   TrackSavedTransactionInput,
-  CreateEmailPipelineServiceDeps,
 } from "./types";
-
-function buildTransactionRow(context: PersistedTransactionContext): TransactionRow {
-  return {
-    id: context.txId,
-    userId: context.userId,
-    type: context.parsed.type,
-    amount: requireCopAmount(context.parsed.amount),
-    categoryId: context.categoryId,
-    description: context.parsed.description,
-    date: requireIsoDate(context.parsed.date),
-    accountId: context.defaultAccount.id,
-    accountAttributionState: "unresolved",
-    source: context.source,
-    createdAt: context.now,
-    updatedAt: context.now,
-  };
-}
-
-function persistTransactionRecordEffect(context: PersistedTransactionContext) {
-  return Effect.gen(function* () {
-    const { insertTransaction } = yield* EmailPipelineDeps.tag;
-    yield* fromThunk(() => insertTransaction(context.db, buildTransactionRow(context)));
-  });
-}
 
 function buildTransactionCaptureEvidenceRows(
   context: EmailTransactionContext,
@@ -87,15 +63,49 @@ function buildTransactionCaptureEvidenceRows(
   );
 }
 
+const buildReviewProcessedEmailRow = (context: EmailTransactionContext): ProcessedEmailRow => ({
+  id: context.processedEmailId,
+  externalId: context.email.externalId,
+  provider: context.email.provider,
+  status: "needs_review",
+  failureReason: null,
+  subject: context.email.subject,
+  rawBodyPreview: context.email.body.slice(0, 500),
+  receivedAt: requireIsoDateTime(context.email.receivedAt),
+  transactionId: null,
+  confidence: context.parsed.confidence,
+  createdAt: context.now,
+});
+
+function persistReviewCandidateBundleEffect(context: EmailTransactionContext) {
+  return Effect.gen(function* () {
+    const deps = yield* EmailPipelineDeps.tag;
+    const processedEmailRow = buildReviewProcessedEmailRow(context);
+
+    yield* fromPromise(async () => {
+      if ("transaction" in context.db && typeof context.db.transaction === "function") {
+        await context.db.transaction(async (tx) => {
+          await commitReviewCandidate({ ...context, db: tx }, deps);
+          await deps.insertProcessedEmail(tx, processedEmailRow);
+        });
+        return;
+      }
+
+      await commitReviewCandidate(context, deps);
+      await deps.insertProcessedEmail(context.db, processedEmailRow);
+    });
+  });
+}
+
 function persistTransactionBundleEffect(context: EmailTransactionContext) {
   return Effect.gen(function* () {
     const {
       buildEmailCaptureEvidence,
       insertProcessedEmail,
       insertTransaction,
+      recordTransaction = defaultRecordTransaction,
       saveCaptureEvidenceRows,
     } = yield* EmailPipelineDeps.tag;
-    const transactionRow = buildTransactionRow(context);
     const processedEmailRow = {
       id: context.processedEmailId,
       externalId: context.email.externalId,
@@ -114,14 +124,22 @@ function persistTransactionBundleEffect(context: EmailTransactionContext) {
     yield* fromPromise(async () => {
       if ("transaction" in context.db && typeof context.db.transaction === "function") {
         await context.db.transaction(async (tx) => {
-          await insertTransaction(tx, transactionRow);
+          await recordTransactionToDb(context, {
+            insertTransaction,
+            recordTransaction,
+            db: tx,
+          });
           await insertProcessedEmail(tx, processedEmailRow);
           await saveCaptureEvidenceRows(tx, evidenceRows);
         });
         return;
       }
 
-      await insertTransaction(context.db, transactionRow);
+      await recordTransactionToDb(context, {
+        insertTransaction,
+        recordTransaction,
+        db: context.db,
+      });
       await insertProcessedEmail(context.db, processedEmailRow);
       await saveCaptureEvidenceRows(context.db, evidenceRows);
     });
@@ -129,10 +147,6 @@ function persistTransactionBundleEffect(context: EmailTransactionContext) {
 }
 
 function trackSavedTransactionEffect(input: TrackSavedTransactionInput) {
-  if (input.status !== "success") {
-    return Effect.succeed(undefined);
-  }
-
   return Effect.flatMap(EmailPipelineDeps.tag, ({ trackTransactionCreated }) =>
     fromThunk(() =>
       trackTransactionCreated({
@@ -212,19 +226,16 @@ function createRetryTransactionContextEffect(input: SaveRetryTransactionInput) {
 
 function persistSuccessfulRetrySideEffectsEffect(context: RetryTransactionContext) {
   return Effect.gen(function* () {
-    if (context.status !== "success") return;
-
     yield* insertMerchantRuleEffect({
       db: context.db,
       userId: context.userId,
-      merchantKey: normalizeMerchant(context.parsed.description),
+      merchantKey: normalizeMerchant(getParsedCounterpartyName(context.parsed)),
       categoryId: context.categoryId,
       createdAt: context.now,
     });
     yield* trackSavedTransactionEffect({
       parsed: context.parsed,
       categoryId: context.categoryId,
-      status: context.status,
     });
   });
 }
@@ -232,11 +243,15 @@ function persistSuccessfulRetrySideEffectsEffect(context: RetryTransactionContex
 export function saveTransactionEffect(input: SaveTransactionInput) {
   return Effect.gen(function* () {
     const context = yield* createEmailTransactionContextEffect(input);
+    if (context.status === "needs_review") {
+      yield* persistReviewCandidateBundleEffect(context);
+      return context.txId;
+    }
+
     yield* persistTransactionBundleEffect(context);
     yield* trackSavedTransactionEffect({
       parsed: context.parsed,
       categoryId: context.categoryId,
-      status: context.status,
     });
     return context.txId;
   });
@@ -245,8 +260,15 @@ export function saveTransactionEffect(input: SaveTransactionInput) {
 export function saveRetryTransactionEffect(input: SaveRetryTransactionInput) {
   return Effect.gen(function* () {
     const context = yield* createRetryTransactionContextEffect(input);
+    if (context.status === "needs_review") {
+      yield* persistReviewCandidateEffect({
+        ...context,
+      });
+      return { txId: null, status: context.status };
+    }
+
     yield* persistTransactionRecordEffect(context);
     yield* persistSuccessfulRetrySideEffectsEffect(context);
-    return { txId: context.txId, status: context.status as EmailSaveStatus };
+    return { txId: context.txId, status: context.status };
   });
 }

--- a/apps/mobile/features/email-capture/services/email-pipeline.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline.ts
@@ -6,6 +6,11 @@ import {
 import { findDuplicateTransaction } from "@/features/capture-sources/lib/dedup";
 import { ensureDefaultFinancialAccount } from "@/features/financial-accounts/public";
 import { insertTransaction } from "@/features/transactions/lib/repository";
+import {
+  type CreateReviewCandidateInput,
+  createReviewCandidateUseCase,
+} from "@/local-ledger/public";
+import { createWriteThroughMutationModule } from "@/mutations";
 import type { AnyDb } from "@/shared/db";
 import { trackTransactionCreated } from "@/shared/lib/analytics";
 import type { UserId } from "@/shared/types/branded";
@@ -55,6 +60,10 @@ const emailPipelineDeps = {
   insertTransaction,
   insertMerchantRule,
   trackTransactionCreated,
+  createReviewCandidate: (db: AnyDb, input: CreateReviewCandidateInput) =>
+    createReviewCandidateUseCase({
+      commit: (command) => createWriteThroughMutationModule(db).commit(command as never),
+    })(input),
 };
 
 const emailPipeline = createEmailPipelineService({

--- a/apps/mobile/features/transactions/lib/build-transaction.ts
+++ b/apps/mobile/features/transactions/lib/build-transaction.ts
@@ -1,5 +1,6 @@
 import { buildDefaultFinancialAccountId } from "@/features/financial-accounts/lib/default-account";
 import { parseDigitsToAmount, parseIsoDate, toIsoDate, toIsoDateTime } from "@/shared/lib";
+import { normalizeTransactionSource } from "@/shared/lib/transaction-source";
 import type {
   CategoryId,
   FinancialAccountId,
@@ -57,9 +58,6 @@ type BuildTransactionContext = {
 
 const OTHER_CATEGORY_ID = getBuiltInCategoryId("other");
 const TRANSACTION_SOURCES_WITH_CONFIRMED_DEFAULT = new Set(["manual"]);
-
-const toTransactionSource = (source: string | undefined | null): "manual" | "automated" =>
-  source === "manual" || source == null ? "manual" : "automated";
 
 const isAccountAttributionState = (state: string | undefined): state is AccountAttributionState =>
   state === "confirmed" || state === "inferred" || state === "unresolved";
@@ -136,7 +134,7 @@ const mapBuiltTransaction = ({
   accountAttributionState: resolveAccountAttribution(existing),
   supersededAt: resolveSupersededAt(existing),
   supersededByTransferId: resolveSupersededByTransferId(existing),
-  source: toTransactionSource(existing?.source),
+  source: normalizeTransactionSource(existing?.source),
 });
 
 const getRowAccountId = (row: TransactionRow): FinancialAccountId =>
@@ -196,7 +194,7 @@ const toStoredTransactionMetadata = (row: TransactionRow) => ({
   accountAttributionState: getRowAttributionState(row),
   supersededAt: toNullableDate(row.supersededAt),
   supersededByTransferId: row.supersededByTransferId ?? null,
-  source: toTransactionSource(row.source),
+  source: normalizeTransactionSource(row.source),
 });
 
 export const toStoredTransaction = (row: TransactionRow): StoredTransaction => ({
@@ -221,5 +219,5 @@ export const toTransactionRow = (tx: StoredTransaction): TransactionRow => ({
   createdAt: toIsoDateTime(tx.createdAt),
   updatedAt: toIsoDateTime(tx.updatedAt),
   voidedAt: serializeNullableDate(tx.voidedAt),
-  source: toTransactionSource(tx.source),
+  source: normalizeTransactionSource(tx.source),
 });

--- a/apps/mobile/infrastructure/local-ledger/transaction-storage.ts
+++ b/apps/mobile/infrastructure/local-ledger/transaction-storage.ts
@@ -1,8 +1,9 @@
-import { buildDefaultFinancialAccountId } from "@/shared/lib/default-financial-account-id";
 import type { RecordTransactionAccepted, RecordTransactionSource } from "@/local-ledger/public";
+import type { transactions } from "@/shared/db/schema";
+import { buildDefaultFinancialAccountId } from "@/shared/lib/default-financial-account-id";
+import { normalizeTransactionSource } from "@/shared/lib/transaction-source";
 import { requireTransactionId } from "@/shared/types/assertions";
 import type { FinancialAccountId, IsoDateTime } from "@/shared/types/branded";
-import type { transactions } from "@/shared/db/schema";
 
 type TransactionStorageRow = typeof transactions.$inferInsert;
 
@@ -29,7 +30,7 @@ type TransactionStorageInput = {
 const toClosedSource = (source: RecordTransactionSource): RecordTransactionSource => source;
 
 const toStorageSource = (source: string | null | undefined): RecordTransactionSource =>
-  source === "manual" || source == null ? "manual" : "automated";
+  normalizeTransactionSource(source);
 
 const defaultAccountAttributionState = (source: RecordTransactionSource): string =>
   source === "manual" ? "confirmed" : "unresolved";

--- a/apps/mobile/shared/lib/generate-id.ts
+++ b/apps/mobile/shared/lib/generate-id.ts
@@ -17,6 +17,9 @@ import type {
   OpeningBalanceId,
   ProcessedCaptureId,
   ProcessedEmailId,
+  ProcessedSourceEventId,
+  ReviewCandidateCaptureEvidenceId,
+  ReviewCandidateId,
   TransactionId,
   TransferId,
   UserCategoryId,
@@ -109,6 +112,18 @@ export function generateProcessedCaptureId(): ProcessedCaptureId {
 
 export function generateProcessedEmailId(): ProcessedEmailId {
   return generateId("pe") as ProcessedEmailId;
+}
+
+export function generateProcessedSourceEventId(): ProcessedSourceEventId {
+  return generateId("pse") as ProcessedSourceEventId;
+}
+
+export function generateReviewCandidateId(): ReviewCandidateId {
+  return generateId("rc") as ReviewCandidateId;
+}
+
+export function generateReviewCandidateCaptureEvidenceId(): ReviewCandidateCaptureEvidenceId {
+  return generateId("rce") as ReviewCandidateCaptureEvidenceId;
 }
 
 export function generateDetectedSmsEventId(): DetectedSmsEventId {

--- a/apps/mobile/shared/lib/transaction-source.ts
+++ b/apps/mobile/shared/lib/transaction-source.ts
@@ -1,0 +1,5 @@
+export type NormalizedTransactionSource = "manual" | "automated";
+
+export const normalizeTransactionSource = (
+  source: string | null | undefined
+): NormalizedTransactionSource => (source === "manual" || source == null ? "manual" : "automated");


### PR DESCRIPTION
- Record high-confidence email captures
- Create review candidates for low confidence
- Use counterparty names for learning and dedup

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates email capture to the local-ledger intake: high-confidence parses record automated transactions with normalized `counterpartyName`; low-confidence parses create review candidates and mark emails as needs review without inserting a transaction (including retries). Implements the intake flow from Linear issue 420.

- **New Features**
  - Use `recordTransaction` to persist high-confidence emails with `counterpartyName` (prefers `counterpartyHint`, trimmed/max 200), `source: "automated"`, `description: null`, and linked evidence.
  - Use `createReviewCandidate`/`createReviewCandidateUseCase` to persist low-confidence parses and processed markers in one DB transaction via write-through commit; no transaction is inserted (`status: needs_review`, `transactionId: null`).

- **Refactors**
  - Dedup and merchant learning now use `counterpartyName`/`counterpartyHint`; skip empty incoming merchants, empty stored counterparties, and description-only rows.
  - Normalize legacy/non-manual `source` to `automated` via `normalizeTransactionSource` across backups, builders, and storage.

<sup>Written for commit 5a45855026cc2cbc499dfe185414df9da8c9324c. Summary will update on new commits. <a href="https://cubic.dev/pr/B4rz99/fidy/pull/435?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

