### PR TITLE
refactor(mobile): move transfer reclassification

### DIFF
--- a/apps/mobile/__tests__/local-ledger/record-transfer.test.ts
+++ b/apps/mobile/__tests__/local-ledger/record-transfer.test.ts
@@ -1,19 +1,23 @@
 import { describe, expect, it } from "vitest";
 import {
   createRecordTransfer,
+  createReclassifyTransactionsAsTransfer,
   type FinancialAccountId,
   type LocalLedgerTransferRepository,
   type LocalLedgerTransferSide,
+  type ReclassifiableTransaction,
   type RecordTransferCommand,
   type TransferId,
   type UserId,
 } from "@/local-ledger/public";
-import type { CopAmount, IsoDate, IsoDateTime } from "@/shared/types/branded";
+import type { CopAmount, IsoDate, IsoDateTime, TransactionId } from "@/shared/types/branded";
 
 const USER_ID = "user-1" as UserId;
 const FROM_ACCOUNT_ID = "account-from" as FinancialAccountId;
 const TO_ACCOUNT_ID = "account-to" as FinancialAccountId;
 const TRANSFER_ID = "transfer-1" as TransferId;
+const OUTGOING_TRANSACTION_ID = "transaction-out" as TransactionId;
+const INCOMING_TRANSACTION_ID = "transaction-in" as TransactionId;
 const NOW = "2026-04-18T10:00:00.000Z" as IsoDateTime;
 const TODAY = "2026-04-18" as IsoDate;
 
@@ -138,4 +142,183 @@ describe("RecordTransfer", () => {
     expect(result).toEqual({ code: "rejected", reason: "account-not-usable", events: [] });
     expect(savedTransfers).toEqual([]);
   });
