### PR TITLE
fix(mobile): guard local ledger purity

### DIFF
--- a/apps/mobile/features/capture-evidence/schema.ts
+++ b/apps/mobile/features/capture-evidence/schema.ts
@@ -2,11 +2,4 @@ import { z } from "zod";
 import { CAPTURE_EVIDENCE_TYPES } from "@/shared/capture-evidence/types";
 
 export const captureEvidenceTypeSchema = z.enum(CAPTURE_EVIDENCE_TYPES);
-export type CaptureEvidenceType = z.infer<typeof captureEvidenceTypeSchema>;
-
-export type CaptureEvidenceSeed = {
-  readonly sourceFamily: string;
-  readonly evidenceType: CaptureEvidenceType;
-  readonly scope: string;
-  readonly value: string;
-};
+export type { CaptureEvidenceSeed, CaptureEvidenceType } from "@/shared/capture-evidence/types";

--- a/apps/mobile/infrastructure/local-ledger/source-events.ts
+++ b/apps/mobile/infrastructure/local-ledger/source-events.ts
@@ -1,5 +1,5 @@
 import { and, eq, isNull } from "drizzle-orm";
-import type { CaptureEvidenceSeed } from "@/features/capture-evidence/schema.public";
+import type { CaptureEvidenceSeed } from "@/shared/capture-evidence/types";
 import type { AnyDb } from "@/shared/db";
 import {
   captureEvidence,

--- a/apps/mobile/local-ledger/domain/public.ts
+++ b/apps/mobile/local-ledger/domain/public.ts
@@ -1,4 +1,4 @@
-import type { CaptureEvidenceType } from "@/features/capture-evidence/schema.public";
+import type { CaptureEvidenceType } from "@/shared/capture-evidence/types";
 import type {
   CopAmount,
   FinancialAccountId,

--- a/apps/mobile/shared/capture-evidence/types.ts
+++ b/apps/mobile/shared/capture-evidence/types.ts
@@ -10,3 +10,12 @@ export const CAPTURE_EVIDENCE_TYPES = [
   "account_type_hint",
   "counterparty_hint",
 ] as const;
+
+export type CaptureEvidenceType = (typeof CAPTURE_EVIDENCE_TYPES)[number];
+
+export type CaptureEvidenceSeed = {
+  readonly sourceFamily: string;
+  readonly evidenceType: CaptureEvidenceType;
+  readonly scope: string;
+  readonly value: string;
+};

--- a/scripts/check-feature-public-imports.test.ts
+++ b/scripts/check-feature-public-imports.test.ts
@@ -80,6 +80,8 @@ test("ignores same-feature barrels, tests, and explicit public imports", () => {
   expect(result.exitCode).toBe(0);
   expect(result.stdout.toString()).toContain("Broad cross-feature barrel imports: 0");
   expect(result.stdout.toString()).toContain("No broad cross-feature barrel imports found.");
+  expect(result.stdout.toString()).toContain("Local Ledger feature imports: 0");
+  expect(result.stdout.toString()).toContain("No Local Ledger feature imports found.");
 });
 
 test("fails in enforce mode when violations are present", () => {
@@ -102,6 +104,29 @@ test("fails in enforce mode when violations are present", () => {
   expect(stdout).toContain("Broad cross-feature barrel imports: 1");
   expect(stdout).toContain(
     "apps/mobile/features/search/store.ts:1 imports @/features/transactions"
+  );
+});
+
+test("fails for Local Ledger feature imports including type-only imports", () => {
+  const root = createTempDir();
+  writeSourceFile(
+    root,
+    "apps/mobile/local-ledger/domain/public.ts",
+    'import type { CaptureEvidenceType } from "@/features/capture-evidence/schema.public";\n'
+  );
+
+  const result = Bun.spawnSync({
+    cmd: ["bun", "scripts/check-feature-public-imports.ts", "--root", root, "--enforce"],
+    cwd: process.cwd(),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  expect(result.exitCode).toBe(1);
+  const stdout = normalizePathSeparators(result.stdout.toString());
+  expect(stdout).toContain("Local Ledger feature imports: 1");
+  expect(stdout).toContain(
+    "apps/mobile/local-ledger/domain/public.ts:1 imports @/features/capture-evidence"
   );
 });
 

--- a/scripts/check-feature-public-imports.ts
+++ b/scripts/check-feature-public-imports.ts
@@ -14,9 +14,10 @@ type ImportViolation = {
 
 const DEFAULT_ROOT = process.cwd();
 const FEATURES_ROOT = join("apps", "mobile", "features");
+const LOCAL_LEDGER_ROOT = join("apps", "mobile", "local-ledger");
 const TEST_FILE_PATTERN = /\.test\.(ts|tsx)$/;
-const FEATURE_IMPORT_PATTERN =
-  /(?:^|\n)\s*(?:import|export)(?:\s+type)?[\s\S]*?\bfrom\s+["']@\/features\/([^/"']+)["']/g;
+const FEATURE_IMPORT_PATTERN = String.raw`(?:^|\n)\s*(?:import|export)(?:\s+type)?[\s\S]*?\bfrom\s+["']@\/features\/([^/"']+)["']`;
+const ANY_FEATURE_IMPORT_PATTERN = String.raw`(?:^|\n)\s*(?:import|export)(?:\s+type)?[\s\S]*?\bfrom\s+["']@\/features\/([^/"']+)(?:\/[^"']*)?["']`;
 const withOptions = (options: CliOptions, patch: Partial<CliOptions>): CliOptions => ({
   ...options,
   ...patch,
@@ -60,7 +61,18 @@ const getDeclarationOffset = (match: RegExpMatchArray): number | null => {
 const collectFeatureImports = (
   source: string
 ): readonly { readonly importedFeature: string; readonly line: number }[] =>
-  Array.from(source.matchAll(FEATURE_IMPORT_PATTERN)).flatMap((match) => {
+  collectImportsMatchingPattern(source, FEATURE_IMPORT_PATTERN);
+
+const collectAnyFeatureImports = (
+  source: string
+): readonly { readonly importedFeature: string; readonly line: number }[] =>
+  collectImportsMatchingPattern(source, ANY_FEATURE_IMPORT_PATTERN);
+
+const collectImportsMatchingPattern = (
+  source: string,
+  pattern: string
+): readonly { readonly importedFeature: string; readonly line: number }[] =>
+  Array.from(source.matchAll(new RegExp(pattern, "g"))).flatMap((match) => {
     const importedFeature = match[1];
     const matchIndex = match.index;
     const declarationOffset = getDeclarationOffset(match);
@@ -97,6 +109,24 @@ export const collectFeaturePublicImportViolations = (root: string): readonly Imp
     });
 };
 
+export const collectLocalLedgerFeatureImportViolations = (
+  root: string
+): readonly ImportViolation[] => {
+  const localLedgerRoot = join(root, LOCAL_LEDGER_ROOT);
+
+  return walk(localLedgerRoot)
+    .filter(isTsSourceFile)
+    .filter((path) => !isIgnoredSourceFile(path))
+    .flatMap((path) => {
+      const source = readFileSync(path, "utf8");
+      return collectAnyFeatureImports(source).map((importedFeature) => ({
+        importer: normalizePath(relative(root, path)),
+        importedFeature: importedFeature.importedFeature,
+        line: importedFeature.line,
+      }));
+    });
+};
+
 const parseArgs = (argv: readonly string[]): CliOptions =>
   argv.reduce<CliOptions>(
     (options, arg, index, allArgs) => {
@@ -117,12 +147,16 @@ const parseArgs = (argv: readonly string[]): CliOptions =>
 const formatViolation = (violation: ImportViolation): string =>
   `${violation.importer}:${violation.line} imports @/features/${violation.importedFeature}`;
 
-const reportViolations = (violations: readonly ImportViolation[]): void => {
+const reportViolations = (
+  violations: readonly ImportViolation[],
+  label: string,
+  emptyMessage: string
+): void => {
   const total = violations.length;
-  console.log(`Broad cross-feature barrel imports: ${total}`);
+  console.log(`${label}: ${total}`);
 
   if (total === 0) {
-    console.log("No broad cross-feature barrel imports found.");
+    console.log(emptyMessage);
     return;
   }
 
@@ -136,10 +170,23 @@ const reportViolations = (violations: readonly ImportViolation[]): void => {
 
 const main = (argv: readonly string[]): number => {
   const options = parseArgs(argv);
-  const violations = collectFeaturePublicImportViolations(options.root);
-  reportViolations(violations);
+  const featureImportViolations = collectFeaturePublicImportViolations(options.root);
+  const localLedgerImportViolations = collectLocalLedgerFeatureImportViolations(options.root);
+  reportViolations(
+    featureImportViolations,
+    "Broad cross-feature barrel imports",
+    "No broad cross-feature barrel imports found."
+  );
+  reportViolations(
+    localLedgerImportViolations,
+    "Local Ledger feature imports",
+    "No Local Ledger feature imports found."
+  );
 
-  return options.enforce && violations.length > 0 ? 1 : 0;
+  return options.enforce &&
+    (featureImportViolations.length > 0 || localLedgerImportViolations.length > 0)
+    ? 1
+    : 0;
 };
 
 if (import.meta.main) {

--- a/scripts/dependency-cruiser-config.test.ts
+++ b/scripts/dependency-cruiser-config.test.ts
@@ -12,11 +12,37 @@ type ForbiddenRule = {
 
 const config = require("../.dependency-cruiser.cjs") as {
   readonly forbidden: readonly ForbiddenRule[];
+  readonly options?: { readonly tsPreCompilationDeps?: boolean | "specify" };
+};
+
+type RepresentativeDependency = {
+  readonly from: string;
+  readonly to: string;
+  readonly dependencyTypes: readonly string[];
 };
 
 const extractPackageAlternatives = (packagePattern: string): readonly string[] => {
   const match = packagePattern.match(/^\^\(node_modules\/\)\?\((.*)\)$/);
   return match?.[1]?.split("|") ?? [];
+};
+
+const matchesPattern = (path: string, pattern: string | undefined): boolean =>
+  pattern === undefined || new RegExp(pattern).test(path);
+
+const matchesRule = (rule: ForbiddenRule, dependency: RepresentativeDependency): boolean => {
+  const fromMatches =
+    matchesPattern(dependency.from, rule.from?.path) &&
+    (rule.from?.pathNot === undefined || !matchesPattern(dependency.from, rule.from.pathNot));
+  const toMatches =
+    matchesPattern(dependency.to, rule.to?.path) &&
+    (rule.to?.pathNot === undefined || !matchesPattern(dependency.to, rule.to.pathNot));
+  const dependencyTypeMatches =
+    rule.to?.dependencyTypes === undefined ||
+    dependency.dependencyTypes.some((dependencyType) =>
+      rule.to?.dependencyTypes?.includes(dependencyType)
+    );
+
+  return fromMatches && toMatches && dependencyTypeMatches;
 };
 
 test("guards pure local-ledger code from app layers and runtime infrastructure", () => {
@@ -39,6 +65,13 @@ test("guards pure local-ledger code from app layers and runtime infrastructure",
   expect(forbiddenPath).toContain("^apps/mobile/shared/(query|effect|components)($|/)");
   expect(forbiddenPath).toContain("^apps/mobile/shared/lib($|\\.public\\.ts|/index\\.ts)");
   expect(forbiddenPath).toContain("^apps/mobile/shared/lib/(analytics|sentry|toast)\\.ts");
+  expect(
+    matchesRule(internalsRule!, {
+      from: "apps/mobile/local-ledger/domain/public.ts",
+      to: "apps/mobile/features/capture-evidence/schema.public.ts",
+      dependencyTypes: ["local", "type-only", "type-import"],
+    })
+  ).toBe(true);
 
   expect(packagesRule).toBeDefined();
   expect(packagesRule?.from?.path).toBe("^apps/mobile/local-ledger/");


### PR DESCRIPTION
- move capture evidence types

- reject local ledger feature imports


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Protects Local Ledger purity by blocking any imports from `@/features/*` (including type-only) and by moving capture-evidence types to shared. Updates imports and guardrail tests to enforce the boundary.

- **New Features**
  - The feature-imports check now scans `apps/mobile/local-ledger/**` and fails on any `@/features/*` import, including type-only, with a dedicated summary in the output.
  - Dependency-cruiser tests assert Local Ledger cannot depend on app/runtime layers or `@/features/*`.

- **Refactors**
  - Moved `CaptureEvidenceType` and `CaptureEvidenceSeed` to `@/shared/capture-evidence/types` and re-exported from the schema.
  - Updated Local Ledger and infra to import types from `@/shared/capture-evidence/types`.

<sup>Written for commit 378cdba30621f34bd218f6cb201759b50aa76ffb. Summary will update on new commits. <a href="https://cubic.dev/pr/B4rz99/fidy/pull/449?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

