### PR TITLE
fix(mobile): migrate email review

### DIFF
--- a/apps/mobile/__tests__/email-capture/financial-meaning-review.test.ts
+++ b/apps/mobile/__tests__/email-capture/financial-meaning-review.test.ts
@@ -348,6 +348,7 @@ describe("financial meaning review", () => {
 
   it("keeps unlinked legacy failed emails in single-owner databases", async () => {
     insertEmailAccount();
+    insertEmailTransactionRow({ id: "tx-user" as TransactionId });
     await insertProcessedEmail(db as any, {
       ...defaultNeedsReviewEmail,
       id: "pe-unlinked-failed" as ProcessedEmailId,
@@ -358,6 +359,33 @@ describe("financial meaning review", () => {
 
     await expect(getFailedEmails(db as any, USER_ID)).resolves.toEqual([
       expect.objectContaining({ id: "pe-unlinked-failed" }),
+    ]);
+  });
+
+  it("does not use global legacy queues when stale transactions belong to another owner", async () => {
+    insertEmailAccount();
+    insertEmailTransactionRow({ id: "tx-user" as TransactionId });
+    insertEmailTransactionRow({
+      id: "tx-other" as TransactionId,
+      userId: "other-user" as UserId,
+    });
+    await insertProcessedEmail(db as any, {
+      ...defaultNeedsReviewEmail,
+      id: "pe-unlinked-failed" as ProcessedEmailId,
+      externalId: "ext-unlinked-failed",
+      status: "failed",
+      transactionId: null,
+    });
+    await insertProcessedEmail(db as any, {
+      ...defaultNeedsReviewEmail,
+      id: "pe-linked-failed" as ProcessedEmailId,
+      externalId: "ext-linked-failed",
+      status: "failed",
+      transactionId: "tx-user" as TransactionId,
+    });
+
+    await expect(getFailedEmails(db as any, USER_ID)).resolves.toEqual([
+      expect.objectContaining({ id: "pe-linked-failed" }),
     ]);
   });
 

--- a/apps/mobile/__tests__/email-capture/financial-meaning-review.test.ts
+++ b/apps/mobile/__tests__/email-capture/financial-meaning-review.test.ts
@@ -21,11 +21,12 @@ import {
   insertProcessedEmail,
 } from "@/features/email-capture/lib/repository";
 import { getTransactionById, insertTransaction } from "@/features/transactions/lib/repository";
-import { processedSourceEvents, reviewCandidates } from "@/shared/db/schema";
+import { emailAccounts, processedSourceEvents, reviewCandidates } from "@/shared/db/schema";
 import type {
   CategoryId,
   CopAmount,
   FinancialAccountId,
+  EmailAccountId,
   IsoDate,
   IsoDateTime,
   ProcessedEmailId,
@@ -218,6 +219,19 @@ function insertReviewCandidate(overrides: ReviewCandidateOverrides = {}) {
     .run();
 }
 
+function insertEmailAccount(userId: UserId = USER_ID) {
+  db.insert(emailAccounts)
+    .values({
+      id: `ea-${userId}` as EmailAccountId,
+      userId,
+      provider: "gmail",
+      email: `${userId}@example.com`,
+      lastFetchedAt: null,
+      createdAt: NOW,
+    })
+    .run();
+}
+
 describe("financial meaning review", () => {
   it("marks a reviewed low-confidence email as success without deleting the linked transaction", async () => {
     insertEmailTransactionRow();
@@ -292,6 +306,8 @@ describe("financial meaning review", () => {
   });
 
   it("scopes legacy failed and needs-review email queues to the active user", async () => {
+    insertEmailAccount();
+    insertEmailAccount("other-user" as UserId);
     insertEmailTransactionRow({ id: "tx-user" as TransactionId });
     insertEmailTransactionRow({
       id: "tx-other" as TransactionId,
@@ -327,6 +343,21 @@ describe("financial meaning review", () => {
     ]);
     await expect(getFailedEmails(db as any, USER_ID)).resolves.toEqual([
       expect.objectContaining({ id: "pe-user-failed" }),
+    ]);
+  });
+
+  it("keeps unlinked legacy failed emails in single-owner databases", async () => {
+    insertEmailAccount();
+    await insertProcessedEmail(db as any, {
+      ...defaultNeedsReviewEmail,
+      id: "pe-unlinked-failed" as ProcessedEmailId,
+      externalId: "ext-unlinked-failed",
+      status: "failed",
+      transactionId: null,
+    });
+
+    await expect(getFailedEmails(db as any, USER_ID)).resolves.toEqual([
+      expect.objectContaining({ id: "pe-unlinked-failed" }),
     ]);
   });
 

--- a/apps/mobile/__tests__/email-capture/financial-meaning-review.test.ts
+++ b/apps/mobile/__tests__/email-capture/financial-meaning-review.test.ts
@@ -12,6 +12,7 @@ import {
   resolveFinancialMeaningReview,
 } from "@/features/email-capture/lib/financial-meaning-review";
 import {
+  getFailedEmails,
   getFailedEmailSourceEvents,
   getNeedsReviewEmails,
   getNeedsReviewEmailSourceEvents,
@@ -52,6 +53,7 @@ afterEach(() => {
 
 type EmailTransactionOverrides = Partial<{
   id: TransactionId;
+  userId: UserId;
   amount: CopAmount;
   description: string;
   date: IsoDate;
@@ -223,7 +225,7 @@ describe("financial meaning review", () => {
 
     await resolveFinancialMeaningReview(db as any, "pe-1" as ProcessedEmailId);
 
-    expect(await getNeedsReviewEmails(db as any)).toEqual([]);
+    expect(await getNeedsReviewEmails(db as any, USER_ID)).toEqual([]);
     expect(await getProcessedEmailByExternalId(db as any, "ext-1")).toEqual(
       expect.objectContaining({
         id: "pe-1",
@@ -289,6 +291,45 @@ describe("financial meaning review", () => {
     ]);
   });
 
+  it("scopes legacy failed and needs-review email queues to the active user", async () => {
+    insertEmailTransactionRow({ id: "tx-user" as TransactionId });
+    insertEmailTransactionRow({
+      id: "tx-other" as TransactionId,
+      userId: "other-user" as UserId,
+    });
+    await insertNeedsReviewEmail({
+      id: "pe-user-review" as ProcessedEmailId,
+      externalId: "ext-user-review",
+      transactionId: "tx-user" as TransactionId,
+    });
+    await insertNeedsReviewEmail({
+      id: "pe-other-review" as ProcessedEmailId,
+      externalId: "ext-other-review",
+      transactionId: "tx-other" as TransactionId,
+    });
+    await insertProcessedEmail(db as any, {
+      ...defaultNeedsReviewEmail,
+      id: "pe-user-failed" as ProcessedEmailId,
+      externalId: "ext-user-failed",
+      status: "failed",
+      transactionId: "tx-user" as TransactionId,
+    });
+    await insertProcessedEmail(db as any, {
+      ...defaultNeedsReviewEmail,
+      id: "pe-other-failed" as ProcessedEmailId,
+      externalId: "ext-other-failed",
+      status: "failed",
+      transactionId: "tx-other" as TransactionId,
+    });
+
+    await expect(getNeedsReviewEmails(db as any, USER_ID)).resolves.toEqual([
+      expect.objectContaining({ id: "pe-user-review" }),
+    ]);
+    await expect(getFailedEmails(db as any, USER_ID)).resolves.toEqual([
+      expect.objectContaining({ id: "pe-user-failed" }),
+    ]);
+  });
+
   it("resolving a missing review item is a no-op", async () => {
     await expect(
       resolveFinancialMeaningReview(db as any, "pe-missing" as ProcessedEmailId)
@@ -335,7 +376,7 @@ describe("financial meaning review", () => {
       now: () => "2026-04-19T11:00:00.000Z" as IsoDateTime,
     });
 
-    expect(await getNeedsReviewEmails(db as any)).toEqual([]);
+    expect(await getNeedsReviewEmails(db as any, USER_ID)).toEqual([]);
     expect(await getProcessedEmailById(db as any, "pe-2" as ProcessedEmailId)).toEqual(
       expect.objectContaining({
         id: "pe-2",

--- a/apps/mobile/__tests__/email-capture/financial-meaning-review.test.ts
+++ b/apps/mobile/__tests__/email-capture/financial-meaning-review.test.ts
@@ -12,6 +12,7 @@ import {
   resolveFinancialMeaningReview,
 } from "@/features/email-capture/lib/financial-meaning-review";
 import {
+  getFailedEmailSourceEvents,
   getNeedsReviewEmails,
   getNeedsReviewEmailSourceEvents,
   getProcessedEmailByExternalId,
@@ -270,6 +271,24 @@ describe("financial meaning review", () => {
     ]);
   });
 
+  it("does not include retry-scheduled source events in the failed queue", async () => {
+    insertNeedsReviewSourceEvent({
+      id: "pse-failed" as ProcessedSourceEventId,
+      status: "failed",
+      failureReason: "parse failed",
+    });
+    insertNeedsReviewSourceEvent({
+      id: "pse-retry" as ProcessedSourceEventId,
+      sourceEventId: "ext-source-retry",
+      status: "pending_retry",
+      failureReason: "temporary failure",
+    });
+
+    await expect(getFailedEmailSourceEvents(db as any, USER_ID)).resolves.toEqual([
+      expect.objectContaining({ id: "pse-failed" }),
+    ]);
+  });
+
   it("resolving a missing review item is a no-op", async () => {
     await expect(
       resolveFinancialMeaningReview(db as any, "pe-missing" as ProcessedEmailId)
@@ -448,6 +467,35 @@ describe("financial meaning review", () => {
       expect.objectContaining({
         id: "rc-review-1",
         status: "accepted",
+      }),
+    ]);
+  });
+
+  it("does not confirm non-email source-event review candidates", async () => {
+    insertNeedsReviewSourceEvent({ sourceFamily: "sms", sourceId: "notification_listener" });
+    insertReviewCandidate();
+
+    await expect(
+      confirmSourceEventFinancialMeaningReview(db as any, {
+        userId: USER_ID,
+        processedSourceEventId: "pse-review-1" as ProcessedSourceEventId,
+        reviewCandidateId: "rc-review-1" as ReviewCandidateId,
+        now: () => "2026-04-19T11:00:00.000Z" as IsoDateTime,
+      })
+    ).resolves.toBe(false);
+
+    expect(db.select().from(processedSourceEvents).all()).toEqual([
+      expect.objectContaining({
+        id: "pse-review-1",
+        sourceFamily: "sms",
+        status: "needs_review",
+        transactionId: null,
+      }),
+    ]);
+    expect(db.select().from(reviewCandidates).all()).toEqual([
+      expect.objectContaining({
+        id: "rc-review-1",
+        status: "pending",
       }),
     ]);
   });

--- a/apps/mobile/__tests__/email-capture/financial-meaning-review.test.ts
+++ b/apps/mobile/__tests__/email-capture/financial-meaning-review.test.ts
@@ -13,6 +13,7 @@ import {
 } from "@/features/email-capture/lib/financial-meaning-review";
 import {
   getNeedsReviewEmails,
+  getNeedsReviewEmailSourceEvents,
   getProcessedEmailByExternalId,
   getProcessedEmailById,
   insertProcessedEmail,
@@ -231,16 +232,11 @@ describe("financial meaning review", () => {
     );
   });
 
-  it("lists only active low-confidence emails that still point at active transactions", async () => {
+  it("does not list legacy processed emails as financial meaning review items", async () => {
     reviewCandidateTransactions.forEach(insertEmailTransactionRow);
     await Promise.all(reviewCandidateEmails.map(insertNeedsReviewEmail));
 
-    await expect(getFinancialMeaningReviewItems(db as any, USER_ID)).resolves.toEqual([
-      expect.objectContaining({
-        processedEmail: expect.objectContaining({ id: "pe-active" }),
-        transaction: expect.objectContaining({ id: "tx-active" }),
-      }),
-    ]);
+    await expect(getFinancialMeaningReviewItems(db as any, USER_ID)).resolves.toEqual([]);
   });
 
   it("lists source-event needs-review candidates in the financial meaning queue", async () => {
@@ -253,6 +249,24 @@ describe("financial meaning review", () => {
         processedSourceEvent: expect.objectContaining({ id: "pse-review-1" }),
         reviewCandidate: expect.objectContaining({ id: "rc-review-1" }),
       }),
+    ]);
+  });
+
+  it("loads needs-review email source events only when a pending review candidate exists", async () => {
+    insertNeedsReviewSourceEvent();
+    insertNeedsReviewSourceEvent({
+      id: "pse-review-without-candidate" as ProcessedSourceEventId,
+      sourceEventId: "ext-source-review-without-candidate",
+    });
+    insertReviewCandidate();
+    insertReviewCandidate({
+      id: "rc-review-rejected" as ReviewCandidateId,
+      processedSourceEventId: "pse-review-without-candidate" as ProcessedSourceEventId,
+      status: "rejected",
+    });
+
+    await expect(getNeedsReviewEmailSourceEvents(db as any, USER_ID)).resolves.toEqual([
+      expect.objectContaining({ id: "pse-review-1" }),
     ]);
   });
 
@@ -354,6 +368,7 @@ describe("financial meaning review", () => {
       db as any,
       USER_ID,
       "pse-review-1" as ProcessedSourceEventId,
+      "rc-review-1" as ReviewCandidateId,
       () => "2026-04-19T11:00:00.000Z" as IsoDateTime
     );
 
@@ -369,6 +384,42 @@ describe("financial meaning review", () => {
         id: "rc-review-1",
         status: "rejected",
         updatedAt: "2026-04-19T11:00:00.000Z",
+      }),
+    ]);
+  });
+
+  it("dismisses only the selected review candidate when sibling candidates remain", async () => {
+    insertNeedsReviewSourceEvent();
+    insertReviewCandidate();
+    insertReviewCandidate({
+      id: "rc-review-2" as ReviewCandidateId,
+      description: "Second possible meaning",
+    });
+
+    await dismissSourceEventFinancialMeaningReview(
+      db as any,
+      USER_ID,
+      "pse-review-1" as ProcessedSourceEventId,
+      "rc-review-1" as ReviewCandidateId,
+      () => "2026-04-19T11:00:00.000Z" as IsoDateTime
+    );
+
+    expect(db.select().from(processedSourceEvents).all()).toEqual([
+      expect.objectContaining({
+        id: "pse-review-1",
+        status: "needs_review",
+        updatedAt: "2026-04-19T11:00:00.000Z",
+      }),
+    ]);
+    expect(db.select().from(reviewCandidates).orderBy(reviewCandidates.id).all()).toEqual([
+      expect.objectContaining({
+        id: "rc-review-1",
+        status: "rejected",
+        updatedAt: "2026-04-19T11:00:00.000Z",
+      }),
+      expect.objectContaining({
+        id: "rc-review-2",
+        status: "pending",
       }),
     ]);
   });
@@ -397,6 +448,42 @@ describe("financial meaning review", () => {
       expect.objectContaining({
         id: "rc-review-1",
         status: "accepted",
+      }),
+    ]);
+  });
+
+  it("accepting one source-event review candidate rejects pending sibling candidates", async () => {
+    insertNeedsReviewSourceEvent();
+    insertReviewCandidate();
+    insertReviewCandidate({
+      id: "rc-review-2" as ReviewCandidateId,
+      description: "Second possible meaning",
+    });
+
+    await expect(
+      confirmSourceEventFinancialMeaningReview(db as any, {
+        userId: USER_ID,
+        processedSourceEventId: "pse-review-1" as ProcessedSourceEventId,
+        reviewCandidateId: "rc-review-1" as ReviewCandidateId,
+        now: () => "2026-04-19T11:00:00.000Z" as IsoDateTime,
+      })
+    ).resolves.toBe(true);
+
+    expect(db.select().from(processedSourceEvents).all()).toEqual([
+      expect.objectContaining({
+        id: "pse-review-1",
+        status: "processed",
+        transactionId: expect.any(String),
+      }),
+    ]);
+    expect(db.select().from(reviewCandidates).orderBy(reviewCandidates.id).all()).toEqual([
+      expect.objectContaining({
+        id: "rc-review-1",
+        status: "accepted",
+      }),
+      expect.objectContaining({
+        id: "rc-review-2",
+        status: "rejected",
       }),
     ]);
   });

--- a/apps/mobile/__tests__/email-capture/financial-meaning-review.test.ts
+++ b/apps/mobile/__tests__/email-capture/financial-meaning-review.test.ts
@@ -389,6 +389,28 @@ describe("financial meaning review", () => {
     ]);
   });
 
+  it("does not use global legacy queues without an email-account owner", async () => {
+    insertEmailTransactionRow({ id: "tx-user" as TransactionId });
+    await insertProcessedEmail(db as any, {
+      ...defaultNeedsReviewEmail,
+      id: "pe-unlinked-failed" as ProcessedEmailId,
+      externalId: "ext-unlinked-failed-no-owner",
+      status: "failed",
+      transactionId: null,
+    });
+    await insertProcessedEmail(db as any, {
+      ...defaultNeedsReviewEmail,
+      id: "pe-linked-failed" as ProcessedEmailId,
+      externalId: "ext-linked-failed-no-owner",
+      status: "failed",
+      transactionId: "tx-user" as TransactionId,
+    });
+
+    await expect(getFailedEmails(db as any, USER_ID)).resolves.toEqual([
+      expect.objectContaining({ id: "pe-linked-failed" }),
+    ]);
+  });
+
   it("resolving a missing review item is a no-op", async () => {
     await expect(
       resolveFinancialMeaningReview(db as any, "pe-missing" as ProcessedEmailId)

--- a/apps/mobile/__tests__/email-capture/repository.test.ts
+++ b/apps/mobile/__tests__/email-capture/repository.test.ts
@@ -16,6 +16,7 @@ const mockSelect = vi.fn<(...args: any[]) => any>().mockReturnThis();
 const mockSelectDistinct = vi.fn<(...args: any[]) => any>().mockReturnThis();
 const mockLimit = vi.fn<(...args: any[]) => any>().mockResolvedValue([]);
 const mockFrom = vi.fn<(...args: any[]) => any>().mockReturnThis();
+const mockInnerJoin = vi.fn<(...args: any[]) => any>().mockReturnThis();
 const mockWhere = vi.fn<(...args: any[]) => any>().mockReturnThis();
 const mockOrderBy = vi.fn<(...args: any[]) => any>().mockResolvedValue([]);
 const mockDelete = vi.fn<(...args: any[]) => any>().mockReturnThis();
@@ -44,7 +45,13 @@ describe("email capture repository", () => {
     mockValues.mockReturnValue({ onConflictDoNothing: mockOnConflictDoNothing });
     mockSelect.mockReturnValue({ from: mockFrom });
     mockSelectDistinct.mockReturnValue({ from: mockFrom });
-    mockFrom.mockReturnValue({ where: mockWhere, orderBy: mockOrderBy, limit: mockLimit });
+    mockFrom.mockReturnValue({
+      innerJoin: mockInnerJoin,
+      where: mockWhere,
+      orderBy: mockOrderBy,
+      limit: mockLimit,
+    });
+    mockInnerJoin.mockReturnValue({ where: mockWhere });
     mockWhere.mockReturnValue({ orderBy: mockOrderBy });
     mockDelete.mockReturnValue({ where: mockDeleteWhere });
     mockUpdate.mockReturnValue({ set: mockSet });
@@ -197,9 +204,10 @@ describe("email capture repository", () => {
     mockOrderBy.mockResolvedValueOnce(mockRows);
 
     const { getFailedEmails } = await import("@/features/email-capture/lib/repository");
-    const result = await getFailedEmails(mockDb);
+    const result = await getFailedEmails(mockDb, "user-1" as UserId);
 
     expect(mockSelect).toHaveBeenCalled();
+    expect(mockInnerJoin).toHaveBeenCalled();
     expect(result).toEqual(mockRows);
   });
 
@@ -250,9 +258,10 @@ describe("email capture repository", () => {
     mockOrderBy.mockResolvedValueOnce(mockRows);
 
     const { getNeedsReviewEmails } = await import("@/features/email-capture/lib/repository");
-    const result = await getNeedsReviewEmails(mockDb);
+    const result = await getNeedsReviewEmails(mockDb, "user-1" as UserId);
 
     expect(mockSelect).toHaveBeenCalled();
+    expect(mockInnerJoin).toHaveBeenCalled();
     expect(result).toEqual(mockRows);
   });
 

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { insertMerchantRule } from "@/features/email-capture/lib/merchant-rules";
 import {
+  getFinancialMeaningQueueItemId,
+  selectFailedEmailBannerCount,
+  selectNeedsReviewBannerCount,
+} from "@/features/email-capture/lib/review-queue-selectors";
+import {
   deleteEmailAccount,
   dismissProcessedEmail,
   getEmailAccounts,
@@ -40,6 +45,7 @@ import type * as SharedLib from "@/shared/lib";
 import type {
   EmailAccountId,
   IsoDateTime,
+  ReviewCandidateId,
   ProcessedEmailId,
   ProcessedSourceEventId,
   TransactionId,
@@ -299,9 +305,55 @@ function makeProcessedEmail(overrides: Record<string, unknown> = {}) {
     transactionId: null as TransactionId | null,
     confidence: null as number | null,
     createdAt: "2026-03-05T10:00:00Z" as IsoDateTime,
-    rawBody: null as string | null,
+    rawBody: null,
     retryCount: 0,
     nextRetryAt: null as IsoDateTime | null,
+    ...overrides,
+  };
+}
+
+function makeProcessedEmailSourceEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "pse-1" as ProcessedSourceEventId,
+    userId: mockUserId as UserId,
+    sourceFamily: "email",
+    sourceId: "email_gmail",
+    sourceEventId: "msg-1",
+    status: "failed",
+    failureReason: null as string | null,
+    subject: "Test",
+    rawBodyPreview: null as string | null,
+    rawBody: null,
+    retryCount: 0,
+    nextRetryAt: null as IsoDateTime | null,
+    transactionId: null as TransactionId | null,
+    confidence: null as number | null,
+    receivedAt: "2026-03-05T10:00:00Z" as IsoDateTime,
+    processedAt: "2026-03-05T10:00:00Z" as IsoDateTime,
+    createdAt: "2026-03-05T10:00:00Z" as IsoDateTime,
+    updatedAt: "2026-03-05T10:00:00Z" as IsoDateTime,
+    deletedAt: null as IsoDateTime | null,
+    ...overrides,
+  };
+}
+
+function makeReviewCandidate(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "rc-1" as ReviewCandidateId,
+    userId: mockUserId as UserId,
+    processedSourceEventId: "pse-1" as ProcessedSourceEventId,
+    status: "pending",
+    candidateKind: "transaction",
+    occurredAt: "2026-03-05T10:00:00Z" as IsoDateTime,
+    amount: null,
+    currency: "COP",
+    transactionType: null,
+    categoryId: null,
+    description: "Review candidate",
+    confidence: 0.5,
+    createdAt: "2026-03-05T10:00:00Z" as IsoDateTime,
+    updatedAt: "2026-03-05T10:00:00Z" as IsoDateTime,
+    deletedAt: null as IsoDateTime | null,
     ...overrides,
   };
 }
@@ -325,8 +377,8 @@ function setAccounts(accounts: TestEmailAccount[] = [makeAccount()]) {
 }
 
 function mockEmptyReviewLoads() {
-  vi.mocked(getFailedEmails).mockResolvedValueOnce([]);
-  vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce([]);
+  vi.mocked(getFailedEmailSourceEvents).mockResolvedValueOnce([]);
+  vi.mocked(getNeedsReviewEmailSourceEvents).mockResolvedValueOnce([]);
 }
 
 function mockProcessResult(overrides: Partial<ProcessSummary> = {}) {
@@ -477,6 +529,56 @@ describe("email capture boundary", () => {
     });
   });
 
+  it("failed banner count ignores legacy processedEmails-backed state", () => {
+    useEmailCaptureStore.setState({
+      failedEmails: [makeProcessedEmail({ id: "pe-legacy" as ProcessedEmailId })],
+      failedEmailSourceEvents: [
+        makeProcessedEmailSourceEvent({ id: "pse-1" as ProcessedSourceEventId }),
+        makeProcessedEmailSourceEvent({ id: "pse-2" as ProcessedSourceEventId }),
+      ],
+    });
+
+    expect(selectFailedEmailBannerCount(useEmailCaptureStore.getState())).toBe(2);
+  });
+
+  it("needs-review banner count ignores legacy processedEmails-backed state", () => {
+    useEmailCaptureStore.setState({
+      needsReviewEmails: [
+        makeProcessedEmail({ id: "pe-legacy" as ProcessedEmailId, status: "needs_review" }),
+      ],
+      needsReviewEmailSourceEvents: [
+        makeProcessedEmailSourceEvent({
+          id: "pse-review" as ProcessedSourceEventId,
+          status: "needs_review",
+        }),
+      ],
+    });
+
+    expect(selectNeedsReviewBannerCount(useEmailCaptureStore.getState())).toBe(1);
+  });
+
+  it("financial meaning queue item ids are scoped to review candidates", () => {
+    const processedSourceEvent = makeProcessedEmailSourceEvent({
+      id: "pse-shared" as ProcessedSourceEventId,
+      status: "needs_review",
+    });
+
+    expect(
+      [
+        {
+          kind: "source_event" as const,
+          processedSourceEvent,
+          reviewCandidate: makeReviewCandidate({ id: "rc-1" as ReviewCandidateId }),
+        },
+        {
+          kind: "source_event" as const,
+          processedSourceEvent,
+          reviewCandidate: makeReviewCandidate({ id: "rc-2" as ReviewCandidateId }),
+        },
+      ].map(getFinancialMeaningQueueItemId)
+    ).toEqual(["rc-1", "rc-2"]);
+  });
+
   it("loadAccounts fetches from DB and sets state", async () => {
     const mockAccounts = [makeAccount()];
     vi.mocked(getEmailAccounts).mockResolvedValueOnce(mockAccounts);
@@ -504,33 +606,38 @@ describe("email capture boundary", () => {
   });
 
   it("loadFailedEmails fetches from DB and sets state", async () => {
-    const mockFailed = [makeProcessedEmail({ failureReason: "parse error", subject: "Compra" })];
-    vi.mocked(getFailedEmails).mockResolvedValueOnce(mockFailed);
+    const mockFailed = [
+      makeProcessedEmailSourceEvent({ failureReason: "parse error", subject: "Compra" }),
+    ];
+    vi.mocked(getFailedEmailSourceEvents).mockResolvedValueOnce(mockFailed);
 
     await loadFailedEmails(mockDb, mockUserId as UserId);
 
-    expect(getFailedEmails).toHaveBeenCalledWith(mockDb);
-    expect(useEmailCaptureStore.getState().failedEmails).toEqual(mockFailed);
-    expect(useEmailCaptureStore.getState().failedEmails).toHaveLength(1);
+    expect(getFailedEmails).not.toHaveBeenCalled();
+    expect(getFailedEmailSourceEvents).toHaveBeenCalledWith(mockDb, mockUserId);
+    expect(useEmailCaptureStore.getState().failedEmails).toEqual([]);
+    expect(useEmailCaptureStore.getState().failedEmailSourceEvents).toEqual(mockFailed);
   });
 
   it("loadNeedsReview fetches from DB and sets state", async () => {
     const mockReview = [
-      makeProcessedEmail({
-        id: "pe-2" as ProcessedEmailId,
-        externalId: "msg-2",
+      makeProcessedEmailSourceEvent({
+        id: "pse-2" as ProcessedSourceEventId,
+        sourceEventId: "msg-2",
         status: "needs_review",
         subject: "Compra aprobada",
         transactionId: "tx-1" as TransactionId,
         confidence: 0.5,
       }),
     ];
-    vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce(mockReview);
+    vi.mocked(getNeedsReviewEmailSourceEvents).mockResolvedValueOnce(mockReview);
 
     await loadNeedsReviewEmails(mockDb, mockUserId as UserId);
 
-    expect(getNeedsReviewEmails).toHaveBeenCalledWith(mockDb);
-    expect(useEmailCaptureStore.getState().needsReviewEmails).toEqual(mockReview);
+    expect(getNeedsReviewEmails).not.toHaveBeenCalled();
+    expect(getNeedsReviewEmailSourceEvents).toHaveBeenCalledWith(mockDb, mockUserId);
+    expect(useEmailCaptureStore.getState().needsReviewEmails).toEqual([]);
+    expect(useEmailCaptureStore.getState().needsReviewEmailSourceEvents).toEqual(mockReview);
   });
 
   it("dismissBanner sets bannerDismissed to true", () => {
@@ -538,14 +645,14 @@ describe("email capture boundary", () => {
     expect(useEmailCaptureStore.getState().bannerDismissed).toBe(true);
   });
 
-  it("dismissFailedEmail removes from DB and state", async () => {
+  it("dismissFailedEmail only clears legacy state without mutating processedEmails", async () => {
     useEmailCaptureStore.setState({
       failedEmails: [makeProcessedEmail()],
     });
 
     await dismissFailedEmail(mockDb, mockUserId as UserId, "pe-1");
 
-    expect(dismissProcessedEmail).toHaveBeenCalledWith(mockDb, "pe-1");
+    expect(dismissProcessedEmail).not.toHaveBeenCalled();
     expect(useEmailCaptureStore.getState().failedEmails).toHaveLength(0);
   });
 

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -606,20 +606,28 @@ describe("email capture boundary", () => {
   });
 
   it("loadFailedEmails fetches from DB and sets state", async () => {
+    const mockLegacyFailed = [makeProcessedEmail({ id: "pe-legacy" as ProcessedEmailId })];
     const mockFailed = [
       makeProcessedEmailSourceEvent({ failureReason: "parse error", subject: "Compra" }),
     ];
+    vi.mocked(getFailedEmails).mockResolvedValueOnce(mockLegacyFailed);
     vi.mocked(getFailedEmailSourceEvents).mockResolvedValueOnce(mockFailed);
 
     await loadFailedEmails(mockDb, mockUserId as UserId);
 
-    expect(getFailedEmails).not.toHaveBeenCalled();
+    expect(getFailedEmails).toHaveBeenCalledWith(mockDb);
     expect(getFailedEmailSourceEvents).toHaveBeenCalledWith(mockDb, mockUserId);
-    expect(useEmailCaptureStore.getState().failedEmails).toEqual([]);
+    expect(useEmailCaptureStore.getState().failedEmails).toEqual(mockLegacyFailed);
     expect(useEmailCaptureStore.getState().failedEmailSourceEvents).toEqual(mockFailed);
   });
 
   it("loadNeedsReview fetches from DB and sets state", async () => {
+    const mockLegacyReview = [
+      makeProcessedEmail({
+        id: "pe-review-legacy" as ProcessedEmailId,
+        status: "needs_review",
+      }),
+    ];
     const mockReview = [
       makeProcessedEmailSourceEvent({
         id: "pse-2" as ProcessedSourceEventId,
@@ -630,13 +638,14 @@ describe("email capture boundary", () => {
         confidence: 0.5,
       }),
     ];
+    vi.mocked(getNeedsReviewEmails).mockResolvedValueOnce(mockLegacyReview);
     vi.mocked(getNeedsReviewEmailSourceEvents).mockResolvedValueOnce(mockReview);
 
     await loadNeedsReviewEmails(mockDb, mockUserId as UserId);
 
-    expect(getNeedsReviewEmails).not.toHaveBeenCalled();
+    expect(getNeedsReviewEmails).toHaveBeenCalledWith(mockDb);
     expect(getNeedsReviewEmailSourceEvents).toHaveBeenCalledWith(mockDb, mockUserId);
-    expect(useEmailCaptureStore.getState().needsReviewEmails).toEqual([]);
+    expect(useEmailCaptureStore.getState().needsReviewEmails).toEqual(mockLegacyReview);
     expect(useEmailCaptureStore.getState().needsReviewEmailSourceEvents).toEqual(mockReview);
   });
 

--- a/apps/mobile/__tests__/email-capture/store.test.ts
+++ b/apps/mobile/__tests__/email-capture/store.test.ts
@@ -615,7 +615,7 @@ describe("email capture boundary", () => {
 
     await loadFailedEmails(mockDb, mockUserId as UserId);
 
-    expect(getFailedEmails).toHaveBeenCalledWith(mockDb);
+    expect(getFailedEmails).toHaveBeenCalledWith(mockDb, mockUserId);
     expect(getFailedEmailSourceEvents).toHaveBeenCalledWith(mockDb, mockUserId);
     expect(useEmailCaptureStore.getState().failedEmails).toEqual(mockLegacyFailed);
     expect(useEmailCaptureStore.getState().failedEmailSourceEvents).toEqual(mockFailed);
@@ -643,7 +643,7 @@ describe("email capture boundary", () => {
 
     await loadNeedsReviewEmails(mockDb, mockUserId as UserId);
 
-    expect(getNeedsReviewEmails).toHaveBeenCalledWith(mockDb);
+    expect(getNeedsReviewEmails).toHaveBeenCalledWith(mockDb, mockUserId);
     expect(getNeedsReviewEmailSourceEvents).toHaveBeenCalledWith(mockDb, mockUserId);
     expect(useEmailCaptureStore.getState().needsReviewEmails).toEqual(mockLegacyReview);
     expect(useEmailCaptureStore.getState().needsReviewEmailSourceEvents).toEqual(mockReview);

--- a/apps/mobile/__tests__/transfers/reclassify-transaction-as-transfer.test.ts
+++ b/apps/mobile/__tests__/transfers/reclassify-transaction-as-transfer.test.ts
@@ -1,6 +1,7 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: integration test uses a real SQLite DB
 import { resolve } from "node:path";
 import Database from "better-sqlite3";
+import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -22,7 +23,7 @@ import { markTransactionSuperseded } from "@/features/transactions/transfer-recl
 import { reclassifyTransactionAsTransfer } from "@/features/transfers/lib/reclassify-transaction-as-transfer";
 import { reclassifyTransactionsAsTransfer } from "@/features/transfers/lib/reclassify-transactions-as-transfer";
 import { getTransferById } from "@/features/transfers/lib/repository";
-import { financialAccounts } from "@/shared/db/schema";
+import { financialAccounts, processedSourceEvents } from "@/shared/db/schema";
 import type {
   CaptureEvidenceId,
   CategoryId,
@@ -31,6 +32,7 @@ import type {
   IsoDate,
   IsoDateTime,
   ProcessedEmailId,
+  ProcessedSourceEventId,
   TransactionId,
   TransferId,
   UserId,
@@ -159,9 +161,36 @@ async function insertPendingProcessedEmail() {
   });
 }
 
+function insertPendingProcessedSourceEvent() {
+  db.insert(processedSourceEvents)
+    .values({
+      id: "pse-1" as ProcessedSourceEventId,
+      userId: USER_ID,
+      sourceFamily: "email",
+      sourceId: "email_gmail",
+      sourceEventId: "ext-1",
+      status: "needs_review",
+      failureReason: null,
+      subject: "Transfer alert",
+      rawBodyPreview: "Transfer to savings",
+      rawBody: null,
+      retryCount: 0,
+      nextRetryAt: null,
+      transactionId: ORIGINAL_TRANSACTION_ID,
+      confidence: 0.52,
+      receivedAt: ORIGINAL_CREATED_AT,
+      processedAt: ORIGINAL_CREATED_AT,
+      createdAt: ORIGINAL_CREATED_AT,
+      updatedAt: ORIGINAL_CREATED_AT,
+      deletedAt: null,
+    })
+    .run();
+}
+
 function seedReclassificationScenario() {
   insertOriginalTransactionRecord();
   insertTransferEvidence();
+  insertPendingProcessedSourceEvent();
   return insertPendingProcessedEmail();
 }
 
@@ -176,7 +205,7 @@ function runReclassification() {
       toSide: { kind: "account", accountId: SAVINGS_ACCOUNT_ID },
       description: "Move to savings",
       date: new Date("2026-04-18T12:00:00.000Z"),
-      processedEmailId: "pe-1" as ProcessedEmailId,
+      processedSourceEventId: "pse-1" as ProcessedSourceEventId,
     },
     {
       now: () => new Date(NOW),
@@ -210,11 +239,27 @@ function expectCreatedTransferState() {
   });
 }
 
-async function expectProcessedEmailSucceeded() {
+async function expectProcessedEmailUnchanged() {
   await expect(getProcessedEmailById(db as any, "pe-1" as ProcessedEmailId)).resolves.toEqual(
     expect.objectContaining({
       id: "pe-1",
-      status: "success",
+      status: "needs_review",
+      transactionId: ORIGINAL_TRANSACTION_ID,
+    })
+  );
+}
+
+function expectProcessedSourceEventSucceeded() {
+  expect(
+    db
+      .select()
+      .from(processedSourceEvents)
+      .where(eq(processedSourceEvents.id, "pse-1" as ProcessedSourceEventId))
+      .get()
+  ).toEqual(
+    expect.objectContaining({
+      id: "pse-1",
+      status: "processed",
       transactionId: ORIGINAL_TRANSACTION_ID,
     })
   );
@@ -234,7 +279,8 @@ describe("reclassifyTransactionAsTransfer", () => {
       }),
     });
     expectCreatedTransferState();
-    await expectProcessedEmailSucceeded();
+    expectProcessedSourceEventSucceeded();
+    await expectProcessedEmailUnchanged();
   });
 });
 

--- a/apps/mobile/__tests__/transfers/reclassify-transaction-as-transfer.test.ts
+++ b/apps/mobile/__tests__/transfers/reclassify-transaction-as-transfer.test.ts
@@ -236,6 +236,26 @@ function runReclassification() {
   );
 }
 
+function runReclassificationWithoutReviewCandidate() {
+  return reclassifyTransactionAsTransfer(
+    db as any,
+    {
+      userId: USER_ID,
+      transactionId: ORIGINAL_TRANSACTION_ID,
+      digits: "350000",
+      fromSide: { kind: "account", accountId: ACCOUNT_ID },
+      toSide: { kind: "account", accountId: SAVINGS_ACCOUNT_ID },
+      description: "Move to savings",
+      date: new Date("2026-04-18T12:00:00.000Z"),
+      processedSourceEventId: "pse-1" as ProcessedSourceEventId,
+    },
+    {
+      now: () => new Date(NOW),
+      createId: () => TRANSFER_ID,
+    }
+  );
+}
+
 function expectCreatedTransferState() {
   expect(getTransferById(db as any, TRANSFER_ID)).toMatchObject({
     id: TRANSFER_ID,
@@ -301,6 +321,36 @@ function expectProcessedSourceEventSucceeded() {
   );
 }
 
+function expectProcessedSourceEventPending() {
+  expect(
+    db
+      .select()
+      .from(processedSourceEvents)
+      .where(eq(processedSourceEvents.id, "pse-1" as ProcessedSourceEventId))
+      .get()
+  ).toEqual(
+    expect.objectContaining({
+      id: "pse-1",
+      status: "needs_review",
+      transactionId: ORIGINAL_TRANSACTION_ID,
+      updatedAt: ORIGINAL_CREATED_AT,
+    })
+  );
+  expect(
+    db
+      .select()
+      .from(reviewCandidates)
+      .where(eq(reviewCandidates.id, "rc-1" as ReviewCandidateId))
+      .get()
+  ).toEqual(
+    expect.objectContaining({
+      id: "rc-1",
+      status: "pending",
+      updatedAt: ORIGINAL_CREATED_AT,
+    })
+  );
+}
+
 describe("reclassifyTransactionAsTransfer", () => {
   it("creates a transfer, supersedes the original transaction, relinks capture evidence,", async () => {
     await seedReclassificationScenario();
@@ -316,6 +366,21 @@ describe("reclassifyTransactionAsTransfer", () => {
     });
     expectCreatedTransferState();
     expectProcessedSourceEventSucceeded();
+    await expectProcessedEmailUnchanged();
+  });
+
+  it("rejects source-event transfer reclassification without a review candidate", async () => {
+    await seedReclassificationScenario();
+    const result = runReclassificationWithoutReviewCandidate();
+
+    expect(result).toEqual({ success: false, error: "reviewCandidateRequired" });
+    expect(getTransferById(db as any, TRANSFER_ID)).toBeNull();
+    expect(getTransactionById(db as any, ORIGINAL_TRANSACTION_ID)).toMatchObject({
+      supersededAt: null,
+      supersededByTransferId: null,
+      updatedAt: ORIGINAL_CREATED_AT,
+    });
+    expectProcessedSourceEventPending();
     await expectProcessedEmailUnchanged();
   });
 });

--- a/apps/mobile/__tests__/transfers/reclassify-transaction-as-transfer.test.ts
+++ b/apps/mobile/__tests__/transfers/reclassify-transaction-as-transfer.test.ts
@@ -23,7 +23,7 @@ import { markTransactionSuperseded } from "@/features/transactions/transfer-recl
 import { reclassifyTransactionAsTransfer } from "@/features/transfers/lib/reclassify-transaction-as-transfer";
 import { reclassifyTransactionsAsTransfer } from "@/features/transfers/lib/reclassify-transactions-as-transfer";
 import { getTransferById } from "@/features/transfers/lib/repository";
-import { financialAccounts, processedSourceEvents } from "@/shared/db/schema";
+import { financialAccounts, processedSourceEvents, reviewCandidates } from "@/shared/db/schema";
 import type {
   CaptureEvidenceId,
   CategoryId,
@@ -33,6 +33,7 @@ import type {
   IsoDateTime,
   ProcessedEmailId,
   ProcessedSourceEventId,
+  ReviewCandidateId,
   TransactionId,
   TransferId,
   UserId,
@@ -185,6 +186,26 @@ function insertPendingProcessedSourceEvent() {
       deletedAt: null,
     })
     .run();
+
+  db.insert(reviewCandidates)
+    .values({
+      id: "rc-1" as ReviewCandidateId,
+      userId: USER_ID,
+      processedSourceEventId: "pse-1" as ProcessedSourceEventId,
+      status: "pending",
+      candidateKind: "transaction",
+      amount: 350000 as CopAmount,
+      currency: "COP",
+      occurredAt: ORIGINAL_CREATED_AT,
+      description: "Transfer to savings",
+      categoryId: null,
+      transactionType: "expense",
+      confidence: 0.52,
+      createdAt: ORIGINAL_CREATED_AT,
+      updatedAt: ORIGINAL_CREATED_AT,
+      deletedAt: null,
+    })
+    .run();
 }
 
 function seedReclassificationScenario() {
@@ -206,6 +227,7 @@ function runReclassification() {
       description: "Move to savings",
       date: new Date("2026-04-18T12:00:00.000Z"),
       processedSourceEventId: "pse-1" as ProcessedSourceEventId,
+      reviewCandidateId: "rc-1" as ReviewCandidateId,
     },
     {
       now: () => new Date(NOW),
@@ -261,6 +283,20 @@ function expectProcessedSourceEventSucceeded() {
       id: "pse-1",
       status: "processed",
       transactionId: ORIGINAL_TRANSACTION_ID,
+      updatedAt: NOW,
+    })
+  );
+  expect(
+    db
+      .select()
+      .from(reviewCandidates)
+      .where(eq(reviewCandidates.id, "rc-1" as ReviewCandidateId))
+      .get()
+  ).toEqual(
+    expect.objectContaining({
+      id: "rc-1",
+      status: "rejected",
+      updatedAt: NOW,
     })
   );
 }

--- a/apps/mobile/app/failed-emails.tsx
+++ b/apps/mobile/app/failed-emails.tsx
@@ -1,13 +1,11 @@
 import { FlashList } from "@shopify/flash-list";
 import { format } from "date-fns";
 import { useRouter } from "expo-router";
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useOptionalUserId } from "@/features/auth";
 import {
-  dismissFailedEmail,
   dismissFailedEmailSourceEvent,
-  type ProcessedEmailRow,
   type ProcessedSourceEventRow,
   useEmailCaptureStore,
 } from "@/features/email-capture";
@@ -20,52 +18,25 @@ import { getDateFnsLocale } from "@/shared/i18n";
 
 const ItemSeparator = () => <View style={{ height: 10 }} />;
 
-type FailedEmailItem =
-  | { readonly kind: "legacy"; readonly email: ProcessedEmailRow }
-  | { readonly kind: "source_event"; readonly email: ProcessedSourceEventRow };
-
-const toLegacyFailedItem = (email: ProcessedEmailRow): FailedEmailItem => ({
-  kind: "legacy",
-  email,
-});
-
-const toSourceEventFailedItem = (email: ProcessedSourceEventRow): FailedEmailItem => ({
-  kind: "source_event",
-  email,
-});
-
 export default function FailedEmailsScreen() {
   const { back, push } = useRouter();
   const { t } = useTranslation();
   const { bottom } = useSafeAreaInsets();
   const userId = useOptionalUserId();
   const db = userId ? tryGetDb(userId) : null;
-  const failedEmails = useEmailCaptureStore((s) => s.failedEmails);
-  const failedEmailSourceEvents = useEmailCaptureStore((s) => s.failedEmailSourceEvents);
-  const failedItems = useMemo(
-    () =>
-      [
-        ...failedEmails.map(toLegacyFailedItem),
-        ...failedEmailSourceEvents.map(toSourceEventFailedItem),
-      ].sort((left, right) => right.email.receivedAt.localeCompare(left.email.receivedAt)),
-    [failedEmailSourceEvents, failedEmails]
-  );
+  const failedItems = useEmailCaptureStore((s) => s.failedEmailSourceEvents);
 
   const handleAddManually = useCallback(() => {
     push("/add-transaction");
   }, [push]);
 
   const renderItem = useCallback(
-    ({ item }: { item: FailedEmailItem }) => (
+    ({ item }: { item: ProcessedSourceEventRow }) => (
       <FailedEmailCard
-        email={item.email}
+        email={item}
         onDismiss={() => {
           if (!db || !userId) return;
-          if (item.kind === "legacy") {
-            void dismissFailedEmail(db, userId, item.email.id);
-            return;
-          }
-          void dismissFailedEmailSourceEvent(db, userId, item.email.id);
+          void dismissFailedEmailSourceEvent(db, userId, item.id);
         }}
         onAddManually={handleAddManually}
       />
@@ -78,7 +49,7 @@ export default function FailedEmailsScreen() {
       <FlashList
         data={failedItems}
         renderItem={renderItem}
-        keyExtractor={(item) => `${item.kind}:${item.email.id}`}
+        keyExtractor={(item) => item.id}
         contentInsetAdjustmentBehavior="automatic"
         contentContainerStyle={{
           paddingBottom: bottom + 40,
@@ -107,7 +78,7 @@ function FailedEmailCard({
   onDismiss,
   onAddManually,
 }: {
-  email: ProcessedEmailRow | ProcessedSourceEventRow;
+  email: ProcessedSourceEventRow;
   onDismiss: () => void;
   onAddManually: () => void;
 }) {
@@ -186,7 +157,6 @@ function formatReason(reason: string, t: (key: string) => string): string {
   return reason;
 }
 
-function getProviderLabel(email: ProcessedEmailRow | ProcessedSourceEventRow) {
-  if ("provider" in email) return email.provider === "gmail" ? "Gmail" : "Outlook";
+function getProviderLabel(email: ProcessedSourceEventRow) {
   return email.sourceId === "email_outlook" ? "Outlook" : "Gmail";
 }

--- a/apps/mobile/features/dashboard/components/NeedsReviewBanner.tsx
+++ b/apps/mobile/features/dashboard/components/NeedsReviewBanner.tsx
@@ -1,13 +1,14 @@
-import { useEmailCaptureStore } from "@/features/email-capture/public";
+import {
+  selectNeedsReviewBannerCount,
+  useEmailCaptureStore,
+} from "@/features/email-capture/public";
 import { ChevronRight, TriangleAlert } from "@/shared/components/icons";
 import { Pressable, Text, View } from "@/shared/components/rn";
 import { useTranslation } from "@/shared/hooks";
 
 export const NeedsReviewBanner = ({ onPress }: { onPress: () => void }) => {
   const { t } = useTranslation();
-  const count = useEmailCaptureStore(
-    (s) => s.needsReviewEmails.length + s.needsReviewEmailSourceEvents.length
-  );
+  const count = useEmailCaptureStore(selectNeedsReviewBannerCount);
 
   if (count === 0) return null;
 

--- a/apps/mobile/features/email-capture/components/FailedEmailsBanner.tsx
+++ b/apps/mobile/features/email-capture/components/FailedEmailsBanner.tsx
@@ -1,13 +1,12 @@
 import { TriangleAlert } from "@/shared/components/icons";
 import { Pressable, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
+import { selectFailedEmailBannerCount } from "../lib/review-queue-selectors";
 import { useEmailCaptureStore } from "../store";
 
 export const FailedEmailsBanner = ({ onPress }: { onPress: () => void }) => {
   const { t } = useTranslation();
-  const failedCount = useEmailCaptureStore(
-    (s) => s.failedEmails.length + s.failedEmailSourceEvents.length
-  );
+  const failedCount = useEmailCaptureStore(selectFailedEmailBannerCount);
   const iconColor = useThemeColor("accentRed");
 
   if (failedCount === 0) return null;

--- a/apps/mobile/features/email-capture/lib/financial-meaning-review.ts
+++ b/apps/mobile/features/email-capture/lib/financial-meaning-review.ts
@@ -1,6 +1,5 @@
 import { ensureDefaultFinancialAccount } from "@/features/financial-accounts/public";
 import { isActiveTransactionRow } from "@/features/transactions/lib/active-transaction-conditions";
-import { toStoredTransaction } from "@/features/transactions/lib/build-transaction";
 import {
   getTransactionById,
   insertTransaction,
@@ -27,24 +26,17 @@ import {
   dismissSourceEventFinancialMeaningReviewById,
   type FinancialMeaningSourceEventReviewRow,
   getFinancialMeaningSourceEventReviewRows,
-  getNeedsReviewEmails,
   getProcessedEmailById,
   getSourceEventReviewCandidateById,
   updateProcessedEmailStatus,
   updateProcessedEmailStatusInTransaction,
 } from "./repository";
 
-export type FinancialMeaningReviewItem =
-  | {
-      readonly kind: "legacy_email";
-      readonly processedEmail: Awaited<ReturnType<typeof getNeedsReviewEmails>>[number];
-      readonly transaction: ReturnType<typeof toStoredTransaction>;
-    }
-  | {
-      readonly kind: "source_event";
-      readonly processedSourceEvent: FinancialMeaningSourceEventReviewRow["processedSourceEvent"];
-      readonly reviewCandidate: FinancialMeaningSourceEventReviewRow["reviewCandidate"];
-    };
+export type FinancialMeaningReviewItem = {
+  readonly kind: "source_event";
+  readonly processedSourceEvent: FinancialMeaningSourceEventReviewRow["processedSourceEvent"];
+  readonly reviewCandidate: FinancialMeaningSourceEventReviewRow["reviewCandidate"];
+};
 
 type DismissFinancialMeaningReviewDeps = {
   readonly now?: () => IsoDateTime;
@@ -55,47 +47,19 @@ type DismissFinancialMeaningReviewDeps = {
 };
 
 export async function getFinancialMeaningReviewItems(db: AnyDb, userId: UserId) {
-  const emails = await getNeedsReviewEmails(db);
   const sourceEventRows = await getFinancialMeaningSourceEventReviewRows(db, userId);
-
-  const legacyItems = emails.flatMap((processedEmail): FinancialMeaningReviewItem[] => {
-    if (processedEmail.transactionId == null) {
-      return [];
-    }
-
-    const transaction = getTransactionById(db, processedEmail.transactionId);
-
-    if (transaction == null || !isActiveTransactionRow(transaction)) {
-      return [];
-    }
-
-    return [
-      {
-        kind: "legacy_email",
-        processedEmail,
-        transaction: toStoredTransaction(transaction),
-      },
-    ];
-  });
-
-  return [
-    ...legacyItems,
-    ...sourceEventRows.map(
+  return sourceEventRows
+    .map(
       (row): FinancialMeaningReviewItem => ({
         kind: "source_event",
         processedSourceEvent: row.processedSourceEvent,
         reviewCandidate: row.reviewCandidate,
       })
-    ),
-  ].sort((left, right) =>
-    getReviewItemReceivedAt(right).localeCompare(getReviewItemReceivedAt(left))
-  );
+    )
+    .sort((left, right) =>
+      right.processedSourceEvent.receivedAt.localeCompare(left.processedSourceEvent.receivedAt)
+    );
 }
-
-const getReviewItemReceivedAt = (item: FinancialMeaningReviewItem) =>
-  item.kind === "legacy_email"
-    ? item.processedEmail.receivedAt
-    : item.processedSourceEvent.receivedAt;
 
 export async function resolveFinancialMeaningReview(db: AnyDb, processedEmailId: ProcessedEmailId) {
   const processedEmail = await getProcessedEmailById(db, processedEmailId);
@@ -253,11 +217,13 @@ export async function dismissSourceEventFinancialMeaningReview(
   db: AnyDb,
   userId: UserId,
   processedSourceEventId: ProcessedSourceEventId,
+  reviewCandidateId: ReviewCandidateId,
   now: () => IsoDateTime = () => toIsoDateTime(new Date())
 ) {
   dismissSourceEventFinancialMeaningReviewById(db, {
     userId,
     processedSourceEventId,
+    reviewCandidateId,
     updatedAt: now(),
   });
 }

--- a/apps/mobile/features/email-capture/lib/repository.ts
+++ b/apps/mobile/features/email-capture/lib/repository.ts
@@ -24,6 +24,7 @@ export {
   dismissSourceEventFinancialMeaningReviewById,
   getFinancialMeaningSourceEventReviewRows,
   getSourceEventReviewCandidateById,
+  markSourceEventReviewCandidateReclassifiedAsTransfer,
   type FinancialMeaningSourceEventReviewRow,
 } from "./source-event-review-repository";
 export {

--- a/apps/mobile/features/email-capture/lib/repository.ts
+++ b/apps/mobile/features/email-capture/lib/repository.ts
@@ -9,20 +9,23 @@ import type {
   UserId,
 } from "@/shared/types/branded";
 export {
-  acceptSourceEventFinancialMeaningReviewById,
-  dismissSourceEventFinancialMeaningReviewById,
-  getFinancialMeaningSourceEventReviewRows,
   getPendingRetryEmailSourceEvents,
   getProcessedEmailSourceEventIds,
-  getSourceEventReviewCandidateById,
   insertProcessedEmailSourceEvent,
   markSourceEventForRetry,
   markSourceEventPermanentlyFailed,
   markSourceEventRetrySuccess,
   updateProcessedSourceEventStatus,
-  type FinancialMeaningSourceEventReviewRow,
+  updateProcessedSourceEventStatusInTransaction,
   type ProcessedSourceEventRow,
 } from "./source-event-repository";
+export {
+  acceptSourceEventFinancialMeaningReviewById,
+  dismissSourceEventFinancialMeaningReviewById,
+  getFinancialMeaningSourceEventReviewRows,
+  getSourceEventReviewCandidateById,
+  type FinancialMeaningSourceEventReviewRow,
+} from "./source-event-review-repository";
 export {
   getFailedEmailSourceEvents,
   getNeedsReviewEmailSourceEvents,

--- a/apps/mobile/features/email-capture/lib/repository.ts
+++ b/apps/mobile/features/email-capture/lib/repository.ts
@@ -1,6 +1,6 @@
-import { and, desc, eq, inArray, lte, sql } from "drizzle-orm";
+import { and, desc, eq, getTableColumns, inArray, lte, sql } from "drizzle-orm";
 import type { AnyDb } from "@/shared/db";
-import { emailAccounts, processedEmails } from "@/shared/db";
+import { emailAccounts, processedEmails, transactions } from "@/shared/db";
 import type {
   EmailAccountId,
   IsoDateTime,
@@ -125,19 +125,21 @@ export async function getProcessedExternalIds(
   return new Set(rows.map(getLegacyEmailSourceEventKey));
 }
 
-export async function getFailedEmails(db: AnyDb) {
+export async function getFailedEmails(db: AnyDb, userId: UserId) {
   return db
-    .select()
+    .select({ ...getTableColumns(processedEmails) })
     .from(processedEmails)
-    .where(eq(processedEmails.status, "failed"))
+    .innerJoin(transactions, eq(transactions.id, processedEmails.transactionId))
+    .where(and(eq(processedEmails.status, "failed"), eq(transactions.userId, userId)))
     .orderBy(desc(processedEmails.receivedAt));
 }
 
-export async function getNeedsReviewEmails(db: AnyDb) {
+export async function getNeedsReviewEmails(db: AnyDb, userId: UserId) {
   return db
-    .select()
+    .select({ ...getTableColumns(processedEmails) })
     .from(processedEmails)
-    .where(eq(processedEmails.status, "needs_review"))
+    .innerJoin(transactions, eq(transactions.id, processedEmails.transactionId))
+    .where(and(eq(processedEmails.status, "needs_review"), eq(transactions.userId, userId)))
     .orderBy(desc(processedEmails.receivedAt));
 }
 

--- a/apps/mobile/features/email-capture/lib/repository.ts
+++ b/apps/mobile/features/email-capture/lib/repository.ts
@@ -111,7 +111,7 @@ async function canUseLegacyProcessedEmailFallback(db: AnyDb, userId: UserId) {
     ...emailAccountOwners.map((owner) => owner.userId),
     ...transactionOwners.map((owner) => owner.userId),
   ]);
-  return owners.size === 1 && owners.has(userId);
+  return emailAccountOwners.length === 1 && owners.size === 1 && owners.has(userId);
 }
 
 export async function getProcessedExternalIds(

--- a/apps/mobile/features/email-capture/lib/repository.ts
+++ b/apps/mobile/features/email-capture/lib/repository.ts
@@ -99,11 +99,19 @@ const getLegacyEmailSourceEventKey = (row: {
 }) => `${row.provider === "gmail" ? "email_gmail" : "email_outlook"}:${row.externalId}`;
 
 async function canUseLegacyProcessedEmailFallback(db: AnyDb, userId: UserId) {
-  const owners = await db
+  const emailAccountOwners = await db
     .selectDistinct({ userId: emailAccounts.userId })
     .from(emailAccounts)
     .limit(2);
-  return owners.length === 1 && owners[0]?.userId === userId;
+  const transactionOwners = await db
+    .selectDistinct({ userId: transactions.userId })
+    .from(transactions)
+    .limit(2);
+  const owners = new Set([
+    ...emailAccountOwners.map((owner) => owner.userId),
+    ...transactionOwners.map((owner) => owner.userId),
+  ]);
+  return owners.size === 1 && owners.has(userId);
 }
 
 export async function getProcessedExternalIds(

--- a/apps/mobile/features/email-capture/lib/repository.ts
+++ b/apps/mobile/features/email-capture/lib/repository.ts
@@ -125,22 +125,33 @@ export async function getProcessedExternalIds(
   return new Set(rows.map(getLegacyEmailSourceEventKey));
 }
 
-export async function getFailedEmails(db: AnyDb, userId: UserId) {
+function getProcessedEmailsByStatus(db: AnyDb, status: string) {
   return db
-    .select({ ...getTableColumns(processedEmails) })
+    .select()
     .from(processedEmails)
-    .innerJoin(transactions, eq(transactions.id, processedEmails.transactionId))
-    .where(and(eq(processedEmails.status, "failed"), eq(transactions.userId, userId)))
+    .where(eq(processedEmails.status, status))
     .orderBy(desc(processedEmails.receivedAt));
 }
 
-export async function getNeedsReviewEmails(db: AnyDb, userId: UserId) {
+function getUserLinkedProcessedEmailsByStatus(db: AnyDb, userId: UserId, status: string) {
   return db
     .select({ ...getTableColumns(processedEmails) })
     .from(processedEmails)
     .innerJoin(transactions, eq(transactions.id, processedEmails.transactionId))
-    .where(and(eq(processedEmails.status, "needs_review"), eq(transactions.userId, userId)))
+    .where(and(eq(processedEmails.status, status), eq(transactions.userId, userId)))
     .orderBy(desc(processedEmails.receivedAt));
+}
+
+export async function getFailedEmails(db: AnyDb, userId: UserId) {
+  return (await canUseLegacyProcessedEmailFallback(db, userId))
+    ? getProcessedEmailsByStatus(db, "failed")
+    : getUserLinkedProcessedEmailsByStatus(db, userId, "failed");
+}
+
+export async function getNeedsReviewEmails(db: AnyDb, userId: UserId) {
+  return (await canUseLegacyProcessedEmailFallback(db, userId))
+    ? getProcessedEmailsByStatus(db, "needs_review")
+    : getUserLinkedProcessedEmailsByStatus(db, userId, "needs_review");
 }
 
 export async function getNeedsReviewEmailByTransactionId(db: AnyDb, transactionId: TransactionId) {

--- a/apps/mobile/features/email-capture/lib/review-queue-selectors.ts
+++ b/apps/mobile/features/email-capture/lib/review-queue-selectors.ts
@@ -1,0 +1,12 @@
+import type { EmailCaptureState } from "../store/state";
+
+export const selectFailedEmailBannerCount = (state: EmailCaptureState) =>
+  state.failedEmailSourceEvents.length;
+
+export const selectNeedsReviewBannerCount = (state: {
+  readonly needsReviewEmailSourceEvents: readonly unknown[];
+}) => state.needsReviewEmailSourceEvents.length;
+
+export const getFinancialMeaningQueueItemId = (item: {
+  readonly reviewCandidate: { readonly id: string };
+}) => item.reviewCandidate.id;

--- a/apps/mobile/features/email-capture/lib/source-event-queue-repository.ts
+++ b/apps/mobile/features/email-capture/lib/source-event-queue-repository.ts
@@ -1,11 +1,13 @@
-import { and, desc, eq, inArray, isNull } from "drizzle-orm";
+import { and, desc, eq, getTableColumns, inArray, isNull, sql } from "drizzle-orm";
 import type { AnyDb } from "@/shared/db";
-import { processedSourceEvents } from "@/shared/db/schema";
+import { processedSourceEvents, reviewCandidates } from "@/shared/db/schema";
 import type { UserId } from "@/shared/types/branded";
+
+const { rawBody: _rawBody, ...sourceEventQueueColumns } = getTableColumns(processedSourceEvents);
 
 const emailSourceEventQueueFilter = (
   userId: UserId,
-  statuses: readonly ("failed" | "needs_review")[]
+  statuses: readonly ("failed" | "needs_review" | "pending_retry")[]
 ) =>
   and(
     eq(processedSourceEvents.userId, userId),
@@ -16,16 +18,28 @@ const emailSourceEventQueueFilter = (
 
 export async function getFailedEmailSourceEvents(db: AnyDb, userId: UserId) {
   return db
-    .select()
+    .select({ ...sourceEventQueueColumns, rawBody: sql<null>`null` })
     .from(processedSourceEvents)
-    .where(emailSourceEventQueueFilter(userId, ["failed"]))
+    .where(emailSourceEventQueueFilter(userId, ["failed", "pending_retry"]))
     .orderBy(desc(processedSourceEvents.receivedAt));
 }
 
 export async function getNeedsReviewEmailSourceEvents(db: AnyDb, userId: UserId) {
   return db
-    .select()
+    .select({ ...sourceEventQueueColumns, rawBody: sql<null>`null` })
     .from(processedSourceEvents)
-    .where(emailSourceEventQueueFilter(userId, ["needs_review"]))
+    .where(
+      and(
+        emailSourceEventQueueFilter(userId, ["needs_review"]),
+        sql`exists (
+          select 1
+          from ${reviewCandidates}
+          where ${reviewCandidates.processedSourceEventId} = ${processedSourceEvents.id}
+            and ${reviewCandidates.userId} = ${userId}
+            and ${reviewCandidates.status} = 'pending'
+            and ${reviewCandidates.deletedAt} is null
+        )`
+      )
+    )
     .orderBy(desc(processedSourceEvents.receivedAt));
 }

--- a/apps/mobile/features/email-capture/lib/source-event-queue-repository.ts
+++ b/apps/mobile/features/email-capture/lib/source-event-queue-repository.ts
@@ -20,7 +20,7 @@ export async function getFailedEmailSourceEvents(db: AnyDb, userId: UserId) {
   return db
     .select({ ...sourceEventQueueColumns, rawBody: sql<null>`null` })
     .from(processedSourceEvents)
-    .where(emailSourceEventQueueFilter(userId, ["failed", "pending_retry"]))
+    .where(emailSourceEventQueueFilter(userId, ["failed"]))
     .orderBy(desc(processedSourceEvents.receivedAt));
 }
 

--- a/apps/mobile/features/email-capture/lib/source-event-repository.ts
+++ b/apps/mobile/features/email-capture/lib/source-event-repository.ts
@@ -122,17 +122,20 @@ export function updateProcessedSourceEventStatusInTransaction(input: {
   readonly userId: UserId;
   readonly status: string;
   readonly transactionId: TransactionId | null;
+  readonly updatedAt: IsoDateTime;
 }) {
   const update = input.db
     .update(processedSourceEvents)
     .set({
       status: input.status,
       transactionId: input.transactionId,
+      updatedAt: input.updatedAt,
     })
     .where(
       and(
         eq(processedSourceEvents.id, input.id),
         eq(processedSourceEvents.userId, input.userId),
+        eq(processedSourceEvents.sourceFamily, "email"),
         eq(processedSourceEvents.status, "needs_review"),
         isNull(processedSourceEvents.deletedAt)
       )

--- a/apps/mobile/features/email-capture/lib/source-event-repository.ts
+++ b/apps/mobile/features/email-capture/lib/source-event-repository.ts
@@ -1,32 +1,14 @@
 import { and, asc, eq, inArray, isNull, lte, sql } from "drizzle-orm";
 import type { AnyDb } from "@/shared/db";
-import { processedSourceEvents, reviewCandidates } from "@/shared/db/schema";
+import { processedSourceEvents } from "@/shared/db/schema";
 import type {
   IsoDateTime,
   ProcessedSourceEventId,
-  ReviewCandidateId,
   TransactionId,
   UserId,
 } from "@/shared/types/branded";
 
 export type ProcessedSourceEventRow = typeof processedSourceEvents.$inferInsert;
-export type ReviewCandidateRow = typeof reviewCandidates.$inferSelect;
-export type FinancialMeaningSourceEventReviewRow = {
-  readonly processedSourceEvent: typeof processedSourceEvents.$inferSelect;
-  readonly reviewCandidate: ReviewCandidateRow;
-};
-
-const selectFinancialMeaningSourceEventReviewRows = (db: AnyDb) =>
-  db
-    .select({
-      processedSourceEvent: processedSourceEvents,
-      reviewCandidate: reviewCandidates,
-    })
-    .from(processedSourceEvents)
-    .innerJoin(
-      reviewCandidates,
-      eq(reviewCandidates.processedSourceEventId, processedSourceEvents.id)
-    );
 
 export async function getProcessedEmailSourceEventIds(
   db: AnyDb,
@@ -78,147 +60,6 @@ export async function getPendingRetryEmailSourceEvents(db: AnyDb, userId: UserId
     )
     .orderBy(asc(processedSourceEvents.nextRetryAt), asc(processedSourceEvents.receivedAt))
     .limit(50);
-}
-
-export async function getFinancialMeaningSourceEventReviewRows(
-  db: AnyDb,
-  userId: UserId
-): Promise<readonly FinancialMeaningSourceEventReviewRow[]> {
-  return selectFinancialMeaningSourceEventReviewRows(db).where(
-    and(
-      eq(processedSourceEvents.userId, userId),
-      eq(reviewCandidates.userId, userId),
-      eq(processedSourceEvents.sourceFamily, "email"),
-      eq(processedSourceEvents.status, "needs_review"),
-      eq(reviewCandidates.status, "pending"),
-      isNull(processedSourceEvents.deletedAt),
-      isNull(reviewCandidates.deletedAt)
-    )
-  );
-}
-
-export function getSourceEventReviewCandidateById(
-  db: AnyDb,
-  input: {
-    readonly userId: UserId;
-    readonly processedSourceEventId: ProcessedSourceEventId;
-    readonly reviewCandidateId: ReviewCandidateId;
-  }
-): FinancialMeaningSourceEventReviewRow | null {
-  const filters = [
-    eq(processedSourceEvents.id, input.processedSourceEventId),
-    eq(processedSourceEvents.userId, input.userId),
-    eq(reviewCandidates.id, input.reviewCandidateId),
-    eq(reviewCandidates.userId, input.userId),
-    eq(reviewCandidates.status, "pending"),
-    isNull(processedSourceEvents.deletedAt),
-    isNull(reviewCandidates.deletedAt),
-  ];
-  const rows = selectFinancialMeaningSourceEventReviewRows(db)
-    .where(and(...filters))
-    .limit(1)
-    .all();
-  return rows[0] ?? null;
-}
-
-export function acceptSourceEventFinancialMeaningReviewById(
-  db: AnyDb,
-  input: {
-    readonly userId: UserId;
-    readonly processedSourceEventId: ProcessedSourceEventId;
-    readonly reviewCandidateId: ReviewCandidateId;
-    readonly transactionId: TransactionId;
-    readonly updatedAt: IsoDateTime;
-  }
-) {
-  if (!markSourceEventReviewAccepted(db, input)) return false;
-  assertReviewCandidateAccepted(db, input);
-  return true;
-}
-
-function markSourceEventReviewAccepted(
-  db: AnyDb,
-  input: {
-    readonly userId: UserId;
-    readonly processedSourceEventId: ProcessedSourceEventId;
-    readonly transactionId: TransactionId;
-    readonly updatedAt: IsoDateTime;
-  }
-) {
-  const update = db
-    .update(processedSourceEvents)
-    .set({ status: "processed", transactionId: input.transactionId, updatedAt: input.updatedAt })
-    .where(
-      and(
-        eq(processedSourceEvents.id, input.processedSourceEventId),
-        eq(processedSourceEvents.userId, input.userId),
-        eq(processedSourceEvents.status, "needs_review"),
-        isNull(processedSourceEvents.deletedAt)
-      )
-    )
-    .run();
-  return update.changes === 1;
-}
-
-function assertReviewCandidateAccepted(
-  db: AnyDb,
-  input: {
-    readonly userId: UserId;
-    readonly processedSourceEventId: ProcessedSourceEventId;
-    readonly reviewCandidateId: ReviewCandidateId;
-    readonly updatedAt: IsoDateTime;
-  }
-) {
-  const update = db
-    .update(reviewCandidates)
-    .set({ status: "accepted", updatedAt: input.updatedAt })
-    .where(
-      and(
-        eq(reviewCandidates.id, input.reviewCandidateId),
-        eq(reviewCandidates.processedSourceEventId, input.processedSourceEventId),
-        eq(reviewCandidates.userId, input.userId),
-        eq(reviewCandidates.status, "pending"),
-        isNull(reviewCandidates.deletedAt)
-      )
-    )
-    .run();
-  if (update.changes !== 1) {
-    throw new Error("Review candidate resolution target was not found");
-  }
-}
-
-export function dismissSourceEventFinancialMeaningReviewById(
-  db: AnyDb,
-  input: {
-    readonly userId: UserId;
-    readonly processedSourceEventId: ProcessedSourceEventId;
-    readonly updatedAt: IsoDateTime;
-  }
-) {
-  db.transaction((tx) => {
-    tx.update(processedSourceEvents)
-      .set({ status: "dismissed", updatedAt: input.updatedAt })
-      .where(
-        and(
-          eq(processedSourceEvents.id, input.processedSourceEventId),
-          eq(processedSourceEvents.userId, input.userId),
-          eq(processedSourceEvents.status, "needs_review"),
-          isNull(processedSourceEvents.deletedAt)
-        )
-      )
-      .run();
-    tx.update(reviewCandidates)
-      .set({ status: "rejected", updatedAt: input.updatedAt })
-      .where(
-        and(
-          eq(reviewCandidates.processedSourceEventId, input.processedSourceEventId),
-          eq(reviewCandidates.userId, input.userId),
-          eq(reviewCandidates.status, "pending"),
-          isNull(reviewCandidates.deletedAt)
-        )
-      )
-      .run();
-  });
 }
 
 function getProcessedSourceEventUpdateQuery(
@@ -274,4 +115,31 @@ export async function updateProcessedSourceEventStatus(input: {
     transactionId: input.transactionId,
     ...rawBodyFields,
   });
+}
+export function updateProcessedSourceEventStatusInTransaction(input: {
+  readonly db: AnyDb;
+  readonly id: ProcessedSourceEventId;
+  readonly userId: UserId;
+  readonly status: string;
+  readonly transactionId: TransactionId | null;
+}) {
+  const update = input.db
+    .update(processedSourceEvents)
+    .set({
+      status: input.status,
+      transactionId: input.transactionId,
+    })
+    .where(
+      and(
+        eq(processedSourceEvents.id, input.id),
+        eq(processedSourceEvents.userId, input.userId),
+        eq(processedSourceEvents.status, "needs_review"),
+        isNull(processedSourceEvents.deletedAt)
+      )
+    )
+    .run();
+
+  if (update.changes !== 1) {
+    throw new Error("Processed source event reclassification target was not found");
+  }
 }

--- a/apps/mobile/features/email-capture/lib/source-event-review-repository.ts
+++ b/apps/mobile/features/email-capture/lib/source-event-review-repository.ts
@@ -57,6 +57,7 @@ export function getSourceEventReviewCandidateById(
       and(
         eq(processedSourceEvents.id, input.processedSourceEventId),
         eq(processedSourceEvents.userId, input.userId),
+        eq(processedSourceEvents.sourceFamily, "email"),
         eq(reviewCandidates.id, input.reviewCandidateId),
         eq(reviewCandidates.userId, input.userId),
         eq(reviewCandidates.status, "pending"),
@@ -106,6 +107,7 @@ const markSourceEventReviewProcessed = (
       and(
         eq(processedSourceEvents.id, input.processedSourceEventId),
         eq(processedSourceEvents.userId, input.userId),
+        eq(processedSourceEvents.sourceFamily, "email"),
         eq(processedSourceEvents.status, "needs_review"),
         isNull(processedSourceEvents.deletedAt)
       )
@@ -222,6 +224,7 @@ const markSourceEventAfterReviewDismissal = (
       and(
         eq(processedSourceEvents.id, input.processedSourceEventId),
         eq(processedSourceEvents.userId, input.userId),
+        eq(processedSourceEvents.sourceFamily, "email"),
         eq(processedSourceEvents.status, "needs_review"),
         isNull(processedSourceEvents.deletedAt)
       )
@@ -248,5 +251,30 @@ export function dismissSourceEventFinancialMeaningReviewById(
     if (sourceEventUpdate.changes !== 1) {
       throw new Error("Review source event was not active");
     }
+  });
+}
+
+export function markSourceEventReviewCandidateReclassifiedAsTransfer(
+  db: AnyDb,
+  input: {
+    readonly userId: UserId;
+    readonly processedSourceEventId: ProcessedSourceEventId;
+    readonly reviewCandidateId: ReviewCandidateId;
+    readonly transactionId: TransactionId;
+    readonly updatedAt: IsoDateTime;
+  }
+) {
+  db.transaction((tx) => {
+    const sourceEventUpdate = markSourceEventReviewProcessed(tx, input);
+    if (sourceEventUpdate.changes !== 1) {
+      throw new Error("Review source event was not active");
+    }
+
+    const rejectedCandidateUpdate = rejectPendingReviewCandidate(tx, input);
+    if (rejectedCandidateUpdate.changes !== 1) {
+      throw new Error("Review candidate resolution target was not found");
+    }
+
+    rejectPendingSiblingCandidates(tx, input);
   });
 }

--- a/apps/mobile/features/email-capture/lib/source-event-review-repository.ts
+++ b/apps/mobile/features/email-capture/lib/source-event-review-repository.ts
@@ -1,0 +1,252 @@
+import { and, eq, isNull } from "drizzle-orm";
+import type { AnyDb } from "@/shared/db";
+import { processedSourceEvents, reviewCandidates } from "@/shared/db/schema";
+import type {
+  IsoDateTime,
+  ProcessedSourceEventId,
+  ReviewCandidateId,
+  TransactionId,
+  UserId,
+} from "@/shared/types/branded";
+
+export type ReviewCandidateRow = typeof reviewCandidates.$inferSelect;
+export type FinancialMeaningSourceEventReviewRow = {
+  readonly processedSourceEvent: typeof processedSourceEvents.$inferSelect;
+  readonly reviewCandidate: ReviewCandidateRow;
+};
+
+const selectFinancialMeaningSourceEventReviewRows = (db: AnyDb) =>
+  db
+    .select({
+      processedSourceEvent: processedSourceEvents,
+      reviewCandidate: reviewCandidates,
+    })
+    .from(processedSourceEvents)
+    .innerJoin(
+      reviewCandidates,
+      eq(reviewCandidates.processedSourceEventId, processedSourceEvents.id)
+    );
+
+export async function getFinancialMeaningSourceEventReviewRows(
+  db: AnyDb,
+  userId: UserId
+): Promise<readonly FinancialMeaningSourceEventReviewRow[]> {
+  return selectFinancialMeaningSourceEventReviewRows(db).where(
+    and(
+      eq(processedSourceEvents.userId, userId),
+      eq(reviewCandidates.userId, userId),
+      eq(processedSourceEvents.sourceFamily, "email"),
+      eq(processedSourceEvents.status, "needs_review"),
+      eq(reviewCandidates.status, "pending"),
+      isNull(processedSourceEvents.deletedAt),
+      isNull(reviewCandidates.deletedAt)
+    )
+  );
+}
+
+export function getSourceEventReviewCandidateById(
+  db: AnyDb,
+  input: {
+    readonly userId: UserId;
+    readonly processedSourceEventId: ProcessedSourceEventId;
+    readonly reviewCandidateId: ReviewCandidateId;
+  }
+): FinancialMeaningSourceEventReviewRow | null {
+  const rows = selectFinancialMeaningSourceEventReviewRows(db)
+    .where(
+      and(
+        eq(processedSourceEvents.id, input.processedSourceEventId),
+        eq(processedSourceEvents.userId, input.userId),
+        eq(reviewCandidates.id, input.reviewCandidateId),
+        eq(reviewCandidates.userId, input.userId),
+        eq(reviewCandidates.status, "pending"),
+        isNull(processedSourceEvents.deletedAt),
+        isNull(reviewCandidates.deletedAt)
+      )
+    )
+    .limit(1)
+    .all();
+  return rows[0] ?? null;
+}
+
+const rejectPendingSiblingCandidates = (
+  tx: AnyDb,
+  input: {
+    readonly userId: UserId;
+    readonly processedSourceEventId: ProcessedSourceEventId;
+    readonly updatedAt: IsoDateTime;
+  }
+) =>
+  tx
+    .update(reviewCandidates)
+    .set({ status: "rejected", updatedAt: input.updatedAt })
+    .where(
+      and(
+        eq(reviewCandidates.processedSourceEventId, input.processedSourceEventId),
+        eq(reviewCandidates.userId, input.userId),
+        eq(reviewCandidates.status, "pending"),
+        isNull(reviewCandidates.deletedAt)
+      )
+    )
+    .run();
+
+const markSourceEventReviewProcessed = (
+  tx: AnyDb,
+  input: {
+    readonly userId: UserId;
+    readonly processedSourceEventId: ProcessedSourceEventId;
+    readonly transactionId: TransactionId;
+    readonly updatedAt: IsoDateTime;
+  }
+) =>
+  tx
+    .update(processedSourceEvents)
+    .set({ status: "processed", transactionId: input.transactionId, updatedAt: input.updatedAt })
+    .where(
+      and(
+        eq(processedSourceEvents.id, input.processedSourceEventId),
+        eq(processedSourceEvents.userId, input.userId),
+        eq(processedSourceEvents.status, "needs_review"),
+        isNull(processedSourceEvents.deletedAt)
+      )
+    )
+    .run();
+
+const acceptPendingReviewCandidate = (
+  tx: AnyDb,
+  input: {
+    readonly userId: UserId;
+    readonly processedSourceEventId: ProcessedSourceEventId;
+    readonly reviewCandidateId: ReviewCandidateId;
+    readonly updatedAt: IsoDateTime;
+  }
+) =>
+  tx
+    .update(reviewCandidates)
+    .set({ status: "accepted", updatedAt: input.updatedAt })
+    .where(
+      and(
+        eq(reviewCandidates.id, input.reviewCandidateId),
+        eq(reviewCandidates.processedSourceEventId, input.processedSourceEventId),
+        eq(reviewCandidates.userId, input.userId),
+        eq(reviewCandidates.status, "pending"),
+        isNull(reviewCandidates.deletedAt)
+      )
+    )
+    .run();
+
+export function acceptSourceEventFinancialMeaningReviewById(
+  db: AnyDb,
+  input: {
+    readonly userId: UserId;
+    readonly processedSourceEventId: ProcessedSourceEventId;
+    readonly reviewCandidateId: ReviewCandidateId;
+    readonly transactionId: TransactionId;
+    readonly updatedAt: IsoDateTime;
+  }
+) {
+  return db.transaction((tx) => {
+    const sourceEventUpdate = markSourceEventReviewProcessed(tx, input);
+    if (sourceEventUpdate.changes !== 1) return false;
+
+    const acceptedCandidateUpdate = acceptPendingReviewCandidate(tx, input);
+    if (acceptedCandidateUpdate.changes !== 1) {
+      throw new Error("Review candidate resolution target was not found");
+    }
+
+    rejectPendingSiblingCandidates(tx, input);
+    return true;
+  });
+}
+
+const rejectPendingReviewCandidate = (
+  tx: AnyDb,
+  input: {
+    readonly userId: UserId;
+    readonly processedSourceEventId: ProcessedSourceEventId;
+    readonly reviewCandidateId: ReviewCandidateId;
+    readonly updatedAt: IsoDateTime;
+  }
+) =>
+  tx
+    .update(reviewCandidates)
+    .set({ status: "rejected", updatedAt: input.updatedAt })
+    .where(
+      and(
+        eq(reviewCandidates.id, input.reviewCandidateId),
+        eq(reviewCandidates.processedSourceEventId, input.processedSourceEventId),
+        eq(reviewCandidates.userId, input.userId),
+        eq(reviewCandidates.status, "pending"),
+        isNull(reviewCandidates.deletedAt)
+      )
+    )
+    .run();
+
+const hasPendingSiblingCandidates = (
+  tx: AnyDb,
+  input: {
+    readonly userId: UserId;
+    readonly processedSourceEventId: ProcessedSourceEventId;
+  }
+) =>
+  tx
+    .select({ id: reviewCandidates.id })
+    .from(reviewCandidates)
+    .where(
+      and(
+        eq(reviewCandidates.processedSourceEventId, input.processedSourceEventId),
+        eq(reviewCandidates.userId, input.userId),
+        eq(reviewCandidates.status, "pending"),
+        isNull(reviewCandidates.deletedAt)
+      )
+    )
+    .limit(1)
+    .all().length > 0;
+
+const markSourceEventAfterReviewDismissal = (
+  tx: AnyDb,
+  input: {
+    readonly userId: UserId;
+    readonly processedSourceEventId: ProcessedSourceEventId;
+    readonly hasPendingCandidates: boolean;
+    readonly updatedAt: IsoDateTime;
+  }
+) =>
+  tx
+    .update(processedSourceEvents)
+    .set({
+      status: input.hasPendingCandidates ? "needs_review" : "dismissed",
+      updatedAt: input.updatedAt,
+    })
+    .where(
+      and(
+        eq(processedSourceEvents.id, input.processedSourceEventId),
+        eq(processedSourceEvents.userId, input.userId),
+        eq(processedSourceEvents.status, "needs_review"),
+        isNull(processedSourceEvents.deletedAt)
+      )
+    )
+    .run();
+
+export function dismissSourceEventFinancialMeaningReviewById(
+  db: AnyDb,
+  input: {
+    readonly userId: UserId;
+    readonly processedSourceEventId: ProcessedSourceEventId;
+    readonly reviewCandidateId: ReviewCandidateId;
+    readonly updatedAt: IsoDateTime;
+  }
+) {
+  db.transaction((tx) => {
+    const rejectedCandidateUpdate = rejectPendingReviewCandidate(tx, input);
+    if (rejectedCandidateUpdate.changes !== 1) return;
+
+    const sourceEventUpdate = markSourceEventAfterReviewDismissal(tx, {
+      ...input,
+      hasPendingCandidates: hasPendingSiblingCandidates(tx, input),
+    });
+    if (sourceEventUpdate.changes !== 1) {
+      throw new Error("Review source event was not active");
+    }
+  });
+}

--- a/apps/mobile/features/email-capture/public.ts
+++ b/apps/mobile/features/email-capture/public.ts
@@ -6,6 +6,10 @@ export {
   resolveFinancialMeaningReview,
 } from "./lib/financial-meaning-review";
 export { insertMerchantRule, lookupMerchantRule } from "./lib/merchant-rules";
+export {
+  getFinancialMeaningQueueItemId,
+  selectNeedsReviewBannerCount,
+} from "./lib/review-queue-selectors";
 export type { ProcessedEmailRow, ProcessedSourceEventRow } from "./lib/repository";
 export { getNeedsReviewEmailByTransactionId } from "./lib/repository";
 export type { BankSender } from "./lib/bank-senders";

--- a/apps/mobile/features/email-capture/services/email-capture-queues.ts
+++ b/apps/mobile/features/email-capture/services/email-capture-queues.ts
@@ -1,12 +1,7 @@
 import type { AnyDb } from "@/shared/db";
 import type { UserId } from "@/shared/types/branded";
 import type { ProcessedEmailRow, ProcessedSourceEventRow } from "../lib/repository";
-import {
-  getFailedEmailSourceEvents,
-  getFailedEmails,
-  getNeedsReviewEmailSourceEvents,
-  getNeedsReviewEmails,
-} from "../lib/repository";
+import { getFailedEmailSourceEvents, getNeedsReviewEmailSourceEvents } from "../lib/repository";
 
 export type EmailCaptureQueues = {
   readonly failedEmails: readonly ProcessedEmailRow[];
@@ -19,18 +14,15 @@ export async function loadEmailCaptureQueues(
   db: AnyDb,
   userId: UserId
 ): Promise<EmailCaptureQueues> {
-  const [failedEmails, failedEmailSourceEvents, needsReviewEmails, needsReviewEmailSourceEvents] =
-    await Promise.all([
-      getFailedEmails(db),
-      getFailedEmailSourceEvents(db, userId),
-      getNeedsReviewEmails(db),
-      getNeedsReviewEmailSourceEvents(db, userId),
-    ]);
+  const [failedEmailSourceEvents, needsReviewEmailSourceEvents] = await Promise.all([
+    getFailedEmailSourceEvents(db, userId),
+    getNeedsReviewEmailSourceEvents(db, userId),
+  ]);
 
   return {
-    failedEmails,
+    failedEmails: [],
     failedEmailSourceEvents,
-    needsReviewEmails,
+    needsReviewEmails: [],
     needsReviewEmailSourceEvents,
   };
 }

--- a/apps/mobile/features/email-capture/services/email-capture-queues.ts
+++ b/apps/mobile/features/email-capture/services/email-capture-queues.ts
@@ -21,9 +21,9 @@ export async function loadEmailCaptureQueues(
 ): Promise<EmailCaptureQueues> {
   const [failedEmails, failedEmailSourceEvents, needsReviewEmails, needsReviewEmailSourceEvents] =
     await Promise.all([
-      getFailedEmails(db),
+      getFailedEmails(db, userId),
       getFailedEmailSourceEvents(db, userId),
-      getNeedsReviewEmails(db),
+      getNeedsReviewEmails(db, userId),
       getNeedsReviewEmailSourceEvents(db, userId),
     ]);
 

--- a/apps/mobile/features/email-capture/services/email-capture-queues.ts
+++ b/apps/mobile/features/email-capture/services/email-capture-queues.ts
@@ -1,7 +1,12 @@
 import type { AnyDb } from "@/shared/db";
 import type { UserId } from "@/shared/types/branded";
 import type { ProcessedEmailRow, ProcessedSourceEventRow } from "../lib/repository";
-import { getFailedEmailSourceEvents, getNeedsReviewEmailSourceEvents } from "../lib/repository";
+import {
+  getFailedEmails,
+  getFailedEmailSourceEvents,
+  getNeedsReviewEmails,
+  getNeedsReviewEmailSourceEvents,
+} from "../lib/repository";
 
 export type EmailCaptureQueues = {
   readonly failedEmails: readonly ProcessedEmailRow[];
@@ -14,15 +19,18 @@ export async function loadEmailCaptureQueues(
   db: AnyDb,
   userId: UserId
 ): Promise<EmailCaptureQueues> {
-  const [failedEmailSourceEvents, needsReviewEmailSourceEvents] = await Promise.all([
-    getFailedEmailSourceEvents(db, userId),
-    getNeedsReviewEmailSourceEvents(db, userId),
-  ]);
+  const [failedEmails, failedEmailSourceEvents, needsReviewEmails, needsReviewEmailSourceEvents] =
+    await Promise.all([
+      getFailedEmails(db),
+      getFailedEmailSourceEvents(db, userId),
+      getNeedsReviewEmails(db),
+      getNeedsReviewEmailSourceEvents(db, userId),
+    ]);
 
   return {
-    failedEmails: [],
+    failedEmails,
     failedEmailSourceEvents,
-    needsReviewEmails: [],
+    needsReviewEmails,
     needsReviewEmailSourceEvents,
   };
 }

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -2,12 +2,9 @@ import type { AnyDb } from "@/shared/db";
 import { captureError, captureWarning, toIsoDateTime } from "@/shared/lib";
 import type { UserId } from "@/shared/types/branded";
 import {
-  dismissProcessedEmail,
   getEmailAccounts,
   getFailedEmailSourceEvents,
-  getFailedEmails,
   getNeedsReviewEmailSourceEvents,
-  getNeedsReviewEmails,
   updateProcessedSourceEventStatus,
 } from "./lib/repository";
 import { shareEmailParseImprovementRequests } from "./services/email-parse-improvement-sharing";
@@ -90,58 +87,40 @@ export async function loadEmailAccounts(db: AnyDb, userId: UserId) {
 }
 export async function loadFailedEmails(db: AnyDb, userId: UserId) {
   const request = beginEmailCaptureRequest("failedEmails", userId);
-  const [failedEmailsResult, sourceEventsResult] = await Promise.allSettled([
-    getFailedEmails(db),
-    getFailedEmailSourceEvents(db, userId),
-  ]);
-  if (!isCurrentEmailCaptureRequest(request)) return;
-  if (failedEmailsResult.status === "fulfilled") {
-    useEmailCaptureStore.getState().setFailedEmails(failedEmailsResult.value);
-  } else {
+
+  try {
+    const failedEmailSourceEvents = await getFailedEmailSourceEvents(db, userId);
+    if (!isCurrentEmailCaptureRequest(request)) return;
     useEmailCaptureStore.getState().setFailedEmails([]);
-    captureWarning("email_capture_failed_queue_load_failed", {
-      errorType:
-        failedEmailsResult.reason instanceof Error ? failedEmailsResult.reason.name : "unknown",
-    });
-  }
-  if (sourceEventsResult.status === "fulfilled") {
-    useEmailCaptureStore.getState().setFailedEmailSourceEvents(sourceEventsResult.value);
-  } else {
+    useEmailCaptureStore.getState().setFailedEmailSourceEvents(failedEmailSourceEvents);
+  } catch (error) {
+    if (!isCurrentEmailCaptureRequest(request)) return;
+    useEmailCaptureStore.getState().setFailedEmails([]);
     useEmailCaptureStore.getState().setFailedEmailSourceEvents([]);
-    captureWarning("email_capture_failed_source_event_queue_load_failed", {
-      errorType:
-        sourceEventsResult.reason instanceof Error ? sourceEventsResult.reason.name : "unknown",
+    captureWarning("email_capture_failed_queue_load_failed", {
+      errorType: error instanceof Error ? error.name : "unknown",
     });
   }
 }
 export async function loadNeedsReviewEmails(db: AnyDb, userId: UserId) {
   const request = beginEmailCaptureRequest("needsReview", userId);
-  const [needsReviewEmailsResult, sourceEventsResult] = await Promise.allSettled([
-    getNeedsReviewEmails(db),
-    getNeedsReviewEmailSourceEvents(db, userId),
-  ]);
-  if (!isCurrentEmailCaptureRequest(request)) return;
-  if (needsReviewEmailsResult.status === "fulfilled") {
-    useEmailCaptureStore.getState().setNeedsReviewEmails(needsReviewEmailsResult.value);
-  } else {
+
+  try {
+    const needsReviewEmailSourceEvents = await getNeedsReviewEmailSourceEvents(db, userId);
+    if (!isCurrentEmailCaptureRequest(request)) return;
+    useEmailCaptureStore.getState().setNeedsReviewEmails([]);
+    useEmailCaptureStore.getState().setNeedsReviewEmailSourceEvents(needsReviewEmailSourceEvents);
+  } catch (error) {
+    if (!isCurrentEmailCaptureRequest(request)) return;
+    useEmailCaptureStore.getState().setNeedsReviewEmails([]);
+    useEmailCaptureStore.getState().setNeedsReviewEmailSourceEvents([]);
     captureWarning("email_capture_needs_review_queue_load_failed", {
-      errorType:
-        needsReviewEmailsResult.reason instanceof Error
-          ? needsReviewEmailsResult.reason.name
-          : "unknown",
-    });
-  }
-  if (sourceEventsResult.status === "fulfilled") {
-    useEmailCaptureStore.getState().setNeedsReviewEmailSourceEvents(sourceEventsResult.value);
-  } else {
-    captureWarning("email_capture_needs_review_source_event_queue_load_failed", {
-      errorType:
-        sourceEventsResult.reason instanceof Error ? sourceEventsResult.reason.name : "unknown",
+      errorType: error instanceof Error ? error.name : "unknown",
     });
   }
 }
 export async function dismissFailedEmail(
-  db: AnyDb,
+  _db: AnyDb,
   userId: UserId,
   processedEmailId: string
 ): Promise<void> {
@@ -150,7 +129,7 @@ export async function dismissFailedEmail(
     .getState()
     .failedEmails.find((email) => email.id === processedEmailId);
   if (!failedEmail || !isActiveEmailCaptureSession(session)) return;
-  await dismissProcessedEmail(db, failedEmail.id);
+
   if (!isActiveEmailCaptureSession(session)) return;
   useEmailCaptureStore.getState().removeFailedEmail(processedEmailId);
 }

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -3,7 +3,9 @@ import { captureError, captureWarning, toIsoDateTime } from "@/shared/lib";
 import type { UserId } from "@/shared/types/branded";
 import {
   getEmailAccounts,
+  getFailedEmails,
   getFailedEmailSourceEvents,
+  getNeedsReviewEmails,
   getNeedsReviewEmailSourceEvents,
   updateProcessedSourceEventStatus,
 } from "./lib/repository";
@@ -89,9 +91,12 @@ export async function loadFailedEmails(db: AnyDb, userId: UserId) {
   const request = beginEmailCaptureRequest("failedEmails", userId);
 
   try {
-    const failedEmailSourceEvents = await getFailedEmailSourceEvents(db, userId);
+    const [failedEmails, failedEmailSourceEvents] = await Promise.all([
+      getFailedEmails(db),
+      getFailedEmailSourceEvents(db, userId),
+    ]);
     if (!isCurrentEmailCaptureRequest(request)) return;
-    useEmailCaptureStore.getState().setFailedEmails([]);
+    useEmailCaptureStore.getState().setFailedEmails(failedEmails);
     useEmailCaptureStore.getState().setFailedEmailSourceEvents(failedEmailSourceEvents);
   } catch (error) {
     if (!isCurrentEmailCaptureRequest(request)) return;
@@ -106,9 +111,12 @@ export async function loadNeedsReviewEmails(db: AnyDb, userId: UserId) {
   const request = beginEmailCaptureRequest("needsReview", userId);
 
   try {
-    const needsReviewEmailSourceEvents = await getNeedsReviewEmailSourceEvents(db, userId);
+    const [needsReviewEmails, needsReviewEmailSourceEvents] = await Promise.all([
+      getNeedsReviewEmails(db),
+      getNeedsReviewEmailSourceEvents(db, userId),
+    ]);
     if (!isCurrentEmailCaptureRequest(request)) return;
-    useEmailCaptureStore.getState().setNeedsReviewEmails([]);
+    useEmailCaptureStore.getState().setNeedsReviewEmails(needsReviewEmails);
     useEmailCaptureStore.getState().setNeedsReviewEmailSourceEvents(needsReviewEmailSourceEvents);
   } catch (error) {
     if (!isCurrentEmailCaptureRequest(request)) return;

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -92,7 +92,7 @@ export async function loadFailedEmails(db: AnyDb, userId: UserId) {
 
   try {
     const [failedEmails, failedEmailSourceEvents] = await Promise.all([
-      getFailedEmails(db),
+      getFailedEmails(db, userId),
       getFailedEmailSourceEvents(db, userId),
     ]);
     if (!isCurrentEmailCaptureRequest(request)) return;
@@ -112,7 +112,7 @@ export async function loadNeedsReviewEmails(db: AnyDb, userId: UserId) {
 
   try {
     const [needsReviewEmails, needsReviewEmailSourceEvents] = await Promise.all([
-      getNeedsReviewEmails(db),
+      getNeedsReviewEmails(db, userId),
       getNeedsReviewEmailSourceEvents(db, userId),
     ]);
     if (!isCurrentEmailCaptureRequest(request)) return;

--- a/apps/mobile/features/email-capture/transfer-reclassification.public.ts
+++ b/apps/mobile/features/email-capture/transfer-reclassification.public.ts
@@ -1,16 +1,18 @@
 import type { AnyDb } from "@/shared/db";
-import type { ProcessedEmailId, TransactionId } from "@/shared/types/branded";
-import { updateProcessedEmailStatusInTransaction } from "./lib/repository";
+import type { ProcessedSourceEventId, TransactionId, UserId } from "@/shared/types/branded";
+import { updateProcessedSourceEventStatusInTransaction } from "./lib/repository";
 
-export function markProcessedEmailReclassifiedAsTransfer(input: {
+export function markProcessedSourceEventReclassifiedAsTransfer(input: {
   readonly db: AnyDb;
-  readonly id: ProcessedEmailId;
+  readonly id: ProcessedSourceEventId;
+  readonly userId: UserId;
   readonly transactionId: TransactionId;
 }) {
-  updateProcessedEmailStatusInTransaction({
+  updateProcessedSourceEventStatusInTransaction({
     db: input.db,
     id: input.id,
-    status: "success",
+    userId: input.userId,
+    status: "processed",
     transactionId: input.transactionId,
   });
 }

--- a/apps/mobile/features/email-capture/transfer-reclassification.public.ts
+++ b/apps/mobile/features/email-capture/transfer-reclassification.public.ts
@@ -1,18 +1,43 @@
 import type { AnyDb } from "@/shared/db";
-import type { ProcessedSourceEventId, TransactionId, UserId } from "@/shared/types/branded";
-import { updateProcessedSourceEventStatusInTransaction } from "./lib/repository";
+import type {
+  IsoDateTime,
+  ProcessedEmailId,
+  ProcessedSourceEventId,
+  ReviewCandidateId,
+  TransactionId,
+  UserId,
+} from "@/shared/types/branded";
+import {
+  markSourceEventReviewCandidateReclassifiedAsTransfer,
+  updateProcessedEmailStatusInTransaction,
+} from "./lib/repository";
+
+export function markProcessedEmailReclassifiedAsTransfer(input: {
+  readonly db: AnyDb;
+  readonly id: ProcessedEmailId;
+  readonly transactionId: TransactionId;
+}) {
+  updateProcessedEmailStatusInTransaction({
+    db: input.db,
+    id: input.id,
+    status: "success",
+    transactionId: input.transactionId,
+  });
+}
 
 export function markProcessedSourceEventReclassifiedAsTransfer(input: {
   readonly db: AnyDb;
   readonly id: ProcessedSourceEventId;
   readonly userId: UserId;
+  readonly reviewCandidateId: ReviewCandidateId;
   readonly transactionId: TransactionId;
+  readonly updatedAt: IsoDateTime;
 }) {
-  updateProcessedSourceEventStatusInTransaction({
-    db: input.db,
-    id: input.id,
+  markSourceEventReviewCandidateReclassifiedAsTransfer(input.db, {
+    processedSourceEventId: input.id,
     userId: input.userId,
-    status: "processed",
+    reviewCandidateId: input.reviewCandidateId,
     transactionId: input.transactionId,
+    updatedAt: input.updatedAt,
   });
 }

--- a/apps/mobile/features/review-queues/components/FinancialMeaningQueueScreen.tsx
+++ b/apps/mobile/features/review-queues/components/FinancialMeaningQueueScreen.tsx
@@ -16,7 +16,7 @@ import { Pressable, Text, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
 import { useAsyncGuard, useThemeColor, useTranslation } from "@/shared/hooks";
 import { getDateFnsLocale } from "@/shared/i18n";
-import { formatMoney, showErrorToast } from "@/shared/lib";
+import { formatMoney, formatSignedMoney, showErrorToast } from "@/shared/lib";
 import type { ProcessedSourceEventId, ReviewCandidateId } from "@/shared/types/branded";
 import { useFinancialMeaningReviewQueue } from "../hooks/use-financial-meaning-review-queue";
 import { styles } from "./FinancialMeaningQueueScreen.styles";
@@ -41,6 +41,8 @@ function FinancialMeaningQueueCard({
   const tertiary = useThemeColor("tertiary");
   const card = useThemeColor("card");
   const borderSubtle = useThemeColor("borderSubtle");
+  const accentGreen = useThemeColor("accentGreen");
+  const accentRed = useThemeColor("accentRed");
   const providerLabel =
     item.processedSourceEvent.sourceId === "email_gmail"
       ? t("financialMeaningReview.providers.gmail")
@@ -52,6 +54,13 @@ function FinancialMeaningQueueCard({
     t("common.unknown");
   const subtitleDate = item.reviewCandidate.occurredAt ?? item.processedSourceEvent.receivedAt;
   const amount = item.reviewCandidate.amount;
+  const transactionType = item.reviewCandidate.transactionType;
+  const amountColor =
+    transactionType === "income"
+      ? accentGreen
+      : transactionType === "expense"
+        ? accentRed
+        : primary;
 
   return (
     <View style={[styles.card, { backgroundColor: card, borderColor: borderSubtle }]}>
@@ -78,11 +87,13 @@ function FinancialMeaningQueueCard({
               style={[
                 styles.cardAmount,
                 {
-                  color: primary,
+                  color: amountColor,
                 },
               ]}
             >
-              {formatMoney(amount)}
+              {transactionType == null
+                ? formatMoney(amount)
+                : formatSignedMoney(amount, transactionType)}
             </Text>
           ) : null}
         </View>

--- a/apps/mobile/features/review-queues/components/FinancialMeaningQueueScreen.tsx
+++ b/apps/mobile/features/review-queues/components/FinancialMeaningQueueScreen.tsx
@@ -5,11 +5,10 @@ import { useState } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useOptionalUserId } from "@/features/auth/public";
 import {
-  dismissFinancialMeaningReview,
   dismissSourceEventFinancialMeaningReview,
+  getFinancialMeaningQueueItemId,
   loadNeedsReviewEmails,
 } from "@/features/email-capture/public";
-import { getTransactionDisplayName } from "@/features/transactions/display.public";
 import { refreshTransactions } from "@/features/transactions/store.public";
 import { ScreenLayout } from "@/shared/components";
 import { ChevronRight, TriangleAlert } from "@/shared/components/icons";
@@ -17,18 +16,11 @@ import { Pressable, Text, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
 import { useAsyncGuard, useThemeColor, useTranslation } from "@/shared/hooks";
 import { getDateFnsLocale } from "@/shared/i18n";
-import { formatMoney, formatSignedMoney, showErrorToast } from "@/shared/lib";
-import type { ProcessedEmailId, ProcessedSourceEventId } from "@/shared/types/branded";
+import { formatMoney, showErrorToast } from "@/shared/lib";
+import type { ProcessedSourceEventId, ReviewCandidateId } from "@/shared/types/branded";
 import { useFinancialMeaningReviewQueue } from "../hooks/use-financial-meaning-review-queue";
 import { styles } from "./FinancialMeaningQueueScreen.styles";
 import { ActionButton, EmptyState, SummaryCard } from "./shared";
-
-type FinancialMeaningQueueItem = ReturnType<typeof useFinancialMeaningReviewQueue>["items"][number];
-
-const getQueueItemId = (item: FinancialMeaningQueueItem) =>
-  item.kind === "legacy_email"
-    ? item.processedEmail.id
-    : `${item.processedSourceEvent.id}:${item.reviewCandidate.id}`;
 
 function FinancialMeaningQueueCard({
   item,
@@ -49,31 +41,17 @@ function FinancialMeaningQueueCard({
   const tertiary = useThemeColor("tertiary");
   const card = useThemeColor("card");
   const borderSubtle = useThemeColor("borderSubtle");
-  const accentRed = useThemeColor("accentRed");
-  const accentGreen = useThemeColor("accentGreen");
-  const isLegacyItem = item.kind === "legacy_email";
-  const providerLabel = isLegacyItem
-    ? item.processedEmail.provider === "gmail"
-      ? t("financialMeaningReview.providers.gmail")
-      : t("financialMeaningReview.providers.outlook")
-    : item.processedSourceEvent.sourceId === "email_gmail"
+  const providerLabel =
+    item.processedSourceEvent.sourceId === "email_gmail"
       ? t("financialMeaningReview.providers.gmail")
       : t("financialMeaningReview.providers.outlook");
-  const subject = isLegacyItem
-    ? item.processedEmail.subject
-    : (item.processedSourceEvent.subject ?? "");
-  const title = isLegacyItem
-    ? getTransactionDisplayName(item.transaction, t("common.unknown"))
-    : (item.reviewCandidate.description ??
-      item.processedSourceEvent.rawBodyPreview ??
-      t("common.unknown"));
-  const subtitleDate = isLegacyItem
-    ? item.transaction.date
-    : (item.reviewCandidate.occurredAt ?? item.processedSourceEvent.receivedAt);
-  const amount = isLegacyItem ? item.transaction.amount : item.reviewCandidate.amount;
-  const transactionType = isLegacyItem
-    ? item.transaction.type
-    : item.reviewCandidate.transactionType;
+  const subject = item.processedSourceEvent.subject ?? "";
+  const title =
+    item.reviewCandidate.description ??
+    item.processedSourceEvent.rawBodyPreview ??
+    t("common.unknown");
+  const subtitleDate = item.reviewCandidate.occurredAt ?? item.processedSourceEvent.receivedAt;
+  const amount = item.reviewCandidate.amount;
 
   return (
     <View style={[styles.card, { backgroundColor: card, borderColor: borderSubtle }]}>
@@ -100,18 +78,11 @@ function FinancialMeaningQueueCard({
               style={[
                 styles.cardAmount,
                 {
-                  color:
-                    transactionType == null
-                      ? primary
-                      : transactionType === "income"
-                        ? accentGreen
-                        : accentRed,
+                  color: primary,
                 },
               ]}
             >
-              {transactionType == null
-                ? formatMoney(amount)
-                : formatSignedMoney(amount, transactionType)}
+              {formatMoney(amount)}
             </Text>
           ) : null}
         </View>
@@ -150,33 +121,26 @@ export function FinancialMeaningQueueScreen() {
   const { isBusy, run: guardedAction } = useAsyncGuard();
   const [skippedIds, setSkippedIds] = useState<readonly string[]>([]);
 
-  const visibleItems = items.filter((item) => !skippedIds.includes(getQueueItemId(item)));
+  const visibleItems = items.filter(
+    (item) => !skippedIds.includes(getFinancialMeaningQueueItemId(item))
+  );
 
-  const handleDismiss = (processedEmailId: ProcessedEmailId) => {
+  const handleDismissSourceEvent = (
+    processedSourceEventId: ProcessedSourceEventId,
+    reviewCandidateId: ReviewCandidateId
+  ) => {
     void guardedAction(async () => {
       if (!db || !userId) {
         return;
       }
 
       try {
-        await dismissFinancialMeaningReview(db, processedEmailId);
-        await loadNeedsReviewEmails(db, userId);
-        await refreshTransactions(db, userId);
-        await reloadQueue();
-      } catch {
-        showErrorToast(t("financialMeaningReview.errors.dismissFailed"));
-      }
-    });
-  };
-
-  const handleDismissSourceEvent = (processedSourceEventId: ProcessedSourceEventId) => {
-    void guardedAction(async () => {
-      if (!db || !userId) {
-        return;
-      }
-
-      try {
-        await dismissSourceEventFinancialMeaningReview(db, userId, processedSourceEventId);
+        await dismissSourceEventFinancialMeaningReview(
+          db,
+          userId,
+          processedSourceEventId,
+          reviewCandidateId
+        );
         await loadNeedsReviewEmails(db, userId);
         await refreshTransactions(db, userId);
         await reloadQueue();
@@ -200,7 +164,7 @@ export function FinancialMeaningQueueScreen() {
       ) : (
         <FlashList
           data={visibleItems}
-          keyExtractor={getQueueItemId}
+          keyExtractor={getFinancialMeaningQueueItemId}
           contentContainerStyle={[styles.listContent, { paddingBottom: bottom + 28 }]}
           contentInsetAdjustmentBehavior="automatic"
           ItemSeparatorComponent={() => <View style={{ height: 14 }} />}
@@ -216,29 +180,22 @@ export function FinancialMeaningQueueScreen() {
               item={item}
               disabled={isBusy}
               onReview={() =>
-                item.kind === "legacy_email"
-                  ? router.push({
-                      pathname: "/meaning-review",
-                      params: { processedEmailId: item.processedEmail.id },
-                    } as never)
-                  : router.push({
-                      pathname: "/meaning-review",
-                      params: {
-                        processedSourceEventId: item.processedSourceEvent.id,
-                        reviewCandidateId: item.reviewCandidate.id,
-                      },
-                    } as never)
+                router.push({
+                  pathname: "/meaning-review",
+                  params: {
+                    processedSourceEventId: item.processedSourceEvent.id,
+                    reviewCandidateId: item.reviewCandidate.id,
+                  },
+                } as never)
               }
               onDismiss={() =>
-                item.kind === "legacy_email"
-                  ? handleDismiss(item.processedEmail.id)
-                  : handleDismissSourceEvent(item.processedSourceEvent.id)
+                handleDismissSourceEvent(item.processedSourceEvent.id, item.reviewCandidate.id)
               }
               onSkip={() =>
                 setSkippedIds((current) =>
-                  current.includes(getQueueItemId(item))
+                  current.includes(getFinancialMeaningQueueItemId(item))
                     ? current
-                    : [...current, getQueueItemId(item)]
+                    : [...current, getFinancialMeaningQueueItemId(item)]
                 )
               }
             />

--- a/apps/mobile/features/review-queues/components/FinancialMeaningReviewScreen.tsx
+++ b/apps/mobile/features/review-queues/components/FinancialMeaningReviewScreen.tsx
@@ -5,12 +5,9 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useOptionalUserId } from "@/features/auth/public";
 import {
   confirmSourceEventFinancialMeaningReview,
-  dismissFinancialMeaningReview,
   dismissSourceEventFinancialMeaningReview,
   loadNeedsReviewEmails,
-  resolveFinancialMeaningReview,
 } from "@/features/email-capture/public";
-import { getTransactionDisplayName } from "@/features/transactions/display.public";
 import { refreshTransactions } from "@/features/transactions/store.public";
 import { ScreenLayout } from "@/shared/components";
 import { ArrowLeftRight, TriangleAlert } from "@/shared/components/icons";
@@ -18,12 +15,8 @@ import { ScrollView, Text, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
 import { useAsyncGuard, useThemeColor, useTranslation } from "@/shared/hooks";
 import { getDateFnsLocale } from "@/shared/i18n";
-import { formatMoney, formatSignedMoney, showErrorToast } from "@/shared/lib";
-import {
-  requireProcessedEmailId,
-  requireProcessedSourceEventId,
-  requireReviewCandidateId,
-} from "@/shared/types/assertions";
+import { formatMoney, showErrorToast } from "@/shared/lib";
+import { requireProcessedSourceEventId, requireReviewCandidateId } from "@/shared/types/assertions";
 import { useFinancialMeaningReviewQueue } from "../hooks/use-financial-meaning-review-queue";
 import { styles } from "./FinancialMeaningReviewScreen.styles";
 import { ActionButton, EmptyState, SummaryCard } from "./shared";
@@ -31,23 +24,14 @@ import { ActionButton, EmptyState, SummaryCard } from "./shared";
 type FinancialMeaningReviewItem = ReturnType<
   typeof useFinancialMeaningReviewQueue
 >["items"][number];
-type LegacyFinancialMeaningReviewItem = Extract<
-  FinancialMeaningReviewItem,
-  { readonly kind: "legacy_email" }
->;
 type SourceEventFinancialMeaningReviewItem = Extract<
   FinancialMeaningReviewItem,
   { readonly kind: "source_event" }
 >;
 
-const isLegacyFinancialMeaningReviewItem = (
-  item: FinancialMeaningReviewItem
-): item is LegacyFinancialMeaningReviewItem => item.kind === "legacy_email";
-
 export function FinancialMeaningReviewScreen() {
   const router = useRouter();
-  const { processedEmailId, processedSourceEventId, reviewCandidateId } = useLocalSearchParams<{
-    processedEmailId?: string;
+  const { processedSourceEventId, reviewCandidateId } = useLocalSearchParams<{
     processedSourceEventId?: string;
     reviewCandidateId?: string;
   }>();
@@ -57,10 +41,6 @@ export function FinancialMeaningReviewScreen() {
   const db = userId ? tryGetDb(userId) : null;
   const { items, hasLoadedQueue } = useFinancialMeaningReviewQueue({ db, userId });
   const { isBusy, run: guardedAction } = useAsyncGuard();
-  const resolvedProcessedEmailId =
-    typeof processedEmailId === "string" && processedEmailId.trim().length > 0
-      ? requireProcessedEmailId(processedEmailId.trim())
-      : null;
   const resolvedProcessedSourceEventId =
     typeof processedSourceEventId === "string" && processedSourceEventId.trim().length > 0
       ? requireProcessedSourceEventId(processedSourceEventId.trim())
@@ -71,29 +51,20 @@ export function FinancialMeaningReviewScreen() {
       : null;
   const reviewItem = useMemo<FinancialMeaningReviewItem | null>(
     () =>
-      resolvedProcessedEmailId
+      resolvedProcessedSourceEventId && resolvedReviewCandidateId
         ? ((items.find(
             (entry) =>
-              isLegacyFinancialMeaningReviewItem(entry) &&
-              entry.processedEmail.id === resolvedProcessedEmailId
-          ) as LegacyFinancialMeaningReviewItem | undefined) ?? null)
-        : resolvedProcessedSourceEventId && resolvedReviewCandidateId
-          ? ((items.find(
-              (entry) =>
-                entry.kind === "source_event" &&
-                entry.processedSourceEvent.id === resolvedProcessedSourceEventId &&
-                entry.reviewCandidate.id === resolvedReviewCandidateId
-            ) as SourceEventFinancialMeaningReviewItem | undefined) ?? null)
-          : null,
-    [items, resolvedProcessedEmailId, resolvedProcessedSourceEventId, resolvedReviewCandidateId]
+              entry.processedSourceEvent.id === resolvedProcessedSourceEventId &&
+              entry.reviewCandidate.id === resolvedReviewCandidateId
+          ) as SourceEventFinancialMeaningReviewItem | undefined) ?? null)
+        : null,
+    [items, resolvedProcessedSourceEventId, resolvedReviewCandidateId]
   );
   const primary = useThemeColor("primary");
   const secondary = useThemeColor("secondary");
   const tertiary = useThemeColor("tertiary");
   const card = useThemeColor("card");
   const borderSubtle = useThemeColor("borderSubtle");
-  const accentRed = useThemeColor("accentRed");
-  const accentGreen = useThemeColor("accentGreen");
 
   if (hasLoadedQueue && reviewItem == null) {
     return (
@@ -121,18 +92,14 @@ export function FinancialMeaningReviewScreen() {
       }
 
       try {
-        if (reviewItem.kind === "legacy_email") {
-          await resolveFinancialMeaningReview(db, reviewItem.processedEmail.id);
-        } else {
-          const confirmed = await confirmSourceEventFinancialMeaningReview(db, {
-            userId,
-            processedSourceEventId: reviewItem.processedSourceEvent.id,
-            reviewCandidateId: reviewItem.reviewCandidate.id,
-          });
-          if (!confirmed) {
-            showErrorToast(t("financialMeaningReview.errors.resolveFailed"));
-            return;
-          }
+        const confirmed = await confirmSourceEventFinancialMeaningReview(db, {
+          userId,
+          processedSourceEventId: reviewItem.processedSourceEvent.id,
+          reviewCandidateId: reviewItem.reviewCandidate.id,
+        });
+        if (!confirmed) {
+          showErrorToast(t("financialMeaningReview.errors.resolveFailed"));
+          return;
         }
         await loadNeedsReviewEmails(db, userId);
         await refreshTransactions(db, userId);
@@ -150,15 +117,12 @@ export function FinancialMeaningReviewScreen() {
       }
 
       try {
-        if (reviewItem.kind === "legacy_email") {
-          await dismissFinancialMeaningReview(db, reviewItem.processedEmail.id);
-        } else {
-          await dismissSourceEventFinancialMeaningReview(
-            db,
-            userId,
-            reviewItem.processedSourceEvent.id
-          );
-        }
+        await dismissSourceEventFinancialMeaningReview(
+          db,
+          userId,
+          reviewItem.processedSourceEvent.id,
+          reviewItem.reviewCandidate.id
+        );
         await loadNeedsReviewEmails(db, userId);
         await refreshTransactions(db, userId);
         router.replace("/needs-review");
@@ -169,27 +133,13 @@ export function FinancialMeaningReviewScreen() {
   };
 
   const title =
-    reviewItem.kind === "legacy_email"
-      ? getTransactionDisplayName(reviewItem.transaction, t("common.unknown"))
-      : (reviewItem.reviewCandidate.description ??
-        reviewItem.processedSourceEvent.rawBodyPreview ??
-        t("common.unknown"));
+    reviewItem.reviewCandidate.description ??
+    reviewItem.processedSourceEvent.rawBodyPreview ??
+    t("common.unknown");
   const subtitleDate =
-    reviewItem.kind === "legacy_email"
-      ? reviewItem.transaction.date
-      : (reviewItem.reviewCandidate.occurredAt ?? reviewItem.processedSourceEvent.receivedAt);
-  const amount =
-    reviewItem.kind === "legacy_email"
-      ? reviewItem.transaction.amount
-      : reviewItem.reviewCandidate.amount;
-  const transactionType =
-    reviewItem.kind === "legacy_email"
-      ? reviewItem.transaction.type
-      : reviewItem.reviewCandidate.transactionType;
-  const subject =
-    reviewItem.kind === "legacy_email"
-      ? reviewItem.processedEmail.subject
-      : (reviewItem.processedSourceEvent.subject ?? "");
+    reviewItem.reviewCandidate.occurredAt ?? reviewItem.processedSourceEvent.receivedAt;
+  const amount = reviewItem.reviewCandidate.amount;
+  const subject = reviewItem.processedSourceEvent.subject ?? "";
 
   return (
     <ScreenLayout
@@ -218,23 +168,7 @@ export function FinancialMeaningReviewScreen() {
               </Text>
             </View>
             {amount != null ? (
-              <Text
-                style={[
-                  styles.amount,
-                  {
-                    color:
-                      transactionType == null
-                        ? primary
-                        : transactionType === "income"
-                          ? accentGreen
-                          : accentRed,
-                  },
-                ]}
-              >
-                {transactionType == null
-                  ? formatMoney(amount)
-                  : formatSignedMoney(amount, transactionType)}
-              </Text>
+              <Text style={[styles.amount, { color: primary }]}>{formatMoney(amount)}</Text>
             ) : null}
           </View>
 
@@ -259,22 +193,6 @@ export function FinancialMeaningReviewScreen() {
             onPress={handleConfirmTransaction}
             disabled={isBusy}
           />
-          {reviewItem.kind === "legacy_email" ? (
-            <ActionButton
-              label={t("financialMeaningReview.transfer")}
-              onPress={() =>
-                router.push({
-                  pathname: "/reclassify-transaction",
-                  params: {
-                    transactionId: reviewItem.transaction.id,
-                    processedEmailId: reviewItem.processedEmail.id,
-                  },
-                } as never)
-              }
-              variant="outline"
-              disabled={isBusy}
-            />
-          ) : null}
           <ActionButton
             label={t("financialMeaningReview.dismiss")}
             onPress={handleDismiss}

--- a/apps/mobile/features/review-queues/components/FinancialMeaningReviewScreen.tsx
+++ b/apps/mobile/features/review-queues/components/FinancialMeaningReviewScreen.tsx
@@ -15,7 +15,7 @@ import { ScrollView, Text, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
 import { useAsyncGuard, useThemeColor, useTranslation } from "@/shared/hooks";
 import { getDateFnsLocale } from "@/shared/i18n";
-import { formatMoney, showErrorToast } from "@/shared/lib";
+import { formatMoney, formatSignedMoney, showErrorToast } from "@/shared/lib";
 import { requireProcessedSourceEventId, requireReviewCandidateId } from "@/shared/types/assertions";
 import { useFinancialMeaningReviewQueue } from "../hooks/use-financial-meaning-review-queue";
 import { styles } from "./FinancialMeaningReviewScreen.styles";
@@ -65,6 +65,8 @@ export function FinancialMeaningReviewScreen() {
   const tertiary = useThemeColor("tertiary");
   const card = useThemeColor("card");
   const borderSubtle = useThemeColor("borderSubtle");
+  const accentGreen = useThemeColor("accentGreen");
+  const accentRed = useThemeColor("accentRed");
 
   if (hasLoadedQueue && reviewItem == null) {
     return (
@@ -139,7 +141,27 @@ export function FinancialMeaningReviewScreen() {
   const subtitleDate =
     reviewItem.reviewCandidate.occurredAt ?? reviewItem.processedSourceEvent.receivedAt;
   const amount = reviewItem.reviewCandidate.amount;
+  const transactionType = reviewItem.reviewCandidate.transactionType;
+  const amountColor =
+    transactionType === "income"
+      ? accentGreen
+      : transactionType === "expense"
+        ? accentRed
+        : primary;
   const subject = reviewItem.processedSourceEvent.subject ?? "";
+
+  const handleConvertToTransfer = () => {
+    if (reviewItem.processedSourceEvent.transactionId == null) return;
+
+    router.push({
+      pathname: "/reclassify-transaction",
+      params: {
+        transactionId: reviewItem.processedSourceEvent.transactionId,
+        processedSourceEventId: reviewItem.processedSourceEvent.id,
+        reviewCandidateId: reviewItem.reviewCandidate.id,
+      },
+    } as never);
+  };
 
   return (
     <ScreenLayout
@@ -168,7 +190,11 @@ export function FinancialMeaningReviewScreen() {
               </Text>
             </View>
             {amount != null ? (
-              <Text style={[styles.amount, { color: primary }]}>{formatMoney(amount)}</Text>
+              <Text style={[styles.amount, { color: amountColor }]}>
+                {transactionType == null
+                  ? formatMoney(amount)
+                  : formatSignedMoney(amount, transactionType)}
+              </Text>
             ) : null}
           </View>
 
@@ -192,6 +218,12 @@ export function FinancialMeaningReviewScreen() {
             label={t("financialMeaningReview.itsTransaction")}
             onPress={handleConfirmTransaction}
             disabled={isBusy}
+          />
+          <ActionButton
+            label={t("financialMeaningReview.transfer")}
+            onPress={handleConvertToTransfer}
+            variant="outline"
+            disabled={isBusy || reviewItem.processedSourceEvent.transactionId == null}
           />
           <ActionButton
             label={t("financialMeaningReview.dismiss")}

--- a/apps/mobile/features/transfers/components/transfer-form/TransferForm.helpers.ts
+++ b/apps/mobile/features/transfers/components/transfer-form/TransferForm.helpers.ts
@@ -40,6 +40,7 @@ const TRANSFER_ERROR_MESSAGE_KEYS = {
   distinctSidesRequired: "transfers.errors.distinctSidesRequired",
   externalLabelRequired: "transfers.errors.saveFailed",
   futureDated: "transfers.errors.saveFailed",
+  reviewCandidateRequired: "transfers.errors.reclassifyFailed",
   saveFailed: "transfers.errors.saveFailed",
   storeNotInitialized: "transfers.errors.saveFailed",
   trackedAccountRequired: "transfers.errors.trackedAccountRequired",

--- a/apps/mobile/features/transfers/components/transfer-form/saveTransferForm.ts
+++ b/apps/mobile/features/transfers/components/transfer-form/saveTransferForm.ts
@@ -14,7 +14,7 @@ import { reclassifyTransactionAsTransfer } from "@/features/transfers/lib/reclas
 import { recordManualTransferWithLocalLedger } from "@/infrastructure/local-ledger/record-transfer";
 import type { AnyDb } from "@/shared/db";
 import { captureWarning } from "@/shared/lib";
-import type { ProcessedEmailId, UserId } from "@/shared/types/branded";
+import type { ProcessedEmailId, ProcessedSourceEventId, UserId } from "@/shared/types/branded";
 
 type SubmitTransferFormInput = {
   readonly date: Date;
@@ -23,6 +23,7 @@ type SubmitTransferFormInput = {
   readonly digits: string;
   readonly fromSide: TransferSide | null;
   readonly processedEmailId: ProcessedEmailId | null;
+  readonly processedSourceEventId?: ProcessedSourceEventId | null;
   readonly sourceTransaction: StoredTransaction | null;
   readonly toSide: TransferSide | null;
   readonly userId: UserId | null | undefined;
@@ -89,6 +90,7 @@ function runReclassifiedTransfer(
       userId: input.userId,
       transactionId: input.sourceTransaction.id,
       processedEmailId: input.processedEmailId ?? undefined,
+      processedSourceEventId: input.processedSourceEventId ?? undefined,
       digits: input.digits,
       fromSide: input.fromSide,
       toSide: input.toSide,
@@ -99,6 +101,7 @@ function runReclassifiedTransfer(
     captureWarning("transfer_reclassification_save_failed", {
       operation: "reclassify_transaction_as_transfer",
       hasProcessedEmail: input.processedEmailId != null,
+      hasProcessedSourceEvent: input.processedSourceEventId != null,
       errorType: error instanceof Error ? error.name : typeof error,
     });
     return { success: false, error: "saveFailed" } as const;
@@ -119,8 +122,11 @@ function didTransferSaveSucceed(
   return result.success;
 }
 
-function resolveTransferDestination(processedEmailId: ProcessedEmailId | null) {
-  return processedEmailId ? "needs-review" : "tabs";
+function resolveTransferDestination(input: {
+  readonly processedEmailId: ProcessedEmailId | null;
+  readonly processedSourceEventId: ProcessedSourceEventId | null;
+}) {
+  return input.processedEmailId || input.processedSourceEventId ? "needs-review" : "tabs";
 }
 
 export async function submitTransferForm(
@@ -144,6 +150,9 @@ export async function submitTransferForm(
 
   return {
     success: true,
-    destination: resolveTransferDestination(input.processedEmailId),
+    destination: resolveTransferDestination({
+      processedEmailId: input.processedEmailId,
+      processedSourceEventId: input.processedSourceEventId ?? null,
+    }),
   };
 }

--- a/apps/mobile/features/transfers/components/transfer-form/saveTransferForm.ts
+++ b/apps/mobile/features/transfers/components/transfer-form/saveTransferForm.ts
@@ -14,7 +14,12 @@ import { reclassifyTransactionAsTransfer } from "@/features/transfers/lib/reclas
 import { recordManualTransferWithLocalLedger } from "@/infrastructure/local-ledger/record-transfer";
 import type { AnyDb } from "@/shared/db";
 import { captureWarning } from "@/shared/lib";
-import type { ProcessedEmailId, ProcessedSourceEventId, UserId } from "@/shared/types/branded";
+import type {
+  ProcessedEmailId,
+  ProcessedSourceEventId,
+  ReviewCandidateId,
+  UserId,
+} from "@/shared/types/branded";
 
 type SubmitTransferFormInput = {
   readonly date: Date;
@@ -24,6 +29,7 @@ type SubmitTransferFormInput = {
   readonly fromSide: TransferSide | null;
   readonly processedEmailId: ProcessedEmailId | null;
   readonly processedSourceEventId?: ProcessedSourceEventId | null;
+  readonly reviewCandidateId?: ReviewCandidateId | null;
   readonly sourceTransaction: StoredTransaction | null;
   readonly toSide: TransferSide | null;
   readonly userId: UserId | null | undefined;
@@ -78,6 +84,36 @@ async function saveReclassifiedTransfer(
   return result;
 }
 
+function buildReclassificationInput(
+  input: SubmitTransferFormInput & {
+    readonly sourceTransaction: StoredTransaction;
+    readonly userId: UserId;
+  }
+) {
+  return {
+    userId: input.userId,
+    transactionId: input.sourceTransaction.id,
+    processedEmailId: input.processedEmailId ?? undefined,
+    processedSourceEventId: input.processedSourceEventId ?? undefined,
+    reviewCandidateId: input.reviewCandidateId ?? undefined,
+    digits: input.digits,
+    fromSide: input.fromSide,
+    toSide: input.toSide,
+    description: input.sourceTransaction.description,
+    date: input.date,
+  };
+}
+
+function captureReclassificationSaveFailure(input: SubmitTransferFormInput, error: unknown) {
+  captureWarning("transfer_reclassification_save_failed", {
+    operation: "reclassify_transaction_as_transfer",
+    hasProcessedEmail: input.processedEmailId != null,
+    hasProcessedSourceEvent: input.processedSourceEventId != null,
+    hasReviewCandidate: input.reviewCandidateId != null,
+    errorType: error instanceof Error ? error.name : typeof error,
+  });
+}
+
 function runReclassifiedTransfer(
   input: SubmitTransferFormInput & {
     readonly db: AnyDb;
@@ -86,24 +122,9 @@ function runReclassifiedTransfer(
   }
 ) {
   try {
-    return reclassifyTransactionAsTransfer(input.db, {
-      userId: input.userId,
-      transactionId: input.sourceTransaction.id,
-      processedEmailId: input.processedEmailId ?? undefined,
-      processedSourceEventId: input.processedSourceEventId ?? undefined,
-      digits: input.digits,
-      fromSide: input.fromSide,
-      toSide: input.toSide,
-      description: input.sourceTransaction.description,
-      date: input.date,
-    });
+    return reclassifyTransactionAsTransfer(input.db, buildReclassificationInput(input));
   } catch (error) {
-    captureWarning("transfer_reclassification_save_failed", {
-      operation: "reclassify_transaction_as_transfer",
-      hasProcessedEmail: input.processedEmailId != null,
-      hasProcessedSourceEvent: input.processedSourceEventId != null,
-      errorType: error instanceof Error ? error.name : typeof error,
-    });
+    captureReclassificationSaveFailure(input, error);
     return { success: false, error: "saveFailed" } as const;
   }
 }

--- a/apps/mobile/features/transfers/components/transfer-form/useTransferForm.ts
+++ b/apps/mobile/features/transfers/components/transfer-form/useTransferForm.ts
@@ -44,6 +44,20 @@ function parseReclassificationReviewCandidateId(
     : null;
 }
 
+function parseSourceEventReviewRouteParams(input: {
+  readonly processedSourceEventId: string | string[] | undefined;
+  readonly reviewCandidateId: string | string[] | undefined;
+}) {
+  const processedSourceEventId = parseReclassificationProcessedSourceEventId(
+    input.processedSourceEventId
+  );
+  const reviewCandidateId = parseReclassificationReviewCandidateId(input.reviewCandidateId);
+
+  return processedSourceEventId && reviewCandidateId
+    ? { processedSourceEventId, reviewCandidateId }
+    : { processedSourceEventId: null, reviewCandidateId: null };
+}
+
 async function navigateAfterTransferSave(
   destination: "needs-review" | "tabs",
   replace: ReturnType<typeof useRouter>["replace"],
@@ -71,6 +85,10 @@ function useTransferFormRouteContext() {
   }>();
   const { back, navigate, replace } = useRouter();
   const userId = useOptionalUserId();
+  const sourceEventReviewParams = parseSourceEventReviewRouteParams({
+    processedSourceEventId: rawProcessedSourceEventId,
+    reviewCandidateId: rawReviewCandidateId,
+  });
 
   return {
     db: userId ? tryGetDb(userId) : null,
@@ -82,8 +100,8 @@ function useTransferFormRouteContext() {
       [navigate, replace]
     ),
     processedEmailId: parseReclassificationProcessedEmailId(rawProcessedEmailId),
-    processedSourceEventId: parseReclassificationProcessedSourceEventId(rawProcessedSourceEventId),
-    reviewCandidateId: parseReclassificationReviewCandidateId(rawReviewCandidateId),
+    processedSourceEventId: sourceEventReviewParams.processedSourceEventId,
+    reviewCandidateId: sourceEventReviewParams.reviewCandidateId,
     reclassificationTransactionId: parseReclassificationTransactionId(rawTransactionId),
     userId,
   };

--- a/apps/mobile/features/transfers/components/transfer-form/useTransferForm.ts
+++ b/apps/mobile/features/transfers/components/transfer-form/useTransferForm.ts
@@ -3,7 +3,11 @@ import { useCallback } from "react";
 import { useOptionalUserId } from "@/features/auth/public";
 import { Platform } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
-import { requireProcessedEmailId, requireTransactionId } from "@/shared/types/assertions";
+import {
+  requireProcessedEmailId,
+  requireProcessedSourceEventId,
+  requireTransactionId,
+} from "@/shared/types/assertions";
 import type { TransferFormScreenProps } from "./TransferForm.types";
 import { useHydrateTransferForm } from "./useHydrateTransferForm";
 import { useTransferFormActions } from "./useTransferFormActions";
@@ -22,6 +26,15 @@ function parseReclassificationProcessedEmailId(rawProcessedEmailId: string | str
     : null;
 }
 
+function parseReclassificationProcessedSourceEventId(
+  rawProcessedSourceEventId: string | string[] | undefined
+) {
+  return typeof rawProcessedSourceEventId === "string" &&
+    rawProcessedSourceEventId.trim().length > 0
+    ? requireProcessedSourceEventId(rawProcessedSourceEventId.trim())
+    : null;
+}
+
 async function navigateAfterTransferSave(
   destination: "needs-review" | "tabs",
   replace: ReturnType<typeof useRouter>["replace"],
@@ -36,8 +49,15 @@ async function navigateAfterTransferSave(
 }
 
 function useTransferFormRouteContext() {
-  const { transactionId: rawTransactionId, processedEmailId: rawProcessedEmailId } =
-    useLocalSearchParams<{ transactionId?: string; processedEmailId?: string }>();
+  const {
+    transactionId: rawTransactionId,
+    processedEmailId: rawProcessedEmailId,
+    processedSourceEventId: rawProcessedSourceEventId,
+  } = useLocalSearchParams<{
+    transactionId?: string;
+    processedEmailId?: string;
+    processedSourceEventId?: string;
+  }>();
   const { back, navigate, replace } = useRouter();
   const userId = useOptionalUserId();
 
@@ -51,6 +71,7 @@ function useTransferFormRouteContext() {
       [navigate, replace]
     ),
     processedEmailId: parseReclassificationProcessedEmailId(rawProcessedEmailId),
+    processedSourceEventId: parseReclassificationProcessedSourceEventId(rawProcessedSourceEventId),
     reclassificationTransactionId: parseReclassificationTransactionId(rawTransactionId),
     userId,
   };
@@ -86,6 +107,7 @@ function useTransferFormDerivedState(
       isIos: route.isIos,
       onSuccessfulSave: props.onSuccessfulSave ?? route.onSuccessfulSave,
       processedEmailId: route.processedEmailId,
+      processedSourceEventId: route.processedSourceEventId,
       setDate: state.setDate,
       setDescription: state.setDescription,
       setDigits: state.setDigits,

--- a/apps/mobile/features/transfers/components/transfer-form/useTransferForm.ts
+++ b/apps/mobile/features/transfers/components/transfer-form/useTransferForm.ts
@@ -6,6 +6,7 @@ import { tryGetDb } from "@/shared/db";
 import {
   requireProcessedEmailId,
   requireProcessedSourceEventId,
+  requireReviewCandidateId,
   requireTransactionId,
 } from "@/shared/types/assertions";
 import type { TransferFormScreenProps } from "./TransferForm.types";
@@ -35,6 +36,14 @@ function parseReclassificationProcessedSourceEventId(
     : null;
 }
 
+function parseReclassificationReviewCandidateId(
+  rawReviewCandidateId: string | string[] | undefined
+) {
+  return typeof rawReviewCandidateId === "string" && rawReviewCandidateId.trim().length > 0
+    ? requireReviewCandidateId(rawReviewCandidateId.trim())
+    : null;
+}
+
 async function navigateAfterTransferSave(
   destination: "needs-review" | "tabs",
   replace: ReturnType<typeof useRouter>["replace"],
@@ -53,10 +62,12 @@ function useTransferFormRouteContext() {
     transactionId: rawTransactionId,
     processedEmailId: rawProcessedEmailId,
     processedSourceEventId: rawProcessedSourceEventId,
+    reviewCandidateId: rawReviewCandidateId,
   } = useLocalSearchParams<{
     transactionId?: string;
     processedEmailId?: string;
     processedSourceEventId?: string;
+    reviewCandidateId?: string;
   }>();
   const { back, navigate, replace } = useRouter();
   const userId = useOptionalUserId();
@@ -72,6 +83,7 @@ function useTransferFormRouteContext() {
     ),
     processedEmailId: parseReclassificationProcessedEmailId(rawProcessedEmailId),
     processedSourceEventId: parseReclassificationProcessedSourceEventId(rawProcessedSourceEventId),
+    reviewCandidateId: parseReclassificationReviewCandidateId(rawReviewCandidateId),
     reclassificationTransactionId: parseReclassificationTransactionId(rawTransactionId),
     userId,
   };
@@ -108,6 +120,7 @@ function useTransferFormDerivedState(
       onSuccessfulSave: props.onSuccessfulSave ?? route.onSuccessfulSave,
       processedEmailId: route.processedEmailId,
       processedSourceEventId: route.processedSourceEventId,
+      reviewCandidateId: route.reviewCandidateId,
       setDate: state.setDate,
       setDescription: state.setDescription,
       setDigits: state.setDigits,

--- a/apps/mobile/features/transfers/components/transfer-form/useTransferFormActions.ts
+++ b/apps/mobile/features/transfers/components/transfer-form/useTransferFormActions.ts
@@ -22,6 +22,7 @@ async function saveTransferFormAction(input: {
   readonly processedSourceEventId: Parameters<
     typeof submitTransferForm
   >[0]["processedSourceEventId"];
+  readonly reviewCandidateId: Parameters<typeof submitTransferForm>[0]["reviewCandidateId"];
   readonly resetDraft: (() => void) | null;
   readonly sourceTransaction: StoredTransaction | null;
   readonly toSide: TransferSide | null;
@@ -52,6 +53,7 @@ export function useTransferFormActions(input: {
   readonly processedSourceEventId: Parameters<
     typeof submitTransferForm
   >[0]["processedSourceEventId"];
+  readonly reviewCandidateId: Parameters<typeof submitTransferForm>[0]["reviewCandidateId"];
   readonly setDate: (date: Date) => void;
   readonly setDescription: (description: string) => void;
   readonly setDigits: (digits: string) => void;
@@ -103,6 +105,7 @@ export function useTransferFormActions(input: {
           onSuccessfulSave: input.onSuccessfulSave,
           processedEmailId: input.processedEmailId,
           processedSourceEventId: input.processedSourceEventId,
+          reviewCandidateId: input.reviewCandidateId,
           resetDraft:
             input.sourceTransaction == null
               ? () => resetSavedTransferDraft(input, input.defaultFromSide)

--- a/apps/mobile/features/transfers/components/transfer-form/useTransferFormActions.ts
+++ b/apps/mobile/features/transfers/components/transfer-form/useTransferFormActions.ts
@@ -19,6 +19,9 @@ async function saveTransferFormAction(input: {
   readonly onError: (error: Parameters<typeof getTransferErrorMessageKey>[0]) => void;
   readonly onSuccessfulSave: (destination: "needs-review" | "tabs") => Promise<void> | void;
   readonly processedEmailId: Parameters<typeof submitTransferForm>[0]["processedEmailId"];
+  readonly processedSourceEventId: Parameters<
+    typeof submitTransferForm
+  >[0]["processedSourceEventId"];
   readonly resetDraft: (() => void) | null;
   readonly sourceTransaction: StoredTransaction | null;
   readonly toSide: TransferSide | null;
@@ -46,6 +49,9 @@ export function useTransferFormActions(input: {
   readonly isIos: boolean;
   readonly onSuccessfulSave: (destination: "needs-review" | "tabs") => Promise<void> | void;
   readonly processedEmailId: Parameters<typeof submitTransferForm>[0]["processedEmailId"];
+  readonly processedSourceEventId: Parameters<
+    typeof submitTransferForm
+  >[0]["processedSourceEventId"];
   readonly setDate: (date: Date) => void;
   readonly setDescription: (description: string) => void;
   readonly setDigits: (digits: string) => void;
@@ -96,6 +102,7 @@ export function useTransferFormActions(input: {
           onError: (error) => showErrorToast(t(getTransferErrorMessageKey(error))),
           onSuccessfulSave: input.onSuccessfulSave,
           processedEmailId: input.processedEmailId,
+          processedSourceEventId: input.processedSourceEventId,
           resetDraft:
             input.sourceTransaction == null
               ? () => resetSavedTransferDraft(input, input.defaultFromSide)

--- a/apps/mobile/features/transfers/lib/reclassify-transaction-as-transfer.ts
+++ b/apps/mobile/features/transfers/lib/reclassify-transaction-as-transfer.ts
@@ -51,7 +51,10 @@ type ReclassifyTransactionAsTransferDeps = {
   readonly saveProcessedSourceEventStatus?: typeof markProcessedSourceEventReclassifiedAsTransfer;
 };
 
-export type ReclassifyTransactionAsTransferError = TransferBuildError | "transactionNotFound";
+export type ReclassifyTransactionAsTransferError =
+  | TransferBuildError
+  | "reviewCandidateRequired"
+  | "transactionNotFound";
 
 export type ReclassifyTransactionAsTransferResult =
   | { success: true; transfer: StoredTransfer }
@@ -80,6 +83,9 @@ export function reclassifyTransactionAsTransfer(
     existingTransaction.supersededAt != null
   ) {
     return { success: false, error: "transactionNotFound" };
+  }
+  if (input.processedSourceEventId && !input.reviewCandidateId) {
+    return { success: false, error: "reviewCandidateRequired" };
   }
 
   const nowDate = now();

--- a/apps/mobile/features/transfers/lib/reclassify-transaction-as-transfer.ts
+++ b/apps/mobile/features/transfers/lib/reclassify-transaction-as-transfer.ts
@@ -1,5 +1,8 @@
 import { relinkCaptureEvidenceToTransfer } from "@/features/capture-evidence/public";
-import { markProcessedSourceEventReclassifiedAsTransfer } from "@/features/email-capture/transfer-reclassification.public";
+import {
+  markProcessedEmailReclassifiedAsTransfer,
+  markProcessedSourceEventReclassifiedAsTransfer,
+} from "@/features/email-capture/transfer-reclassification.public";
 import {
   getTransactionById,
   markTransactionSuperseded,
@@ -9,6 +12,7 @@ import type {
   IsoDateTime,
   ProcessedEmailId,
   ProcessedSourceEventId,
+  ReviewCandidateId,
   TransactionId,
   TransferId,
   UserId,
@@ -28,6 +32,7 @@ type ReclassifyTransactionAsTransferInput = {
   readonly transactionId: TransactionId;
   readonly processedEmailId?: ProcessedEmailId;
   readonly processedSourceEventId?: ProcessedSourceEventId;
+  readonly reviewCandidateId?: ReviewCandidateId;
   readonly digits: string;
   readonly fromSide: TransferSide | null;
   readonly toSide: TransferSide | null;
@@ -42,6 +47,7 @@ type ReclassifyTransactionAsTransferDeps = {
   readonly loadTransactionById?: typeof getTransactionById;
   readonly saveTransactionRow?: typeof markTransactionSuperseded;
   readonly relinkEvidenceToTransfer?: typeof relinkCaptureEvidenceToTransfer;
+  readonly saveProcessedEmailStatus?: typeof markProcessedEmailReclassifiedAsTransfer;
   readonly saveProcessedSourceEventStatus?: typeof markProcessedSourceEventReclassifiedAsTransfer;
 };
 
@@ -61,6 +67,7 @@ export function reclassifyTransactionAsTransfer(
     loadTransactionById = getTransactionById,
     saveTransactionRow = markTransactionSuperseded,
     relinkEvidenceToTransfer = relinkCaptureEvidenceToTransfer,
+    saveProcessedEmailStatus = markProcessedEmailReclassifiedAsTransfer,
     saveProcessedSourceEventStatus = markProcessedSourceEventReclassifiedAsTransfer,
   }: ReclassifyTransactionAsTransferDeps = {}
 ): ReclassifyTransactionAsTransferResult {
@@ -112,11 +119,19 @@ export function reclassifyTransactionAsTransfer(
       updatedAt,
     });
 
-    if (input.processedSourceEventId) {
+    if (input.processedSourceEventId && input.reviewCandidateId) {
       saveProcessedSourceEventStatus({
         db: tx,
         id: input.processedSourceEventId,
         userId: input.userId,
+        reviewCandidateId: input.reviewCandidateId,
+        transactionId: existingTransaction.id,
+        updatedAt,
+      });
+    } else if (input.processedEmailId) {
+      saveProcessedEmailStatus({
+        db: tx,
+        id: input.processedEmailId,
         transactionId: existingTransaction.id,
       });
     }

--- a/apps/mobile/features/transfers/lib/reclassify-transaction-as-transfer.ts
+++ b/apps/mobile/features/transfers/lib/reclassify-transaction-as-transfer.ts
@@ -1,5 +1,5 @@
 import { relinkCaptureEvidenceToTransfer } from "@/features/capture-evidence/public";
-import { markProcessedEmailReclassifiedAsTransfer } from "@/features/email-capture/transfer-reclassification.public";
+import { markProcessedSourceEventReclassifiedAsTransfer } from "@/features/email-capture/transfer-reclassification.public";
 import {
   getTransactionById,
   markTransactionSuperseded,
@@ -8,6 +8,7 @@ import { generateTransferId, toIsoDateTime } from "@/shared/lib.public";
 import type {
   IsoDateTime,
   ProcessedEmailId,
+  ProcessedSourceEventId,
   TransactionId,
   TransferId,
   UserId,
@@ -26,6 +27,7 @@ type ReclassifyTransactionAsTransferInput = {
   readonly userId: UserId;
   readonly transactionId: TransactionId;
   readonly processedEmailId?: ProcessedEmailId;
+  readonly processedSourceEventId?: ProcessedSourceEventId;
   readonly digits: string;
   readonly fromSide: TransferSide | null;
   readonly toSide: TransferSide | null;
@@ -40,7 +42,7 @@ type ReclassifyTransactionAsTransferDeps = {
   readonly loadTransactionById?: typeof getTransactionById;
   readonly saveTransactionRow?: typeof markTransactionSuperseded;
   readonly relinkEvidenceToTransfer?: typeof relinkCaptureEvidenceToTransfer;
-  readonly saveProcessedEmailStatus?: typeof markProcessedEmailReclassifiedAsTransfer;
+  readonly saveProcessedSourceEventStatus?: typeof markProcessedSourceEventReclassifiedAsTransfer;
 };
 
 export type ReclassifyTransactionAsTransferError = TransferBuildError | "transactionNotFound";
@@ -59,7 +61,7 @@ export function reclassifyTransactionAsTransfer(
     loadTransactionById = getTransactionById,
     saveTransactionRow = markTransactionSuperseded,
     relinkEvidenceToTransfer = relinkCaptureEvidenceToTransfer,
-    saveProcessedEmailStatus = markProcessedEmailReclassifiedAsTransfer,
+    saveProcessedSourceEventStatus = markProcessedSourceEventReclassifiedAsTransfer,
   }: ReclassifyTransactionAsTransferDeps = {}
 ): ReclassifyTransactionAsTransferResult {
   const existingTransaction = loadTransactionById(db, input.transactionId);
@@ -110,10 +112,11 @@ export function reclassifyTransactionAsTransfer(
       updatedAt,
     });
 
-    if (input.processedEmailId) {
-      saveProcessedEmailStatus({
+    if (input.processedSourceEventId) {
+      saveProcessedSourceEventStatus({
         db: tx,
-        id: input.processedEmailId,
+        id: input.processedSourceEventId,
+        userId: input.userId,
         transactionId: existingTransaction.id,
       });
     }


### PR DESCRIPTION
- source-event review queues

- candidate-scoped review resolution

- transfer reclassification linkage

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the financial-meaning review to source-event + review-candidate flows with signed amounts, safer queues, and stricter legacy scoping. The UI lists only email source-event items; legacy queues are still loaded but require owner proof.

- New Features
  - Queue shows only email source events that have a pending review candidate; legacy `processedEmails` are hidden.
  - Accepting a candidate marks the source event processed and rejects siblings; dismissing rejects only the selected candidate. Confirming review is limited to email source events.
  - Reclassifying a transaction as a transfer from review requires a review candidate; on success it marks the source event processed and rejects the chosen + sibling candidates. Legacy `processedEmails` remain unchanged.
  - Dashboard banners use lightweight selectors (`selectNeedsReviewBannerCount`, `selectFailedEmailBannerCount`).

- Refactors
  - Split queue vs. review repositories; added `source-event-review-repository.ts`. Source-event updates run in a single transaction.
  - Queue queries drop raw bodies, require a pending candidate for needs-review, and exclude `pending_retry` from failed.
  - Queue item IDs are candidate-scoped via `getFinancialMeaningQueueItemId`; UI routes pass `processedSourceEventId` + `reviewCandidateId`.
  - Legacy failed/needs-review queries now require user ownership via the linked email account, with a fallback for items linked to a user-owned transaction.

<sup>Written for commit 81b1d96e3e984b4f8ec26f69d3921a32d4b9babd. Summary will update on new commits. <a href="https://cubic.dev/pr/B4rz99/fidy/pull/462?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