+});
+
+function makeReclassifiableTransaction(
+  overrides: Partial<ReclassifiableTransaction> = {}
+): ReclassifiableTransaction {
+  return {
+    id: OUTGOING_TRANSACTION_ID,
+    userId: USER_ID,
+    type: "expense",
+    amount: 250000 as CopAmount,
+    accountId: FROM_ACCOUNT_ID,
+    accountAttributionState: "confirmed",
+    date: TODAY,
+    voidedAt: null,
+    supersededAt: null,
+    ...overrides,
+  };
+}
+
+function createReclassificationHarness(
+  overrides: {
+    readonly outgoing?: Partial<ReclassifiableTransaction> | null;
+    readonly incoming?: Partial<ReclassifiableTransaction> | null;
+    readonly commit?: "committed" | "rejected";
+  } = {}
+) {
+  const commits: unknown[] = [];
+  const transactions = new Map<TransactionId, ReclassifiableTransaction>();
+  if (overrides.outgoing !== null) {
+    transactions.set(
+      OUTGOING_TRANSACTION_ID,
+      makeReclassifiableTransaction(overrides.outgoing ?? {})
+    );
+  }
+  if (overrides.incoming !== null) {
+    transactions.set(
+      INCOMING_TRANSACTION_ID,
+      makeReclassifiableTransaction({
+        id: INCOMING_TRANSACTION_ID,
+        type: "income",
+        accountId: TO_ACCOUNT_ID,
+        ...overrides.incoming,
+      })
+    );
+  }
+
+  const reclassifyTransactionsAsTransfer = createReclassifyTransactionsAsTransfer({
+    userId: USER_ID,
+    source: "capture-match",
+    now: () => NOW,
+    generateTransferId: () => TRANSFER_ID,
+    ports: {
+      loadTransaction: async (transactionId) => transactions.get(transactionId) ?? null,
+      commitReclassification: async (input) => {
+        commits.push(input);
+        return overrides.commit === "rejected"
+          ? { code: "rejected", reason: "transactions-not-reclassifiable" }
+          : { code: "committed", transfer: input.transfer };
+      },
+    },
+  });
+
+  return { commits, reclassifyTransactionsAsTransfer };
+}
+
+it("reclassifies a matching expense and income pair through Local Ledger ports", async () => {
+  const { commits, reclassifyTransactionsAsTransfer } = createReclassificationHarness();
+
+  const result = await reclassifyTransactionsAsTransfer({
+    outgoingTransactionId: OUTGOING_TRANSACTION_ID,
+    incomingTransactionId: INCOMING_TRANSACTION_ID,
+    description: " Move to savings ",
+  });
+
+  expect(result).toEqual({
+    code: "reclassified",
+    transfer: {
+      id: TRANSFER_ID,
+      userId: USER_ID,
+      amount: 250000,
+      fromSide: { kind: "account", accountId: FROM_ACCOUNT_ID },
+      toSide: { kind: "account", accountId: TO_ACCOUNT_ID },
+      description: "Move to savings",
+      date: TODAY,
+      source: "capture-match",
+      createdAt: NOW,
+      updatedAt: NOW,
+      voidedAt: null,
+    },
+    events: [
+      {
+        type: "local-ledger.transfer-recorded",
+        transferId: TRANSFER_ID,
+        userId: USER_ID,
+        occurredAt: NOW,
+      },
+    ],
+  });
+  expect(commits).toEqual([
+    expect.objectContaining({
+      outgoingTransactionId: OUTGOING_TRANSACTION_ID,
+      incomingTransactionId: INCOMING_TRANSACTION_ID,
+      supersededAt: NOW,
+    }),
+  ]);
+});
+
+it.each([
+  ["missing outgoing", { outgoing: null }, "transactions-not-found"],
+  ["other user", { incoming: { userId: "other-user" as UserId } }, "transactions-not-found"],
+  ["voided transaction", { outgoing: { voidedAt: NOW } }, "transactions-not-found"],
+  ["superseded transaction", { incoming: { supersededAt: NOW } }, "transactions-not-found"],
+  [
+    "same transaction id",
+    { incoming: { id: OUTGOING_TRANSACTION_ID } },
+    "transactions-not-reclassifiable",
+  ],
+  [
+    "wrong outgoing type",
+    { outgoing: { type: "income" as const } },
+    "transactions-not-reclassifiable",
+  ],
+  [
+    "wrong incoming type",
+    { incoming: { type: "expense" as const } },
+    "transactions-not-reclassifiable",
+  ],
+  [
+    "amount mismatch",
+    { incoming: { amount: 100000 as CopAmount } },
+    "transactions-not-reclassifiable",
+  ],
+  [
+    "non-positive amount",
+    { outgoing: { amount: 0 as CopAmount }, incoming: { amount: 0 as CopAmount } },
+    "transactions-not-reclassifiable",
+  ],
+  [
+    "date mismatch",
+    { incoming: { date: "2026-04-19" as IsoDate } },
+    "transactions-not-reclassifiable",
+  ],
+  [
+    "unresolved attribution",
+    { incoming: { accountAttributionState: "unresolved" as const } },
+    "transactions-not-reclassifiable",
+  ],
+  ["missing account", { outgoing: { accountId: null } }, "transactions-not-reclassifiable"],
+  ["same account", { incoming: { accountId: FROM_ACCOUNT_ID } }, "transactions-not-reclassifiable"],
+] as const)("rejects %s before commit", async (_label, overrides, reason) => {
+  const { commits, reclassifyTransactionsAsTransfer } = createReclassificationHarness(overrides);
+
+  const result = await reclassifyTransactionsAsTransfer({
+    outgoingTransactionId: OUTGOING_TRANSACTION_ID,
+    incomingTransactionId: INCOMING_TRANSACTION_ID,
+    description: "Move to savings",
+  });
+
+  expect(result).toEqual({ code: "rejected", reason, events: [] });
+  expect(commits).toEqual([]);
+});
+
+it("returns a rejection when the commit port rejects the current rows", async () => {
+  const { commits, reclassifyTransactionsAsTransfer } = createReclassificationHarness({
+    commit: "rejected",
+  });
+
+  const result = await reclassifyTransactionsAsTransfer({
+    outgoingTransactionId: OUTGOING_TRANSACTION_ID,
+    incomingTransactionId: INCOMING_TRANSACTION_ID,
+    description: "Move to savings",
+  });
+
+  expect(result).toEqual({
+    code: "rejected",
+    reason: "transactions-not-reclassifiable",
+    events: [],
+  });
+  expect(commits).toHaveLength(1);
 });

