### PR TITLE
fix(mobile): raise ios deployment target

### DIFF
--- a/.agents/skills/opening-pr/SKILL.md
+++ b/.agents/skills/opening-pr/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: opening-pr
-description: Sync with main, review the diff, commit, push, and open a PR. Use when the user asks to open a PR or when a task explicitly requires the repo's PR workflow.
+description: Sync with main, commit, push, and open a PR. Use when the user asks to open a PR or when a task explicitly requires the repo's PR workflow.
 ---
 
-Use this workflow when the user wants a PR opened. Keep it narrow: validate the current change, create the commit, push the branch, and open the PR. Do not merge unless the user asks in a separate step.
+Use this workflow when the user wants a PR opened. Keep it narrow: sync the branch, create the commit, push the branch, and open the PR. Do not merge unless the user asks in a separate step.
 
 ## Step 1 — Sync Branch
 
@@ -13,21 +13,7 @@ git pull --rebase --autostash origin main
 
 Start from an up-to-date branch before verifying or committing.
 
-## Step 2 — Review The Diff
-
-Review the current diff before proceeding. Deploy multiple subagents in parallel, each focused on one review lens:
-
-- perform a high-quality security review, including secrets, unsafe data handling, auth boundaries, privacy leaks, and injection risks
-- perform a quality code review, including correctness, regressions, edge cases, error handling, naming, and missing tests
-- simplify code by consolidating related logic where reuse would reduce duplication or clarify ownership
-- check functional programming patterns, especially avoiding unnecessary mutation in pure modules
-- check atomicity patterns, especially transaction boundaries, partial writes, stale completions, and cleanup on failure
-- check purism patterns, especially side effects leaking into `lib/`, schemas, utilities, or other pure surfaces
-- identify where Sentry logs or breadcrumbs are necessary for production diagnosability without adding noisy or sensitive logging
-
-Synthesize the subagent findings before editing. Fix important issues before moving on, and do not defer findings that would make the PR unsafe, misleading, or difficult to review.
-
-## Step 3 — Commit
+## Step 2 — Commit
 
 Stage the relevant files and commit following these rules enforced by lefthook:
 
@@ -47,7 +33,7 @@ type(scope): message
 
 **Never include** `Co-Authored-By` lines.
 
-## Step 4 — Push And Open The PR
+## Step 3 — Push And Open The PR
 
 Push to the feature branch after committing. Main is protected — direct pushes are not allowed.
 

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: review
+description: Review the current diff before a PR or handoff. Use when the user asks for a review, diff review, pre-PR review, security review, quality review, or wants changes checked before commit.
+---
+
+Use this workflow to review the current diff before a PR, commit, or handoff. Keep the output focused on actionable findings and fixes.
+
+## Step 1 — Establish Scope
+
+Inspect the current branch and diff. Identify which files are part of the intended change and ignore unrelated dirty work unless it affects the review.
+
+## Step 2 — Review The Diff
+
+Review the current diff. When the user explicitly asks for subagents, deploy multiple subagents in parallel, each focused on one review lens:
+
+- perform a high-quality security review, including secrets, unsafe data handling, auth boundaries, privacy leaks, and injection risks
+- perform a quality code review, including correctness, regressions, edge cases, error handling, naming, and missing tests
+- simplify code by consolidating related logic where reuse would reduce duplication or clarify ownership
+- check functional programming patterns, especially avoiding unnecessary mutation in pure modules
+- check atomicity patterns, especially transaction boundaries, partial writes, stale completions, and cleanup on failure
+- check purism patterns, especially side effects leaking into `lib/`, schemas, utilities, or other pure surfaces
+- identify where Sentry logs or breadcrumbs are necessary for production diagnosability without adding noisy or sensitive logging
+
+If subagents are not available or not requested, cover the same lenses locally.
+
+## Step 3 — Synthesize And Act
+
+Synthesize findings before editing. Fix important issues when the user asked you to prepare the change for PR or handoff.
+
+Do not defer findings that would make the PR unsafe, misleading, or difficult to review.
+
+## Step 4 — Report
+
+Lead with findings, ordered by severity, with file and line references where possible. If no issues are found, say so clearly and mention any remaining test gaps or residual risk.

