### PR TITLE
fix(mobile): migrate capture intake

### DIFF
--- a/apps/mobile/__tests__/capture-sources/apple-pay-pipeline.test.ts
+++ b/apps/mobile/__tests__/capture-sources/apple-pay-pipeline.test.ts
@@ -13,6 +13,9 @@ const mockIsCaptureProcessed = vi.fn<(...args: any[]) => any>().mockResolvedValu
 const mockFindDuplicateTransaction = vi.fn<(...args: any[]) => any>().mockResolvedValue(null);
 const mockCaptureFingerprint = vi.fn<(...args: any[]) => any>().mockReturnValue("test-fingerprint");
 const mockInsertProcessedCapture = vi.fn<(...args: any[]) => any>();
+const mockPersistProcessedSourceEvent = vi.fn<(...args: any[]) => any>();
+const mockPersistCommittedCaptureSourceEvent = vi.fn<(...args: any[]) => any>();
+const mockRecordAutomatedTransactionWithLocalLedger = vi.fn<(...args: any[]) => any>();
 const mockEnsureDefaultFinancialAccount = vi.fn<(...args: any[]) => any>().mockReturnValue({
   id: "fa-default-user-1" as FinancialAccountId,
   userId: "user-1",
@@ -53,8 +56,39 @@ function materializeCaptureEvidenceRows(evidence: any[], link: Record<string, un
   return evidence.map((row, index) => materializeCaptureEvidenceRow(link, row, index));
 }
 
+function mockRecordedApplePayTransaction(input: any) {
+  const { command } = input;
+  mockInsertTransaction(input.db, {
+    id: input.transactionId,
+    userId: command.userId,
+    type: command.type,
+    amount: command.amount,
+    categoryId: command.categoryId,
+    description: command.description,
+    date: command.occurredOn,
+    accountId: command.accountId,
+    accountAttributionState: command.accountAttributionState,
+    source: command.source,
+    createdAt: input.now,
+    updatedAt: input.now,
+  });
+}
+
 vi.mock("@/features/transactions/lib/repository", () => ({
   insertTransaction: (...args: any[]) => mockInsertTransaction(...args),
+}));
+
+vi.mock("@/infrastructure/local-ledger/record-transaction", () => ({
+  recordAutomatedTransactionWithLocalLedger: (...args: any[]) =>
+    mockRecordAutomatedTransactionWithLocalLedger(...args),
+}));
+
+vi.mock("@/infrastructure/local-ledger/source-events", () => ({
+  persistProcessedSourceEvent: (...args: any[]) => mockPersistProcessedSourceEvent(...args),
+  persistCommittedCaptureSourceEvent: (...args: any[]) =>
+    mockPersistCommittedCaptureSourceEvent(...args),
+  persistCommittedCaptureSourceEventInTransaction: (...args: any[]) =>
+    mockPersistCommittedCaptureSourceEvent(...args),
 }));
 
 vi.mock("@/features/email-capture/lib/merchant-rules", () => ({
@@ -118,25 +152,25 @@ function expectSavedApplePayTransaction(transactionId: string) {
       description: "Farmatodo",
       accountId: "fa-default-user-1",
       accountAttributionState: "unresolved",
-      source: "apple_pay",
+      source: "automated",
     })
   );
   expect(transactionId).toBe("tx-1");
 }
 
 function expectSavedApplePayEvidence(transactionId: string) {
-  expect(mockSaveCaptureEvidenceRows).toHaveBeenCalledWith(
+  expect(mockPersistCommittedCaptureSourceEvent).toHaveBeenCalledWith(
     mockDb,
-    expect.arrayContaining([
-      expect.objectContaining({
-        userId: USER_ID,
-        processedCaptureId: expect.any(String),
-        processedEmailId: null,
-        transactionId,
-        scope: "apple_pay:card_hint",
-        value: "visa *1234",
-      }),
-    ])
+    expect.objectContaining({
+      userId: USER_ID,
+      transactionId,
+      evidence: expect.arrayContaining([
+        expect.objectContaining({
+          scope: "apple_pay:card_hint",
+          value: "visa *1234",
+        }),
+      ]),
+    })
   );
 }
 
@@ -157,9 +191,16 @@ describe("processApplePayIntent", () => {
     mockBuildApplePayCaptureEvidence.mockReturnValue([DEFAULT_APPLE_PAY_CAPTURE_EVIDENCE]);
     mockFindMatchingFinancialAccountId.mockReturnValue(null);
     mockSaveCaptureEvidenceRows.mockResolvedValue(undefined);
+    mockPersistProcessedSourceEvent.mockReturnValue(undefined);
+    mockPersistCommittedCaptureSourceEvent.mockReturnValue(undefined);
+    mockRecordAutomatedTransactionWithLocalLedger.mockImplementation(async (input: any) => {
+      input.afterRecord?.(input.db, { id: input.transactionId });
+      mockRecordedApplePayTransaction(input);
+      return { success: true, transaction: { id: input.transactionId } };
+    });
   });
 
-  it("saves transaction with apple_pay source", async () => {
+  it("saves automated transaction with Apple Pay source event evidence", async () => {
     const result = await processApplePayIntent(mockDb, USER_ID, makeIntent());
 
     expect(result.saved).toBe(true);
@@ -184,6 +225,9 @@ describe("processApplePayIntent", () => {
     expect(result.saved).toBe(false);
     expect(result.skippedDuplicate).toBe(true);
     expect(mockInsertTransaction).not.toHaveBeenCalled();
+    expect(mockPersistProcessedSourceEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "processed", failureReason: "already_processed_duplicate" })
+    );
   });
 
   it("skips when cross-source duplicate found", async () => {
@@ -194,10 +238,11 @@ describe("processApplePayIntent", () => {
     expect(result.saved).toBe(false);
     expect(result.skippedDuplicate).toBe(true);
     expect(result.transactionId).toBe("existing-tx-1");
-    expect(mockInsertProcessedCapture).toHaveBeenCalledWith(
+    expect(mockPersistCommittedCaptureSourceEvent).toHaveBeenCalledWith(
       mockDb,
       expect.objectContaining({
-        status: "skipped_duplicate",
+        status: "processed",
+        failureReason: "duplicate:existing-tx-1",
         transactionId: "existing-tx-1",
       })
     );
@@ -259,12 +304,31 @@ describe("processApplePayIntent", () => {
   it("records processed capture on success", async () => {
     await processApplePayIntent(mockDb, USER_ID, makeIntent());
 
-    expect(mockInsertProcessedCapture).toHaveBeenCalledWith(
+    expect(mockPersistCommittedCaptureSourceEvent).toHaveBeenCalledWith(
       mockDb,
       expect.objectContaining({
-        source: "apple_pay",
-        status: "success",
-        confidence: 1.0,
+        sourceFamily: "apple_pay",
+        status: "processed",
+        failureReason: null,
+      })
+    );
+  });
+
+  it("records failed source event before throwing when Local Ledger rejects", async () => {
+    mockRecordAutomatedTransactionWithLocalLedger.mockResolvedValueOnce({
+      success: false,
+      error: "account-not-usable",
+    });
+
+    await expect(processApplePayIntent(mockDb, USER_ID, makeIntent())).rejects.toThrow(
+      "Local Ledger rejected Apple Pay transaction: account-not-usable"
+    );
+
+    expect(mockPersistProcessedSourceEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceFamily: "apple_pay",
+        status: "failed",
+        failureReason: "local_ledger_rejected:account-not-usable",
       })
     );
   });

--- a/apps/mobile/__tests__/capture-sources/dedup.test.ts
+++ b/apps/mobile/__tests__/capture-sources/dedup.test.ts
@@ -74,11 +74,17 @@ describe("isCaptureProcessed", () => {
     mockWhere.mockResolvedValue([]);
   });
 
-  it("returns true when fingerprint exists in DB", async () => {
-    mockWhere.mockResolvedValueOnce([{ id: "pc-1" }]);
+  it("returns true when matching non-failed processed source event exists", async () => {
+    mockWhere.mockResolvedValueOnce([{ id: "pse-1", status: "processed" }]);
 
     const { isCaptureProcessed } = await import("@/features/capture-sources/lib/dedup");
-    const result = await isCaptureProcessed(mockDb, "fp-hash-123");
+    const result = await isCaptureProcessed({
+      db: mockDb,
+      userId: "user-1",
+      sourceFamily: "notification",
+      sourceId: "notification",
+      sourceEventId: "fp-hash-123",
+    });
 
     expect(result).toBe(true);
     expect(mockSelect).toHaveBeenCalled();
@@ -86,11 +92,73 @@ describe("isCaptureProcessed", () => {
     expect(mockWhere).toHaveBeenCalled();
   });
 
-  it("returns false when fingerprint is not found", async () => {
+  it("does not block retries for failed processed source events", async () => {
+    mockWhere.mockResolvedValueOnce([{ id: "pse-1", status: "failed" }]).mockResolvedValueOnce([]);
+
+    const { isCaptureProcessed } = await import("@/features/capture-sources/lib/dedup");
+    const result = await isCaptureProcessed({
+      db: mockDb,
+      userId: "user-1",
+      sourceFamily: "widget",
+      sourceId: "widget",
+      sourceEventId: "fp-hash-retry",
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("uses the processed source event semantic key for lookup", async () => {
     mockWhere.mockResolvedValueOnce([]);
 
     const { isCaptureProcessed } = await import("@/features/capture-sources/lib/dedup");
-    const result = await isCaptureProcessed(mockDb, "fp-hash-missing");
+    await isCaptureProcessed({
+      db: mockDb,
+      userId: "user-1",
+      sourceFamily: "notification",
+      sourceId: "notification",
+      sourceEventId: "fp-hash-123",
+    });
+
+    expect(mockWhere).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        op: "and",
+        args: expect.arrayContaining([
+          expect.objectContaining({ val: "user-1" }),
+          expect.objectContaining({ val: "notification" }),
+          expect.objectContaining({ val: "fp-hash-123" }),
+          expect.objectContaining({ op: "isNull" }),
+        ]),
+      })
+    );
+  });
+
+  it("keeps legacy processed capture fallback", async () => {
+    mockWhere.mockResolvedValueOnce([]).mockResolvedValueOnce([{ id: "pc-1" }]);
+
+    const { isCaptureProcessed } = await import("@/features/capture-sources/lib/dedup");
+    const result = await isCaptureProcessed({
+      db: mockDb,
+      userId: "user-1",
+      sourceFamily: "notification",
+      sourceId: "notification",
+      sourceEventId: "fp-hash-123",
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("returns false when fingerprint is not found", async () => {
+    mockWhere.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+    const { isCaptureProcessed } = await import("@/features/capture-sources/lib/dedup");
+    const result = await isCaptureProcessed({
+      db: mockDb,
+      userId: "user-1",
+      sourceFamily: "notification",
+      sourceId: "notification",
+      sourceEventId: "fp-hash-missing",
+    });
 
     expect(result).toBe(false);
   });

--- a/apps/mobile/__tests__/capture-sources/notification-pipeline.test.ts
+++ b/apps/mobile/__tests__/capture-sources/notification-pipeline.test.ts
@@ -13,6 +13,9 @@ const mockIsCaptureProcessed = vi.fn<(...args: any[]) => any>().mockResolvedValu
 const mockFindDuplicateTransaction = vi.fn<(...args: any[]) => any>().mockResolvedValue(null);
 const mockCaptureFingerprint = vi.fn<(...args: any[]) => any>().mockReturnValue("test-fingerprint");
 const mockInsertProcessedCapture = vi.fn<(...args: any[]) => any>();
+const mockPersistProcessedSourceEvent = vi.fn<(...args: any[]) => any>();
+const mockPersistCommittedCaptureSourceEvent = vi.fn<(...args: any[]) => any>();
+const mockPersistReviewCandidateCapture = vi.fn<(...args: any[]) => any>();
 const mockStripPii = vi.fn<(...args: any[]) => any>().mockImplementation((t: string) => t);
 const mockEnsureDefaultFinancialAccount = vi.fn<(...args: any[]) => any>().mockReturnValue({
   id: "fa-default-user-1" as FinancialAccountId,
@@ -57,8 +60,43 @@ function materializeCaptureEvidenceRows(evidence: any[], link: Record<string, un
   return evidence.map((row, index) => materializeCaptureEvidenceRow(link, row, index));
 }
 
+function mockRecordedTransaction(input: any) {
+  const { command } = input;
+  mockInsertTransaction(input.db, {
+    id: input.transactionId,
+    userId: command.userId,
+    type: command.type,
+    amount: command.amount,
+    categoryId: command.categoryId,
+    description: command.description,
+    date: command.occurredOn,
+    accountId: command.accountId,
+    accountAttributionState: command.accountAttributionState,
+    source: command.source,
+    createdAt: input.now,
+    updatedAt: input.now,
+  });
+}
+
 vi.mock("@/features/transactions/lib/repository", () => ({
   insertTransaction: (...args: any[]) => mockInsertTransaction(...args),
+}));
+
+vi.mock("@/infrastructure/local-ledger/record-transaction", () => ({
+  recordAutomatedTransactionWithLocalLedger: async (input: any) => {
+    input.afterRecord?.(input.db, { id: input.transactionId });
+    mockRecordedTransaction(input);
+    return { success: true, transaction: { id: input.transactionId } };
+  },
+}));
+
+vi.mock("@/infrastructure/local-ledger/source-events", () => ({
+  persistProcessedSourceEvent: (...args: any[]) => mockPersistProcessedSourceEvent(...args),
+  persistCommittedCaptureSourceEvent: (...args: any[]) =>
+    mockPersistCommittedCaptureSourceEvent(...args),
+  persistCommittedCaptureSourceEventInTransaction: (...args: any[]) =>
+    mockPersistCommittedCaptureSourceEvent(...args),
+  persistReviewCandidateCapture: (...args: any[]) => mockPersistReviewCandidateCapture(...args),
 }));
 
 vi.mock("@/features/email-capture/lib/merchant-rules", () => ({
@@ -121,18 +159,18 @@ function makeNotification(overrides: Partial<NotificationData> = {}): Notificati
 }
 
 function expectSavedNotificationEvidence(transactionId: string) {
-  expect(mockSaveCaptureEvidenceRows).toHaveBeenCalledWith(
+  expect(mockPersistCommittedCaptureSourceEvent).toHaveBeenCalledWith(
     mockDb,
-    expect.arrayContaining([
-      expect.objectContaining({
-        userId: USER_ID,
-        processedCaptureId: expect.any(String),
-        processedEmailId: null,
-        transactionId,
-        scope: "notification:bancolombia:last4",
-        value: "1234",
-      }),
-    ])
+    expect.objectContaining({
+      userId: USER_ID,
+      transactionId,
+      evidence: expect.arrayContaining([
+        expect.objectContaining({
+          scope: "notification:bancolombia:last4",
+          value: "1234",
+        }),
+      ]),
+    })
   );
 }
 
@@ -200,6 +238,9 @@ describe("processNotification", () => {
     mockBuildNotificationLlmAccountHintCaptureEvidence.mockReturnValue([]);
     mockFindMatchingFinancialAccountId.mockReturnValue(null);
     mockSaveCaptureEvidenceRows.mockResolvedValue(undefined);
+    mockPersistProcessedSourceEvent.mockReturnValue(undefined);
+    mockPersistCommittedCaptureSourceEvent.mockReturnValue(undefined);
+    mockPersistReviewCandidateCapture.mockReturnValue(undefined);
   });
 
   it("saves transaction when LLM parses a notification with regex hints", async () => {
@@ -272,9 +313,8 @@ describe("processNotification", () => {
     expect(result.saved).toBe(false);
     expect(result.skippedDuplicate).toBe(false);
     expect(mockInsertTransaction).not.toHaveBeenCalled();
-    expect(mockInsertProcessedCapture).toHaveBeenCalledWith(
-      mockDb,
-      expect.objectContaining({ status: "failed" })
+    expect(mockPersistProcessedSourceEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ db: mockDb, status: "failed", failureReason: "parse_failed" })
     );
   });
 
@@ -294,14 +334,14 @@ describe("processNotification", () => {
       makeNotification({ text: "Formato raro con $35,000" })
     );
 
-    expect(result.saved).toBe(true);
-    expect(mockInsertTransaction).toHaveBeenCalledWith(
-      mockDb,
-      expect.objectContaining({ type: "income", amount: 35000 })
-    );
-    expect(mockInsertProcessedCapture).toHaveBeenCalledWith(
-      mockDb,
-      expect.objectContaining({ status: "needs_review", confidence: 0.5 })
+    expect(result.saved).toBe(false);
+    expect(mockInsertTransaction).not.toHaveBeenCalled();
+    expect(mockPersistReviewCandidateCapture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        db: mockDb,
+        status: "needs_review",
+        candidate: expect.objectContaining({ amount: 35000, confidence: 0.5 }),
+      })
     );
     expect(mockInsertMerchantRule).not.toHaveBeenCalled();
   });
@@ -315,7 +355,9 @@ describe("processNotification", () => {
     expect(result.saved).toBe(false);
     expect(result.skippedDuplicate).toBe(true);
     expect(mockInsertTransaction).not.toHaveBeenCalled();
-    expect(mockInsertProcessedCapture).not.toHaveBeenCalled();
+    expect(mockPersistProcessedSourceEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "processed", failureReason: "already_processed_duplicate" })
+    );
   });
 
   it("skips when cross-source duplicate found", async () => {
@@ -328,11 +370,15 @@ describe("processNotification", () => {
     expect(result.skippedDuplicate).toBe(true);
     expect(result.transactionId).toBe("existing-tx-1");
     expect(mockInsertTransaction).not.toHaveBeenCalled();
-    expect(mockInsertProcessedCapture).toHaveBeenCalledWith(
+    expect(mockPersistCommittedCaptureSourceEvent).toHaveBeenCalledWith(
       mockDb,
       expect.objectContaining({
-        status: "skipped_duplicate",
+        status: "processed",
+        failureReason: "duplicate:existing-tx-1",
         transactionId: "existing-tx-1",
+        evidence: expect.arrayContaining([
+          expect.objectContaining({ scope: "notification:bancolombia:last4" }),
+        ]),
       })
     );
   });
@@ -404,9 +450,9 @@ describe("processNotification", () => {
     );
 
     expect(result.saved).toBe(true);
-    expect(mockInsertTransaction).toHaveBeenCalledWith(
+    expect(mockPersistCommittedCaptureSourceEvent).toHaveBeenCalledWith(
       mockDb,
-      expect.objectContaining({ source: "google_pay" })
+      expect.objectContaining({ sourceFamily: "google_pay", status: "processed" })
     );
   });
 });

--- a/apps/mobile/__tests__/capture-sources/widget-pipeline.test.ts
+++ b/apps/mobile/__tests__/capture-sources/widget-pipeline.test.ts
@@ -8,17 +8,57 @@ const mockInsertTransaction = vi.fn<(...args: any[]) => any>();
 const mockIsCaptureProcessed = vi.fn<(...args: any[]) => any>();
 const mockFindDuplicateTransaction = vi.fn<(...args: any[]) => any>();
 const mockInsertProcessedCapture = vi.fn<(...args: any[]) => any>();
+const mockPersistProcessedSourceEvent = vi.fn<(...args: any[]) => any>();
+const mockPersistCommittedCaptureSourceEvent = vi.fn<(...args: any[]) => any>();
+const mockPersistCommittedCaptureSourceEventInTransaction = vi.fn<(...args: any[]) => any>();
+const mockRecordAutomatedTransactionWithLocalLedger = vi.fn<(...args: any[]) => any>();
 const mockGetPendingTransactions = vi.fn<(...args: any[]) => any>();
 const mockRemovePendingTransactions = vi.fn<(...args: any[]) => any>();
 const mockIsAvailable = vi.fn<(...args: any[]) => any>();
 const mockGenerateProcessedCaptureId = vi.fn<(...args: any[]) => any>();
+const mockEnsureDefaultFinancialAccount = vi.fn<(...args: any[]) => any>().mockReturnValue({
+  id: "fa-default-user-1",
+});
 type CaptureFingerprintArgs = readonly [string, number, string, string];
 
 const buildFingerprint = ([source, amount, date, merchant]: CaptureFingerprintArgs) =>
   `fp:${source}:${amount}:${date}:${merchant}`;
 
+function mockRecordedWidgetTransaction(input: any) {
+  const { command } = input;
+  mockInsertTransaction(input.db, {
+    id: input.transactionId,
+    userId: command.userId,
+    type: command.type,
+    amount: command.amount,
+    categoryId: command.categoryId,
+    description: command.description,
+    date: command.occurredOn,
+    source: command.source,
+    createdAt: input.now,
+    updatedAt: input.now,
+  });
+}
+
 vi.mock("@/features/transactions/lib/repository", () => ({
   insertTransaction: (...args: any[]) => mockInsertTransaction(...args),
+}));
+
+vi.mock("@/features/financial-accounts/public", () => ({
+  ensureDefaultFinancialAccount: (...args: any[]) => mockEnsureDefaultFinancialAccount(...args),
+}));
+
+vi.mock("@/infrastructure/local-ledger/record-transaction", () => ({
+  recordAutomatedTransactionWithLocalLedger: (...args: any[]) =>
+    mockRecordAutomatedTransactionWithLocalLedger(...args),
+}));
+
+vi.mock("@/infrastructure/local-ledger/source-events", () => ({
+  persistProcessedSourceEvent: (...args: any[]) => mockPersistProcessedSourceEvent(...args),
+  persistCommittedCaptureSourceEvent: (...args: any[]) =>
+    mockPersistCommittedCaptureSourceEvent(...args),
+  persistCommittedCaptureSourceEventInTransaction: (...args: any[]) =>
+    mockPersistCommittedCaptureSourceEventInTransaction(...args),
 }));
 
 vi.mock("@/features/transactions/lib/categories", () => ({
@@ -74,6 +114,15 @@ describe("processWidgetTransactions", () => {
     mockIsCaptureProcessed.mockResolvedValue(false);
     mockFindDuplicateTransaction.mockResolvedValue(null);
     mockGenerateProcessedCaptureId.mockReturnValue("pc-1");
+    mockEnsureDefaultFinancialAccount.mockReturnValue({ id: "fa-default-user-1" });
+    mockPersistProcessedSourceEvent.mockReturnValue(undefined);
+    mockPersistCommittedCaptureSourceEvent.mockReturnValue(undefined);
+    mockPersistCommittedCaptureSourceEventInTransaction.mockReturnValue(undefined);
+    mockRecordAutomatedTransactionWithLocalLedger.mockImplementation(async (input: any) => {
+      input.afterRecord?.(input.db, { id: input.transactionId });
+      mockRecordedWidgetTransaction(input);
+      return { success: true, transaction: { id: input.transactionId } };
+    });
   });
 
   it("early-returns when isAvailable() is false", async () => {
@@ -96,7 +145,7 @@ describe("processWidgetTransactions", () => {
     expect(result).toEqual({ saved: 0, skippedDuplicate: 0, errors: 0 });
   });
 
-  it("saves a single pending transaction with widget source", async () => {
+  it("saves a single pending transaction through the automated ledger source", async () => {
     mockGetPendingTransactions.mockResolvedValue([
       { id: "abc-123", amount: 25000, createdAt: "2026-03-27T10:00:00Z" },
     ]);
@@ -113,7 +162,7 @@ describe("processWidgetTransactions", () => {
         amount: 25000,
         categoryId: "other",
         description: "",
-        source: "widget",
+        source: "automated",
       })
     );
     expect(result.saved).toBe(1);
@@ -285,6 +334,9 @@ describe("processWidgetTransactions", () => {
 
     expect(mockInsertTransaction).not.toHaveBeenCalled();
     expect(result.skippedDuplicate).toBe(1);
+    expect(mockPersistProcessedSourceEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "processed", failureReason: "already_processed_duplicate" })
+    );
     expect(mockRemovePendingTransactions).toHaveBeenCalledWith(["seen-before"]);
   });
 
@@ -298,27 +350,27 @@ describe("processWidgetTransactions", () => {
 
     expect(mockInsertTransaction).not.toHaveBeenCalled();
     expect(result.skippedDuplicate).toBe(1);
-    expect(mockInsertProcessedCapture).toHaveBeenCalledWith(
-      mockDb,
+    expect(mockPersistProcessedSourceEvent).toHaveBeenCalledWith(
       expect.objectContaining({
-        status: "skipped_duplicate",
-        transactionId: "txn-existing-1",
+        status: "processed",
+        failureReason: "duplicate:txn-existing-1",
       })
     );
   });
 
-  it("records processed capture on success", async () => {
+  it("records processed capture on success inside the ledger transaction", async () => {
     mockGetPendingTransactions.mockResolvedValue([
       { id: "cap-test", amount: 7000, createdAt: "2026-03-27T10:00:00Z" },
     ]);
 
     await processWidgetTransactions(mockDb, USER_ID);
 
-    expect(mockInsertProcessedCapture).toHaveBeenCalledWith(
+    expect(mockPersistCommittedCaptureSourceEvent).not.toHaveBeenCalled();
+    expect(mockPersistCommittedCaptureSourceEventInTransaction).toHaveBeenCalledWith(
       mockDb,
       expect.objectContaining({
-        source: "widget",
-        status: "success",
+        sourceFamily: "widget",
+        status: "processed",
         transactionId: "txn-widget-cap-test",
       })
     );
@@ -343,6 +395,45 @@ describe("processWidgetTransactions", () => {
     expect(result.saved).toBe(2);
     expect(result.errors).toBe(1);
     expect(mockRemovePendingTransactions).toHaveBeenCalledWith(["good-1", "good-2"]);
+  });
+
+  it("continues processing when failed source-event persistence also fails", async () => {
+    mockGetPendingTransactions.mockResolvedValue([
+      { id: "bad-audit", amount: 1000, createdAt: "2026-03-27T10:00:00Z" },
+      { id: "good-after-audit", amount: 2000, createdAt: "2026-03-27T10:00:00Z" },
+    ]);
+    mockIsCaptureProcessed
+      .mockRejectedValueOnce(new Error("dedup failed"))
+      .mockResolvedValueOnce(false);
+    mockPersistProcessedSourceEvent.mockImplementationOnce(() => {
+      throw new Error("failed audit write");
+    });
+
+    const result = await processWidgetTransactions(mockDb, USER_ID);
+
+    expect(result).toEqual({ saved: 1, skippedDuplicate: 0, errors: 1 });
+    expect(mockRemovePendingTransactions).toHaveBeenCalledWith(["good-after-audit"]);
+  });
+
+  it("records Local Ledger rejection reason when widget recording fails", async () => {
+    mockGetPendingTransactions.mockResolvedValue([
+      { id: "bad-ledger", amount: 1000, createdAt: "2026-03-27T10:00:00Z" },
+    ]);
+    mockRecordAutomatedTransactionWithLocalLedger.mockResolvedValueOnce({
+      success: false,
+      error: "category-not-usable",
+    });
+
+    const result = await processWidgetTransactions(mockDb, USER_ID);
+
+    expect(result.errors).toBe(1);
+    expect(mockPersistProcessedSourceEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "failed",
+        failureReason: "local_ledger_rejected:category-not-usable",
+      })
+    );
+    expect(mockRemovePendingTransactions).not.toHaveBeenCalled();
   });
 
   it("does not remove entries that failed processing", async () => {

--- a/apps/mobile/__tests__/local-ledger/source-events.test.ts
+++ b/apps/mobile/__tests__/local-ledger/source-events.test.ts
@@ -1,0 +1,330 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: fake drizzle db keeps test focused on persistence contract
+import { getTableName } from "drizzle-orm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AnyDb } from "@/shared/db";
+import {
+  captureEvidence,
+  processedSourceEvents,
+  reviewCandidateCaptureEvidence,
+  reviewCandidates,
+} from "@/shared/db/schema";
+import type { CopAmount, IsoDateTime, TransactionId, UserId } from "@/shared/types/branded";
+
+vi.mock("@/shared/lib/generate-id", () => ({
+  generateCaptureEvidenceId: vi.fn(() => "ce-1"),
+  generateId: vi.fn((prefix: string) => `${prefix}-1`),
+  generateProcessedSourceEventId: vi.fn(() => "pse-1"),
+  generateReviewCandidateCaptureEvidenceId: vi.fn(() => "rcce-1"),
+  generateReviewCandidateId: vi.fn(() => "rc-1"),
+}));
+
+const NOW = "2026-04-12T10:00:00.000Z" as IsoDateTime;
+const USER_ID = "user-1" as UserId;
+
+type InsertedRow = { readonly table: string; readonly row: any };
+
+function makeDb(
+  existingSourceEvent: any | null = null,
+  options: { readonly failCaptureEvidenceInsert?: boolean } = {}
+) {
+  const inserted: InsertedRow[] = [];
+  const sourceRows = existingSourceEvent ? [existingSourceEvent] : [];
+  let transactionState: { inserted: InsertedRow[]; sourceRows: any[] } | null = null;
+  let selectedTable: unknown = null;
+  const activeInserted = () => transactionState?.inserted ?? inserted;
+  const activeSourceRows = () => transactionState?.sourceRows ?? sourceRows;
+
+  const db = {
+    transaction: vi.fn((fn: (tx: AnyDb) => unknown) => {
+      const previous = transactionState;
+      const staged = {
+        inserted: [] as InsertedRow[],
+        sourceRows: activeSourceRows().map((row) => ({ ...row })),
+      };
+      transactionState = staged;
+      try {
+        const result = fn(db as AnyDb);
+        sourceRows.splice(0, sourceRows.length, ...staged.sourceRows);
+        inserted.push(...staged.inserted);
+        return result;
+      } finally {
+        transactionState = previous;
+      }
+    }),
+    select: vi.fn(() => ({
+      from: vi.fn((table: unknown) => {
+        selectedTable = table;
+        return {
+          where: vi.fn(() => ({
+            limit: vi.fn(() => ({
+              all: vi.fn(() =>
+                selectedTable === processedSourceEvents
+                  ? activeSourceRows().map((row) => ({ id: row.id, status: row.status }))
+                  : []
+              ),
+            })),
+          })),
+        };
+      }),
+    })),
+    insert: vi.fn((table: unknown) => ({
+      values: vi.fn((row: any) => ({
+        onConflictDoNothing: vi.fn(() => ({
+          run: vi.fn(() => {
+            if (table !== processedSourceEvents) return;
+            const duplicate = activeSourceRows().some(
+              (existing) =>
+                existing.userId === row.userId &&
+                existing.sourceFamily === row.sourceFamily &&
+                existing.sourceId === row.sourceId &&
+                existing.sourceEventId === row.sourceEventId &&
+                existing.deletedAt === null
+            );
+            if (!duplicate) {
+              activeSourceRows().push(row);
+              activeInserted().push({ table: getTableName(table as never), row });
+            }
+          }),
+        })),
+        run: vi.fn(() => {
+          if (table === captureEvidence && options.failCaptureEvidenceInsert) {
+            throw new Error("capture evidence insert failed");
+          }
+          activeSourceRows().push(...(table === processedSourceEvents ? [row] : []));
+          activeInserted().push({ table: getTableName(table as never), row });
+        }),
+      })),
+    })),
+    update: vi.fn((table: unknown) => ({
+      set: vi.fn((values: any) => ({
+        where: vi.fn(() => ({
+          run: vi.fn(() => {
+            if (table !== processedSourceEvents) return;
+            const row = activeSourceRows()[0];
+            if (row) Object.assign(row, values);
+            activeInserted().push({ table: getTableName(table as never), row: values });
+          }),
+        })),
+      })),
+    })),
+  } as unknown as AnyDb;
+
+  return { db, inserted };
+}
+
+const baseSource = {
+  userId: USER_ID,
+  sourceFamily: "notification",
+  sourceId: "notification",
+  sourceEventId: "fingerprint-1",
+  status: "needs_review" as const,
+  failureReason: "low_confidence",
+  receivedAt: NOW,
+  processedAt: NOW,
+};
+
+describe("Local Ledger source-event persistence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates needs-review source event, review candidate, evidence, and link atomically", async () => {
+    const { persistReviewCandidateCapture } =
+      await import("@/infrastructure/local-ledger/source-events");
+    const { db, inserted } = makeDb();
+
+    persistReviewCandidateCapture({
+      db,
+      ...baseSource,
+      candidate: {
+        occurredAt: NOW,
+        amount: 12500 as CopAmount,
+        description: "Low confidence cafe capture",
+        confidence: 0.42,
+      },
+      evidence: [
+        {
+          sourceFamily: "notification",
+          evidenceType: "counterparty_hint",
+          scope: "merchant",
+          value: "Cafe",
+        },
+      ],
+    });
+
+    expect(db.transaction).toHaveBeenCalledOnce();
+    expect(inserted.map((entry) => entry.table)).toEqual([
+      getTableName(processedSourceEvents),
+      getTableName(reviewCandidates),
+      getTableName(captureEvidence),
+      getTableName(reviewCandidateCaptureEvidence),
+    ]);
+    expect(inserted[1]?.row).toEqual(
+      expect.objectContaining({ processedSourceEventId: "pse-1", status: "pending" })
+    );
+  });
+
+  it("does not create child rows when the source event already exists", async () => {
+    const { persistReviewCandidateCapture } =
+      await import("@/infrastructure/local-ledger/source-events");
+    const { db, inserted } = makeDb({
+      id: "pse-existing",
+      ...baseSource,
+      deletedAt: null,
+    });
+
+    persistReviewCandidateCapture({
+      db,
+      ...baseSource,
+      candidate: {
+        occurredAt: NOW,
+        amount: 12500 as CopAmount,
+        description: "Low confidence cafe capture",
+        confidence: 0.42,
+      },
+      evidence: [],
+    });
+
+    expect(inserted).toEqual([]);
+  });
+
+  it("rejects review candidate persistence for non-review source-event status", async () => {
+    const { persistReviewCandidateCapture } =
+      await import("@/infrastructure/local-ledger/source-events");
+    const { db, inserted } = makeDb();
+
+    expect(() =>
+      persistReviewCandidateCapture({
+        db,
+        ...baseSource,
+        status: "processed",
+        failureReason: null,
+        candidate: {
+          occurredAt: NOW,
+          amount: 12500 as CopAmount,
+          description: "Contradictory review candidate",
+          confidence: 1,
+        },
+        evidence: [],
+      } as any)
+    ).toThrow("Review candidate captures must use needs_review source-event status");
+    expect(db.transaction).not.toHaveBeenCalled();
+    expect(inserted).toEqual([]);
+  });
+
+  it("does not link committed-capture evidence to a generated orphan source event on conflict", async () => {
+    const { persistCommittedCaptureSourceEvent } =
+      await import("@/infrastructure/local-ledger/source-events");
+    const { db, inserted } = makeDb({
+      id: "pse-existing",
+      ...baseSource,
+      deletedAt: null,
+    });
+
+    persistCommittedCaptureSourceEvent(db, {
+      ...baseSource,
+      status: "processed",
+      failureReason: null,
+      transactionId: "tx-1" as TransactionId,
+      evidence: [
+        {
+          sourceFamily: "notification",
+          evidenceType: "counterparty_hint",
+          scope: "merchant",
+          value: "Cafe",
+        },
+      ],
+    });
+
+    expect(inserted).toEqual([]);
+  });
+
+  it("promotes a failed source event and records committed-capture evidence on retry", async () => {
+    const { persistCommittedCaptureSourceEvent } =
+      await import("@/infrastructure/local-ledger/source-events");
+    const { db, inserted } = makeDb({
+      id: "pse-existing",
+      ...baseSource,
+      status: "failed",
+      deletedAt: null,
+    });
+
+    persistCommittedCaptureSourceEvent(db, {
+      ...baseSource,
+      status: "processed",
+      failureReason: null,
+      transactionId: "tx-1" as TransactionId,
+      evidence: [
+        {
+          sourceFamily: "notification",
+          evidenceType: "counterparty_hint",
+          scope: "merchant",
+          value: "Cafe",
+        },
+      ],
+    });
+
+    expect(inserted.map((entry) => entry.table)).toEqual([
+      getTableName(processedSourceEvents),
+      getTableName(captureEvidence),
+    ]);
+    expect(inserted[1]?.row).toEqual(
+      expect.objectContaining({
+        processedSourceEventId: "pse-existing",
+        transactionId: "tx-1",
+      })
+    );
+  });
+
+  it("persists committed source event and capture evidence inside one transaction", async () => {
+    const { persistCommittedCaptureSourceEvent } =
+      await import("@/infrastructure/local-ledger/source-events");
+    const { db, inserted } = makeDb();
+
+    persistCommittedCaptureSourceEvent(db, {
+      ...baseSource,
+      status: "processed",
+      failureReason: null,
+      transactionId: "tx-1" as TransactionId,
+      evidence: [
+        {
+          sourceFamily: "notification",
+          evidenceType: "counterparty_hint",
+          scope: "merchant",
+          value: "Cafe",
+        },
+      ],
+    });
+
+    expect(db.transaction).toHaveBeenCalledOnce();
+    expect(inserted.map((entry) => entry.table)).toEqual([
+      getTableName(processedSourceEvents),
+      getTableName(captureEvidence),
+    ]);
+  });
+
+  it("propagates committed-capture evidence insert failures from the transaction boundary", async () => {
+    const { persistCommittedCaptureSourceEvent } =
+      await import("@/infrastructure/local-ledger/source-events");
+    const { db, inserted } = makeDb(null, { failCaptureEvidenceInsert: true });
+
+    expect(() =>
+      persistCommittedCaptureSourceEvent(db, {
+        ...baseSource,
+        status: "processed",
+        failureReason: null,
+        transactionId: "tx-1" as TransactionId,
+        evidence: [
+          {
+            sourceFamily: "notification",
+            evidenceType: "counterparty_hint",
+            scope: "merchant",
+            value: "Cafe",
+          },
+        ],
+      })
+    ).toThrow("capture evidence insert failed");
+    expect(db.transaction).toHaveBeenCalledOnce();
+    expect(inserted).toEqual([]);
+  });
+});

--- a/apps/mobile/features/capture-sources/lib/dedup.ts
+++ b/apps/mobile/features/capture-sources/lib/dedup.ts
@@ -1,7 +1,7 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { getActiveTransactionConditions } from "@/features/transactions/lib/active-transaction-conditions";
 import type { AnyDb } from "@/shared/db/client";
-import { processedCaptures, transactions } from "@/shared/db/schema";
+import { processedCaptures, processedSourceEvents, transactions } from "@/shared/db/schema";
 import { merchantsMatch, normalizeMerchant } from "@/shared/lib/normalize-merchant";
 import { assertCopAmount, assertIsoDate, assertUserId } from "@/shared/types/assertions";
 import type { TransactionId } from "@/shared/types/branded";
@@ -19,6 +19,13 @@ type DuplicateTransactionLookupInput = {
   readonly date: string;
   readonly merchant: string;
 };
+type CaptureProcessedLookupInput = {
+  readonly db: AnyDb;
+  readonly userId: string;
+  readonly sourceFamily: string;
+  readonly sourceId: string;
+  readonly sourceEventId: string;
+};
 
 /**
  * Creates a fingerprint hash for deduplication across capture sources.
@@ -31,12 +38,27 @@ export function captureFingerprint(input: CaptureFingerprintInput): string {
 /**
  * Checks whether a capture with this fingerprint has already been processed.
  */
-export async function isCaptureProcessed(db: AnyDb, fingerprintHash: string): Promise<boolean> {
-  const rows = await db
+export async function isCaptureProcessed(input: CaptureProcessedLookupInput): Promise<boolean> {
+  assertUserId(input.userId);
+  const sourceEventRows = await input.db
+    .select({ id: processedSourceEvents.id, status: processedSourceEvents.status })
+    .from(processedSourceEvents)
+    .where(
+      and(
+        eq(processedSourceEvents.userId, input.userId),
+        eq(processedSourceEvents.sourceFamily, input.sourceFamily),
+        eq(processedSourceEvents.sourceId, input.sourceId),
+        eq(processedSourceEvents.sourceEventId, input.sourceEventId),
+        isNull(processedSourceEvents.deletedAt)
+      )
+    );
+  if (sourceEventRows.some((row) => row.status !== "failed")) return true;
+
+  const legacyRows = await input.db
     .select({ id: processedCaptures.id })
     .from(processedCaptures)
-    .where(eq(processedCaptures.fingerprintHash, fingerprintHash));
-  return rows.length > 0;
+    .where(eq(processedCaptures.fingerprintHash, input.sourceEventId));
+  return legacyRows.length > 0;
 }
 
 /**

--- a/apps/mobile/features/capture-sources/services/apple-pay-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/apple-pay-pipeline.ts
@@ -1,9 +1,5 @@
 import { findMatchingFinancialAccountId } from "@/features/account-suggestions/public";
-import {
-  buildApplePayCaptureEvidence,
-  materializeCaptureEvidenceRows,
-  saveCaptureEvidenceRows,
-} from "@/features/capture-evidence/public";
+import { buildApplePayCaptureEvidence } from "@/features/capture-evidence/public";
 import {
   buildTransactionCandidate,
   validateCaptureCandidateForLocalLedger,
@@ -14,12 +10,16 @@ import {
 } from "@/features/email-capture/merchant-rules.public";
 import { classifyMerchantApi } from "@/features/email-capture/parsing.public";
 import { ensureDefaultFinancialAccount } from "@/features/financial-accounts/public";
-import { insertTransaction } from "@/features/transactions/write.public";
+import { recordAutomatedTransactionWithLocalLedger } from "@/infrastructure/local-ledger/record-transaction";
+import {
+  persistCommittedCaptureSourceEvent,
+  persistCommittedCaptureSourceEventInTransaction,
+  persistProcessedSourceEvent,
+} from "@/infrastructure/local-ledger/source-events";
 import { CATEGORY_IDS } from "@/shared/categories";
 import type { AnyDb } from "@/shared/db";
 import {
   capturePipelineEvent,
-  generateProcessedCaptureId,
   generateTransactionId,
   normalizeMerchant,
   toIsoDate,
@@ -29,7 +29,6 @@ import {
 import { assertCopAmount, assertUserId } from "@/shared/types/assertions";
 import type { CategoryId, IsoDate, TransactionId } from "@/shared/types/branded";
 import { captureFingerprint, findDuplicateTransaction, isCaptureProcessed } from "../lib/dedup";
-import { insertProcessedCapture } from "../lib/repository";
 import type { ApplePayIntentData } from "../schema";
 
 const inFlightFingerprints = new Set<string>();
@@ -117,8 +116,26 @@ export async function processApplePayIntent(
   inFlightFingerprints.add(fingerprint);
 
   try {
-    const alreadyProcessed = await isCaptureProcessed(db, fingerprint);
+    const alreadyProcessed = await isCaptureProcessed({
+      db,
+      userId,
+      sourceFamily: source,
+      sourceId: source,
+      sourceEventId: fingerprint,
+    });
     if (alreadyProcessed) {
+      const now = toIsoDateTime(new Date());
+      persistProcessedSourceEvent({
+        db,
+        userId,
+        sourceFamily: source,
+        sourceId: source,
+        sourceEventId: fingerprint,
+        status: "processed",
+        failureReason: "already_processed_duplicate",
+        receivedAt: now,
+        processedAt: now,
+      });
       capturePipelineEvent({ source: "apple_pay", saved: 0, skippedDuplicate: 1 });
       return { saved: false, skippedDuplicate: true, transactionId: null };
     }
@@ -133,29 +150,18 @@ export async function processApplePayIntent(
 
     if (existingTxId) {
       const now = toIsoDateTime(new Date());
-      const processedCaptureId = generateProcessedCaptureId();
-      await insertProcessedCapture(db, {
-        id: processedCaptureId,
-        fingerprintHash: fingerprint,
-        source,
-        status: "skipped_duplicate",
-        rawText: `${intent.merchant} $${intent.amount}`,
-        transactionId: existingTxId,
-        confidence: 1.0,
+      persistCommittedCaptureSourceEvent(db, {
+        userId,
+        sourceFamily: source,
+        sourceId: source,
+        sourceEventId: fingerprint,
+        status: "processed",
+        failureReason: `duplicate:${existingTxId}`,
         receivedAt: now,
-        createdAt: now,
+        processedAt: now,
+        transactionId: existingTxId,
+        evidence: captureEvidence,
       });
-      await saveCaptureEvidenceRows(
-        db,
-        materializeCaptureEvidenceRows(captureEvidence, {
-          userId,
-          transactionId: existingTxId,
-          processedEmailId: null,
-          processedCaptureId,
-          createdAt: now,
-          updatedAt: now,
-        })
-      );
       capturePipelineEvent({ source: "apple_pay", saved: 0, skippedDuplicate: 1 });
       return { saved: false, skippedDuplicate: true, transactionId: existingTxId };
     }
@@ -179,45 +185,52 @@ export async function processApplePayIntent(
     const defaultAccount = ensureDefaultFinancialAccount(db, userId, { now });
     const matchedAccountId = findMatchingFinancialAccountId(db, userId, captureEvidence);
 
-    insertTransaction(db, {
-      id: txId,
-      userId,
-      type: "expense",
-      amount,
-      categoryId,
-      description: intent.merchant,
-      date: today,
-      accountId: matchedAccountId ?? defaultAccount.id,
-      accountAttributionState: matchedAccountId ? "inferred" : "unresolved",
-      source,
-      createdAt: now,
-      updatedAt: now,
+    const recordResult = await recordAutomatedTransactionWithLocalLedger({
+      db,
+      transactionId: txId,
+      now,
+      command: {
+        userId,
+        type: "expense",
+        amount,
+        categoryId,
+        description: intent.merchant,
+        counterpartyName: intent.merchant,
+        occurredOn: today,
+        accountId: matchedAccountId ?? defaultAccount.id,
+        accountAttributionState: matchedAccountId ? "inferred" : "unresolved",
+        source: "automated",
+      },
+      afterRecord: (tx) => {
+        persistCommittedCaptureSourceEventInTransaction(tx, {
+          userId,
+          sourceFamily: source,
+          sourceId: source,
+          sourceEventId: fingerprint,
+          status: "processed",
+          failureReason: null,
+          receivedAt: now,
+          processedAt: now,
+          transactionId: txId,
+          evidence: captureEvidence,
+        });
+      },
     });
 
-    // Record in processedCaptures
-    const processedCaptureId = generateProcessedCaptureId();
-    await insertProcessedCapture(db, {
-      id: processedCaptureId,
-      fingerprintHash: fingerprint,
-      source,
-      status: "success",
-      rawText: `${intent.merchant} $${intent.amount}`,
-      transactionId: txId,
-      confidence: 1.0,
-      receivedAt: now,
-      createdAt: now,
-    });
-    await saveCaptureEvidenceRows(
-      db,
-      materializeCaptureEvidenceRows(captureEvidence, {
+    if (!recordResult.success) {
+      persistProcessedSourceEvent({
+        db,
         userId,
-        transactionId: txId,
-        processedEmailId: null,
-        processedCaptureId,
-        createdAt: now,
-        updatedAt: now,
-      })
-    );
+        sourceFamily: source,
+        sourceId: source,
+        sourceEventId: fingerprint,
+        status: "failed",
+        failureReason: `local_ledger_rejected:${recordResult.error}`,
+        receivedAt: now,
+        processedAt: now,
+      });
+      throw new Error(`Local Ledger rejected Apple Pay transaction: ${recordResult.error}`);
+    }
 
     // Always cache merchant rule (Apple Pay data is high confidence)
     await insertMerchantRule(db, userId, merchantKey, categoryId, now);

--- a/apps/mobile/features/capture-sources/services/notification-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/notification-pipeline.ts
@@ -133,7 +133,15 @@ async function handleParsedNotification(
 async function findDuplicateCapture(
   context: ParsedNotificationContext
 ): Promise<DuplicateCheckResult | null> {
-  if (await isCaptureProcessed(context.db, context.fingerprint)) {
+  if (
+    await isCaptureProcessed({
+      db: context.db,
+      userId: context.userId,
+      sourceFamily: context.source,
+      sourceId: context.source,
+      sourceEventId: context.fingerprint,
+    })
+  ) {
     return { kind: "already_processed" };
   }
 

--- a/apps/mobile/features/capture-sources/services/notification-pipeline/outcomes.ts
+++ b/apps/mobile/features/capture-sources/services/notification-pipeline/outcomes.ts
@@ -1,17 +1,18 @@
-import {
-  materializeCaptureEvidenceRows,
-  saveCaptureEvidenceRows,
-} from "@/features/capture-evidence/public";
 import { insertMerchantRule } from "@/features/email-capture/merchant-rules.public";
-import { insertTransaction } from "@/features/transactions/write.public";
+import { recordAutomatedTransactionWithLocalLedger } from "@/infrastructure/local-ledger/record-transaction";
+import {
+  persistCommittedCaptureSourceEvent,
+  persistCommittedCaptureSourceEventInTransaction,
+  persistProcessedSourceEvent,
+  persistReviewCandidateCapture,
+} from "@/infrastructure/local-ledger/source-events";
 import {
   capturePipelineEvent,
-  generateProcessedCaptureId,
   generateTransactionId,
   toIsoDateTime,
   trackTransactionCreated,
 } from "@/shared/lib";
-import { insertProcessedCapture } from "../../lib/repository";
+import { requireIsoDateTime } from "@/shared/types/assertions";
 import { buildFailedFingerprint } from "./context";
 import type {
   DuplicateCheckResult,
@@ -19,40 +20,8 @@ import type {
   NotificationStageContext,
   NotificationStageMetrics,
   ParsedNotificationContext,
-  PersistedCaptureOutcome,
   ResolvedNotificationContext,
 } from "./types";
-
-async function persistCaptureOutcome(
-  context: NotificationStageContext,
-  outcome: PersistedCaptureOutcome
-) {
-  const processedCaptureId = generateProcessedCaptureId();
-
-  await insertProcessedCapture(context.db, {
-    id: processedCaptureId,
-    fingerprintHash: outcome.fingerprintHash,
-    source: context.source,
-    status: outcome.status,
-    rawText: context.sanitizedText,
-    transactionId: outcome.transactionId,
-    confidence: outcome.confidence,
-    receivedAt: context.receivedAt,
-    createdAt: outcome.now,
-  });
-
-  await saveCaptureEvidenceRows(
-    context.db,
-    materializeCaptureEvidenceRows(context.captureEvidence, {
-      userId: context.userId,
-      transactionId: outcome.transactionId,
-      processedEmailId: null,
-      processedCaptureId,
-      createdAt: outcome.now,
-      updatedAt: outcome.now,
-    })
-  );
-}
 
 async function cacheMerchantRuleIfEligible(context: ResolvedNotificationContext) {
   if (context.parsed.confidence < 0.7) {
@@ -113,23 +82,44 @@ function buildParseImprovementRequest(
   };
 }
 
-function saveTransactionRecord(context: ResolvedNotificationContext) {
+async function saveTransactionRecord(context: ResolvedNotificationContext) {
   const transactionId = generateTransactionId();
 
-  insertTransaction(context.db, {
-    id: transactionId,
-    userId: context.userId,
-    type: context.parsed.type,
-    amount: context.parsed.amount,
-    categoryId: context.categoryId,
-    description: context.parsed.merchant,
-    date: context.parsed.date,
-    accountId: context.accountId,
-    accountAttributionState: context.accountAttributionState,
-    source: context.source,
-    createdAt: context.now,
-    updatedAt: context.now,
+  const result = await recordAutomatedTransactionWithLocalLedger({
+    db: context.db,
+    transactionId,
+    now: context.now,
+    command: {
+      userId: context.userId,
+      type: context.parsed.type,
+      amount: context.parsed.amount,
+      accountId: context.accountId,
+      accountAttributionState: context.accountAttributionState,
+      categoryId: context.categoryId,
+      occurredOn: context.parsed.date,
+      description: context.parsed.merchant,
+      counterpartyName: context.parsed.merchant,
+      source: "automated",
+    },
+    afterRecord: (tx) => {
+      persistCommittedCaptureSourceEventInTransaction(tx, {
+        userId: context.userId,
+        sourceFamily: context.source,
+        sourceId: context.source,
+        sourceEventId: context.fingerprint,
+        status: "processed",
+        failureReason: null,
+        receivedAt: context.receivedAt,
+        processedAt: context.now,
+        transactionId,
+        evidence: context.captureEvidence,
+      });
+    },
   });
+
+  if (!result.success) {
+    throw new Error(`Local Ledger rejected notification transaction: ${result.error}`);
+  }
 
   return transactionId;
 }
@@ -156,13 +146,16 @@ export async function persistFailedNotification(
   context: NotificationStageContext
 ): Promise<NotificationPipelineResult> {
   const now = toIsoDateTime(new Date());
-
-  await persistCaptureOutcome(context, {
+  persistProcessedSourceEvent({
+    db: context.db,
+    userId: context.userId,
+    sourceFamily: context.source,
+    sourceId: context.source,
+    sourceEventId: buildFailedFingerprint(context.notification),
     status: "failed",
-    fingerprintHash: buildFailedFingerprint(context.notification),
-    transactionId: null,
-    confidence: null,
-    now,
+    failureReason: "parse_failed",
+    receivedAt: context.receivedAt,
+    processedAt: now,
   });
   trackNotificationPipeline(context, {
     saved: 0,
@@ -186,15 +179,31 @@ export async function persistDuplicateNotification(
   duplicate: DuplicateCheckResult
 ): Promise<NotificationPipelineResult> {
   if (duplicate.kind === "already_processed") {
+    persistProcessedSourceEvent({
+      db: context.db,
+      userId: context.userId,
+      sourceFamily: context.source,
+      sourceId: context.source,
+      sourceEventId: context.fingerprint,
+      status: "processed",
+      failureReason: "already_processed_duplicate",
+      receivedAt: context.receivedAt,
+      processedAt: toIsoDateTime(new Date()),
+    });
     return reportSkippedDuplicate(context, null);
   }
 
-  await persistCaptureOutcome(context, {
-    status: "skipped_duplicate",
-    fingerprintHash: context.fingerprint,
+  persistCommittedCaptureSourceEvent(context.db, {
+    userId: context.userId,
+    sourceFamily: context.source,
+    sourceId: context.source,
+    sourceEventId: context.fingerprint,
+    status: "processed",
+    failureReason: `duplicate:${duplicate.transactionId}`,
+    receivedAt: context.receivedAt,
+    processedAt: toIsoDateTime(new Date()),
     transactionId: duplicate.transactionId,
-    confidence: context.parsed.confidence,
-    now: toIsoDateTime(new Date()),
+    evidence: context.captureEvidence,
   });
 
   return reportSkippedDuplicate(context, duplicate.transactionId);
@@ -203,27 +212,46 @@ export async function persistDuplicateNotification(
 export async function persistSuccessfulNotification(
   context: ResolvedNotificationContext
 ): Promise<NotificationPipelineResult> {
-  const transactionId = saveTransactionRecord(context);
+  if (resolveProcessedCaptureStatus(context) === "needs_review") {
+    persistReviewCandidateCapture({
+      db: context.db,
+      userId: context.userId,
+      sourceFamily: context.source,
+      sourceId: context.source,
+      sourceEventId: context.fingerprint,
+      status: "needs_review",
+      failureReason: "low_confidence",
+      receivedAt: context.receivedAt,
+      processedAt: context.now,
+      candidate: {
+        occurredAt: requireIsoDateTime(`${context.parsed.date}T00:00:00.000Z`),
+        amount: context.parsed.amount,
+        description: context.parsed.merchant,
+        confidence: context.parsed.confidence,
+      },
+      evidence: context.captureEvidence,
+    });
 
-  await persistCaptureOutcome(context, {
-    status: resolveProcessedCaptureStatus(context),
-    fingerprintHash: context.fingerprint,
-    transactionId,
-    confidence: context.parsed.confidence,
-    now: context.now,
-  });
+    trackNotificationPipeline(context, {
+      saved: 0,
+      skippedDuplicate: 0,
+      parseFailed: 0,
+    });
+
+    return {
+      saved: false,
+      skippedDuplicate: false,
+      transactionId: null,
+      parseImprovementRequest: buildParseImprovementRequest(context, {
+        status: "needs_review",
+        confidence: context.parsed.confidence,
+      }),
+    };
+  }
+
+  const transactionId = await saveTransactionRecord(context);
   await cacheMerchantRuleIfEligible(context);
   await trackSuccessfulNotification(context);
 
-  return resolveProcessedCaptureStatus(context) === "needs_review"
-    ? {
-        saved: true,
-        skippedDuplicate: false,
-        transactionId,
-        parseImprovementRequest: buildParseImprovementRequest(context, {
-          status: "needs_review",
-          confidence: context.parsed.confidence,
-        }),
-      }
-    : { saved: true, skippedDuplicate: false, transactionId };
+  return { saved: true, skippedDuplicate: false, transactionId };
 }

--- a/apps/mobile/features/capture-sources/services/widget-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/widget-pipeline.ts
@@ -1,10 +1,15 @@
-import { insertTransaction, isValidCategoryId } from "@/features/transactions/write.public";
+import { isValidCategoryId } from "@/features/transactions/write.public";
+import { ensureDefaultFinancialAccount } from "@/features/financial-accounts/public";
+import { recordAutomatedTransactionWithLocalLedger } from "@/infrastructure/local-ledger/record-transaction";
+import {
+  persistCommittedCaptureSourceEventInTransaction,
+  persistProcessedSourceEvent,
+} from "@/infrastructure/local-ledger/source-events";
 import type { AnyDb } from "@/shared/db";
 import {
   captureError,
   capturePipelineEvent,
   captureWarning,
-  generateProcessedCaptureId,
   toIsoDate,
   toIsoDateTime,
   trackTransactionCreated,
@@ -12,7 +17,6 @@ import {
 import { assertCopAmount, assertTransactionId } from "@/shared/types/assertions";
 import type { TransactionId, UserId } from "@/shared/types/branded";
 import { captureFingerprint, findDuplicateTransaction, isCaptureProcessed } from "../lib/dedup";
-import { insertProcessedCapture } from "../lib/repository";
 
 // Guard against concurrent invocations (mount + immediate AppState "active").
 const inFlightFingerprints = new Set<string>();
@@ -34,14 +38,18 @@ export type WidgetPipelineResult = {
 };
 
 const errorType = (error: unknown): string => (error instanceof Error ? error.name : typeof error);
+const localLedgerRejectionReason = (error: string): string => `local_ledger_rejected:${error}`;
+const failureReason = (error: unknown): string =>
+  error instanceof Error && error.message.startsWith("local_ledger_rejected:")
+    ? error.message
+    : errorType(error);
 
 export async function processWidgetTransactions(
   db: AnyDb,
   userId: UserId
 ): Promise<WidgetPipelineResult> {
-  const { isAvailable, getPendingTransactions, removePendingTransactions } = await import(
-    "@/modules/expo-app-intents"
-  );
+  const { isAvailable, getPendingTransactions, removePendingTransactions } =
+    await import("@/modules/expo-app-intents");
 
   if (!isAvailable()) {
     return { saved: 0, skippedDuplicate: 0, errors: 0 };
@@ -85,8 +93,25 @@ export async function processWidgetTransactions(
     inFlightFingerprints.add(fingerprint);
 
     try {
-      const alreadyProcessed = await isCaptureProcessed(db, fingerprint);
+      const alreadyProcessed = await isCaptureProcessed({
+        db,
+        userId,
+        sourceFamily: "widget",
+        sourceId: "widget",
+        sourceEventId: fingerprint,
+      });
       if (alreadyProcessed) {
+        persistProcessedSourceEvent({
+          db,
+          userId,
+          sourceFamily: "widget",
+          sourceId: "widget",
+          sourceEventId: fingerprint,
+          status: "processed",
+          failureReason: "already_processed_duplicate",
+          receivedAt: now,
+          processedAt: now,
+        });
         skippedDuplicate++;
         succeededEntryIds.push(item.id);
         continue;
@@ -101,16 +126,16 @@ export async function processWidgetTransactions(
       });
 
       if (existingTxId) {
-        await insertProcessedCapture(db, {
-          id: generateProcessedCaptureId(),
-          fingerprintHash: fingerprint,
-          source: "widget",
-          status: "skipped_duplicate",
-          rawText: description,
-          transactionId: existingTxId,
-          confidence: null,
+        persistProcessedSourceEvent({
+          db,
+          userId,
+          sourceFamily: "widget",
+          sourceId: "widget",
+          sourceEventId: fingerprint,
+          status: "processed",
+          failureReason: `duplicate:${existingTxId}`,
           receivedAt: now,
-          createdAt: now,
+          processedAt: now,
         });
 
         skippedDuplicate++;
@@ -118,30 +143,42 @@ export async function processWidgetTransactions(
         continue;
       }
 
-      insertTransaction(db, {
-        id: txId,
-        userId,
-        type,
-        amount,
-        categoryId,
-        description,
-        date,
-        source: "widget",
-        createdAt: now,
-        updatedAt: now,
+      const defaultAccount = ensureDefaultFinancialAccount(db, userId, { now });
+      const recordResult = await recordAutomatedTransactionWithLocalLedger({
+        db,
+        transactionId: txId,
+        now,
+        command: {
+          userId,
+          type,
+          amount,
+          categoryId,
+          description,
+          counterpartyName: description,
+          occurredOn: date,
+          accountId: defaultAccount.id,
+          accountAttributionState: "unresolved",
+          source: "automated",
+        },
+        afterRecord: (tx) => {
+          persistCommittedCaptureSourceEventInTransaction(tx, {
+            userId,
+            sourceFamily: "widget",
+            sourceId: "widget",
+            sourceEventId: fingerprint,
+            status: "processed",
+            failureReason: null,
+            receivedAt: now,
+            processedAt: now,
+            transactionId: txId,
+            evidence: [],
+          });
+        },
       });
 
-      await insertProcessedCapture(db, {
-        id: generateProcessedCaptureId(),
-        fingerprintHash: fingerprint,
-        source: "widget",
-        status: "success",
-        rawText: description,
-        transactionId: txId,
-        confidence: null,
-        receivedAt: now,
-        createdAt: now,
-      });
+      if (!recordResult.success) {
+        throw new Error(localLedgerRejectionReason(recordResult.error));
+      }
 
       trackTransactionCreated({
         type,
@@ -152,6 +189,24 @@ export async function processWidgetTransactions(
       saved++;
       succeededEntryIds.push(item.id);
     } catch (error) {
+      try {
+        persistProcessedSourceEvent({
+          db,
+          userId,
+          sourceFamily: "widget",
+          sourceId: "widget",
+          sourceEventId: fingerprint,
+          status: "failed",
+          failureReason: failureReason(error),
+          receivedAt: now,
+          processedAt: now,
+        });
+      } catch (persistError) {
+        captureWarning("widget_failed_source_event_persist_failed", {
+          sourceEventId: fingerprint,
+          errorType: errorType(persistError),
+        });
+      }
       captureError(error);
       errors++;
     } finally {

--- a/apps/mobile/infrastructure/local-ledger/record-transaction.ts
+++ b/apps/mobile/infrastructure/local-ledger/record-transaction.ts
@@ -3,13 +3,21 @@ import {
   recordTransaction,
   type LocalLedgerEntryId,
   type RecordTransactionAccepted,
+  type RecordTransactionCommand,
   type RecordTransactionRejectCode,
 } from "@/local-ledger/public";
 import { getBuiltInCategoryId, isValidCategoryId } from "@/shared/categories";
 import type { AnyDb } from "@/shared/db";
 import { financialAccounts, transactions, userCategories } from "@/shared/db/schema";
 import { parseDigitsToAmount, toIsoDate, toIsoDateTime } from "@/shared/lib";
-import type { CategoryId, FinancialAccountId, TransactionId, UserId } from "@/shared/types/branded";
+import { requireIsoDate } from "@/shared/types/assertions";
+import type {
+  CategoryId,
+  FinancialAccountId,
+  IsoDateTime,
+  TransactionId,
+  UserId,
+} from "@/shared/types/branded";
 import { toTransactionStorageRow } from "./transaction-storage";
 
 type ManualTransactionInput = {
@@ -29,10 +37,23 @@ type RecordManualTransactionInput = {
   readonly now: Date;
 };
 
+type RecordAutomatedTransactionInput = {
+  readonly db: AnyDb;
+  readonly command: RecordTransactionCommand;
+  readonly transactionId: TransactionId;
+  readonly now: IsoDateTime;
+  readonly afterRecord?: (tx: AnyDb, transaction: RecordTransactionAccepted) => void;
+};
+
 type CommitPolicyRejection = {
   readonly ok: false;
   readonly code: "account-not-usable" | "category-not-usable";
 };
+
+function toLocalLedgerEntryId(transactionId: TransactionId): LocalLedgerEntryId {
+  // Transaction-backed ledger entries use the persisted transaction ID as their ledger entry ID.
+  return transactionId as unknown as LocalLedgerEntryId;
+}
 
 export type RecordManualTransactionResult =
   | { readonly success: true; readonly transaction: typeof transactions.$inferInsert }
@@ -46,6 +67,10 @@ export type RecordManualTransactionError =
   | "missingAccount"
   | "missingCategory"
   | "manualSourceRequiresResolvedAccount";
+
+export type RecordAutomatedTransactionResult =
+  | { readonly success: true; readonly transaction: RecordTransactionAccepted }
+  | { readonly success: false; readonly error: RecordTransactionRejectCode };
 
 const rejectionErrorMap: Record<RecordTransactionRejectCode, RecordManualTransactionError> = {
   "account-not-usable": "accountNotUsable",
@@ -140,7 +165,7 @@ export async function recordManualTransactionWithLocalLedger({
           tx.insert(transactions).values(row).run();
           return { ok: true, transaction };
         }),
-      generateEntryId: () => transactionId as string as LocalLedgerEntryId,
+      generateEntryId: () => toLocalLedgerEntryId(transactionId),
       today: () => toIsoDate(now),
     },
   });
@@ -151,4 +176,36 @@ export async function recordManualTransactionWithLocalLedger({
         transaction: toTransactionStorageRow({ transaction: result.transaction, now: nowIso }),
       }
     : { success: false, error: rejectionErrorMap[result.code] };
+}
+
+export async function recordAutomatedTransactionWithLocalLedger({
+  db,
+  command,
+  transactionId,
+  now,
+  afterRecord,
+}: RecordAutomatedTransactionInput): Promise<RecordAutomatedTransactionResult> {
+  const result = await recordTransaction({
+    command: { ...command, source: "automated" },
+    ports: {
+      canUseAccount: async ({ accountId }) =>
+        hasActiveFinancialAccount(db, command.userId, accountId),
+      canUseCategory: async ({ categoryId }) => hasUsableCategory(db, command.userId, categoryId),
+      today: () => requireIsoDate(now.slice(0, 10)),
+      generateEntryId: () => toLocalLedgerEntryId(transactionId),
+      commit: async (transaction) =>
+        db.transaction((tx) => {
+          const policyRejection = getCommitPolicyRejection(tx, transaction);
+          if (policyRejection) return policyRejection;
+
+          tx.insert(transactions).values(toTransactionStorageRow({ transaction, now })).run();
+          afterRecord?.(tx, transaction);
+          return { ok: true, transaction };
+        }),
+    },
+  });
+
+  return result.ok
+    ? { success: true, transaction: result.transaction }
+    : { success: false, error: result.code };
 }

--- a/apps/mobile/infrastructure/local-ledger/source-events.ts
+++ b/apps/mobile/infrastructure/local-ledger/source-events.ts
@@ -1,0 +1,246 @@
+import { and, eq, isNull } from "drizzle-orm";
+import type { CaptureEvidenceSeed } from "@/features/capture-evidence/schema.public";
+import type { AnyDb } from "@/shared/db";
+import {
+  captureEvidence,
+  processedSourceEvents,
+  reviewCandidateCaptureEvidence,
+  reviewCandidates,
+} from "@/shared/db/schema";
+import {
+  generateCaptureEvidenceId,
+  generateProcessedSourceEventId,
+  generateReviewCandidateCaptureEvidenceId,
+  generateReviewCandidateId,
+} from "@/shared/lib/generate-id";
+import type {
+  CaptureEvidenceId,
+  CopAmount,
+  IsoDateTime,
+  ProcessedSourceEventId,
+  TransactionId,
+  UserId,
+} from "@/shared/types/branded";
+
+type SourceEventStatus = "processed" | "needs_review" | "failed";
+
+type SourceEventInput = {
+  readonly userId: UserId;
+  readonly sourceFamily: string;
+  readonly sourceId: string;
+  readonly sourceEventId: string;
+  readonly status: SourceEventStatus;
+  readonly failureReason: string | null;
+  readonly receivedAt: IsoDateTime;
+  readonly processedAt: IsoDateTime;
+};
+
+type PersistSourceEventInput = SourceEventInput & {
+  readonly db: AnyDb;
+};
+
+type PersistReviewCandidateInput = Omit<PersistSourceEventInput, "status"> & {
+  readonly status: "needs_review";
+  readonly candidate: {
+    readonly occurredAt: IsoDateTime | null;
+    readonly amount: CopAmount | null;
+    readonly description: string | null;
+    readonly confidence: number | null;
+  };
+  readonly evidence: readonly CaptureEvidenceSeed[];
+};
+
+type PersistCommittedCaptureInput = PersistSourceEventInput & {
+  readonly transactionId: TransactionId;
+  readonly evidence: readonly CaptureEvidenceSeed[];
+};
+
+const isSourceEventStatus = (status: string): status is SourceEventStatus =>
+  status === "processed" || status === "needs_review" || status === "failed";
+
+const findSourceEvent = (
+  db: AnyDb,
+  input: Pick<SourceEventInput, "userId" | "sourceFamily" | "sourceId" | "sourceEventId">
+) => {
+  const rows = db
+    .select({ id: processedSourceEvents.id, status: processedSourceEvents.status })
+    .from(processedSourceEvents)
+    .where(
+      and(
+        eq(processedSourceEvents.userId, input.userId),
+        eq(processedSourceEvents.sourceFamily, input.sourceFamily),
+        eq(processedSourceEvents.sourceId, input.sourceId),
+        eq(processedSourceEvents.sourceEventId, input.sourceEventId),
+        isNull(processedSourceEvents.deletedAt)
+      )
+    )
+    .limit(1)
+    .all();
+
+  const row = rows[0];
+  if (!row) return null;
+  if (!isSourceEventStatus(row.status)) {
+    throw new Error(`Unknown processed source event status: ${row.status}`);
+  }
+  return { id: row.id, status: row.status };
+};
+
+const updateFailedSourceEvent = (
+  db: AnyDb,
+  input: SourceEventInput,
+  id: ProcessedSourceEventId
+) => {
+  db.update(processedSourceEvents)
+    .set({
+      status: input.status,
+      failureReason: input.failureReason,
+      receivedAt: input.receivedAt,
+      processedAt: input.processedAt,
+      updatedAt: input.processedAt,
+    })
+    .where(eq(processedSourceEvents.id, id))
+    .run();
+};
+
+const insertSourceEvent = (
+  db: AnyDb,
+  input: SourceEventInput,
+  id: ProcessedSourceEventId = generateProcessedSourceEventId()
+) => {
+  const existing = findSourceEvent(db, input);
+  if (existing !== null) {
+    if (existing.status === "failed" && input.status !== "failed") {
+      updateFailedSourceEvent(db, input, existing.id);
+      return { id: existing.id, inserted: true };
+    }
+
+    return { id: existing.id, inserted: false };
+  }
+
+  db.insert(processedSourceEvents)
+    .values({
+      id,
+      userId: input.userId,
+      sourceFamily: input.sourceFamily,
+      sourceId: input.sourceId,
+      sourceEventId: input.sourceEventId,
+      status: input.status,
+      failureReason: input.failureReason,
+      receivedAt: input.receivedAt,
+      processedAt: input.processedAt,
+      createdAt: input.processedAt,
+      updatedAt: input.processedAt,
+      deletedAt: null,
+    })
+    .onConflictDoNothing()
+    .run();
+
+  const persisted = findSourceEvent(db, input);
+  return { id: persisted?.id ?? id, inserted: persisted?.id === id };
+};
+
+const insertCaptureEvidence = (
+  db: AnyDb,
+  input: SourceEventInput & {
+    readonly processedSourceEventId: ProcessedSourceEventId;
+    readonly transactionId: TransactionId | null;
+    readonly evidence: readonly CaptureEvidenceSeed[];
+  }
+) =>
+  input.evidence.map((row) => {
+    const id = generateCaptureEvidenceId();
+    db.insert(captureEvidence)
+      .values({
+        id,
+        userId: input.userId,
+        sourceFamily: row.sourceFamily,
+        evidenceType: row.evidenceType,
+        scope: row.scope,
+        value: row.value,
+        transactionId: input.transactionId,
+        transferId: null,
+        processedEmailId: null,
+        processedCaptureId: null,
+        processedSourceEventId: input.processedSourceEventId,
+        createdAt: input.processedAt,
+        updatedAt: input.processedAt,
+        deletedAt: null,
+      })
+      .run();
+    return id;
+  });
+
+export const persistProcessedSourceEvent = (input: PersistSourceEventInput) => {
+  insertSourceEvent(input.db, input);
+};
+
+export const persistCommittedCaptureSourceEventInTransaction = (
+  db: AnyDb,
+  input: Omit<PersistCommittedCaptureInput, "db">
+) => {
+  const sourceEvent = insertSourceEvent(db, input);
+  if (!sourceEvent.inserted) return;
+
+  insertCaptureEvidence(db, {
+    ...input,
+    processedSourceEventId: sourceEvent.id,
+    transactionId: input.transactionId,
+  });
+};
+
+export const persistCommittedCaptureSourceEvent = (
+  db: AnyDb,
+  input: Omit<PersistCommittedCaptureInput, "db">
+) => {
+  db.transaction((tx) => {
+    persistCommittedCaptureSourceEventInTransaction(tx, input);
+  });
+};
+
+export const persistReviewCandidateCapture = (input: PersistReviewCandidateInput) => {
+  if (input.status !== "needs_review") {
+    throw new Error("Review candidate captures must use needs_review source-event status");
+  }
+
+  input.db.transaction((tx) => {
+    const sourceEvent = insertSourceEvent(tx, input);
+    if (!sourceEvent.inserted) return;
+
+    const reviewCandidateId = generateReviewCandidateId();
+    tx.insert(reviewCandidates)
+      .values({
+        id: reviewCandidateId,
+        userId: input.userId,
+        processedSourceEventId: sourceEvent.id,
+        status: "pending",
+        candidateKind: "transaction",
+        occurredAt: input.candidate.occurredAt,
+        amount: input.candidate.amount,
+        currency: "COP",
+        description: input.candidate.description,
+        confidence: input.candidate.confidence,
+        createdAt: input.processedAt,
+        updatedAt: input.processedAt,
+        deletedAt: null,
+      })
+      .run();
+
+    const evidenceIds = insertCaptureEvidence(tx, {
+      ...input,
+      processedSourceEventId: sourceEvent.id,
+      transactionId: null,
+    });
+    evidenceIds.forEach((captureEvidenceId: CaptureEvidenceId) => {
+      tx.insert(reviewCandidateCaptureEvidence)
+        .values({
+          id: generateReviewCandidateCaptureEvidenceId(),
+          userId: input.userId,
+          reviewCandidateId,
+          captureEvidenceId,
+          createdAt: input.processedAt,
+          deletedAt: null,
+        })
+        .run();
+    });
+  });
+};


### PR DESCRIPTION
- route accepted captures through ledger

- record source event outcomes

- add source event persistence tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates capture intake to the Local Ledger and adds semantic source‑event tracking across Apple Pay, Notification, and Widget. Accepted captures now record via the ledger (`source: automated`), while duplicates, failures, and low‑confidence events are tracked with reasons, evidence, and review candidates.

- **New Features**
  - Route accepted captures through `@/infrastructure/local-ledger/record-transaction` (`recordAutomatedTransactionWithLocalLedger`) and persist source‑event + evidence atomically via `@/infrastructure/local-ledger/source-events` (`persistCommittedCaptureSourceEventInTransaction`).
  - Persist outcomes using semantic keys `{userId, sourceFamily, sourceId, sourceEventId}`; low‑confidence notifications create review candidates via `persistReviewCandidateCapture` without saving a transaction.
  - Record duplicates as `processed` with `failureReason` `already_processed_duplicate` or `duplicate:<txId>`; on Local Ledger rejection, save `failed` with `local_ledger_rejected:<code>` using `persistProcessedSourceEvent`. Evidence is linked only when a transaction exists.

- **Refactors**
  - `isCaptureProcessed` now takes `{db, userId, sourceFamily, sourceId, sourceEventId}`, checks `processedSourceEvents` (ignores `failed`), and falls back to legacy `processedCaptures`.
  - Widget and Apple Pay resolve accounts via `ensureDefaultFinancialAccount`; all pipeline‑created transactions now store `source` as `automated`.
  - Replaced direct capture‑evidence writes with source‑event persistence and added tests for source‑event behavior (atomic commits, conflict handling, failed→processed promotion) and pipeline flows.

<sup>Written for commit 20ab1206fcb0caf92562a2f7d9221f0eaaf91ffc. Summary will update on new commits. <a href="https://cubic.dev/pr/B4rz99/fidy/pull/436?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