--- a/apps/mobile/__tests__/transfers/reclassify-transaction-as-transfer.test.ts
+++ b/apps/mobile/__tests__/transfers/reclassify-transaction-as-transfer.test.ts
@@ -239,12 +239,12 @@ describe("reclassifyTransactionAsTransfer", () => {
 });
 
 describe("reclassifyTransactionsAsTransfer", () => {
-  it("creates one transfer and supersedes the matching outgoing and incoming transactions", () => {
+  it("creates one transfer and supersedes the matching outgoing and incoming transactions", async () => {
     insertReclassificationAccounts();
     insertOriginalTransactionRecord();
     insertIncomingTransactionRecord();
 
-    const result = reclassifyTransactionsAsTransfer(
+    const result = await reclassifyTransactionsAsTransfer(
       db as any,
       {
         userId: USER_ID,
@@ -291,12 +291,12 @@ describe("reclassifyTransactionsAsTransfer", () => {
     expect(getSpendingByCategoryAggregate(db as any, USER_ID, "2026-04" as any)).toEqual([]);
   });
 
-  it("rolls back the transfer and supersession links when the atomic commit fails", () => {
+  it("rolls back the transfer and supersession links when the atomic commit fails", async () => {
     insertReclassificationAccounts();
     insertOriginalTransactionRecord();
     insertIncomingTransactionRecord();
 
-    expect(() =>
+    await expect(
       reclassifyTransactionsAsTransfer(
         db as any,
         {
@@ -316,7 +316,7 @@ describe("reclassifyTransactionsAsTransfer", () => {
           },
         }
       )
-    ).toThrow("failed to supersede incoming transaction");
+    ).rejects.toThrow("failed to supersede incoming transaction");
 
     expect(getTransferById(db as any, TRANSFER_ID)).toBeNull();
     expect(getTransactionById(db as any, ORIGINAL_TRANSACTION_ID)).toMatchObject({
@@ -331,7 +331,45 @@ describe("reclassifyTransactionsAsTransfer", () => {
     });
   });
 
-  it("rejects transactions that do not both belong to the user", () => {
+  it("rolls back when a supersession writer silently skips one source transaction", async () => {
+    insertReclassificationAccounts();
+    insertOriginalTransactionRecord();
+    insertIncomingTransactionRecord();
+
+    await expect(
+      reclassifyTransactionsAsTransfer(
+        db as any,
+        {
+          userId: USER_ID,
+          outgoingTransactionId: ORIGINAL_TRANSACTION_ID,
+          incomingTransactionId: INCOMING_TRANSACTION_ID,
+          description: "Move to savings",
+        },
+        {
+          now: () => new Date(NOW),
+          createId: () => TRANSFER_ID,
+          saveTransactionRow: (tx, input) => {
+            if (input.id === INCOMING_TRANSACTION_ID) return;
+            return markTransactionSuperseded(tx, input);
+          },
+        }
+      )
+    ).rejects.toThrow("transfer reclassification did not supersede both source transactions");
+
+    expect(getTransferById(db as any, TRANSFER_ID)).toBeNull();
+    expect(getTransactionById(db as any, ORIGINAL_TRANSACTION_ID)).toMatchObject({
+      supersededAt: null,
+      supersededByTransferId: null,
+      updatedAt: ORIGINAL_CREATED_AT,
+    });
+    expect(getTransactionById(db as any, INCOMING_TRANSACTION_ID)).toMatchObject({
+      supersededAt: null,
+      supersededByTransferId: null,
+      updatedAt: ORIGINAL_CREATED_AT,
+    });
+  });
+
+  it("rejects transactions that do not both belong to the user", async () => {
     insertOriginalTransactionRecord();
     insertTransaction(db as any, {
       id: INCOMING_TRANSACTION_ID,
@@ -350,7 +388,7 @@ describe("reclassifyTransactionsAsTransfer", () => {
       source: "email_capture",
     });
 
-    const result = reclassifyTransactionsAsTransfer(
+    const result = await reclassifyTransactionsAsTransfer(
       db as any,
       {
         userId: USER_ID,
@@ -376,7 +414,7 @@ describe("reclassifyTransactionsAsTransfer", () => {
     });
   });
 
-  it("rejects same-amount transactions from different dates", () => {
+  it("rejects same-amount transactions from different dates", async () => {
     insertReclassificationAccounts();
     insertOriginalTransactionRecord();
     insertIncomingTransactionRecord();
@@ -397,7 +435,7 @@ describe("reclassifyTransactionsAsTransfer", () => {
       source: "email_capture",
     });
 
-    const result = reclassifyTransactionsAsTransfer(
+    const result = await reclassifyTransactionsAsTransfer(
       db as any,
       {
         userId: USER_ID,
@@ -423,7 +461,7 @@ describe("reclassifyTransactionsAsTransfer", () => {
     });
   });
 
-  it("rejects transactions with unresolved account attribution", () => {
+  it("rejects transactions with unresolved account attribution", async () => {
     insertReclassificationAccounts();
     insertOriginalTransactionRecord();
     insertTransaction(db as any, {
@@ -443,7 +481,7 @@ describe("reclassifyTransactionsAsTransfer", () => {
       source: "email_capture",
     });
 
-    const result = reclassifyTransactionsAsTransfer(
+    const result = await reclassifyTransactionsAsTransfer(
       db as any,
       {
         userId: USER_ID,
@@ -469,13 +507,13 @@ describe("reclassifyTransactionsAsTransfer", () => {
     });
   });
 
-  it("rejects transactions whose accounts are not active accounts for the user", () => {
+  it("rejects transactions whose accounts are not active accounts for the user", async () => {
     insertFinancialAccount(ACCOUNT_ID);
     insertFinancialAccount(SAVINGS_ACCOUNT_ID, { userId: "other-user" as UserId });
     insertOriginalTransactionRecord();
     insertIncomingTransactionRecord();
 
-    const result = reclassifyTransactionsAsTransfer(
+    const result = await reclassifyTransactionsAsTransfer(
       db as any,
       {
         userId: USER_ID,

--- a/apps/mobile/features/transfers/lib/reclassify-transactions-as-transfer.ts
+++ b/apps/mobile/features/transfers/lib/reclassify-transactions-as-transfer.ts
@@ -1,8 +1,14 @@
 import { and, eq, inArray, isNull } from "drizzle-orm";
 import {
+  createReclassifyTransactionsAsTransfer,
+  type LocalLedgerTransfer,
+  type ReclassifiableTransaction,
+} from "@/local-ledger/public";
+import {
   getTransactionById,
   markTransactionSuperseded,
 } from "@/features/transactions/transfer-reclassification.public";
+import { toTransferRow } from "@/infrastructure/local-ledger/record-transfer";
 import type { AnyDb } from "@/shared/db";
 import { financialAccounts } from "@/shared/db/schema";
 import { parseIsoDate, toIsoDateTime } from "@/shared/lib/format-date";
@@ -14,13 +20,7 @@ import type {
   TransferId,
   UserId,
 } from "@/shared/types/branded";
-import {
-  buildTransfer,
-  type StoredTransfer,
-  type TransferBuildError,
-  toTransferRow,
-} from "./build-transfer";
-import type { TransferRow } from "./repository";
+import type { StoredTransfer } from "./build-transfer";
 import { saveTransfer } from "./repository";
 
 type ReclassifyTransactionsAsTransferInput = {
@@ -33,14 +33,32 @@ type ReclassifyTransactionsAsTransferInput = {
 type ReclassifyTransactionsAsTransferDeps = {
   readonly now?: () => Date;
   readonly createId?: () => TransferId;
-  readonly saveTransferRow?: (db: Parameters<typeof saveTransfer>[0], row: TransferRow) => void;
   readonly loadTransactionById?: typeof getTransactionById;
+  readonly saveTransferRow?: (
+    db: Parameters<typeof saveTransfer>[0],
+    row: ReturnType<typeof toTransferRow>
+  ) => void;
   readonly saveTransactionRow?: typeof markTransactionSuperseded;
   readonly canUseAccounts?: typeof canUseAccountsForReclassification;
 };
 
+type ReclassificationCommitDeps = {
+  readonly canUseAccounts: typeof canUseAccountsForReclassification;
+  readonly loadTransactionById: typeof getTransactionById;
+  readonly saveTransactionRow: typeof markTransactionSuperseded;
+  readonly saveTransferRow: NonNullable<ReclassifyTransactionsAsTransferDeps["saveTransferRow"]>;
+};
+
+type ReclassificationCommitInput = {
+  readonly db: Parameters<typeof saveTransfer>[0];
+  readonly userId: UserId;
+  readonly transfer: LocalLedgerTransfer;
+  readonly outgoingTransactionId: TransactionId;
+  readonly incomingTransactionId: TransactionId;
+  readonly supersededAt: IsoDateTime;
+};
+
 export type ReclassifyTransactionsAsTransferError =
-  | TransferBuildError
   | "transactionsNotFound"
   | "transactionsNotReclassifiable";
 
@@ -48,17 +66,19 @@ export type ReclassifyTransactionsAsTransferResult =
   | { readonly success: true; readonly transfer: StoredTransfer }
   | { readonly success: false; readonly error: ReclassifyTransactionsAsTransferError };
 
-function isActiveUserTransaction(
-  transaction: ReturnType<typeof getTransactionById>,
-  userId: UserId
-): transaction is NonNullable<ReturnType<typeof getTransactionById>> {
-  return (
-    transaction != null &&
-    transaction.userId === userId &&
-    transaction.voidedAt == null &&
-    transaction.supersededAt == null
-  );
-}
+const toStoredTransfer = (transfer: LocalLedgerTransfer): StoredTransfer => ({
+  id: transfer.id,
+  userId: transfer.userId,
+  amount: transfer.amount,
+  fromSide: transfer.fromSide,
+  toSide: transfer.toSide,
+  description: transfer.description,
+  date: parseIsoDate(transfer.date),
+  source: transfer.source,
+  createdAt: new Date(transfer.createdAt),
+  updatedAt: new Date(transfer.updatedAt),
+  deletedAt: transfer.voidedAt === null ? null : new Date(transfer.voidedAt),
+});
 
 const countActiveAccountsForReclassification = (
   db: AnyDb,
@@ -82,96 +102,199 @@ const canUseAccountsForReclassification = (
   db: AnyDb,
   userId: UserId,
   accountIds: readonly [FinancialAccountId, FinancialAccountId]
-): boolean => {
-  return countActiveAccountsForReclassification(db, userId, accountIds) === accountIds.length;
+): boolean => countActiveAccountsForReclassification(db, userId, accountIds) === accountIds.length;
+
+const toReclassifiableTransaction = (
+  transaction: ReturnType<typeof getTransactionById>
+): ReclassifiableTransaction | null =>
+  transaction === null || (transaction.type !== "expense" && transaction.type !== "income")
+    ? null
+    : {
+        id: transaction.id,
+        userId: transaction.userId,
+        type: transaction.type,
+        amount: transaction.amount,
+        accountId: transaction.accountId ?? null,
+        accountAttributionState:
+          transaction.accountAttributionState === "confirmed" ||
+          transaction.accountAttributionState === "inferred"
+            ? transaction.accountAttributionState
+            : "unresolved",
+        date: transaction.date,
+        voidedAt: transaction.voidedAt ?? null,
+        supersededAt: transaction.supersededAt ?? null,
+      };
+
+const mapReclassificationError = (
+  reason: "transactions-not-found" | "transactions-not-reclassifiable"
+): ReclassifyTransactionsAsTransferError =>
+  reason === "transactions-not-found" ? "transactionsNotFound" : "transactionsNotReclassifiable";
+
+const canCommitCurrentTransactions = (
+  outgoing: ReclassifiableTransaction | null,
+  incoming: ReclassifiableTransaction | null,
+  transfer: LocalLedgerTransfer,
+  userId: UserId
+): boolean =>
+  outgoing !== null &&
+  incoming !== null &&
+  outgoing.userId === userId &&
+  incoming.userId === userId &&
+  outgoing.id !== incoming.id &&
+  outgoing.type === "expense" &&
+  incoming.type === "income" &&
+  outgoing.amount === transfer.amount &&
+  incoming.amount === transfer.amount &&
+  outgoing.date === transfer.date &&
+  incoming.date === transfer.date &&
+  outgoing.accountId ===
+    (transfer.fromSide.kind === "account" ? transfer.fromSide.accountId : null) &&
+  incoming.accountId === (transfer.toSide.kind === "account" ? transfer.toSide.accountId : null) &&
+  outgoing.accountAttributionState !== "unresolved" &&
+  incoming.accountAttributionState !== "unresolved" &&
+  outgoing.voidedAt === null &&
+  incoming.voidedAt === null &&
+  outgoing.supersededAt === null &&
+  incoming.supersededAt === null;
+
+const isSupersededByTransfer = (
+  transaction: ReturnType<typeof getTransactionById>,
+  transferId: TransferId,
+  supersededAt: IsoDateTime
+): boolean =>
+  transaction !== null &&
+  transaction.supersededAt === supersededAt &&
+  transaction.supersededByTransferId === transferId;
+
+const getTransferAccountIds = (
+  transfer: LocalLedgerTransfer
+): readonly [FinancialAccountId, FinancialAccountId] | null => {
+  const fromAccountId = transfer.fromSide.kind === "account" ? transfer.fromSide.accountId : null;
+  const toAccountId = transfer.toSide.kind === "account" ? transfer.toSide.accountId : null;
+  return fromAccountId === null || toAccountId === null ? null : [fromAccountId, toAccountId];
 };
 
-function hasResolvedAccountAttribution(
-  transaction: NonNullable<ReturnType<typeof getTransactionById>>
-): boolean {
-  return transaction.accountAttributionState !== "unresolved";
+const hasCommittedSupersessions = (
+  db: Parameters<typeof saveTransfer>[0],
+  input: ReclassificationCommitInput,
+  loadTransactionById: typeof getTransactionById
+): boolean =>
+  isSupersededByTransfer(
+    loadTransactionById(db, input.outgoingTransactionId),
+    input.transfer.id,
+    input.supersededAt
+  ) &&
+  isSupersededByTransfer(
+    loadTransactionById(db, input.incomingTransactionId),
+    input.transfer.id,
+    input.supersededAt
+  );
+
+const rejectedCommit = () =>
+  ({ code: "rejected", reason: "transactions-not-reclassifiable" }) as const;
+
+const canCommitReclassification = (
+  input: ReclassificationCommitInput,
+  deps: ReclassificationCommitDeps
+): boolean => {
+  const accountIds = getTransferAccountIds(input.transfer);
+  const outgoing = toReclassifiableTransaction(
+    deps.loadTransactionById(input.db, input.outgoingTransactionId)
+  );
+  const incoming = toReclassifiableTransaction(
+    deps.loadTransactionById(input.db, input.incomingTransactionId)
+  );
+  return (
+    accountIds !== null &&
+    deps.canUseAccounts(input.db, input.userId, accountIds) &&
+    canCommitCurrentTransactions(outgoing, incoming, input.transfer, input.userId)
+  );
+};
+
+function persistSupersessions(
+  input: ReclassificationCommitInput,
+  deps: ReclassificationCommitDeps
+) {
+  deps.saveTransferRow(input.db, toTransferRow(input.transfer));
+  deps.saveTransactionRow(input.db, {
+    id: input.outgoingTransactionId,
+    supersededAt: input.supersededAt,
+    supersededByTransferId: input.transfer.id,
+    updatedAt: input.supersededAt,
+  });
+  deps.saveTransactionRow(input.db, {
+    id: input.incomingTransactionId,
+    supersededAt: input.supersededAt,
+    supersededByTransferId: input.transfer.id,
+    updatedAt: input.supersededAt,
+  });
 }
 
-export function reclassifyTransactionsAsTransfer(
+function commitReclassification(
+  input: ReclassificationCommitInput,
+  deps: ReclassificationCommitDeps
+) {
+  if (!canCommitReclassification(input, deps)) return rejectedCommit();
+
+  persistSupersessions(input, deps);
+  if (!hasCommittedSupersessions(input.db, input, deps.loadTransactionById)) {
+    throw new Error("transfer reclassification did not supersede both source transactions");
+  }
+
+  return { code: "committed", transfer: input.transfer } as const;
+}
+
+export async function reclassifyTransactionsAsTransfer(
   db: Parameters<typeof saveTransfer>[0],
   input: ReclassifyTransactionsAsTransferInput,
   {
     now = () => new Date(),
     createId = generateTransferId,
-    saveTransferRow = saveTransfer,
     loadTransactionById = getTransactionById,
+    saveTransferRow = saveTransfer,
     saveTransactionRow = markTransactionSuperseded,
     canUseAccounts = canUseAccountsForReclassification,
   }: ReclassifyTransactionsAsTransferDeps = {}
-): ReclassifyTransactionsAsTransferResult {
-  const outgoing = loadTransactionById(db, input.outgoingTransactionId);
-  const incoming = loadTransactionById(db, input.incomingTransactionId);
-
-  if (
-    !isActiveUserTransaction(outgoing, input.userId) ||
-    !isActiveUserTransaction(incoming, input.userId)
-  ) {
-    return { success: false, error: "transactionsNotFound" };
-  }
-
-  if (
-    outgoing.id === incoming.id ||
-    outgoing.type !== "expense" ||
-    incoming.type !== "income" ||
-    outgoing.amount !== incoming.amount ||
-    outgoing.date !== incoming.date ||
-    !hasResolvedAccountAttribution(outgoing) ||
-    !hasResolvedAccountAttribution(incoming) ||
-    outgoing.accountId == null ||
-    incoming.accountId == null ||
-    outgoing.accountId === incoming.accountId
-  ) {
-    return { success: false, error: "transactionsNotReclassifiable" };
-  }
-
-  const accountIds = [outgoing.accountId, incoming.accountId] as const;
+): Promise<ReclassifyTransactionsAsTransferResult> {
   const nowDate = now();
-  const built = buildTransfer({
-    input: {
-      digits: String(outgoing.amount),
-      fromSide: { kind: "account", accountId: outgoing.accountId },
-      toSide: { kind: "account", accountId: incoming.accountId },
-      description: input.description,
-      date: parseIsoDate(outgoing.date),
-    },
+  const nowIso = toIsoDateTime(nowDate) as IsoDateTime;
+  const reclassify = createReclassifyTransactionsAsTransfer({
     userId: input.userId,
-    id: createId(),
-    now: nowDate,
     source: "capture-match",
+    now: () => nowIso,
+    generateTransferId: createId,
+    ports: {
+      loadTransaction: async (transactionId) =>
+        toReclassifiableTransaction(loadTransactionById(db, transactionId)),
+      commitReclassification: async ({
+        transfer,
+        outgoingTransactionId,
+        incomingTransactionId,
+        supersededAt,
+      }) =>
+        db.transaction((tx) =>
+          commitReclassification(
+            {
+              db: tx,
+              userId: input.userId,
+              transfer,
+              outgoingTransactionId,
+              incomingTransactionId,
+              supersededAt,
+            },
+            { canUseAccounts, loadTransactionById, saveTransferRow, saveTransactionRow }
+          )
+        ),
+    },
   });
 
-  if (!built.success) {
-    return built;
-  }
-
-  const updatedAt = toIsoDateTime(nowDate) as IsoDateTime;
-
-  const commitResult = db.transaction((tx) => {
-    if (!canUseAccounts(tx, input.userId, accountIds)) {
-      return { success: false, error: "transactionsNotReclassifiable" } as const;
-    }
-
-    saveTransferRow(tx, toTransferRow(built.transfer));
-    saveTransactionRow(tx, {
-      id: outgoing.id,
-      supersededAt: updatedAt,
-      supersededByTransferId: built.transfer.id,
-      updatedAt,
-    });
-    saveTransactionRow(tx, {
-      id: incoming.id,
-      supersededAt: updatedAt,
-      supersededByTransferId: built.transfer.id,
-      updatedAt,
-    });
-
-    return { success: true, transfer: built.transfer } as const;
+  const result = await reclassify({
+    outgoingTransactionId: input.outgoingTransactionId,
+    incomingTransactionId: input.incomingTransactionId,
+    description: input.description,
   });
 
-  return commitResult;
+  return result.code === "reclassified"
+    ? { success: true, transfer: toStoredTransfer(result.transfer) }
+    : { success: false, error: mapReclassificationError(result.reason) };
 }

--- a/apps/mobile/local-ledger/public.ts
+++ b/apps/mobile/local-ledger/public.ts
@@ -32,6 +32,18 @@ export type {
   IntakeLocalLedgerCandidateResult,
 } from "./use-cases/intake.public";
 export {
+  createReclassifyTransactionsAsTransfer,
+  type ReclassifiableTransaction,
+  type ReclassifyTransactionsAsTransfer,
+  type ReclassifyTransactionsAsTransferCommand,
+  type ReclassifyTransactionsAsTransferCommitInput,
+  type ReclassifyTransactionsAsTransferCommitResult,
+  type ReclassifyTransactionsAsTransferDependencies,
+  type ReclassifyTransactionsAsTransferPorts,
+  type ReclassifyTransactionsAsTransferRejectionReason,
+  type ReclassifyTransactionsAsTransferResult,
+} from "./use-cases/reclassify-transactions-as-transfer.public";
+export {
   createRecordTransfer,
   recordTransaction,
   type RecordTransactionAccepted,

--- a/apps/mobile/local-ledger/use-cases/reclassify-transactions-as-transfer.public.ts
+++ b/apps/mobile/local-ledger/use-cases/reclassify-transactions-as-transfer.public.ts
@@ -1,0 +1,174 @@
+import type {
+  CopAmount,
+  FinancialAccountId,
+  IsoDate,
+  IsoDateTime,
+  TransactionId,
+} from "@/shared/types/branded";
+import type {
+  LocalLedgerDomainEvent,
+  LocalLedgerTransfer,
+  TransferSource,
+  TransferId,
+  UserId,
+} from "../domain/public";
+import type { RecordTransactionAccountAttributionState } from "./write.public";
+import { transferRecordedEvent } from "./record-transfer-builders";
+
+export type ReclassifiableTransaction = {
+  readonly id: TransactionId;
+  readonly userId: UserId;
+  readonly type: "expense" | "income";
+  readonly amount: CopAmount;
+  readonly accountId: FinancialAccountId | null;
+  readonly accountAttributionState: RecordTransactionAccountAttributionState;
+  readonly date: IsoDate;
+  readonly voidedAt: IsoDateTime | null;
+  readonly supersededAt: IsoDateTime | null;
+};
+
+export type ReclassifyTransactionsAsTransferCommand = {
+  readonly outgoingTransactionId: TransactionId;
+  readonly incomingTransactionId: TransactionId;
+  readonly description: string;
+};
+
+export type ReclassifyTransactionsAsTransferCommitInput = {
+  readonly transfer: LocalLedgerTransfer;
+  readonly outgoingTransactionId: TransactionId;
+  readonly incomingTransactionId: TransactionId;
+  readonly supersededAt: IsoDateTime;
+};
+
+export type ReclassifyTransactionsAsTransferCommitResult =
+  | { readonly code: "committed"; readonly transfer: LocalLedgerTransfer }
+  | { readonly code: "rejected"; readonly reason: "transactions-not-reclassifiable" };
+
+export type ReclassifyTransactionsAsTransferPorts = {
+  readonly loadTransaction: (
+    transactionId: TransactionId
+  ) => Promise<ReclassifiableTransaction | null>;
+  readonly commitReclassification: (
+    input: ReclassifyTransactionsAsTransferCommitInput
+  ) => Promise<ReclassifyTransactionsAsTransferCommitResult>;
+};
+
+export type ReclassifyTransactionsAsTransferDependencies = {
+  readonly userId: UserId;
+  readonly source: TransferSource;
+  readonly now: () => IsoDateTime;
+  readonly generateTransferId: () => TransferId;
+  readonly ports: ReclassifyTransactionsAsTransferPorts;
+};
+
+export type ReclassifyTransactionsAsTransferRejectionReason =
+  | "transactions-not-found"
+  | "transactions-not-reclassifiable";
+
+export type ReclassifyTransactionsAsTransferResult =
+  | {
+      readonly code: "reclassified";
+      readonly transfer: LocalLedgerTransfer;
+      readonly events: readonly LocalLedgerDomainEvent[];
+    }
+  | {
+      readonly code: "rejected";
+      readonly reason: ReclassifyTransactionsAsTransferRejectionReason;
+      readonly events: readonly [];
+    };
+
+export type ReclassifyTransactionsAsTransfer = (
+  command: ReclassifyTransactionsAsTransferCommand
+) => Promise<ReclassifyTransactionsAsTransferResult>;
+
+type ReclassifiableAccountTransaction = ReclassifiableTransaction & {
+  readonly accountId: FinancialAccountId;
+};
+
+const rejectReclassification = (
+  reason: ReclassifyTransactionsAsTransferRejectionReason
+): ReclassifyTransactionsAsTransferResult => ({ code: "rejected", reason, events: [] });
+
+const isActiveUserTransaction = (
+  transaction: ReclassifiableTransaction | null,
+  userId: UserId
+): transaction is ReclassifiableTransaction =>
+  transaction != null &&
+  transaction.userId === userId &&
+  transaction.voidedAt === null &&
+  transaction.supersededAt === null;
+
+const hasResolvedAccountAttribution = (transaction: ReclassifiableTransaction): boolean =>
+  transaction.accountAttributionState !== "unresolved";
+
+const canReclassifyPair = (
+  outgoing: ReclassifiableTransaction,
+  incoming: ReclassifiableTransaction
+): outgoing is ReclassifiableAccountTransaction =>
+  outgoing.id !== incoming.id &&
+  outgoing.type === "expense" &&
+  incoming.type === "income" &&
+  outgoing.amount > 0 &&
+  outgoing.amount === incoming.amount &&
+  outgoing.date === incoming.date &&
+  hasResolvedAccountAttribution(outgoing) &&
+  hasResolvedAccountAttribution(incoming) &&
+  outgoing.accountId !== null &&
+  incoming.accountId !== null &&
+  outgoing.accountId !== incoming.accountId;
+
+const hasReclassifiableIncomingAccount = (
+  transaction: ReclassifiableTransaction
+): transaction is ReclassifiableAccountTransaction => transaction.accountId !== null;
+
+export function createReclassifyTransactionsAsTransfer(
+  dependencies: ReclassifyTransactionsAsTransferDependencies
+): ReclassifyTransactionsAsTransfer {
+  return async (command) => {
+    const [outgoing, incoming] = await Promise.all([
+      dependencies.ports.loadTransaction(command.outgoingTransactionId),
+      dependencies.ports.loadTransaction(command.incomingTransactionId),
+    ]);
+
+    if (
+      !isActiveUserTransaction(outgoing, dependencies.userId) ||
+      !isActiveUserTransaction(incoming, dependencies.userId)
+    ) {
+      return rejectReclassification("transactions-not-found");
+    }
+
+    if (!canReclassifyPair(outgoing, incoming) || !hasReclassifiableIncomingAccount(incoming)) {
+      return rejectReclassification("transactions-not-reclassifiable");
+    }
+
+    const now = dependencies.now();
+    const transfer: LocalLedgerTransfer = {
+      id: dependencies.generateTransferId(),
+      userId: dependencies.userId,
+      amount: outgoing.amount,
+      fromSide: { kind: "account", accountId: outgoing.accountId },
+      toSide: { kind: "account", accountId: incoming.accountId },
+      description: command.description.trim(),
+      date: outgoing.date,
+      source: dependencies.source,
+      createdAt: now,
+      updatedAt: now,
+      voidedAt: null,
+    };
+
+    const commitResult = await dependencies.ports.commitReclassification({
+      transfer,
+      outgoingTransactionId: outgoing.id,
+      incomingTransactionId: incoming.id,
+      supersededAt: now,
+    });
+
+    return commitResult.code === "committed"
+      ? {
+          code: "reclassified",
+          transfer: commitResult.transfer,
+          events: [transferRecordedEvent(commitResult.transfer, now)],
+        }
+      : rejectReclassification("transactions-not-reclassifiable");
+  };
+}


### PR DESCRIPTION
- Local Ledger use case

- Atomic adapter commit

- Public boundary tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves transfer reclassification into a Local Ledger use case with stricter validation and an atomic commit port, and updates mobile code to delegate to it. Aligns with Linear issue 446 by enforcing a clear domain boundary and safer writes.

- **Refactors**
  - Added `createReclassifyTransactionsAsTransfer` use case in `@/local-ledger` and exported via `@/local-ledger/public`.
  - Mobile `reclassify-transactions-as-transfer` now calls the use case, commits atomically in one port, and throws if both source transactions aren’t superseded.
  - Mapped `LocalLedgerTransfer` to stored rows and standardized error mapping.
  - Converted tests to async, added rollback coverage (including silent-skip case), and added public boundary tests.

- **Migration**
  - `reclassifyTransactionsAsTransfer` is now async. Update callers to await its result.

<sup>Written for commit d5ababc274f6d8fc4c59542aa7c5ae4bd317ebc5. Summary will update on new commits. <a href="https://cubic.dev/pr/B4rz99/fidy/pull/455?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

