### PR TITLE
refactor(mobile): tighten ledger guardrails

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -67,6 +67,17 @@ module.exports = {
       },
     },
     {
+      name: "local-ledger-consumers-must-use-public-entrypoints",
+      severity: "error",
+      from: {
+        pathNot: "^apps/mobile/(local-ledger/|infrastructure/local-ledger/|__tests__/)",
+      },
+      to: {
+        path: "^apps/mobile/local-ledger/",
+        pathNot: "^apps/mobile/local-ledger/(public|snapshot\\.public)\\.ts$",
+      },
+    },
+    {
       name: "only-app-or-features-may-depend-on-mutations",
       severity: "error",
       from: { pathNot: "^apps/mobile/(app/.+|features/.+)" },

--- a/apps/mobile/__tests__/capture-sources/apple-pay-pipeline.test.ts
+++ b/apps/mobile/__tests__/capture-sources/apple-pay-pipeline.test.ts
@@ -12,7 +12,6 @@ const mockClassifyMerchantApi = vi.fn<(...args: any[]) => any>().mockResolvedVal
 const mockIsCaptureProcessed = vi.fn<(...args: any[]) => any>().mockResolvedValue(false);
 const mockFindDuplicateTransaction = vi.fn<(...args: any[]) => any>().mockResolvedValue(null);
 const mockCaptureFingerprint = vi.fn<(...args: any[]) => any>().mockReturnValue("test-fingerprint");
-const mockInsertProcessedCapture = vi.fn<(...args: any[]) => any>();
 const mockPersistProcessedSourceEvent = vi.fn<(...args: any[]) => any>();
 const mockPersistCommittedCaptureSourceEvent = vi.fn<(...args: any[]) => any>();
 const mockRecordAutomatedTransactionWithLocalLedger = vi.fn<(...args: any[]) => any>();
@@ -104,10 +103,6 @@ vi.mock("@/features/capture-sources/lib/dedup", () => ({
   isCaptureProcessed: (...args: any[]) => mockIsCaptureProcessed(...args),
   findDuplicateTransaction: (...args: any[]) => mockFindDuplicateTransaction(...args),
   captureFingerprint: (...args: any[]) => mockCaptureFingerprint(...args),
-}));
-
-vi.mock("@/features/capture-sources/lib/repository", () => ({
-  insertProcessedCapture: (...args: any[]) => mockInsertProcessedCapture(...args),
 }));
 
 vi.mock("@/features/financial-accounts", () => ({

--- a/apps/mobile/__tests__/capture-sources/notification-pipeline.test.ts
+++ b/apps/mobile/__tests__/capture-sources/notification-pipeline.test.ts
@@ -12,7 +12,6 @@ const mockParseNotificationApi = vi.fn<(...args: any[]) => any>().mockResolvedVa
 const mockIsCaptureProcessed = vi.fn<(...args: any[]) => any>().mockResolvedValue(false);
 const mockFindDuplicateTransaction = vi.fn<(...args: any[]) => any>().mockResolvedValue(null);
 const mockCaptureFingerprint = vi.fn<(...args: any[]) => any>().mockReturnValue("test-fingerprint");
-const mockInsertProcessedCapture = vi.fn<(...args: any[]) => any>();
 const mockRecordAutomatedTransactionWithLocalLedger = vi.fn<(...args: any[]) => any>();
 const mockPersistProcessedSourceEvent = vi.fn<(...args: any[]) => any>();
 const mockPersistCommittedCaptureSourceEvent = vi.fn<(...args: any[]) => any>();
@@ -110,10 +109,6 @@ vi.mock("@/features/capture-sources/lib/dedup", () => ({
   isCaptureProcessed: (...args: any[]) => mockIsCaptureProcessed(...args),
   findDuplicateTransaction: (...args: any[]) => mockFindDuplicateTransaction(...args),
   captureFingerprint: (...args: any[]) => mockCaptureFingerprint(...args),
-}));
-
-vi.mock("@/features/capture-sources/lib/repository", () => ({
-  insertProcessedCapture: (...args: any[]) => mockInsertProcessedCapture(...args),
 }));
 
 vi.mock("@/features/email-capture/services/parse-email-api", () => ({

--- a/apps/mobile/__tests__/capture-sources/repository-sms-events.test.ts
+++ b/apps/mobile/__tests__/capture-sources/repository-sms-events.test.ts
@@ -9,9 +9,9 @@ import {
   getProcessedCapturesBySource,
   getUndismissedSmsEvents,
   insertDetectedSmsEvent,
-  insertProcessedCapture,
   upsertNotificationSource,
 } from "@/features/capture-sources/lib/repository";
+import { processedCaptures } from "@/shared/db/schema";
 import type {
   DetectedSmsEventId,
   IsoDateTime,
@@ -56,7 +56,7 @@ const insertSmsEventRow = (
     createdAt: CREATED_AT,
   });
 
-const insertProcessedCaptureRow = (
+const seedLegacyProcessedCaptureRow = (
   overrides: Partial<{
     id: ProcessedCaptureId;
     fingerprintHash: string;
@@ -68,17 +68,20 @@ const insertProcessedCaptureRow = (
     receivedAt: IsoDateTime;
   }> = {}
 ) =>
-  insertProcessedCapture(db as any, {
-    id: overrides.id ?? ("pc-1" as ProcessedCaptureId),
-    fingerprintHash: overrides.fingerprintHash ?? "hash-1",
-    source: overrides.source ?? "sms",
-    status: overrides.status ?? "accepted",
-    rawText: overrides.rawText ?? "Compra aprobada",
-    transactionId: overrides.transactionId ?? null,
-    confidence: overrides.confidence ?? 0.9,
-    receivedAt: overrides.receivedAt ?? ("2026-04-10T08:00:00.000Z" as IsoDateTime),
-    createdAt: CREATED_AT,
-  });
+  db
+    .insert(processedCaptures)
+    .values({
+      id: overrides.id ?? ("pc-1" as ProcessedCaptureId),
+      fingerprintHash: overrides.fingerprintHash ?? "hash-1",
+      source: overrides.source ?? "sms",
+      status: overrides.status ?? "accepted",
+      rawText: overrides.rawText ?? "Compra aprobada",
+      transactionId: overrides.transactionId ?? null,
+      confidence: overrides.confidence ?? 0.9,
+      receivedAt: overrides.receivedAt ?? ("2026-04-10T08:00:00.000Z" as IsoDateTime),
+      createdAt: CREATED_AT,
+    })
+    .run();
 
 const insertNotificationSourceRow = (
   overrides: Partial<{
@@ -173,21 +176,21 @@ describe("capture-sources repository SMS events", () => {
   });
 
   it("returns only captures for the requested source in newest-first order", async () => {
-    await insertProcessedCaptureRow({
+    await seedLegacyProcessedCaptureRow({
       id: "pc-1" as ProcessedCaptureId,
       fingerprintHash: "hash-1",
       source: "sms",
       receivedAt: "2026-04-10T08:00:00.000Z" as IsoDateTime,
       rawText: "Older SMS capture",
     });
-    await insertProcessedCaptureRow({
+    await seedLegacyProcessedCaptureRow({
       id: "pc-2" as ProcessedCaptureId,
       fingerprintHash: "hash-2",
       source: "push",
       receivedAt: "2026-04-10T09:30:00.000Z" as IsoDateTime,
       rawText: "Other source capture",
     });
-    await insertProcessedCaptureRow({
+    await seedLegacyProcessedCaptureRow({
       id: "pc-3" as ProcessedCaptureId,
       fingerprintHash: "hash-3",
       source: "sms",

--- a/apps/mobile/__tests__/capture-sources/repository.test.ts
+++ b/apps/mobile/__tests__/capture-sources/repository.test.ts
@@ -6,13 +6,7 @@ import {
   requireTransactionId,
   requireUserId,
 } from "@/shared/types/assertions";
-import type {
-  DetectedSmsEventId,
-  IsoDateTime,
-  ProcessedCaptureId,
-  TransactionId,
-  UserId,
-} from "@/shared/types/branded";
+import type { DetectedSmsEventId, IsoDateTime, UserId } from "@/shared/types/branded";
 
 vi.mock("drizzle-orm", () => ({
   eq: vi.fn<(...args: any[]) => any>((...args: any[]) => ({ eq: args })),
@@ -55,7 +49,6 @@ vi.mock("@/shared/lib/generate-id", () => ({
   generateNotificationSourceId: () => "ns-mock-id",
 }));
 
-const mockOnConflictDoNothing = vi.fn<(...args: any[]) => any>().mockResolvedValue(undefined);
 const mockOnConflictDoUpdate = vi.fn<(...args: any[]) => any>().mockResolvedValue(undefined);
 const mockValues = vi.fn<(...args: any[]) => any>().mockReturnThis();
 const mockInsert = vi.fn<(...args: any[]) => any>(() => ({ values: mockValues }));
@@ -89,35 +82,10 @@ describe("capture-sources repository", () => {
     mockWhere.mockReturnValue({ orderBy: mockOrderBy, limit: mockLimit });
     mockInsert.mockReturnValue({ values: mockValues });
     mockValues.mockReturnValue({
-      onConflictDoNothing: mockOnConflictDoNothing,
       onConflictDoUpdate: mockOnConflictDoUpdate,
     });
     mockUpdate.mockReturnValue({ set: mockSet });
     mockSet.mockReturnValue({ where: mockUpdateWhere });
-  });
-
-  // -- insertProcessedCapture --
-
-  it("insertProcessedCapture calls db.insert with correct data", async () => {
-    const { insertProcessedCapture } = await import("@/features/capture-sources/lib/repository");
-
-    const row = {
-      id: "pc-1" as ProcessedCaptureId,
-      fingerprintHash: "abc123",
-      source: "sms",
-      status: "success",
-      rawText: "Compra aprobada",
-      transactionId: "tx-1" as TransactionId,
-      confidence: 0.95,
-      receivedAt: "2026-03-07T10:00:00Z" as IsoDateTime,
-      createdAt: "2026-03-07T10:00:00Z" as IsoDateTime,
-    };
-
-    await insertProcessedCapture(mockDb, row);
-
-    expect(mockInsert).toHaveBeenCalled();
-    expect(mockValues).toHaveBeenCalledWith(row);
-    expect(mockOnConflictDoNothing).toHaveBeenCalled();
   });
 
   // -- hasProcessedCaptures --

--- a/apps/mobile/__tests__/capture-sources/widget-pipeline.test.ts
+++ b/apps/mobile/__tests__/capture-sources/widget-pipeline.test.ts
@@ -7,7 +7,6 @@ import type { UserId } from "@/shared/types/branded";
 const mockInsertTransaction = vi.fn<(...args: any[]) => any>();
 const mockIsCaptureProcessed = vi.fn<(...args: any[]) => any>();
 const mockFindDuplicateTransaction = vi.fn<(...args: any[]) => any>();
-const mockInsertProcessedCapture = vi.fn<(...args: any[]) => any>();
 const mockPersistProcessedSourceEvent = vi.fn<(...args: any[]) => any>();
 const mockPersistCommittedCaptureSourceEvent = vi.fn<(...args: any[]) => any>();
 const mockPersistCommittedCaptureSourceEventInTransaction = vi.fn<(...args: any[]) => any>();
@@ -80,10 +79,6 @@ vi.mock("@/features/capture-sources/lib/dedup", () => ({
   isCaptureProcessed: (...args: any[]) => mockIsCaptureProcessed(...args),
   findDuplicateTransaction: (...args: any[]) => mockFindDuplicateTransaction(...args),
   captureFingerprint: (...args: CaptureFingerprintArgs) => buildFingerprint(args),
-}));
-
-vi.mock("@/features/capture-sources/lib/repository", () => ({
-  insertProcessedCapture: (...args: any[]) => mockInsertProcessedCapture(...args),
 }));
 
 vi.mock("@/modules/expo-app-intents", () => ({

--- a/apps/mobile/features/capture-sources/lib/repository.ts
+++ b/apps/mobile/features/capture-sources/lib/repository.ts
@@ -51,13 +51,7 @@ export async function upsertNotificationSource(
     });
 }
 
-// -- processedCaptures CRUD --
-
-export type ProcessedCaptureRow = typeof processedCaptures.$inferInsert;
-
-export async function insertProcessedCapture(db: AnyDb, row: ProcessedCaptureRow) {
-  await db.insert(processedCaptures).values(row).onConflictDoNothing();
-}
+// -- processedCaptures reads --
 
 export async function getProcessedCapturesBySource(db: AnyDb, source: string) {
   return db

--- a/scripts/dependency-cruiser-config.test.ts
+++ b/scripts/dependency-cruiser-config.test.ts
@@ -2,10 +2,11 @@ import { expect, test } from "bun:test";
 
 type ForbiddenRule = {
   readonly name: string;
-  readonly from?: { readonly path?: string };
+  readonly from?: { readonly path?: string; readonly pathNot?: string };
   readonly to?: {
     readonly dependencyTypes?: readonly string[];
     readonly path?: string;
+    readonly pathNot?: string;
   };
 };
 
@@ -56,4 +57,19 @@ test("guards pure local-ledger code from app layers and runtime infrastructure",
     "@supabase/",
     "@sentry/",
   ]);
+});
+
+test("guards local-ledger internals behind public entrypoints for consumers", () => {
+  const publicImportsRule = config.forbidden.find(
+    (forbiddenRule) => forbiddenRule.name === "local-ledger-consumers-must-use-public-entrypoints"
+  );
+
+  expect(publicImportsRule).toBeDefined();
+  expect(publicImportsRule?.from?.pathNot).toBe(
+    "^apps/mobile/(local-ledger/|infrastructure/local-ledger/|__tests__/)"
+  );
+  expect(publicImportsRule?.to?.path).toBe("^apps/mobile/local-ledger/");
+  expect(publicImportsRule?.to?.pathNot).toBe(
+    "^apps/mobile/local-ledger/(public|snapshot\\.public)\\.ts$"
+  );
 });


### PR DESCRIPTION
- Enforce public ledger imports
- Remove capture write hatch
- Verify issue 426 checks


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces public-only imports for the local ledger and removes the legacy processed-capture write hatch. Aligns with Linear 426 and adds tests to lock in the guardrails.

- **Refactors**
  - Adds a `dependency-cruiser` rule to block imports to `apps/mobile/local-ledger/**` except via `public.ts` or `snapshot.public.ts` (ledger internals, infra, and tests are exempt); includes a config test to verify it.
  - Removes `insertProcessedCapture` from `capture-sources` and related mocks/tests; tests now seed via the `processedCaptures` schema to avoid external writes.

<sup>Written for commit 6a189c64c8c182fd53b7201471bfe63a80840b4e. Summary will update on new commits. <a href="https://cubic.dev/pr/B4rz99/fidy/pull/439?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

