### PR TITLE
fix(mobile): rename transfer lifecycle

### DIFF
--- a/apps/mobile/__tests__/local-ledger/record-transfer.test.ts
+++ b/apps/mobile/__tests__/local-ledger/record-transfer.test.ts
@@ -75,7 +75,7 @@ describe("RecordTransfer", () => {
         date: TODAY,
         createdAt: NOW,
         updatedAt: NOW,
-        deletedAt: null,
+        voidedAt: null,
       },
       events: [
         {

--- a/apps/mobile/__tests__/transfers/manual-transfer-local-ledger.test.ts
+++ b/apps/mobile/__tests__/transfers/manual-transfer-local-ledger.test.ts
@@ -1,8 +1,18 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: boundary test uses a focused Drizzle double
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { submitTransferForm } from "@/features/transfers/components/transfer-form/saveTransferForm";
-import { recordManualTransferWithLocalLedger } from "@/infrastructure/local-ledger/record-transfer";
-import type { FinancialAccountId, TransferId, UserId } from "@/shared/types/branded";
+import {
+  recordManualTransferWithLocalLedger,
+  toTransferRow,
+} from "@/infrastructure/local-ledger/record-transfer";
+import type {
+  CopAmount,
+  FinancialAccountId,
+  IsoDate,
+  IsoDateTime,
+  TransferId,
+  UserId,
+} from "@/shared/types/branded";
 
 const { refreshTransactionsMock } = vi.hoisted(() => ({
   refreshTransactionsMock: vi.fn<(...args: any[]) => any>(),
@@ -81,7 +91,7 @@ describe("manual transfer Local Ledger writer", () => {
         date: "2026-04-18",
         createdAt: "2026-04-18T10:00:00.000Z",
         updatedAt: "2026-04-18T10:00:00.000Z",
-        deletedAt: null,
+        voidedAt: null,
       },
     });
     expect(insertedTransfers).toEqual([
@@ -122,6 +132,27 @@ describe("manual transfer Local Ledger writer", () => {
 
     expect(result).toEqual({ success: false, error: "accountNotUsable" });
     expect(insertedTransfers).toEqual([]);
+  });
+
+  it("maps a voided Local Ledger transfer to the legacy deletedAt storage column", () => {
+    const row = toTransferRow({
+      id: "tr-voided" as TransferId,
+      userId: USER_ID,
+      amount: 450000 as CopAmount,
+      fromSide: { kind: "account", accountId: ACTIVE_ACCOUNT_ID },
+      toSide: { kind: "external", label: "Outside Fidy" },
+      description: "Voided transfer",
+      date: "2026-04-18" as IsoDate,
+      createdAt: "2026-04-18T10:00:00.000Z" as IsoDateTime,
+      updatedAt: "2026-04-18T10:00:00.000Z" as IsoDateTime,
+      voidedAt: "2026-04-18T11:00:00.000Z" as IsoDateTime,
+    });
+
+    expect(row).toMatchObject({
+      id: "tr-voided",
+      deletedAt: "2026-04-18T11:00:00.000Z",
+    });
+    expect(row).not.toHaveProperty("voidedAt");
   });
 
   it("enforces Local Ledger validation through the full manual transfer form save path", async () => {

--- a/apps/mobile/__tests__/transfers/mutation-service.test.ts
+++ b/apps/mobile/__tests__/transfers/mutation-service.test.ts
@@ -51,7 +51,7 @@ describe("transfer mutation service", () => {
         date: "2026-04-19",
         createdAt: "2026-04-19T10:00:00.000Z",
         updatedAt: "2026-04-19T10:00:00.000Z",
-        deletedAt: null,
+        voidedAt: null,
       },
     });
     refresh = refreshMock as ServiceDeps["refresh"];
@@ -112,6 +112,35 @@ describe("transfer mutation service", () => {
       now,
     });
     expect(refreshMock).toHaveBeenCalledOnce();
+  });
+
+  it("maps Local Ledger voided transfer state into the existing transfer read model", async () => {
+    recordTransferMock.mockResolvedValueOnce({
+      success: true,
+      transfer: {
+        id: "tr-new" as TransferId,
+        userId: "user-1" as UserId,
+        amount: 450000,
+        fromSide: validInput.fromSide,
+        toSide: validInput.toSide,
+        description: "Visa payment",
+        date: "2026-04-19",
+        createdAt: "2026-04-19T10:00:00.000Z",
+        updatedAt: "2026-04-19T10:00:00.000Z",
+        voidedAt: "2026-04-20T08:00:00.000Z",
+      },
+    });
+    const service = createService();
+
+    const result = await service.save(validInput);
+
+    expect(result).toEqual({
+      success: true,
+      transfer: expect.objectContaining({
+        deletedAt: new Date("2026-04-20T08:00:00.000Z"),
+      }),
+    });
+    expect(result.success ? result.transfer : null).not.toHaveProperty("voidedAt");
   });
 
   it("returns Local Ledger validation failures without refreshing", async () => {

--- a/apps/mobile/features/transfers/lib/mutation-service.ts
+++ b/apps/mobile/features/transfers/lib/mutation-service.ts
@@ -51,11 +51,16 @@ type CreateTransferMutationServiceDeps = {
 
 function toStoredTransfer(transfer: LocalLedgerTransfer): StoredTransfer {
   return {
-    ...transfer,
+    id: transfer.id,
+    userId: transfer.userId,
+    amount: transfer.amount,
+    fromSide: transfer.fromSide,
+    toSide: transfer.toSide,
+    description: transfer.description,
     date: parseIsoDate(transfer.date),
     createdAt: new Date(transfer.createdAt),
     updatedAt: new Date(transfer.updatedAt),
-    deletedAt: transfer.deletedAt == null ? null : new Date(transfer.deletedAt),
+    deletedAt: transfer.voidedAt == null ? null : new Date(transfer.voidedAt),
   };
 }
 

--- a/apps/mobile/infrastructure/local-ledger/record-transfer.ts
+++ b/apps/mobile/infrastructure/local-ledger/record-transfer.ts
@@ -70,7 +70,7 @@ function hasActiveFinancialAccount(db: AnyDb, userId: UserId, accountId: Financi
   return rows.length > 0;
 }
 
-function toTransferRow(transfer: LocalLedgerTransfer): typeof transfers.$inferInsert {
+export function toTransferRow(transfer: LocalLedgerTransfer): typeof transfers.$inferInsert {
   return {
     id: transfer.id,
     userId: transfer.userId,
@@ -83,7 +83,7 @@ function toTransferRow(transfer: LocalLedgerTransfer): typeof transfers.$inferIn
     date: transfer.date,
     createdAt: transfer.createdAt,
     updatedAt: transfer.updatedAt,
-    deletedAt: transfer.deletedAt,
+    deletedAt: transfer.voidedAt,
   };
 }
 

--- a/apps/mobile/local-ledger/domain/public.ts
+++ b/apps/mobile/local-ledger/domain/public.ts
@@ -56,7 +56,7 @@ export type LocalLedgerTransfer = {
   readonly date: IsoDate;
   readonly createdAt: IsoDateTime;
   readonly updatedAt: IsoDateTime;
-  readonly deletedAt: IsoDateTime | null;
+  readonly voidedAt: IsoDateTime | null;
 };
 
 export type LocalLedgerTransferRecorded = {

--- a/apps/mobile/local-ledger/use-cases/record-transfer-builders.ts
+++ b/apps/mobile/local-ledger/use-cases/record-transfer-builders.ts
@@ -16,7 +16,7 @@ export function toLocalLedgerTransfer(
     date: command.date,
     createdAt: command.now,
     updatedAt: command.now,
-    deletedAt: null,
+    voidedAt: null,
   };
 }
 


### PR DESCRIPTION
- local ledger voidedAt

- transfer adapter mapping

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed Local Ledger transfer lifecycle to use a `voided` state in mobile. Preserved backward compatibility by mapping `voidedAt` to the existing `deletedAt` column in storage and to the read model.

- **Refactors**
  - Replaced `deletedAt` with `voidedAt` in `LocalLedgerTransfer` and builders.
  - Exported `toTransferRow` and mapped `voidedAt` -> `deletedAt` for DB inserts.
  - Updated mutation service to map `voidedAt` -> `deletedAt` in the read model without exposing `voidedAt`.
  - Updated tests, adding coverage for DB row mapping and read model `deletedAt`.

<sup>Written for commit 8a8f5fbdb5fca2087193352ae2ec29069a7afe78. Summary will update on new commits. <a href="https://cubic.dev/pr/B4rz99/fidy/pull/451?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