--- a/apps/mobile/features/onboarding/components/SyncProgressStep.helpers.ts
+++ b/apps/mobile/features/onboarding/components/SyncProgressStep.helpers.ts
@@ -1,0 +1,16 @@
+export type SyncOutcome = {
+  readonly savedCount: number;
+  readonly hasAccountSuggestions: boolean;
+  readonly importComplete: boolean;
+};
+
+export const RECENT_TRANSACTION_PREVIEW_LIMIT = 10;
+
+export const byRecentlyCaptured = (
+  a: { readonly updatedAt: Date },
+  b: { readonly updatedAt: Date }
+) => b.updatedAt.getTime() - a.updatedAt.getTime();
+
+export const getRecentTransactionPreview = <T extends { readonly updatedAt: Date }>(
+  transactions: readonly T[]
+) => [...transactions].sort(byRecentlyCaptured).slice(0, RECENT_TRANSACTION_PREVIEW_LIMIT);

--- a/apps/mobile/features/onboarding/components/SyncProgressStep.styles.ts
+++ b/apps/mobile/features/onboarding/components/SyncProgressStep.styles.ts
@@ -28,6 +28,9 @@ export const styles = StyleSheet.create({
   previewSection: {
     gap: 8,
   },
+  previewList: {
+    maxHeight: 168,
+  },
   previewTitle: {
     fontFamily: "Poppins_600SemiBold",
     fontSize: 13,

--- a/apps/mobile/features/onboarding/components/SyncProgressStep.tsx
+++ b/apps/mobile/features/onboarding/components/SyncProgressStep.tsx
@@ -17,15 +17,13 @@ import { useMountEffect, useThemeColor, useTranslation } from "@/shared/hooks";
 import { SYNC_EARLY_UNLOCK_TIMEOUT_MS, shouldUnlockEmailSyncStep } from "../lib/sync-unlock";
 import { logOnboardingEvent, trackOnboardingEvent } from "../lib/telemetry";
 import { useOnboardingStore } from "../store";
+import {
+  getRecentTransactionPreview,
+  RECENT_TRANSACTION_PREVIEW_LIMIT,
+  type SyncOutcome,
+} from "./SyncProgressStep.helpers";
 import { styles } from "./SyncProgressStep.styles";
 import { SyncTransactionPreview } from "./SyncTransactionPreview";
-
-type SyncOutcome = {
-  readonly savedCount: number;
-  readonly hasAccountSuggestions: boolean;
-  readonly importComplete: boolean;
-};
-const RECENT_TRANSACTION_PREVIEW_LIMIT = 3;
 
 export function SyncProgressStep() {
   const { t } = useTranslation();
@@ -37,7 +35,7 @@ export function SyncProgressStep() {
   const shareAnonymizedParseSamples = useSettingsStore((s) => s.shareAnonymizedParseSamples);
   const [syncOutcome, setSyncOutcome] = useState<SyncOutcome | null>(null);
   const recentTransactions = useTransactionStore(
-    useShallow((s) => s.pages.slice(0, RECENT_TRANSACTION_PREVIEW_LIMIT))
+    useShallow((s) => getRecentTransactionPreview(s.pages))
   );
   const primaryColor = useThemeColor("primary");
   const secondaryColor = useThemeColor("secondary");
@@ -195,7 +193,9 @@ export function SyncProgressStep() {
               failedCount: outcome.failedCount,
               foundCount,
               hasAccountSuggestions,
-              recentTransactionCount: useTransactionStore.getState().pages.slice(0, 3).length,
+              recentTransactionCount: getRecentTransactionPreview(
+                useTransactionStore.getState().pages
+              ).length,
             });
             unlockSync({
               foundCount,
@@ -236,8 +236,8 @@ export function SyncProgressStep() {
 
   const importComplete = syncOutcome?.importComplete ?? false;
   const percent = importComplete ? 100 : livePercent;
-  const savedCount =
-    syncOutcome?.savedCount ?? (progress ? progress.saved + progress.needsReview : 0);
+  const liveFoundCount = progress ? progress.saved + progress.needsReview : 0;
+  const savedCount = Math.max(syncOutcome?.savedCount ?? 0, liveFoundCount);
   const hasAccountSuggestions = syncOutcome?.hasAccountSuggestions ?? false;
 
   return (

--- a/apps/mobile/features/onboarding/components/SyncTransactionPreview.tsx
+++ b/apps/mobile/features/onboarding/components/SyncTransactionPreview.tsx
@@ -1,5 +1,5 @@
 import type { StoredTransaction } from "@/features/transactions/query.public";
-import { Text, View } from "@/shared/components/rn";
+import { ScrollView, Text, View } from "@/shared/components/rn";
 import { formatMoney } from "@/shared/lib";
 import { styles } from "./SyncProgressStep.styles";
 
@@ -21,16 +21,18 @@ export function SyncTransactionPreview({
   return (
     <View style={styles.previewSection}>
       <Text style={[styles.previewTitle, { color: secondaryColor }]}>{title}</Text>
-      {transactions.map((tx) => (
-        <View key={tx.id} style={styles.previewRow}>
-          <Text style={[styles.previewDescription, { color: primaryColor }]} numberOfLines={1}>
-            {tx.description || fallbackLabel}
-          </Text>
-          <Text style={[styles.previewAmount, { color: primaryColor }]}>
-            {formatMoney(tx.amount)}
-          </Text>
-        </View>
-      ))}
+      <ScrollView style={styles.previewList} nestedScrollEnabled showsVerticalScrollIndicator>
+        {transactions.map((tx) => (
+          <View key={tx.id} style={styles.previewRow}>
+            <Text style={[styles.previewDescription, { color: primaryColor }]} numberOfLines={1}>
+              {tx.description || fallbackLabel}
+            </Text>
+            <Text style={[styles.previewAmount, { color: primaryColor }]}>
+              {formatMoney(tx.amount)}
+            </Text>
+          </View>
+        ))}
+      </ScrollView>
     </View>
   );
 }

--- a/apps/mobile/plugins/withFidyWidget.deploymentTarget.js
+++ b/apps/mobile/plugins/withFidyWidget.deploymentTarget.js
@@ -1,0 +1,91 @@
+const { withPodfile, withPodfileProperties } = require("expo/config-plugins");
+
+const PODS_DEPLOYMENT_TARGET_PATCH_START = "# @generated begin fidy pods deployment target";
+const PODS_DEPLOYMENT_TARGET_PATCH_END = "# @generated end fidy pods deployment target";
+const PODS_DEPLOYMENT_TARGET_PATCH_REGEX = new RegExp(
+  `${PODS_DEPLOYMENT_TARGET_PATCH_START}[\\s\\S]*?${PODS_DEPLOYMENT_TARGET_PATCH_END}`
+);
+const LEGACY_PODS_DEPLOYMENT_TARGET_PATCH_REGEX =
+  /\n\s+installer\.pods_project\.targets\.each do \|target\|\n\s+target\.build_configurations\.each do \|config\|\n\s+deployment_target = config\.build_settings\['IPHONEOS_DEPLOYMENT_TARGET'\]\n\s+if deployment_target\.nil\? \|\| Gem::Version\.new\(deployment_target\) < Gem::Version\.new\('[^']+'\)\n\s+config\.build_settings\['IPHONEOS_DEPLOYMENT_TARGET'\] = '[^']+'\n\s+end\n\s+end\n\s+end\n/;
+
+const buildPodsDeploymentTargetPatch = (deploymentTarget) => `
+    ${PODS_DEPLOYMENT_TARGET_PATCH_START}
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        deployment_target = config.build_settings['IPHONEOS_DEPLOYMENT_TARGET']
+        if deployment_target.nil? || Gem::Version.new(deployment_target) < Gem::Version.new('${deploymentTarget}')
+          config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '${deploymentTarget}'
+        end
+      end
+    end
+    ${PODS_DEPLOYMENT_TARGET_PATCH_END}
+`;
+
+const getBuildConfigurations = (project) => project.hash.project.objects.XCBuildConfiguration ?? {};
+
+const parseVersion = (version) => version.split(".").map((part) => Number.parseInt(part, 10));
+
+const compareVersions = (left, right) => {
+  const leftParts = parseVersion(left);
+  const rightParts = parseVersion(right);
+  const partCount = Math.max(leftParts.length, rightParts.length);
+  for (let index = 0; index < partCount; index += 1) {
+    const leftPart = leftParts[index] ?? 0;
+    const rightPart = rightParts[index] ?? 0;
+    if (leftPart !== rightPart) return leftPart - rightPart;
+  }
+  return 0;
+};
+
+const isLowerDeploymentTarget = (value, minimumTarget) =>
+  typeof value === "string" && compareVersions(value, minimumTarget) < 0;
+
+const reconcileAppDeploymentTarget = (project, deploymentTarget) => {
+  for (const config of Object.values(getBuildConfigurations(project))) {
+    const currentDeploymentTarget = config?.buildSettings?.IPHONEOS_DEPLOYMENT_TARGET;
+    if (isLowerDeploymentTarget(currentDeploymentTarget, deploymentTarget)) {
+      config.buildSettings.IPHONEOS_DEPLOYMENT_TARGET = deploymentTarget;
+    }
+  }
+};
+
+const withIosDeploymentTarget = (config, deploymentTarget) =>
+  withPodfileProperties(config, (modConfig) => {
+    modConfig.modResults["ios.deploymentTarget"] = deploymentTarget;
+    return modConfig;
+  });
+
+const withPodsDeploymentTarget = (config, deploymentTarget) =>
+  withPodfile(config, (modConfig) => {
+    const patch = buildPodsDeploymentTargetPatch(deploymentTarget);
+    if (PODS_DEPLOYMENT_TARGET_PATCH_REGEX.test(modConfig.modResults.contents)) {
+      modConfig.modResults.contents = modConfig.modResults.contents.replace(
+        PODS_DEPLOYMENT_TARGET_PATCH_REGEX,
+        patch.trim()
+      );
+      return modConfig;
+    }
+    if (LEGACY_PODS_DEPLOYMENT_TARGET_PATCH_REGEX.test(modConfig.modResults.contents)) {
+      modConfig.modResults.contents = modConfig.modResults.contents.replace(
+        LEGACY_PODS_DEPLOYMENT_TARGET_PATCH_REGEX,
+        `\n${patch}`
+      );
+      return modConfig;
+    }
+
+    const nextContents = modConfig.modResults.contents.replace(
+      /(\s+react_native_post_install\([\s\S]*?\n\s+\))/,
+      `$1\n${patch}`
+    );
+    if (nextContents === modConfig.modResults.contents) {
+      throw new Error("Unable to inject Fidy pods deployment target patch into Podfile.");
+    }
+    modConfig.modResults.contents = nextContents;
+    return modConfig;
+  });
+
+module.exports = {
+  reconcileAppDeploymentTarget,
+  withIosDeploymentTarget,
+  withPodsDeploymentTarget,
+};

--- a/apps/mobile/plugins/withFidyWidget.js
+++ b/apps/mobile/plugins/withFidyWidget.js
@@ -15,6 +15,11 @@ const {
   withXcodeProject,
 } = require("expo/config-plugins");
 const {
+  reconcileAppDeploymentTarget,
+  withIosDeploymentTarget,
+  withPodsDeploymentTarget,
+} = require("./withFidyWidget.deploymentTarget");
+const {
   copyWidgetFiles,
   deploymentTarget: DEPLOYMENT_TARGET,
   extensionName: EXTENSION_NAME,
@@ -25,14 +30,6 @@ const {
   swiftFiles: SWIFT_FILES,
   swiftVersion: SWIFT_VERSION,
 } = require("./withFidyWidget.files");
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
-// Xcode helpers
-// ---------------------------------------------------------------------------
 
 const generateUuid = (project) => project.generateUuid();
 
@@ -276,6 +273,7 @@ const withWidgetExtensionTarget = (config) =>
     const project = modConfig.modResults;
 
     copyWidgetFiles(projectRoot, config);
+    reconcileAppDeploymentTarget(project, DEPLOYMENT_TARGET);
     addWidgetExtensionTarget(project, config);
 
     return modConfig;
@@ -284,7 +282,15 @@ const withWidgetExtensionTarget = (config) =>
 const withFidyWidget = (config) => {
   const configWithEntitlements = withAppGroupEntitlement(config);
   const configWithInfoPlist = withAppGroupInfoPlistKey(configWithEntitlements);
-  const configWithExtension = withWidgetExtensionTarget(configWithInfoPlist);
+  const configWithDeploymentTarget = withIosDeploymentTarget(
+    configWithInfoPlist,
+    DEPLOYMENT_TARGET
+  );
+  const configWithPodsDeploymentTarget = withPodsDeploymentTarget(
+    configWithDeploymentTarget,
+    DEPLOYMENT_TARGET
+  );
+  const configWithExtension = withWidgetExtensionTarget(configWithPodsDeploymentTarget);
   return configWithExtension;
 };
 


### PR DESCRIPTION
- add review skill

- keep PR workflow narrow

- keep onboarding sync preview under file-size limit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise the iOS deployment target to 16.4 across the app, Pods, and widget to fix build issues and meet widget requirements. Also tighten the onboarding preview and move review into its own skill to keep the PR workflow focused.

- **Bug Fixes**
  - Enforce iOS 16.4 via `expo/config-plugins`: set `ios.deploymentTarget`, patch Podfile targets, and reconcile Xcode build settings; integrated in `withFidyWidget` via `withFidyWidget.deploymentTarget`.
  - Onboarding: sort recent transactions by recency, raise preview to 10, render in a capped scroll list, and keep the saved count from decreasing during live updates.

- **Refactors**
  - Extracted review into `.agents/skills/review` and simplified `.agents/skills/opening-pr`.
  - Added onboarding helpers and constants (`SyncProgressStep.helpers.ts`) for clarity.

<sup>Written for commit 6895dc499ac18d59ae80ba6c74c132a8bd2b964a. Summary will update on new commits. <a href="https://cubic.dev/pr/B4rz99/fidy/pull/470?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

