### PR TITLE
fix(mobile): silence iOS window warnings

### DIFF
--- a/apps/mobile/__tests__/capture-sources/notification-parse-improvement-repository.test.ts
+++ b/apps/mobile/__tests__/capture-sources/notification-parse-improvement-repository.test.ts
@@ -24,6 +24,7 @@ describe("notification parse improvement repository", () => {
       userId: "user-1",
       sample: {
         template: "Compra por [AMOUNT] en [MERCHANT].",
+        senderDomain: "davibank.com",
         source: "notification_android",
         status: "failed",
         confidenceBucket: "none",
@@ -36,6 +37,7 @@ describe("notification parse improvement repository", () => {
       expect.objectContaining({
         user_id: "user-1",
         template: "Compra por [AMOUNT] en [MERCHANT].",
+        sender_domain: "davibank.com",
         source: "notification_android",
         status: "failed",
         confidence_bucket: "none",

--- a/apps/mobile/__tests__/capture-sources/notification-parse-improvement-schema.test.ts
+++ b/apps/mobile/__tests__/capture-sources/notification-parse-improvement-schema.test.ts
@@ -10,6 +10,10 @@ const EMAIL_SOURCES_MIGRATION = resolve(
   __dirname,
   "../../supabase/migrations/20260503153000_parse_improvement_email_sources.sql"
 );
+const EMAIL_CONTEXT_MIGRATION = resolve(
+  __dirname,
+  "../../supabase/migrations/20260518152000_parse_improvement_email_context.sql"
+);
 
 describe("notification parse improvement remote schema", () => {
   it("stores anonymized templates with insert-only RLS and review indexing", () => {
@@ -48,5 +52,15 @@ describe("notification parse improvement remote schema", () => {
     expect(sql).toContain(
       "check (source in ('notification_android', 'google_pay', 'email_gmail', 'email_outlook'))"
     );
+  });
+
+  it("adds nullable sender-domain context for email template review", () => {
+    const sql = readFileSync(EMAIL_CONTEXT_MIGRATION, "utf8").toLowerCase();
+
+    expect(sql).toContain("add column if not exists sender_domain text");
+    expect(sql).toContain("notification_parse_improvement_samples_sender_domain_check");
+    expect(sql).toContain("sender_domain is null");
+    expect(sql).toContain("idx_notification_parse_samples_sender_domain");
+    expect(sql).not.toMatch(/raw_text|raw_body|merchant_name|amount_value/u);
   });
 });

--- a/apps/mobile/__tests__/capture-sources/notification-parse-improvement.test.ts
+++ b/apps/mobile/__tests__/capture-sources/notification-parse-improvement.test.ts
@@ -164,4 +164,30 @@ describe("notification parse improvement samples", () => {
     expect(JSON.stringify(mockCapturePipelineEvent.mock.calls)).not.toContain("1234");
     expect(JSON.stringify(mockCapturePipelineEvent.mock.calls)).not.toContain("MERCHANT");
   });
+
+  it("uses a prebuilt parser template for opted-in email samples", async () => {
+    await shareNotificationParseImprovementSample({
+      consent: true,
+      userId: "user-1",
+      parserTemplate: "Compra [MERCHANT] por [AMOUNT] con tarjeta [CARD].",
+      rawText: "Compra EXITO por $50,000 con tarjeta *1234.",
+      senderDomain: "davibank.com",
+      source: "email_gmail",
+      status: "needs_review",
+      confidence: 0.4,
+      parseMethod: "llm",
+    });
+
+    expect(mockInsertNotificationParseImprovementSample).toHaveBeenCalledWith({
+      userId: "user-1",
+      sample: {
+        template: "Compra [MERCHANT] por [AMOUNT] con tarjeta [CARD].",
+        senderDomain: "davibank.com",
+        source: "email_gmail",
+        status: "needs_review",
+        confidenceBucket: "low",
+        parseMethod: "llm",
+      },
+    });
+  });
 });

--- a/apps/mobile/__tests__/capture-sources/notification-pipeline.test.ts
+++ b/apps/mobile/__tests__/capture-sources/notification-pipeline.test.ts
@@ -270,6 +270,59 @@ describe("processNotification", () => {
     expectSavedLlmNotificationTransaction();
   });
 
+  it("uses deterministic regex parsing before the LLM for known bank notifications", async () => {
+    const result = await processNotification(
+      mockDb,
+      USER_ID,
+      makeNotification({
+        packageName: "com.bbva.nxt_colombia",
+        text: "Compra aprobada en EXITO COLOMBIA por $50.000 el 18/05/2026 con tarjeta terminada en 1234.",
+        timestamp: new Date("2026-05-18T19:04:59.000Z").getTime(),
+      })
+    );
+
+    expect(result.saved).toBe(true);
+    expect(mockParseNotificationApi).not.toHaveBeenCalled();
+    expect(mockInsertTransaction).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        amount: 50000,
+        categoryId: "other",
+        counterpartyName: "EXITO COLOMBIA",
+        date: "2026-05-18",
+      })
+    );
+    expect(mockBuildNotificationLlmAccountHintCaptureEvidence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cardProductHint: "tarjeta 1234",
+        counterpartyHint: "EXITO COLOMBIA",
+      })
+    );
+  });
+
+  it("falls back to LLM and requests a regex template when known notification regex misses", async () => {
+    mockNotificationLlmAccountHintParse();
+
+    const result = await processNotification(
+      mockDb,
+      USER_ID,
+      makeNotification({
+        packageName: "com.bbva.nxt_colombia",
+        text: "Formato nuevo de compra en Super Nuevo Comercio con tarjeta 1234.",
+      })
+    );
+
+    expect(result.saved).toBe(true);
+    expect(mockParseNotificationApi).toHaveBeenCalled();
+    expect(result.parseImprovementRequest).toEqual({
+      source: "notification_android",
+      status: "failed",
+      confidence: null,
+      parseMethod: "regex",
+      parserTemplate: "[ENTITY] nuevo de [COUNTERPARTY] con tarjeta [CARD].",
+    });
+  });
+
   it("uses generic regex matches as LLM hints instead of saving fallback categories", async () => {
     mockNotificationLlmAccountHintParse();
     mockStripPii.mockReturnValueOnce("Tu compra fue aprobada por [AMOUNT] en [MERCHANT].");

--- a/apps/mobile/__tests__/email-capture/bank-email-parser.test.ts
+++ b/apps/mobile/__tests__/email-capture/bank-email-parser.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { parseKnownBankEmail } from "@/features/email-capture/services/bank-email-parser";
+import type { RawEmail } from "@/features/email-capture/schema";
+
+const makeEmail = (overrides: Partial<RawEmail>): RawEmail => ({
+  externalId: "email-1",
+  from: "alertas@davibank.com",
+  subject: "Compra aprobada",
+  body: "",
+  receivedAt: "2026-05-18T19:04:59.000Z",
+  provider: "gmail",
+  ...overrides,
+});
+
+describe("known bank email parser", () => {
+  it("extracts Davibank transaction details without calling the LLM", () => {
+    const result = parseKnownBankEmail(
+      makeEmail({
+        from: "Alertas Davibank <alertas@davibank.com>",
+        body: "Compra aprobada en EXITO COLOMBIA por $50.000 el 18/05/2026 con tarjeta **** 1234.",
+      })
+    );
+
+    expect(result).toEqual({
+      kind: "parsed",
+      parserKey: "davibank:purchase",
+      parsed: {
+        type: "expense",
+        amount: 50000,
+        categoryId: "other",
+        description: "EXITO COLOMBIA",
+        counterpartyHint: "EXITO COLOMBIA",
+        date: "2026-05-18",
+        confidence: 0.92,
+        cardProductHint: "tarjeta 1234",
+      },
+    });
+  });
+
+  it("returns a redacted regex failure request for known banks with unknown templates", () => {
+    const result = parseKnownBankEmail(
+      makeEmail({
+        from: "Alertas Davibank <alertas@davibank.com>",
+        body: "Operacion bancaria nueva en Super Nuevo Comercio con tarjeta 1234.",
+      })
+    );
+
+    expect(result).toEqual({
+      kind: "failed",
+      parserKey: "davibank",
+      request: {
+        rawText:
+          "Compra aprobada\n\nOperacion bancaria nueva en Super Nuevo Comercio con tarjeta 1234.",
+        parserTemplate:
+          "Compra aprobada Operacion bancaria nueva en [MERCHANT] con tarjeta [CARD].",
+        senderDomain: "davibank.com",
+        source: "email_gmail",
+        status: "failed",
+        confidence: null,
+        parseMethod: "regex",
+      },
+    });
+  });
+
+  it("does not treat lookalike domains as known banks", () => {
+    const result = parseKnownBankEmail(
+      makeEmail({
+        from: "Alertas <alertas@fake-davibank.com>",
+        body: "Compra aprobada en EXITO COLOMBIA por $50.000 el 18/05/2026.",
+      })
+    );
+
+    expect(result).toEqual({ kind: "unsupported" });
+  });
+
+  it("allows exact known domains and their subdomains", () => {
+    const result = parseKnownBankEmail(
+      makeEmail({
+        from: "Alertas <alertas@mail.davibank.com>",
+        body: "Compra aprobada en EXITO COLOMBIA por $50.000 el 18/05/2026.",
+      })
+    );
+
+    expect(result.kind).toBe("parsed");
+  });
+});

--- a/apps/mobile/__tests__/email-capture/email-parser-template.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-parser-template.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildEmailParserTemplate,
+  normalizeEmailParserText,
+} from "@/features/email-capture/services/email-parser-template";
+
+describe("email parser templates", () => {
+  it("normalizes provider text noise before parser matching", () => {
+    expect(normalizeEmailParserText(" Compra&nbsp;aprobada\n\n\tpor   $50.000 ")).toBe(
+      "Compra aprobada por $50.000"
+    );
+  });
+
+  it("keeps bank email structure while removing sensitive values", () => {
+    const template = buildEmailParserTemplate(
+      "Compra aprobada en EXITO COLOMBIA por $50.000 el 18/05/2026 con tarjeta **** 1234. Cuenta 12345678901."
+    );
+
+    expect(template).toBe(
+      "Compra aprobada en [MERCHANT] por [AMOUNT] el [DATE] con tarjeta [CARD]. [ACCOUNT]."
+    );
+    expect(template).not.toMatch(/EXITO|50\.000|18\/05\/2026|1234|12345678901/u);
+  });
+
+  it("redacts merchant names when the amount follows the merchant", () => {
+    const template = buildEmailParserTemplate("Compra EXITO COLOMBIA por $50.000 aprobada");
+
+    expect(template).toBe("Compra [MERCHANT] por [AMOUNT] aprobada");
+    expect(template).not.toMatch(/EXITO|COLOMBIA|50\.000/u);
+  });
+});

--- a/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
+++ b/apps/mobile/__tests__/email-capture/email-pipeline.test.ts
@@ -114,6 +114,7 @@ vi.mock("@/features/email-capture/lib/merchant-rules", () => ({
 vi.mock("@/features/email-capture/services/parse-email-api", () => ({
   parseEmailApi: (...args: unknown[]) => mockParseEmailApi(...args),
   retryableParseEmailApi: (...args: unknown[]) => mockParseEmailApi(...args),
+  stripPii: (text: string) => text,
 }));
 
 vi.mock("@/features/financial-accounts", () => ({
@@ -598,6 +599,66 @@ describe("email processing pipeline", () => {
     });
   });
 
+  it("uses deterministic bank parsing before the LLM for known bank emails", async () => {
+    const email = makeRawEmail({
+      from: "alertas@davibank.com",
+      subject: "Compra aprobada",
+      body: "Compra aprobada en EXITO COLOMBIA por $50.000 el 18/05/2026 con tarjeta **** 1234.",
+      receivedAt: "2026-05-18T19:04:59.000Z",
+    });
+
+    const result = await processEmails(mockDb, USER_ID, [email]);
+
+    expect(result.saved).toBe(1);
+    expect(mockParseEmailApi).not.toHaveBeenCalled();
+    expectSavedTransaction({
+      userId: USER_ID,
+      type: "expense",
+      amount: 50000,
+      accountId: "fa-default-user-1",
+      accountAttributionState: "unresolved",
+      description: null,
+      counterpartyName: "EXITO COLOMBIA",
+      source: "email_capture",
+      date: "2026-05-18",
+    });
+    expect(mockBuildEmailCaptureEvidence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: "alertas@davibank.com",
+        body: email.body,
+        cardProductHint: "tarjeta 1234",
+        counterpartyHint: "EXITO COLOMBIA",
+      })
+    );
+    expect(mockInsertMerchantRule).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the LLM and records a regex template when a known bank regex misses", async () => {
+    const email = makeRawEmail({
+      from: "alertas@davibank.com",
+      subject: "Compra aprobada",
+      body: "Operacion bancaria nueva en Super Nuevo Comercio con tarjeta 1234.",
+    });
+    mockParseEmailApi.mockResolvedValueOnce(makeParsedEmailResult());
+
+    const result = await processEmails(mockDb, USER_ID, [email]);
+
+    expect(result.saved).toBe(1);
+    expect(mockParseEmailApi).toHaveBeenCalledWith(email.body);
+    expect(result.parseImprovementRequests).toEqual([
+      expect.objectContaining({
+        parserTemplate:
+          "Compra aprobada Operacion bancaria nueva en [MERCHANT] con tarjeta [CARD].",
+        senderDomain: "davibank.com",
+        source: "email_gmail",
+        status: "failed",
+        confidence: null,
+        parseMethod: "regex",
+      }),
+    ]);
+    expect(result.parseImprovementRequests[0]?.rawText).toContain("Super Nuevo Comercio");
+  });
+
   it("does not persist raw body previews for processed source events", async () => {
     mockParseEmailApi.mockResolvedValueOnce(makeParsedEmailResult());
     const longBody = "x".repeat(501);
@@ -808,7 +869,8 @@ describe("email processing pipeline", () => {
     processEmailsFn:
       | typeof processEmails
       | typeof processBackgroundEmails
-      | typeof processInitialSyncEmails
+      | typeof processInitialSyncEmails,
+    expectedConcurrency = 15
   ) {
     const parseStarts: string[] = [];
     const pendingParses: Array<(result: null) => void> = [];
@@ -820,16 +882,18 @@ describe("email processing pipeline", () => {
     const processing = processEmailsFn(
       mockDb,
       USER_ID,
-      Array.from({ length: 16 }, (_, index) =>
+      Array.from({ length: expectedConcurrency + 1 }, (_, index) =>
         makeRawEmail({ externalId: `ext-${index + 1}`, body: `Compra ${index + 1}` })
       )
     );
 
-    await vi.waitFor(() => expect(parseStarts).toHaveLength(15));
-    expect(parseStarts).not.toContain("parse:Compra 16");
+    await vi.waitFor(() => expect(parseStarts).toHaveLength(expectedConcurrency));
+    expect(parseStarts).not.toContain(`parse:Compra ${expectedConcurrency + 1}`);
 
     pendingParses[0]?.(null);
-    await vi.waitFor(() => expect(parseStarts).toContain("parse:Compra 16"));
+    await vi.waitFor(() =>
+      expect(parseStarts).toContain(`parse:Compra ${expectedConcurrency + 1}`)
+    );
 
     pendingParses.slice(1).forEach((resolve) => {
       resolve(null);
@@ -958,7 +1022,7 @@ describe("email processing pipeline", () => {
     await processing;
   });
 
-  it("does not stop scheduling initial sync parses after the preview target is reached", async () => {
+  it("starts larger initial sync batches within the shared parse concurrency", async () => {
     const events: string[] = [];
     const pendingParses: Array<(result: ReturnType<typeof makeParsedEmailResult>) => void> = [];
     mockParseEmailApi.mockImplementation(async (body: string) => {
@@ -983,13 +1047,9 @@ describe("email processing pipeline", () => {
       "parse:Compra 5",
       "parse:Compra 6",
     ]);
-
-    pendingParses[0]?.(makeParsedEmailResult({ description: "Compra 1" }));
-    pendingParses[1]?.(makeParsedEmailResult({ description: "Compra 2" }));
-    pendingParses[2]?.(makeParsedEmailResult({ description: "Compra 3" }));
-    pendingParses[3]?.(makeParsedEmailResult({ description: "Compra 4" }));
-    pendingParses[4]?.(makeParsedEmailResult({ description: "Compra 5" }));
-    pendingParses[5]?.(makeParsedEmailResult({ description: "Compra 6" }));
+    pendingParses.forEach((resolve, index) => {
+      resolve(makeParsedEmailResult({ description: `Compra ${index + 1}` }));
+    });
 
     const result = await processing;
 
@@ -1052,6 +1112,8 @@ describe("email processing pipeline", () => {
         status: "needs_review",
         confidence: 0.5,
         parseMethod: "llm",
+        parserTemplate: "Compra aprobada Su compra por [AMOUNT] fue aprobada",
+        senderDomain: "bancolombia.com.co",
       },
     ]);
   });
@@ -1247,6 +1309,8 @@ describe("email processing pipeline", () => {
         status: "failed",
         confidence: null,
         parseMethod: "llm",
+        parserTemplate: "Compra aprobada Su compra por [AMOUNT] fue aprobada",
+        senderDomain: "bancolombia.com.co",
       },
     ]);
   });

--- a/apps/mobile/__tests__/email-capture/parse-improvement-sharing.test.ts
+++ b/apps/mobile/__tests__/email-capture/parse-improvement-sharing.test.ts
@@ -19,7 +19,9 @@ vi.mock("@/shared/lib", () => ({
 }));
 
 const request = {
+  parserTemplate: "Subject Body",
   rawText: "Subject\n\nBody",
+  senderDomain: "davibank.com",
   source: "email_gmail" as const,
   status: "needs_review" as const,
   confidence: 0.4,

--- a/apps/mobile/__tests__/email-capture/parse-improvement.test.ts
+++ b/apps/mobile/__tests__/email-capture/parse-improvement.test.ts
@@ -28,7 +28,9 @@ describe("email parse improvement requests", () => {
 
     expect(result.parseImprovementRequests).toEqual([
       {
+        parserTemplate: "Compra aprobada",
         rawText: "Compra aprobada",
+        senderDomain: "example.com",
         source: "email_gmail",
         status: "failed",
         confidence: null,
@@ -53,7 +55,9 @@ describe("email parse improvement requests", () => {
 
     expect(result.parseImprovementRequests).toEqual([
       {
+        parserTemplate: "Compra aprobada Su compra por [AMOUNT] fue aprobada",
         rawText: "Compra aprobada\n\nSu compra por $50.000 fue aprobada",
+        senderDomain: "example.com",
         source: "email_outlook",
         status: "needs_review",
         confidence: 0.4,

--- a/apps/mobile/features/capture-sources/lib/notification-parse-improvement-repository.ts
+++ b/apps/mobile/features/capture-sources/lib/notification-parse-improvement-repository.ts
@@ -2,6 +2,7 @@ import { getSupabase } from "@/shared/db";
 
 export type PersistedNotificationParseImprovementSample = {
   readonly template: string;
+  readonly senderDomain?: string | null;
   readonly source: string;
   readonly status: "failed" | "needs_review";
   readonly confidenceBucket: "none" | "low" | "medium" | "high";
@@ -89,6 +90,7 @@ export async function insertNotificationParseImprovementSample(
     .insert({
       user_id: input.userId,
       source: input.sample.source,
+      sender_domain: input.sample.senderDomain ?? null,
       status: input.sample.status,
       confidence_bucket: input.sample.confidenceBucket,
       parse_method: input.sample.parseMethod,

--- a/apps/mobile/features/capture-sources/lib/notification-parse-improvement.ts
+++ b/apps/mobile/features/capture-sources/lib/notification-parse-improvement.ts
@@ -8,6 +8,8 @@ export type ConfidenceBucket = "none" | "low" | "medium" | "high";
 
 export type ParseImprovementInput = {
   readonly rawText: string;
+  readonly parserTemplate?: string;
+  readonly senderDomain?: string | null;
   readonly source: string;
   readonly status: ParseImprovementStatus;
   readonly confidence: number | null;
@@ -33,6 +35,10 @@ const SENSITIVE_VALUE_RULES: readonly RedactionRule[] = [
   { pattern: /\b\d{3}\.\d{3}\.\d{3,4}-?\d?\b/g, replacement: "[ID]" },
   {
     pattern: /\btarjeta\s+(?:terminada|finalizada)\s+en\s+\d{4}\b/gi,
+    replacement: "tarjeta [CARD]",
+  },
+  {
+    pattern: /\btarjeta\s+\d{4}\b/gi,
     replacement: "tarjeta [CARD]",
   },
   { pattern: /\b\d{11,14}\b/g, replacement: "[ACCOUNT]" },
@@ -134,7 +140,8 @@ export function anonymizeNotificationParseSample(rawText: string): string {
 
 export function buildNotificationParseImprovementSample(input: ParseImprovementInput) {
   return {
-    template: anonymizeNotificationParseSample(input.rawText),
+    template: input.parserTemplate ?? anonymizeNotificationParseSample(input.rawText),
+    ...(input.senderDomain ? { senderDomain: input.senderDomain } : {}),
     source: input.source,
     status: input.status,
     confidenceBucket: confidenceBucket(input.confidence),

--- a/apps/mobile/features/capture-sources/services/notification-pipeline.ts
+++ b/apps/mobile/features/capture-sources/services/notification-pipeline.ts
@@ -8,6 +8,7 @@ import type { CategoryId } from "@/shared/types/branded";
 import { findDuplicateTransaction, isCaptureProcessed } from "../lib/dedup";
 import { parseNotificationLocalHint } from "../lib/notification-parser";
 import type { NotificationData } from "../schema";
+import { parseNotificationWithRegex } from "./notification-regex-parser";
 import {
   appendParsedNotificationEvidence,
   buildNotificationFingerprint,
@@ -26,7 +27,6 @@ import {
 import type {
   DuplicateCheckResult,
   NotificationContext,
-  NotificationParseMethod,
   NotificationPipelineResult,
   ParsedNotificationContext,
   ParseStageResult,
@@ -64,13 +64,37 @@ export async function processNotification(
 }
 
 async function parseNotificationStage(context: NotificationContext): Promise<ParseStageResult> {
-  const parseMethod: NotificationParseMethod = "llm";
+  const regexParse = parseNotificationWithRegex(context.notification, context.notificationText);
+  if (regexParse.kind === "parsed") {
+    const parsed = normalizeParsedNotification(regexParse.parsed);
+    const parsedContext = appendParsedNotificationEvidence(context, parsed);
+    const fingerprint = buildNotificationFingerprint(context, parsed);
+    return {
+      kind: "parsed",
+      context: {
+        ...parsedContext,
+        parseMethod: "regex",
+        parsed,
+        fingerprint,
+      },
+    };
+  }
+
   const localHint = parseNotificationLocalHint(context.notificationText);
   const rawParsed = await parseNotificationWithLlm(
     buildNotificationLlmInput(context.sanitizedText, localHint)
   );
   if (!rawParsed) {
-    return { kind: "failed", context: { ...context, parseMethod } };
+    return {
+      kind: "failed",
+      context: {
+        ...context,
+        parseMethod: "llm",
+        ...(regexParse.kind === "failed"
+          ? { regexParseImprovementTemplate: regexParse.parserTemplate }
+          : {}),
+      },
+    };
   }
   const parsed = normalizeParsedNotification(rawParsed);
   const parsedContext = appendParsedNotificationEvidence(context, parsed);
@@ -79,7 +103,10 @@ async function parseNotificationStage(context: NotificationContext): Promise<Par
     kind: "parsed",
     context: {
       ...parsedContext,
-      parseMethod,
+      parseMethod: "llm",
+      ...(regexParse.kind === "failed"
+        ? { regexParseImprovementTemplate: regexParse.parserTemplate }
+        : {}),
       parsed,
       fingerprint,
     },

--- a/apps/mobile/features/capture-sources/services/notification-pipeline/outcomes.ts
+++ b/apps/mobile/features/capture-sources/services/notification-pipeline/outcomes.ts
@@ -84,7 +84,10 @@ function buildParseImprovementRequest(
     source: context.source,
     status: input.status,
     confidence: input.confidence,
-    parseMethod: context.parseMethod,
+    parseMethod: context.regexParseImprovementTemplate ? "regex" : context.parseMethod,
+    ...(context.regexParseImprovementTemplate
+      ? { parserTemplate: context.regexParseImprovementTemplate }
+      : {}),
   };
 }
 
@@ -272,5 +275,17 @@ export async function persistSuccessfulNotification(
   await cacheMerchantRuleIfEligible(context);
   await trackSuccessfulNotification(context);
 
-  return { saved: true, skippedDuplicate: false, transactionId };
+  return {
+    saved: true,
+    skippedDuplicate: false,
+    transactionId,
+    ...(context.regexParseImprovementTemplate
+      ? {
+          parseImprovementRequest: buildParseImprovementRequest(context, {
+            status: "failed",
+            confidence: null,
+          }),
+        }
+      : {}),
+  };
 }

--- a/apps/mobile/features/capture-sources/services/notification-pipeline/types.ts
+++ b/apps/mobile/features/capture-sources/services/notification-pipeline/types.ts
@@ -55,6 +55,7 @@ export type NotificationContext = NotificationCommand & {
 
 export type NotificationStageContext = NotificationContext & {
   parseMethod: NotificationParseMethod;
+  regexParseImprovementTemplate?: string;
 };
 
 export type ParsedNotificationContext = NotificationStageContext & {
@@ -95,5 +96,6 @@ export type NotificationPipelineResult = {
     readonly status: "failed" | "needs_review";
     readonly confidence: number | null;
     readonly parseMethod: NotificationParseMethod;
+    readonly parserTemplate?: string;
   };
 };

--- a/apps/mobile/features/capture-sources/services/notification-regex-parser.ts
+++ b/apps/mobile/features/capture-sources/services/notification-regex-parser.ts
@@ -1,0 +1,98 @@
+import { anonymizeNotificationParseSample } from "../lib/notification-parse-improvement";
+import type { NotificationData } from "../schema";
+import type { RawParsedNotification } from "./notification-pipeline/types";
+
+type ParsedNotificationRegexResult = {
+  readonly kind: "parsed";
+  readonly parsed: RawParsedNotification;
+};
+
+type FailedNotificationRegexResult = {
+  readonly kind: "failed";
+  readonly parserTemplate: string;
+};
+
+type UnsupportedNotificationRegexResult = {
+  readonly kind: "unsupported";
+};
+
+export type NotificationRegexParseResult =
+  | ParsedNotificationRegexResult
+  | FailedNotificationRegexResult
+  | UnsupportedNotificationRegexResult;
+
+const KNOWN_REGEX_PACKAGES = new Set([
+  "com.bbva.nxt_colombia",
+  "com.rappi.card",
+  "com.davivienda.daviplataapp",
+]);
+
+const normalizeNotificationText = (text: string): string =>
+  text
+    .normalize("NFC")
+    .replace(/\u00a0/g, " ")
+    .replace(/[\u200b-\u200d\ufeff]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const parseCopAmount = (rawAmount: string): number | null => {
+  const amount = Number(rawAmount.replace(/[^\d]/g, ""));
+  return Number.isSafeInteger(amount) && amount > 0 ? amount : null;
+};
+
+const parseDate = (rawDate: string): string | null => {
+  const match = rawDate.match(/^(\d{1,2})[/-](\d{1,2})[/-](\d{2}|\d{4})$/);
+  if (!match) return null;
+  const rawDay = match[1];
+  const rawMonth = match[2];
+  const rawYear = match[3];
+  if (!rawDay || !rawMonth || !rawYear) return null;
+  const year = rawYear.length === 2 ? `20${rawYear}` : rawYear;
+  return `${year}-${rawMonth.padStart(2, "0")}-${rawDay.padStart(2, "0")}`;
+};
+
+const notificationDate = (notification: NotificationData): string =>
+  new Date(notification.timestamp).toISOString().slice(0, 10);
+
+const parseCardProductHint = (text: string): string | undefined => {
+  const last4 = text.match(/\b(?:tarjeta|card)\s+(?:terminada\s+en\s+|[*xX]+\s*)?(\d{4})\b/i)?.[1];
+  return last4 ? `tarjeta ${last4}` : undefined;
+};
+
+const parsePurchaseNotification = (
+  text: string,
+  notification: NotificationData
+): RawParsedNotification | null => {
+  const match = text.match(
+    /\b(?:compra|purchase|pago|payment)\b(?:\s+aprobada|\s+aprobado|\s+realizada|\s+exitos[ao])?\s+(?:en|at)\s+(.+?)\s+(?:por|for)\s+(?:\$|COP)?\s*([\d.,]+)(?:\s+(?:el|on)\s+(\d{1,2}[/-]\d{1,2}[/-]\d{2,4}))?/i
+  );
+  const merchant = match?.[1]?.trim();
+  const amount = match?.[2] ? parseCopAmount(match[2]) : null;
+  const date = match?.[3] ? parseDate(match[3]) : notificationDate(notification);
+  const cardProductHint = parseCardProductHint(text);
+  return merchant && amount && date
+    ? {
+        type: "expense",
+        amount,
+        categoryId: "other",
+        merchant,
+        date,
+        confidence: 0.92,
+        counterpartyHint: merchant,
+        ...(cardProductHint ? { cardProductHint } : {}),
+      }
+    : null;
+};
+
+export const parseNotificationWithRegex = (
+  notification: NotificationData,
+  rawText: string
+): NotificationRegexParseResult => {
+  if (!KNOWN_REGEX_PACKAGES.has(notification.packageName)) return { kind: "unsupported" };
+
+  const normalizedText = normalizeNotificationText(rawText);
+  const parsed = parsePurchaseNotification(normalizedText, notification);
+  return parsed
+    ? { kind: "parsed", parsed }
+    : { kind: "failed", parserTemplate: anonymizeNotificationParseSample(normalizedText) };
+};

--- a/apps/mobile/features/capture-sources/services/notification-regex-parser.ts
+++ b/apps/mobile/features/capture-sources/services/notification-regex-parser.ts
@@ -27,6 +27,9 @@ const KNOWN_REGEX_PACKAGES = new Set([
   "com.davivienda.daviplataapp",
 ]);
 
+const PURCHASE_PATTERN =
+  /\b(?:compra|purchase|pago|payment)\b(?:\s+aprobada|\s+aprobado|\s+realizada|\s+exitos[ao])?\s+(?:en|at)\s+(.+?)\s+(?:por|for)\s+(?:\$|COP)?\s*([\d.,]+)(?:\s+(?:el|on)\s+(\d{1,2}[/-]\d{1,2}[/-]\d{2,4}))?/i;
+
 const normalizeNotificationText = (text: string): string =>
   text
     .normalize("NFC")
@@ -63,9 +66,7 @@ const parsePurchaseNotification = (
   text: string,
   notification: NotificationData
 ): RawParsedNotification | null => {
-  const match = text.match(
-    /\b(?:compra|purchase|pago|payment)\b(?:\s+aprobada|\s+aprobado|\s+realizada|\s+exitos[ao])?\s+(?:en|at)\s+(.+?)\s+(?:por|for)\s+(?:\$|COP)?\s*([\d.,]+)(?:\s+(?:el|on)\s+(\d{1,2}[/-]\d{1,2}[/-]\d{2,4}))?/i
-  );
+  const match = text.match(PURCHASE_PATTERN);
   const merchant = match?.[1]?.trim();
   const amount = match?.[2] ? parseCopAmount(match[2]) : null;
   const date = match?.[3] ? parseDate(match[3]) : notificationDate(notification);

--- a/apps/mobile/features/email-capture/services/bank-email-parser.ts
+++ b/apps/mobile/features/email-capture/services/bank-email-parser.ts
@@ -30,6 +30,9 @@ const KNOWN_BANK_DOMAINS = [
   { domain: "rappi.com", parserKey: "rappicard" },
 ] as const;
 
+const PURCHASE_PATTERN =
+  /\b(?:compra|purchase|pago|payment)\b(?:\s+aprobada|\s+aprobado|\s+realizada|\s+exitos[ao])?\s+(?:en|at)\s+(.+?)\s+(?:por|for)\s+(?:\$|COP)?\s*([\d.,]+)(?:\s+(?:el|on)\s+(\d{1,2}[/-]\d{1,2}[/-]\d{2,4}))?/i;
+
 export const buildEmailParseImprovementRawText = (email: RawEmail): string =>
   [email.subject, email.body].filter((part) => part.trim().length > 0).join("\n\n");
 
@@ -74,9 +77,7 @@ const parseCardProductHint = (text: string): string | undefined => {
 };
 
 const parsePurchase = (text: string, email: RawEmail): LlmParsedTransaction | null => {
-  const match = text.match(
-    /\b(?:compra|purchase|pago|payment)\b(?:\s+aprobada|\s+aprobado|\s+realizada|\s+exitos[ao])?\s+(?:en|at)\s+(.+?)\s+(?:por|for)\s+(?:\$|COP)?\s*([\d.,]+)(?:\s+(?:el|on)\s+(\d{1,2}[/-]\d{1,2}[/-]\d{2,4}))?/i
-  );
+  const match = text.match(PURCHASE_PATTERN);
   const merchant = match?.[1]?.trim();
   const amount = match?.[2] ? parseCopAmount(match[2]) : null;
   const date = match?.[3] ? parseDate(match[3]) : getReceivedDate(email);

--- a/apps/mobile/features/email-capture/services/bank-email-parser.ts
+++ b/apps/mobile/features/email-capture/services/bank-email-parser.ts
@@ -1,0 +1,127 @@
+import { buildEmailParserTemplate, normalizeEmailParserText } from "./email-parser-template";
+import type {
+  EmailParseImprovementRequest,
+  LlmParsedTransaction,
+  RawEmail,
+} from "./email-pipeline-service/types";
+
+type ParsedBankEmail = {
+  readonly kind: "parsed";
+  readonly parserKey: string;
+  readonly parsed: LlmParsedTransaction;
+};
+
+type FailedBankEmail = {
+  readonly kind: "failed";
+  readonly parserKey: string;
+  readonly request: EmailParseImprovementRequest;
+};
+
+type UnsupportedBankEmail = {
+  readonly kind: "unsupported";
+};
+
+type BankEmailParseResult = ParsedBankEmail | FailedBankEmail | UnsupportedBankEmail;
+
+const KNOWN_BANK_DOMAINS = [
+  { domain: "davibank.com", parserKey: "davibank" },
+  { domain: "bbvanet.com.co", parserKey: "bbva" },
+  { domain: "rappicard.com", parserKey: "rappicard" },
+  { domain: "rappi.com", parserKey: "rappicard" },
+] as const;
+
+export const buildEmailParseImprovementRawText = (email: RawEmail): string =>
+  [email.subject, email.body].filter((part) => part.trim().length > 0).join("\n\n");
+
+export const getEmailSenderDomain = (email: Pick<RawEmail, "from">): string | null =>
+  email.from.match(/@([^>\s]+)(?:>|$)/)?.[1]?.toLowerCase() ?? null;
+
+const getKnownBank = (email: RawEmail) => {
+  const senderDomain = getEmailSenderDomain(email);
+  return {
+    senderDomain,
+    bank: KNOWN_BANK_DOMAINS.find(
+      (entry) => senderDomain === entry.domain || senderDomain?.endsWith(`.${entry.domain}`)
+    ),
+  };
+};
+
+const parseCopAmount = (rawAmount: string): number | null => {
+  const normalized = rawAmount.replace(/[^\d]/g, "");
+  const amount = Number(normalized);
+  return Number.isSafeInteger(amount) && amount > 0 ? amount : null;
+};
+
+const parseDate = (rawDate: string): string | null => {
+  const match = rawDate.match(/^(\d{1,2})[/-](\d{1,2})[/-](\d{2}|\d{4})$/);
+  if (!match) return null;
+  const rawDay = match[1];
+  const rawMonth = match[2];
+  const rawYear = match[3];
+  if (!rawDay || !rawMonth || !rawYear) return null;
+  const year = rawYear.length === 2 ? `20${rawYear}` : rawYear;
+  const month = rawMonth.padStart(2, "0");
+  const day = rawDay.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+const getReceivedDate = (email: RawEmail): string | null =>
+  email.receivedAt.match(/^(\d{4}-\d{2}-\d{2})/)?.[1] ?? null;
+
+const parseCardProductHint = (text: string): string | undefined => {
+  const last4 = text.match(/\b(?:tarjeta|card)\s+(?:[*xX]+\s*)?(\d{4})\b/i)?.[1];
+  return last4 ? `tarjeta ${last4}` : undefined;
+};
+
+const parsePurchase = (text: string, email: RawEmail): LlmParsedTransaction | null => {
+  const match = text.match(
+    /\b(?:compra|purchase|pago|payment)\b(?:\s+aprobada|\s+aprobado|\s+realizada|\s+exitos[ao])?\s+(?:en|at)\s+(.+?)\s+(?:por|for)\s+(?:\$|COP)?\s*([\d.,]+)(?:\s+(?:el|on)\s+(\d{1,2}[/-]\d{1,2}[/-]\d{2,4}))?/i
+  );
+  const merchant = match?.[1]?.trim();
+  const amount = match?.[2] ? parseCopAmount(match[2]) : null;
+  const date = match?.[3] ? parseDate(match[3]) : getReceivedDate(email);
+  const cardProductHint = parseCardProductHint(text);
+  return merchant && amount && date
+    ? {
+        type: "expense",
+        amount,
+        categoryId: "other",
+        description: merchant,
+        counterpartyHint: merchant,
+        date,
+        confidence: 0.92,
+        ...(cardProductHint ? { cardProductHint } : {}),
+      }
+    : null;
+};
+
+const buildRegexFailureRequest = (
+  email: RawEmail,
+  senderDomain: string | null
+): EmailParseImprovementRequest => {
+  const rawText = buildEmailParseImprovementRawText(email);
+  return {
+    rawText,
+    parserTemplate: buildEmailParserTemplate(rawText),
+    senderDomain,
+    source: email.provider === "gmail" ? "email_gmail" : "email_outlook",
+    status: "failed",
+    confidence: null,
+    parseMethod: "regex",
+  };
+};
+
+export const parseKnownBankEmail = (email: RawEmail): BankEmailParseResult => {
+  const { senderDomain, bank } = getKnownBank(email);
+  if (!bank) return { kind: "unsupported" };
+
+  const text = normalizeEmailParserText(buildEmailParseImprovementRawText(email));
+  const parsed = parsePurchase(text, email);
+  return parsed
+    ? { kind: "parsed", parserKey: `${bank.parserKey}:purchase`, parsed }
+    : {
+        kind: "failed",
+        parserKey: bank.parserKey,
+        request: buildRegexFailureRequest(email, senderDomain),
+      };
+};

--- a/apps/mobile/features/email-capture/services/email-parser-template.ts
+++ b/apps/mobile/features/email-capture/services/email-parser-template.ts
@@ -1,0 +1,89 @@
+import { stripPii } from "../parsing.public";
+
+type RedactionRule = {
+  readonly pattern: RegExp;
+  readonly replacement: string;
+};
+
+const DATE_RULES: readonly RedactionRule[] = [
+  {
+    pattern: /\b\d{4}-\d{2}-\d{2}\b|\b\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b/g,
+    replacement: "[DATE]",
+  },
+];
+
+const AMOUNT_RULES: readonly RedactionRule[] = [
+  { pattern: /\$\s*\d(?:[\d.,]*\d)?/g, replacement: "[AMOUNT]" },
+  { pattern: /\bCOP\s*\d(?:[\d.,]*\d)?/gi, replacement: "[AMOUNT]" },
+];
+
+const ACCOUNT_RULES: readonly RedactionRule[] = [
+  {
+    pattern: /\b(?:cuenta|account)\s+\d{6,}\b/gi,
+    replacement: "[ACCOUNT]",
+  },
+];
+
+const CARD_RULES: readonly RedactionRule[] = [
+  {
+    pattern: /\b(?:tarjeta|card)\s+(?:[*xX]+\s*)?\d{4}\b/gi,
+    replacement: "tarjeta [CARD]",
+  },
+];
+
+const COUNTERPARTY_RULES: readonly RedactionRule[] = [
+  {
+    pattern: /(\ben\s+)(.+?)(?=\s+(?:por|el|con|tarjeta|cuenta|card)\b|[.;]|$)/gi,
+    replacement: "$1[MERCHANT]",
+  },
+  {
+    pattern: /(\bat\s+)(.+?)(?=\s+(?:for|on|with|card|account)\b|[.;]|$)/gi,
+    replacement: "$1[MERCHANT]",
+  },
+  {
+    pattern:
+      /(\b(?:comercio|establecimiento)\s*:?\s*)(.+?)(?=\s+(?:por|el|con|tarjeta|cuenta|card)\b|[.;]|$)/gi,
+    replacement: "$1[MERCHANT]",
+  },
+  {
+    pattern:
+      /(\b(?:compra|purchase|pago|payment)\s+)(?!por\b|of\b|for\b|aprobada\b|aprobado\b|realizada\b|exitos[ao]\b)(.+?)(?=\s+(?:por|of|for|el|con|with|tarjeta|cuenta|card)\b|[.;]|$)/gi,
+    replacement: "$1[MERCHANT]",
+  },
+  {
+    pattern:
+      /(\b(?:beneficiario|destinatario|para|de|a)\s+)(.+?)(?=\s+(?:por|el|con|tarjeta|cuenta|card)\b|[.;]|$)/gi,
+    replacement: "$1[COUNTERPARTY]",
+  },
+];
+
+const applyRedactionRule = (text: string, rule: RedactionRule): string =>
+  text.replace(rule.pattern, rule.replacement);
+
+const normalizeTemplateWhitespace = (value: string): string => value.replace(/\s+/g, " ").trim();
+
+export const normalizeEmailParserText = (rawText: string): string =>
+  normalizeTemplateWhitespace(
+    rawText
+      .normalize("NFC")
+      .replace(/&nbsp;/gi, " ")
+      .replace(/\u00a0/g, " ")
+      .replace(/[\u200b-\u200d\ufeff]/g, "")
+  );
+
+export const buildEmailParserTemplate = (rawText: string): string =>
+  normalizeTemplateWhitespace(
+    COUNTERPARTY_RULES.reduce(
+      applyRedactionRule,
+      CARD_RULES.reduce(
+        applyRedactionRule,
+        ACCOUNT_RULES.reduce(
+          applyRedactionRule,
+          AMOUNT_RULES.reduce(
+            applyRedactionRule,
+            DATE_RULES.reduce(applyRedactionRule, stripPii(normalizeEmailParserText(rawText)))
+          )
+        )
+      )
+    )
+  );

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-batch.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-batch.ts
@@ -39,7 +39,37 @@ type EmailBatchTimingAccumulator = {
   readonly persistenceTotalDurationMs: number;
 };
 
+type RegexParseAccumulator = {
+  readonly parsed: number;
+  readonly missed: number;
+  readonly unsupported: number;
+};
+
 const nowMs = (): number => Date.now();
+
+const isEmailCaptureDebugEnabled = (): boolean =>
+  process.env.EXPO_PUBLIC_EMAIL_CAPTURE_DEBUG === "1";
+
+const logRegexSummaryForDebug = (input: {
+  readonly emailCount: number;
+  readonly regex: RegexParseAccumulator;
+  readonly result: PipelineResult;
+}): void => {
+  if (!isEmailCaptureDebugEnabled()) return;
+
+  // eslint-disable-next-line no-console
+  console.log("[email-capture] regex.summary", {
+    emailCount: input.emailCount,
+    regexCandidates: input.regex.parsed + input.regex.missed,
+    regexParsed: input.regex.parsed,
+    regexMissed: input.regex.missed,
+    regexUnsupported: input.regex.unsupported,
+    saved: input.result.saved,
+    needsReview: input.result.needsReview,
+    filtered: input.result.filtered,
+    failed: input.result.failed,
+  });
+};
 
 async function createEmailBatchPlan(
   runtime: PipelineRuntime,
@@ -111,9 +141,11 @@ async function runEmailWorker(input: {
 }): Promise<void> {
   // FP exemption: workers share a queue so parse calls can run without artificial batching.
   while (true) {
+    if (input.context.signal?.aborted) return;
     const email = getNextQueuedEmail(input.queue);
     if (!email) return;
     await waitForParseRateLimit(input.context);
+    if (input.context.signal?.aborted) return;
     input.onOutcome(await processIncomingEmail(input.context, email));
   }
 }
@@ -147,6 +179,12 @@ const createTimingAccumulator = (): EmailBatchTimingAccumulator => ({
   persistenceTotalDurationMs: 0,
 });
 
+const createRegexAccumulator = (): RegexParseAccumulator => ({
+  parsed: 0,
+  missed: 0,
+  unsupported: 0,
+});
+
 const addOutcomeTiming = (
   timing: EmailBatchTimingAccumulator,
   outcome: IncomingEmailOutcome
@@ -171,6 +209,14 @@ const summarizeBatchTiming = (
   firstSavedLatencyMs,
 });
 
+const addRegexOutcome = (
+  regex: RegexParseAccumulator,
+  outcome: IncomingEmailOutcome
+): RegexParseAccumulator => ({
+  ...regex,
+  [outcome.regexParseStatus]: regex[outcome.regexParseStatus] + 1,
+});
+
 export async function processEmailBatch(runtime: PipelineRuntime, input: ProcessEmailsInput) {
   const batchStartedAt = nowMs();
   const batch = await createEmailBatchPlan(runtime, input.db, input.userId, input.rawEmails);
@@ -178,6 +224,7 @@ export async function processEmailBatch(runtime: PipelineRuntime, input: Process
     runtime,
     db: input.db,
     userId: input.userId,
+    signal: input.signal,
     parseStarts: 0,
     parseStartGate: Promise.resolve(),
     persistenceGate: Promise.resolve(),
@@ -185,6 +232,7 @@ export async function processEmailBatch(runtime: PipelineRuntime, input: Process
   let completed = 0;
   let firstSavedLatencyMs: number | null = null;
   let timing = createTimingAccumulator();
+  let regex = createRegexAccumulator();
   let progressResult = batch.result;
   const reportProgress = () => {
     input.onProgress?.(getProgressSnapshot(batch.total, completed, progressResult));
@@ -197,6 +245,7 @@ export async function processEmailBatch(runtime: PipelineRuntime, input: Process
     onOutcome: (outcome) => {
       completed += 1;
       timing = addOutcomeTiming(timing, outcome);
+      regex = addRegexOutcome(regex, outcome);
       if (firstSavedLatencyMs === null && outcome.savedTransaction) {
         firstSavedLatencyMs = nowMs() - batchStartedAt;
       }
@@ -211,5 +260,10 @@ export async function processEmailBatch(runtime: PipelineRuntime, input: Process
     timing: summarizeBatchTiming(timing, nowMs() - batchStartedAt, firstSavedLatencyMs),
   });
   await runtime.runTelemetryEffect(capturePipelineEventEffect(telemetry));
+  logRegexSummaryForDebug({
+    emailCount: batch.total,
+    regex,
+    result: progressResult,
+  });
   return progressResult;
 }

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-email-record.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-email-record.ts
@@ -1,0 +1,30 @@
+import { saveEmailCaptureEvidenceEffect, insertProcessedEmailSourceEventEffect } from "./runtime";
+import type { EmailBatchContext, RawEmail, TransactionId } from "./types";
+
+type IncomingEmailPersistenceInput = {
+  readonly context: EmailBatchContext;
+  readonly email: RawEmail;
+  readonly sourceEventRow: Parameters<typeof insertProcessedEmailSourceEventEffect>[1];
+  readonly processedSourceEventId: Parameters<
+    typeof saveEmailCaptureEvidenceEffect
+  >[0]["processedSourceEventId"];
+  readonly transactionId: TransactionId | null;
+  readonly createdAt: Parameters<typeof saveEmailCaptureEvidenceEffect>[0]["now"];
+};
+
+export async function persistIncomingEmailRecord(input: IncomingEmailPersistenceInput) {
+  await input.context.runtime.runEmailEffect(
+    insertProcessedEmailSourceEventEffect(input.context.db, input.sourceEventRow)
+  );
+  await input.context.runtime.runEmailEffect(
+    saveEmailCaptureEvidenceEffect({
+      db: input.context.db,
+      userId: input.context.userId,
+      from: input.email.from,
+      body: input.email.body,
+      processedSourceEventId: input.processedSourceEventId,
+      transactionId: input.transactionId,
+      now: input.createdAt,
+    })
+  );
+}

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-email-record.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-email-record.ts
@@ -5,9 +5,6 @@ type IncomingEmailPersistenceInput = {
   readonly context: EmailBatchContext;
   readonly email: RawEmail;
   readonly sourceEventRow: Parameters<typeof insertProcessedEmailSourceEventEffect>[1];
-  readonly processedSourceEventId: Parameters<
-    typeof saveEmailCaptureEvidenceEffect
-  >[0]["processedSourceEventId"];
   readonly transactionId: TransactionId | null;
   readonly createdAt: Parameters<typeof saveEmailCaptureEvidenceEffect>[0]["now"];
 };
@@ -22,7 +19,7 @@ export async function persistIncomingEmailRecord(input: IncomingEmailPersistence
       userId: input.context.userId,
       from: input.email.from,
       body: input.email.body,
-      processedSourceEventId: input.processedSourceEventId,
+      processedSourceEventId: input.sourceEventRow.id,
       transactionId: input.transactionId,
       now: input.createdAt,
     })

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-email.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-email.ts
@@ -14,6 +14,7 @@ import {
 import {
   buildDuplicateProcessedSourceEventRow,
   buildUnparsedProcessedSourceEventRow,
+  appendEmailParseImprovementRequest,
   createPipelineMetricResult,
   getEmailSourceId,
   getEmailSourceEventKey,
@@ -26,6 +27,7 @@ import type {
   EmailSaveStatus,
   IncomingEmailOutcome,
   IncomingEmailPersistenceOutcome,
+  EmailParseImprovementRequest,
   LlmParsedTransaction,
   PipelineResult,
   RawEmail,
@@ -168,6 +170,7 @@ async function persistIncomingTransaction(input: {
   readonly email: RawEmail;
   readonly parsed: LlmParsedTransaction;
   readonly status: EmailSaveStatus;
+  readonly regexParseStatus: IncomingEmailOutcome["regexParseStatus"];
 }): Promise<EmailSaveStatus | null> {
   try {
     const persistedStatus = await input.context.runtime.runEmailWithClock(
@@ -180,7 +183,11 @@ async function persistIncomingTransaction(input: {
       })
     );
     if (persistedStatus === "success") {
-      await cacheMerchantRule({ context: input.context, parsed: input.parsed });
+      await cacheMerchantRule({
+        context: input.context,
+        parsed: input.parsed,
+        regexParseStatus: input.regexParseStatus,
+      });
     }
     return persistedStatus;
   } catch (error) {
@@ -192,7 +199,9 @@ async function persistIncomingTransaction(input: {
 async function processParsedIncomingEmail(
   context: EmailBatchContext,
   email: RawEmail,
-  parsed: LlmParsedTransaction
+  parsed: LlmParsedTransaction,
+  regexParseStatus: IncomingEmailOutcome["regexParseStatus"],
+  parseImprovementRequest?: EmailParseImprovementRequest
 ): Promise<IncomingEmailPersistenceOutcome> {
   const persistenceStartedAt = nowMs();
   const result = await runSerializedPersistence(context, async () => {
@@ -211,7 +220,13 @@ async function processParsedIncomingEmail(
     }
 
     const status = resolveEmailStatus(parsed.confidence);
-    const persistedStatus = await persistIncomingTransaction({ context, email, parsed, status });
+    const persistedStatus = await persistIncomingTransaction({
+      context,
+      email,
+      parsed,
+      status,
+      regexParseStatus,
+    });
     if (persistedStatus === null) {
       return persistFailedIncomingEmail(context, email, null);
     }
@@ -225,12 +240,21 @@ async function processParsedIncomingEmail(
     return savedResult;
   });
 
+  const resultWithParseImprovement = parseImprovementRequest
+    ? appendEmailParseImprovementRequest({ result, request: parseImprovementRequest })
+    : result;
   return {
-    result,
+    result: resultWithParseImprovement,
     persistenceDurationMs: nowMs() - persistenceStartedAt,
-    savedTransaction: result.saved > 0 || result.needsReview > 0,
+    savedTransaction:
+      resultWithParseImprovement.saved > 0 || resultWithParseImprovement.needsReview > 0,
   };
 }
+
+const appendOptionalParseImprovementRequest = (
+  result: PipelineResult,
+  request?: EmailParseImprovementRequest
+): PipelineResult => (request ? appendEmailParseImprovementRequest({ result, request }) : result);
 
 export async function processIncomingEmail(
   context: EmailBatchContext,
@@ -242,30 +266,45 @@ export async function processIncomingEmail(
   if (parsed.kind !== "parsed") {
     if (parsed.kind === "failed") {
       const persistenceStartedAt = nowMs();
-      const result = await persistFailedIncomingEmail(context, email, "parse_error");
+      const result = appendOptionalParseImprovementRequest(
+        await persistFailedIncomingEmail(context, email, "parse_error"),
+        parsed.parseImprovementRequest
+      );
       return {
         result,
         parseDurationMs,
         persistenceDurationMs: nowMs() - persistenceStartedAt,
         savedTransaction: false,
+        regexParseStatus: parsed.regexParseStatus,
       };
     }
 
     const persistenceStartedAt = nowMs();
-    const result = await persistSkippedIncomingEmail(context, email, parsed.kind);
+    const result = appendOptionalParseImprovementRequest(
+      await persistSkippedIncomingEmail(context, email, parsed.kind),
+      parsed.parseImprovementRequest
+    );
     return {
       result,
       parseDurationMs,
       persistenceDurationMs: nowMs() - persistenceStartedAt,
       savedTransaction: false,
+      regexParseStatus: parsed.regexParseStatus,
     };
   }
 
-  const persistence = await processParsedIncomingEmail(context, email, parsed.parsed);
+  const persistence = await processParsedIncomingEmail(
+    context,
+    email,
+    parsed.parsed,
+    parsed.regexParseStatus,
+    parsed.parseImprovementRequest
+  );
   return {
     result: persistence.result,
     parseDurationMs,
     persistenceDurationMs: persistence.persistenceDurationMs,
     savedTransaction: persistence.savedTransaction,
+    regexParseStatus: parsed.regexParseStatus,
   };
 }

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-email.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-email.ts
@@ -1,5 +1,6 @@
 import { captureErrorEffect, capturePipelineEventEffect } from "@/shared/effect/telemetry";
 import { buildSkippedEmailDiagnostics } from "./email-telemetry";
+import { persistIncomingEmailRecord } from "./incoming-email-record";
 import { cacheMerchantRule, lookupIncomingDuplicate } from "./incoming-parsed-helpers";
 import { createIncomingEmailPersistenceState, parseIncomingEmail } from "./incoming-parse";
 import {
@@ -9,7 +10,6 @@ import {
 import {
   getProcessedEmailSourceEventIdsEffect,
   insertProcessedEmailSourceEventEffect,
-  saveEmailCaptureEvidenceEffect,
 } from "./runtime";
 import {
   buildDuplicateProcessedSourceEventRow,
@@ -36,34 +36,6 @@ import type {
 } from "./types";
 
 const nowMs = (): number => Date.now();
-
-type IncomingEmailPersistenceInput = {
-  readonly context: EmailBatchContext;
-  readonly email: RawEmail;
-  readonly sourceEventRow: Parameters<typeof insertProcessedEmailSourceEventEffect>[1];
-  readonly processedSourceEventId: Parameters<
-    typeof saveEmailCaptureEvidenceEffect
-  >[0]["processedSourceEventId"];
-  readonly transactionId: TransactionId | null;
-  readonly createdAt: Parameters<typeof saveEmailCaptureEvidenceEffect>[0]["now"];
-};
-
-async function persistIncomingEmailRecord(input: IncomingEmailPersistenceInput) {
-  await input.context.runtime.runEmailEffect(
-    insertProcessedEmailSourceEventEffect(input.context.db, input.sourceEventRow)
-  );
-  await input.context.runtime.runEmailEffect(
-    saveEmailCaptureEvidenceEffect({
-      db: input.context.db,
-      userId: input.context.userId,
-      from: input.email.from,
-      body: input.email.body,
-      processedSourceEventId: input.processedSourceEventId,
-      transactionId: input.transactionId,
-      now: input.createdAt,
-    })
-  );
-}
 
 async function persistFailedIncomingEmail(
   context: EmailBatchContext,

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-email.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-email.ts
@@ -69,7 +69,6 @@ async function persistFailedIncomingEmail(
     context,
     email,
     sourceEventRow,
-    processedSourceEventId,
     transactionId: null,
     createdAt,
   });
@@ -130,7 +129,6 @@ async function persistDuplicateIncomingEmail(input: {
     context: input.context,
     email: input.email,
     sourceEventRow,
-    processedSourceEventId,
     transactionId: input.transactionId,
     createdAt,
   });

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-parse.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-parse.ts
@@ -1,6 +1,7 @@
 import { currentIsoDateTimeEffect } from "@/shared/effect/clock";
 import { generateProcessedSourceEventId } from "@/shared/lib/generate-id";
 import { assertIsoDateTime } from "@/shared/types/assertions";
+import { parseKnownBankEmail } from "../bank-email-parser";
 import { parseEmailBodyOrReport } from "./parse-email-body";
 import type { EmailBatchContext, IncomingParseOutcome, RawEmail } from "./types";
 
@@ -8,16 +9,23 @@ export async function parseIncomingEmail(
   context: EmailBatchContext,
   email: RawEmail
 ): Promise<IncomingParseOutcome> {
+  const bankParse = parseKnownBankEmail(email);
+  if (bankParse.kind === "parsed") {
+    return { kind: "parsed", parsed: bankParse.parsed, regexParseStatus: "parsed" };
+  }
+
   const result = await parseEmailBodyOrReport(context, {
     body: email.body,
     provider: email.provider,
     warningName: "email_parse_exception",
   });
+  const parseImprovementRequest = bankParse.kind === "failed" ? bankParse.request : undefined;
+  const regexParseStatus = bankParse.kind === "failed" ? "missed" : "unsupported";
   return result.kind === "failed"
-    ? { kind: "failed" }
+    ? { kind: "failed", parseImprovementRequest, regexParseStatus }
     : result.parsed
-      ? { kind: "parsed", parsed: result.parsed }
-      : { kind: "filtered" };
+      ? { kind: "parsed", parsed: result.parsed, parseImprovementRequest, regexParseStatus }
+      : { kind: "filtered", parseImprovementRequest, regexParseStatus };
 }
 
 export async function createIncomingEmailPersistenceState(

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-parsed-helpers.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-parsed-helpers.ts
@@ -3,7 +3,12 @@ import { captureErrorEffect } from "@/shared/effect/telemetry";
 import { normalizeMerchant } from "@/shared/lib/normalize-merchant";
 import { findDuplicateTransactionEffect, insertMerchantRuleEffect } from "./runtime";
 import { getParsedCounterpartyName, getPersistedCategoryId } from "./shared";
-import type { DuplicateLookupOutcome, EmailBatchContext, LlmParsedTransaction } from "./types";
+import type {
+  DuplicateLookupOutcome,
+  EmailBatchContext,
+  IncomingEmailOutcome,
+  LlmParsedTransaction,
+} from "./types";
 
 export async function lookupIncomingDuplicate(
   context: EmailBatchContext,
@@ -23,7 +28,12 @@ export async function lookupIncomingDuplicate(
 export async function cacheMerchantRule(input: {
   readonly context: EmailBatchContext;
   readonly parsed: LlmParsedTransaction;
+  readonly regexParseStatus: IncomingEmailOutcome["regexParseStatus"];
 }) {
+  if (input.regexParseStatus === "parsed" && input.parsed.categoryId === "other") {
+    return;
+  }
+
   try {
     const createdAt = await input.context.runtime.runClockEffect(currentIsoDateTimeEffect);
     await input.context.runtime.runEmailEffect(

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/internal-types.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/internal-types.ts
@@ -167,11 +167,13 @@ export type ProcessEmailsInput = {
   readonly userId: UserId;
   readonly rawEmails: RawEmail[];
   readonly onProgress?: ProgressCallback;
+  readonly signal?: AbortSignal;
 };
 
 export type ProcessRetriesInput = {
   readonly db: AnyDb;
   readonly userId: UserId;
+  readonly signal?: AbortSignal;
 };
 
 export type EmailBatchPlan = {
@@ -186,6 +188,7 @@ export type EmailBatchContext = {
   readonly runtime: PipelineRuntime;
   readonly db: AnyDb;
   readonly userId: UserId;
+  readonly signal?: AbortSignal;
   parseStarts: number;
   parseStartGate: Promise<void>;
   persistenceGate: Promise<void>;
@@ -195,6 +198,7 @@ export type RetryBatchContext = {
   readonly runtime: PipelineRuntime;
   readonly db: AnyDb;
   readonly userId: UserId;
+  readonly signal?: AbortSignal;
   readonly result: RetryResult;
 };
 
@@ -204,15 +208,29 @@ export type EmailQueue = {
 };
 
 export type IncomingParseOutcome =
-  | { readonly kind: "parsed"; readonly parsed: LlmParsedTransaction }
-  | { readonly kind: "filtered" }
-  | { readonly kind: "failed" };
+  | {
+      readonly kind: "parsed";
+      readonly parsed: LlmParsedTransaction;
+      readonly parseImprovementRequest?: EmailParseImprovementRequest;
+      readonly regexParseStatus: "parsed" | "missed" | "unsupported";
+    }
+  | {
+      readonly kind: "filtered";
+      readonly parseImprovementRequest?: EmailParseImprovementRequest;
+      readonly regexParseStatus: "parsed" | "missed" | "unsupported";
+    }
+  | {
+      readonly kind: "failed";
+      readonly parseImprovementRequest?: EmailParseImprovementRequest;
+      readonly regexParseStatus: "parsed" | "missed" | "unsupported";
+    };
 
 export type IncomingEmailOutcome = {
   readonly result: PipelineResult;
   readonly parseDurationMs: number;
   readonly persistenceDurationMs: number;
   readonly savedTransaction: boolean;
+  readonly regexParseStatus: "parsed" | "missed" | "unsupported";
 };
 
 export type IncomingEmailPersistenceOutcome = {

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/parse-improvement.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/parse-improvement.ts
@@ -1,8 +1,7 @@
 import { appendEmailParseImprovementRequest, getTransactionSource } from "./shared";
+import { buildEmailParseImprovementRawText, getEmailSenderDomain } from "../bank-email-parser";
+import { buildEmailParserTemplate } from "../email-parser-template";
 import type { PipelineResult, RawEmail } from "./types";
-
-const buildEmailParseImprovementRawText = (email: RawEmail): string =>
-  [email.subject, email.body].filter((part) => part.trim().length > 0).join("\n\n");
 
 export function appendFailedEmailParseImprovementRequest(
   result: PipelineResult,
@@ -12,6 +11,8 @@ export function appendFailedEmailParseImprovementRequest(
     result,
     request: {
       rawText: buildEmailParseImprovementRawText(email),
+      parserTemplate: buildEmailParserTemplate(buildEmailParseImprovementRawText(email)),
+      senderDomain: getEmailSenderDomain(email),
       source: getTransactionSource(email.provider),
       status: "failed",
       confidence: null,
@@ -29,6 +30,8 @@ export function appendNeedsReviewEmailParseImprovementRequest(
     result,
     request: {
       rawText: buildEmailParseImprovementRawText(email),
+      parserTemplate: buildEmailParserTemplate(buildEmailParseImprovementRawText(email)),
+      senderDomain: getEmailSenderDomain(email),
       source: getTransactionSource(email.provider),
       status: "needs_review",
       confidence,

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/public-types.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/public-types.ts
@@ -47,10 +47,12 @@ export type PipelineResult = {
 
 export type EmailParseImprovementRequest = {
   readonly rawText: string;
+  readonly parserTemplate?: string;
+  readonly senderDomain?: string | null;
   readonly source: "email_gmail" | "email_outlook";
   readonly status: "failed" | "needs_review";
   readonly confidence: number | null;
-  readonly parseMethod: "llm";
+  readonly parseMethod: "llm" | "regex";
 };
 
 export type ProgressCallback = (progress: {
@@ -70,7 +72,7 @@ export type RetryResult = {
 export type CreateEmailPipelineServiceDeps = {
   readonly parseEmailApi: (
     body: string,
-    options?: { readonly parseContext?: ParseContext }
+    options?: { readonly parseContext?: ParseContext; readonly signal?: AbortSignal }
   ) => Promise<LlmParsedTransaction | null>;
   readonly parseContext?: ParseContext;
   readonly lookupMerchantRule: (
@@ -179,7 +181,8 @@ export type EmailPipelineService = {
     db: AnyDb,
     userId: UserId,
     rawEmails: RawEmail[],
-    onProgress?: ProgressCallback
+    onProgress?: ProgressCallback,
+    signal?: AbortSignal
   ) => Promise<PipelineResult>;
   readonly processRetries: (db: AnyDb, userId: UserId) => Promise<RetryResult>;
 };

--- a/apps/mobile/plugins/withFidyWidget.appDelegate.js
+++ b/apps/mobile/plugins/withFidyWidget.appDelegate.js
@@ -2,14 +2,15 @@ const { withDangerousMod } = require("expo/config-plugins");
 const { readFileSync, writeFileSync } = require("node:fs");
 const path = require("node:path");
 
-const legacyWindowCreation =
-  "    window = UIWindow(frame: UIScreen.main.bounds)\n" + "    factory.startReactNative(\n";
-const sceneAwareWindowCreation =
-  "    window = makeRootWindow(for: application)\n" + "    factory.startReactNative(\n";
-const legacyOpenUrlSignature = "  public override func application(\n    _ app: UIApplication,";
+const legacyWindowCreationPattern =
+  /^(\s*)window\s*=\s*UIWindow\(frame:\s*UIScreen\.main\.bounds\)(\s*\n\s*factory\.startReactNative\()/m;
 const annotatedOpenUrlSignature =
   "  @available(iOS, introduced: 9.0, deprecated: 26.0)\n  public override func application(\n    _ app: UIApplication,";
-const reactNativeDelegateMarker = "\nclass ReactNativeDelegate: ExpoReactNativeFactoryDelegate {";
+const openUrlSignaturePattern =
+  /^(\s*)public\s+override\s+func\s+application\(\s*\n\s*_ app:\s*UIApplication,/m;
+const reactNativeDelegatePattern =
+  /^class\s+ReactNativeDelegate:\s+ExpoReactNativeFactoryDelegate\s*\{/m;
+const reactNativeDelegateDeclaration = "class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {";
 const rootWindowHelpers =
   "\n#if os(iOS) || os(tvOS)\n" +
   "private func makeRootWindow(for application: UIApplication) -> UIWindow {\n" +
@@ -27,6 +28,44 @@ const rootWindowHelpers =
   "}\n" +
   "#endif\n";
 
+const replaceRequired = (source, pattern, replacement, label) => {
+  const patched = source.replace(pattern, replacement);
+  if (patched === source) {
+    throw new Error(`Unable to patch generated AppDelegate.swift ${label}`);
+  }
+  return patched;
+};
+
+const patchRootWindowCreation = (source) =>
+  source.includes("window = makeRootWindow(for:")
+    ? source
+    : replaceRequired(
+        source,
+        legacyWindowCreationPattern,
+        "$1window = makeRootWindow(for: application)$2",
+        "root window creation"
+      );
+
+const patchOpenUrlAvailability = (source) =>
+  source.includes(annotatedOpenUrlSignature)
+    ? source
+    : replaceRequired(
+        source,
+        openUrlSignaturePattern,
+        annotatedOpenUrlSignature,
+        "open URL availability annotation"
+      );
+
+const insertRootWindowHelpers = (source) =>
+  source.includes("private func makeRootWindow(")
+    ? source
+    : replaceRequired(
+        source,
+        reactNativeDelegatePattern,
+        `${rootWindowHelpers}${reactNativeDelegateDeclaration}`,
+        "root window helpers"
+      );
+
 const getAppDelegatePath = (modConfig) =>
   path.join(
     modConfig.modRequest.platformProjectRoot,
@@ -35,13 +74,9 @@ const getAppDelegatePath = (modConfig) =>
   );
 
 const patchAppDelegateSource = (source) => {
-  const windowPatched = source.replace(legacyWindowCreation, sceneAwareWindowCreation);
-  const openUrlPatched = windowPatched.includes(annotatedOpenUrlSignature)
-    ? windowPatched
-    : windowPatched.replace(legacyOpenUrlSignature, annotatedOpenUrlSignature);
-  return openUrlPatched.includes("private func makeRootWindow(")
-    ? openUrlPatched
-    : openUrlPatched.replace(reactNativeDelegateMarker, `${rootWindowHelpers}${reactNativeDelegateMarker}`);
+  const windowPatched = patchRootWindowCreation(source);
+  const openUrlPatched = patchOpenUrlAvailability(windowPatched);
+  return insertRootWindowHelpers(openUrlPatched);
 };
 
 const markAppDelegateIos26Compatibility = (config) =>

--- a/apps/mobile/plugins/withFidyWidget.appDelegate.js
+++ b/apps/mobile/plugins/withFidyWidget.appDelegate.js
@@ -1,0 +1,63 @@
+const { withDangerousMod } = require("expo/config-plugins");
+const { readFileSync, writeFileSync } = require("node:fs");
+const path = require("node:path");
+
+const legacyWindowCreation =
+  "    window = UIWindow(frame: UIScreen.main.bounds)\n" + "    factory.startReactNative(\n";
+const sceneAwareWindowCreation =
+  "    window = makeRootWindow(for: application)\n" + "    factory.startReactNative(\n";
+const legacyOpenUrlSignature = "  public override func application(\n    _ app: UIApplication,";
+const annotatedOpenUrlSignature =
+  "  @available(iOS, introduced: 9.0, deprecated: 26.0)\n  public override func application(\n    _ app: UIApplication,";
+const reactNativeDelegateMarker = "\nclass ReactNativeDelegate: ExpoReactNativeFactoryDelegate {";
+const rootWindowHelpers =
+  "\n#if os(iOS) || os(tvOS)\n" +
+  "private func makeRootWindow(for application: UIApplication) -> UIWindow {\n" +
+  "  if let windowScene = application.connectedScenes.compactMap({ $0 as? UIWindowScene }).first {\n" +
+  "    return UIWindow(windowScene: windowScene)\n" +
+  "  }\n" +
+  "\n" +
+  "  return makeLegacyRootWindow()\n" +
+  "}\n" +
+  "\n" +
+  "@available(iOS, deprecated: 26.0)\n" +
+  "@available(tvOS, deprecated: 26.0)\n" +
+  "private func makeLegacyRootWindow() -> UIWindow {\n" +
+  "  UIWindow(frame: UIScreen.main.bounds)\n" +
+  "}\n" +
+  "#endif\n";
+
+const getAppDelegatePath = (modConfig) =>
+  path.join(
+    modConfig.modRequest.platformProjectRoot,
+    modConfig.modRequest.projectName,
+    "AppDelegate.swift"
+  );
+
+const patchAppDelegateSource = (source) => {
+  const windowPatched = source.replace(legacyWindowCreation, sceneAwareWindowCreation);
+  const openUrlPatched = windowPatched.includes(annotatedOpenUrlSignature)
+    ? windowPatched
+    : windowPatched.replace(legacyOpenUrlSignature, annotatedOpenUrlSignature);
+  return openUrlPatched.includes("private func makeRootWindow(")
+    ? openUrlPatched
+    : openUrlPatched.replace(reactNativeDelegateMarker, `${rootWindowHelpers}${reactNativeDelegateMarker}`);
+};
+
+const markAppDelegateIos26Compatibility = (config) =>
+  withDangerousMod(config, [
+    "ios",
+    (modConfig) => {
+      const appDelegatePath = getAppDelegatePath(modConfig);
+      const source = readFileSync(appDelegatePath, "utf8");
+      const patched = patchAppDelegateSource(source);
+
+      if (patched !== source) {
+        writeFileSync(appDelegatePath, patched);
+      }
+
+      return modConfig;
+    },
+  ]);
+
+module.exports = { markAppDelegateIos26Compatibility };

--- a/apps/mobile/plugins/withFidyWidget.js
+++ b/apps/mobile/plugins/withFidyWidget.js
@@ -11,17 +11,15 @@
 const {
   createRunOncePlugin,
   withEntitlementsPlist,
-  withDangerousMod,
   withInfoPlist,
   withXcodeProject,
 } = require("expo/config-plugins");
-const { readFileSync, writeFileSync } = require("node:fs");
-const path = require("node:path");
 const {
   reconcileAppDeploymentTarget,
   withIosDeploymentTarget,
   withPodsDeploymentTarget,
 } = require("./withFidyWidget.deploymentTarget");
+const { markAppDelegateIos26Compatibility } = require("./withFidyWidget.appDelegate");
 const {
   copyWidgetFiles,
   deploymentTarget: DEPLOYMENT_TARGET,
@@ -242,63 +240,6 @@ const addWidgetExtensionTarget = (project, config) => {
   reconcileBuildSettings(project, settings);
 };
 
-const markAppDelegateIos26Compatibility = (config) =>
-  withDangerousMod(config, [
-    "ios",
-    (modConfig) => {
-      const appDelegatePath = path.join(
-        modConfig.modRequest.platformProjectRoot,
-        modConfig.modRequest.projectName,
-        "AppDelegate.swift"
-      );
-      const source = readFileSync(appDelegatePath, "utf8");
-      const legacyWindowCreation =
-        "    window = UIWindow(frame: UIScreen.main.bounds)\n" +
-        "    factory.startReactNative(\n";
-      const sceneAwareWindowCreation =
-        "    window = makeRootWindow(for: application)\n" +
-        "    factory.startReactNative(\n";
-      const legacyOpenUrlSignature = "  public override func application(\n    _ app: UIApplication,";
-      const annotatedOpenUrlSignature =
-        "  @available(iOS, introduced: 9.0, deprecated: 26.0)\n  public override func application(\n    _ app: UIApplication,";
-      const reactNativeDelegateMarker = "\nclass ReactNativeDelegate: ExpoReactNativeFactoryDelegate {";
-      const rootWindowHelpers =
-        "\n#if os(iOS) || os(tvOS)\n" +
-        "private func makeRootWindow(for application: UIApplication) -> UIWindow {\n" +
-        "  if let windowScene = application.connectedScenes.compactMap({ $0 as? UIWindowScene }).first {\n" +
-        "    return UIWindow(windowScene: windowScene)\n" +
-        "  }\n" +
-        "\n" +
-        "  return makeLegacyRootWindow()\n" +
-        "}\n" +
-        "\n" +
-        "@available(iOS, deprecated: 26.0)\n" +
-        "@available(tvOS, deprecated: 26.0)\n" +
-        "private func makeLegacyRootWindow() -> UIWindow {\n" +
-        "  UIWindow(frame: UIScreen.main.bounds)\n" +
-        "}\n" +
-        "#endif\n";
-
-      const windowPatched = source.replace(legacyWindowCreation, sceneAwareWindowCreation);
-      const openUrlPatched = windowPatched.includes(annotatedOpenUrlSignature)
-        ? windowPatched
-        : windowPatched.replace(legacyOpenUrlSignature, annotatedOpenUrlSignature);
-      const helpersPatched = openUrlPatched.includes("private func makeRootWindow(")
-        ? openUrlPatched
-        : openUrlPatched.replace(reactNativeDelegateMarker, `${rootWindowHelpers}${reactNativeDelegateMarker}`);
-
-      if (helpersPatched !== source) {
-        writeFileSync(appDelegatePath, helpersPatched);
-      }
-
-      return modConfig;
-    },
-  ]);
-
-// ---------------------------------------------------------------------------
-// Plugin composition
-// ---------------------------------------------------------------------------
-
 const withAppGroupEntitlement = (config) => {
   const appGroup = getAppGroup(config);
 
@@ -347,8 +288,7 @@ const withFidyWidget = (config) => {
     DEPLOYMENT_TARGET
   );
   const configWithExtension = withWidgetExtensionTarget(configWithPodsDeploymentTarget);
-  const configWithAppDelegateCompatibility =
-    markAppDelegateIos26Compatibility(configWithExtension);
+  const configWithAppDelegateCompatibility = markAppDelegateIos26Compatibility(configWithExtension);
   return configWithAppDelegateCompatibility;
 };
 

--- a/apps/mobile/plugins/withFidyWidget.js
+++ b/apps/mobile/plugins/withFidyWidget.js
@@ -11,9 +11,12 @@
 const {
   createRunOncePlugin,
   withEntitlementsPlist,
+  withDangerousMod,
   withInfoPlist,
   withXcodeProject,
 } = require("expo/config-plugins");
+const { readFileSync, writeFileSync } = require("node:fs");
+const path = require("node:path");
 const {
   reconcileAppDeploymentTarget,
   withIosDeploymentTarget,
@@ -239,6 +242,59 @@ const addWidgetExtensionTarget = (project, config) => {
   reconcileBuildSettings(project, settings);
 };
 
+const markAppDelegateIos26Compatibility = (config) =>
+  withDangerousMod(config, [
+    "ios",
+    (modConfig) => {
+      const appDelegatePath = path.join(
+        modConfig.modRequest.platformProjectRoot,
+        modConfig.modRequest.projectName,
+        "AppDelegate.swift"
+      );
+      const source = readFileSync(appDelegatePath, "utf8");
+      const legacyWindowCreation =
+        "    window = UIWindow(frame: UIScreen.main.bounds)\n" +
+        "    factory.startReactNative(\n";
+      const sceneAwareWindowCreation =
+        "    window = makeRootWindow(for: application)\n" +
+        "    factory.startReactNative(\n";
+      const legacyOpenUrlSignature = "  public override func application(\n    _ app: UIApplication,";
+      const annotatedOpenUrlSignature =
+        "  @available(iOS, introduced: 9.0, deprecated: 26.0)\n  public override func application(\n    _ app: UIApplication,";
+      const reactNativeDelegateMarker = "\nclass ReactNativeDelegate: ExpoReactNativeFactoryDelegate {";
+      const rootWindowHelpers =
+        "\n#if os(iOS) || os(tvOS)\n" +
+        "private func makeRootWindow(for application: UIApplication) -> UIWindow {\n" +
+        "  if let windowScene = application.connectedScenes.compactMap({ $0 as? UIWindowScene }).first {\n" +
+        "    return UIWindow(windowScene: windowScene)\n" +
+        "  }\n" +
+        "\n" +
+        "  return makeLegacyRootWindow()\n" +
+        "}\n" +
+        "\n" +
+        "@available(iOS, deprecated: 26.0)\n" +
+        "@available(tvOS, deprecated: 26.0)\n" +
+        "private func makeLegacyRootWindow() -> UIWindow {\n" +
+        "  UIWindow(frame: UIScreen.main.bounds)\n" +
+        "}\n" +
+        "#endif\n";
+
+      const windowPatched = source.replace(legacyWindowCreation, sceneAwareWindowCreation);
+      const openUrlPatched = windowPatched.includes(annotatedOpenUrlSignature)
+        ? windowPatched
+        : windowPatched.replace(legacyOpenUrlSignature, annotatedOpenUrlSignature);
+      const helpersPatched = openUrlPatched.includes("private func makeRootWindow(")
+        ? openUrlPatched
+        : openUrlPatched.replace(reactNativeDelegateMarker, `${rootWindowHelpers}${reactNativeDelegateMarker}`);
+
+      if (helpersPatched !== source) {
+        writeFileSync(appDelegatePath, helpersPatched);
+      }
+
+      return modConfig;
+    },
+  ]);
+
 // ---------------------------------------------------------------------------
 // Plugin composition
 // ---------------------------------------------------------------------------
@@ -291,7 +347,9 @@ const withFidyWidget = (config) => {
     DEPLOYMENT_TARGET
   );
   const configWithExtension = withWidgetExtensionTarget(configWithPodsDeploymentTarget);
-  return configWithExtension;
+  const configWithAppDelegateCompatibility =
+    markAppDelegateIos26Compatibility(configWithExtension);
+  return configWithAppDelegateCompatibility;
 };
 
 module.exports = createRunOncePlugin(withFidyWidget, "withFidyWidget", "1.0.0");

--- a/apps/mobile/supabase/migrations/20260518152000_parse_improvement_email_context.sql
+++ b/apps/mobile/supabase/migrations/20260518152000_parse_improvement_email_context.sql
@@ -1,0 +1,16 @@
+alter table public.notification_parse_improvement_samples
+  add column if not exists sender_domain text;
+
+alter table public.notification_parse_improvement_samples
+  drop constraint if exists notification_parse_improvement_samples_sender_domain_check;
+
+alter table public.notification_parse_improvement_samples
+  add constraint notification_parse_improvement_samples_sender_domain_check
+  check (
+    sender_domain is null
+    or sender_domain ~ '^[a-z0-9][a-z0-9.-]*\.[a-z]{2,}$'
+  );
+
+create index if not exists idx_notification_parse_samples_sender_domain
+  on public.notification_parse_improvement_samples (sender_domain, review_status, created_at desc)
+  where sender_domain is not null;

--- a/apps/mobile/supabase/migrations/20260518190500_trigger_parse_improvement_context_deploy.sql
+++ b/apps/mobile/supabase/migrations/20260518190500_trigger_parse_improvement_context_deploy.sql
@@ -1,0 +1,4 @@
+do $$
+begin
+  null;
+end $$;

--- a/apps/mobile/supabase/migrations/20260518190500_trigger_parse_improvement_context_deploy.sql
+++ b/apps/mobile/supabase/migrations/20260518190500_trigger_parse_improvement_context_deploy.sql
@@ -1,4 +1,0 @@
-do $$
-begin
-  null;
-end $$;


### PR DESCRIPTION
- patch generated AppDelegate window setup

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silences iOS 26 window warnings by making the AppDelegate scene-aware and hardening the patcher. Adds regex-first parsing for known bank notifications and emails, with LLM fallback and anonymized template capture.

- **Bug Fixes**
  - `withFidyWidget`: creates the root window from `UIWindowScene`, annotates legacy APIs, moves the patcher into a helper, and hardens it with tolerant Swift patterns that fail fast on unexpected shapes; reconciles the iOS deployment target.
  - Email capture: derives the evidence source id from the inserted processed event to prevent mismatched ids.

- **New Features**
  - Uses deterministic regex parsing for known Android notification packages and bank email domains; falls back to the LLM only when regex can’t parse and records a `parserTemplate` for misses.
  - Stores anonymized `parserTemplate` and `sender_domain` in parse-improvement requests with `parseMethod: regex` (adds column, check, and index in Supabase); adds email parser template builder and regex helpers to normalize text and redact PII.

<sup>Written for commit 23f88657e94ef1d3791bf47f4e385dc2f10cf646. Summary will update on new commits. <a href="https://cubic.dev/pr/B4rz99/fidy/pull/472?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

