### PR TITLE
fix(mobile): sharpen ux copy

### DIFF
--- a/apps/mobile/__tests__/error-handling/error-boundary.test.ts
+++ b/apps/mobile/__tests__/error-handling/error-boundary.test.ts
@@ -29,8 +29,8 @@ describe("ErrorFallback component", () => {
       "utf-8"
     );
 
-    expect(source).toContain("Something went wrong");
-    expect(source).toContain("Restart App");
+    expect(source).toContain('t("errorFallback.title")');
+    expect(source).toContain('t("errorFallback.restart")');
     expect(source).toContain("reloadAsync");
   });
 

--- a/apps/mobile/__tests__/i18n/i18n.test.ts
+++ b/apps/mobile/__tests__/i18n/i18n.test.ts
@@ -43,7 +43,7 @@ describe("i18n core", () => {
     const { default: i18n } = await import("@/shared/i18n/i18n");
     i18n.locale = "es";
     expect(i18n.t("bills.deleteBillConfirm", { billName: "Netflix" })).toBe(
-      '¿Estás seguro de que quieres eliminar "Netflix"?'
+      '¿Eliminar "Netflix"? Se detendrán los recordatorios futuros de este gasto fijo.'
     );
   });
 });

--- a/apps/mobile/features/dashboard/components/home-screen/useHomeActivityFeed.ts
+++ b/apps/mobile/features/dashboard/components/home-screen/useHomeActivityFeed.ts
@@ -144,9 +144,9 @@ export function useHomeActivityFeed({
   const onDeleteTransaction = useCallback(
     (id: TransactionId) => {
       Alert.alert(t("transactions.deleteConfirmTitle"), t("transactions.deleteConfirmMessage"), [
-        { text: t("common.cancel"), style: "cancel" },
+        { text: t("transactions.keepTransaction"), style: "cancel" },
         {
-          text: t("common.delete"),
+          text: t("transactions.deleteTransaction"),
           style: "destructive",
           onPress: () => {
             if (!db || !userId) return;

--- a/apps/mobile/features/goals/components/goal-sheet/useGoalEditActions.ts
+++ b/apps/mobile/features/goals/components/goal-sheet/useGoalEditActions.ts
@@ -78,9 +78,9 @@ function showDeleteConfirmation({
     t("goals.edit.deleteConfirmTitle"),
     t("goals.edit.deleteConfirmMessage", { goalName }),
     [
-      { text: t("common.cancel"), style: "cancel" },
+      { text: t("goals.edit.keepGoal"), style: "cancel" },
       {
-        text: t("common.delete"),
+        text: t("goals.edit.deleteGoal"),
         style: "destructive",
         onPress: () => {
           const db = tryGetDb(userId);

--- a/apps/mobile/features/goals/components/goal-sheet/useGoalEditActions.ts
+++ b/apps/mobile/features/goals/components/goal-sheet/useGoalEditActions.ts
@@ -75,7 +75,7 @@ function showDeleteConfirmation({
   readonly userId: UserId;
 }) {
   Alert.alert(
-    t("goals.edit.deleteConfirmTitle"),
+    t("goals.edit.deleteConfirmTitle", { goalName }),
     t("goals.edit.deleteConfirmMessage", { goalName }),
     [
       { text: t("goals.edit.keepGoal"), style: "cancel" },

--- a/apps/mobile/features/settings/components/ProfileScreen.tsx
+++ b/apps/mobile/features/settings/components/ProfileScreen.tsx
@@ -31,7 +31,7 @@ export function ProfileScreen() {
 
   const handleLogOut = () => {
     Alert.alert(t("settings.logoutConfirmTitle"), t("settings.logoutConfirmMessage"), [
-      { text: t("common.cancel"), style: "cancel" },
+      { text: t("settings.staySignedIn"), style: "cancel" },
       {
         text: t("settings.logout"),
         style: "destructive",
@@ -111,7 +111,7 @@ export function ProfileScreen() {
             </Text>
           </Pressable>
 
-          {/* Log Out Button */}
+          {/* Sign-out button */}
           <Pressable
             onPress={handleLogOut}
             className="flex-row items-center justify-center bg-card dark:bg-card-dark rounded-2xl w-full"

--- a/apps/mobile/shared/components/ErrorFallback.tsx
+++ b/apps/mobile/shared/components/ErrorFallback.tsx
@@ -1,8 +1,11 @@
 import * as Updates from "expo-updates";
 import { Image, Pressable, Text, View } from "@/shared/components/rn";
 import { Colors } from "@/shared/constants/theme";
+import { useTranslation } from "@/shared/hooks/use-translation";
 
 export function ErrorFallback() {
+  const { t } = useTranslation();
+
   return (
     <View
       style={{
@@ -27,7 +30,7 @@ export function ErrorFallback() {
           textAlign: "center",
         }}
       >
-        Something went wrong
+        {t("errorFallback.title")}
       </Text>
       <Text
         style={{
@@ -39,7 +42,7 @@ export function ErrorFallback() {
           lineHeight: 22,
         }}
       >
-        {"Don't worry — your data is safe.\nPlease restart the app to continue."}
+        {t("errorFallback.body")}
       </Text>
       <Pressable
         onPress={() => {
@@ -60,7 +63,7 @@ export function ErrorFallback() {
             color: Colors.light.card,
           }}
         >
-          Restart App
+          {t("errorFallback.restart")}
         </Text>
       </Pressable>
     </View>

--- a/apps/mobile/shared/i18n/locales/en.ts
+++ b/apps/mobile/shared/i18n/locales/en.ts
@@ -104,24 +104,24 @@ const en = {
     expense: "Expense",
     income: "Income",
     saved: "Transaction saved",
-    saveTransaction: "Save Transaction",
+    saveTransaction: "Save transaction",
     descriptionOptional: "Description (optional)",
     noTransactionsYet: "No transactions yet",
-    noTransactionsHint: "Connect an email account or add transactions manually to get started",
-    deleteConfirmTitle: "Delete Transaction",
-    deleteConfirmMessage: "Are you sure you want to delete this transaction?",
-    editTransaction: "Edit Transaction",
-    deleteTransaction: "Delete",
+    noTransactionsHint: "Connect an email account or add your first transaction.",
+    deleteConfirmTitle: "Delete transaction?",
+    deleteConfirmMessage: "It will no longer count in your spending, budgets, or reports.",
+    keepTransaction: "Keep transaction",
+    deleteTransaction: "Delete transaction",
+    editTransaction: "Edit transaction",
     convertToTransfer: "Convert to transfer",
-    updateFailed: "Could not update transaction",
-    deleteFailed: "Could not delete transaction",
+    updateFailed: "Transaction was not updated. Check the details and try again.",
+    deleteFailed: "Transaction was not deleted. Check your connection and try again.",
   },
 
   transfers: {
     title: "New transfer",
     reclassifyTitle: "Convert to transfer",
-    subtitle:
-      "Transfers move money between accounts or between one tracked account and an explicit outside-fidy side.",
+    subtitle: "Transfers move money between tracked accounts, cash, or another untracked account.",
     reclassifySubtitle:
       "Replace this captured transaction with the transfer it actually represents, without losing the original evidence.",
     outsideSubtitle:
@@ -133,14 +133,14 @@ const en = {
     toLabel: "To",
     dateLabel: "Transfer date",
     chooseSide: "Choose side",
-    chooseSideHint: "Choose an account or Outside Fidy",
+    chooseSideHint: "Choose an account, cash, or another untracked account",
     chooseDifferentSide: "Choose different side",
     saved: "Transfer saved",
     save: "Record transfer",
     outsideFidy: "Outside Fidy",
-    outsideFidyDescription: "Cash or another untracked side",
+    outsideFidyDescription: "Cash or another untracked account",
     outsideHint:
-      "Need cash or another untracked side? Choose it explicitly from the side picker instead of saving a fake expense.",
+      "Need cash or another untracked account? Choose it explicitly instead of saving a fake expense.",
     reclassifyHint:
       "Saving will supersede the original transaction, keep the capture evidence attached, and stop the old record from counting as spending.",
     outsideSelectedHint:
@@ -149,7 +149,7 @@ const en = {
       "Choose two different sides. A transfer cannot start and end in the same financial account.",
     pickerTitle: "Choose transfer side",
     pickerSubtitle:
-      "Pick a tracked financial account, or explicitly choose an outside-Fidy side for cash or external funding.",
+      "Pick a tracked financial account, or choose Outside Fidy for cash or external funding.",
     a11y: {
       amountField: "Edit transfer amount",
       selectSide: "Select %{side} side",
@@ -161,7 +161,7 @@ const en = {
       trackedAccountRequired: "At least one side must be a tracked account",
       distinctSidesRequired: "Choose two different sides",
       reclassifyFailed: "Could not convert this transaction into a transfer",
-      saveFailed: "Could not save transfer",
+      saveFailed: "Transfer was not saved. Check both sides and try again.",
     },
     reclassifySave: "Convert to transfer",
     activity: {
@@ -192,7 +192,7 @@ const en = {
       settingsRow: "Financial accounts",
       title: "Financial accounts",
       subtitle:
-        "Create and edit the accounts you use for balances, transfers, and manual entry. Connected capture sources stay in Connected Accounts.",
+        "Create and edit the accounts you use for balances, transfers, and manual entry. Email and notification capture stay in Connected accounts.",
       regularSection: "Cash and bank accounts",
       creditSection: "Credit cards",
       emptyTitle: "No financial accounts yet",
@@ -217,7 +217,7 @@ const en = {
       editCta: "Edit account",
       billingGapTitle: "Card cycle dates missing",
       billingGapBody:
-        "Statement-aware card features stay off until you add fecha de corte and fecha limite de pago.",
+        "Statement-aware card features stay off until you add the statement closing day and payment due day.",
     },
     form: {
       createTitle: "Add account",
@@ -233,7 +233,7 @@ const en = {
       datePlaceholder: "Choose a date",
       dayPlaceholder: "Day",
       billingHint:
-        "Optional. Add fecha de corte and fecha limite de pago later if you do not have them yet.",
+        "Optional. Add the statement closing day and payment due day later if you do not have them yet.",
       statementClosingDay: "Fecha de corte",
       paymentDueDay: "Fecha limite de pago",
       saveCreate: "Create account",
@@ -245,7 +245,7 @@ const en = {
       missingCta: "Back to accounts",
       invalidOpeningBalance: "Add both an amount and an effective date, or leave both empty.",
       invalidBillingDay: "Enter a day between 1 and 31.",
-      saveFailed: "Could not save account",
+      saveFailed: "Account was not saved. Check the details and try again.",
     },
     identifierSheet: {
       title: "Add identifier",
@@ -254,20 +254,20 @@ const en = {
       placeholder: "e.g. Visa gold",
       note: "Keep it short and stable. You can add more hints later.",
       save: "Save identifier",
-      saveFailed: "Could not save identifier",
+      saveFailed: "Identifier was not saved. Try again.",
     },
   },
 
   // Bills / Calendar
   bills: {
-    addBill: "Add Bill",
-    editBill: "Edit Bill",
+    addBill: "Add bill",
+    editBill: "Edit bill",
     frequency: "Frequency",
-    startDate: "Start Date",
-    saveChanges: "Save Changes",
+    startDate: "Start date",
+    saveChanges: "Save changes",
     add: "Add",
-    deleteBill: "Delete Bill",
-    deleteBillConfirm: 'Are you sure you want to delete "%{billName}"?',
+    deleteBill: "Delete bill",
+    deleteBillConfirm: 'Delete "%{billName}"? Future reminders for this bill will stop.',
     noBillsOnDay: "No bills on this day",
     weekly: "Weekly",
     biweekly: "Biweekly",
@@ -310,7 +310,7 @@ const en = {
       nameTooLong: "Name must be under 32 characters",
       iconRequired: "Please select an icon",
       colorRequired: "Please select a color",
-      saveFailed: "Could not save category",
+      saveFailed: "Category was not saved. Choose a name, icon, and color, then try again.",
     },
   },
 
@@ -324,13 +324,13 @@ const en = {
       createManually: "Create manually",
     },
     create: {
-      title: "Create Budget",
+      title: "Create budget",
       selectCategory: "Select a category",
       enterAmount: "Monthly budget amount",
       lastMonthHint: "You spent %{amount} on %{category} last month",
     },
     edit: {
-      title: "Edit Budget",
+      title: "Edit budget",
     },
     card: {
       remaining: "%{amount} remaining",
@@ -338,7 +338,7 @@ const en = {
       used: "%{percent}% used",
     },
     summary: {
-      totalBudget: "Total Budget",
+      totalBudget: "Total budget",
       used: "%{percent}% used",
     },
     alerts: {
@@ -348,14 +348,14 @@ const en = {
       overBudget: "%{category} is over budget at %{percent}%",
     },
     autoSuggest: {
-      title: "Auto-setup Budgets",
+      title: "Auto-setup budgets",
       subtitle: "Based on last month's spending",
       skipAll: "Skip",
       acceptSelected: "Accept selected",
       noSuggestions: "No spending data from last month",
     },
     upcomingBills: {
-      title: "Upcoming Bills",
+      title: "Upcoming bills",
       seeAll: "See all",
       noBills: "No upcoming bills",
     },
@@ -375,7 +375,7 @@ const en = {
       createGoal: "Create a goal",
     },
     create: {
-      title: "Create Goal",
+      title: "Create goal",
       goalName: "Goal name",
       goalNamePlaceholder: "e.g., Trip to Holland",
       targetAmount: "Target amount",
@@ -387,17 +387,18 @@ const en = {
       noProjectionHint: "Add income transactions for a projection",
     },
     edit: {
-      title: "Edit Goal",
-      saveChanges: "Save Changes",
-      deleteGoal: "Delete Goal",
-      deleteConfirmTitle: "Delete Goal",
-      deleteConfirmMessage: 'Are you sure you want to delete "%{goalName}"?',
+      title: "Edit goal",
+      saveChanges: "Save changes",
+      deleteGoal: "Delete goal",
+      deleteConfirmTitle: 'Delete "%{goalName}"?',
+      deleteConfirmMessage: "This will remove the goal and its contribution history.",
+      keepGoal: "Keep goal",
     },
     card: {
       installments: "%{current}/%{total}",
       almostThere: "Almost there!",
       completed: "Completed!",
-      addPayment: "+ Add Payment",
+      addPayment: "+ Add payment",
       paceAhead: "↑ Ahead %{amount}",
       paceBehind: "↓ Behind %{amount}",
       startSaving: "Start saving",
@@ -412,7 +413,7 @@ const en = {
       paymentTooLow: "Payment doesn't cover interest",
       progress: "%{percent}% complete",
       remaining: "%{amount} remaining",
-      addPayment: "Add Payment",
+      addPayment: "Add payment",
       noContributions: "No contributions yet",
       contributionNote: "Note: %{note}",
       recommendation: "Fidy's recommendation",
@@ -422,8 +423,8 @@ const en = {
       manualPayment: "Manual payment",
     },
     payment: {
-      title: "Add Payment",
-      addPaymentCta: "+ Add Payment",
+      title: "Add payment",
+      addPaymentCta: "+ Add payment",
       amount: "Amount",
       noteOptional: "Note (optional)",
       notePlaceholder: "e.g., Monthly savings",
@@ -475,7 +476,7 @@ const en = {
 
   // Connected Accounts
   connectedAccounts: {
-    title: "Connected Accounts",
+    title: "Connected accounts",
     subtitle:
       "Manage your connected accounts and capture sources for automatic transaction tracking.",
     connected: "Connected",
@@ -611,7 +612,7 @@ const en = {
 
   // AI Chat
   aiChat: {
-    title: "AI Chat",
+    title: "AI chat",
     fidyAi: "Fidy AI",
     memories: "Memory",
     newChat: "New chat",
@@ -658,13 +659,13 @@ const en = {
     language: "Language",
     languageEnglish: "English",
     languageSpanish: "Español",
-    connectedEmails: "Connected Emails",
+    connectedEmails: "Connected emails",
     connectedEmailsCount: {
       one: "%{count} account",
       other: "%{count} accounts",
     },
     notifications: "Notifications",
-    privateBackup: "Private Backup",
+    privateBackup: "Private backup",
     parseImprovementSharing: "Improve capture parsing",
     parseImprovementSharingSubtitle:
       "Share redacted email and notification formats when parsing struggles. Amounts, merchants, dates, names, and cards are removed first.",
@@ -676,25 +677,26 @@ const en = {
     },
     on: "On",
     off: "Off",
-    helpSupport: "Help & Support",
-    privacyPolicy: "Privacy Policy",
-    termsOfService: "Terms of Service",
+    helpSupport: "Help & support",
+    privacyPolicy: "Privacy policy",
+    termsOfService: "Terms of service",
     designSystem: "Design system",
     designSystemSubtitle: "Preview shared UI components",
     version: "Version",
-    deleteAccount: "Delete Account",
-    deleteAccountTitle: "Delete Account",
+    deleteAccount: "Delete account",
+    deleteAccountTitle: "Delete account",
     deleteAccountWarning:
       "This will permanently delete your account, encrypted backups, and all remote data. Old encrypted backups cannot be recovered after deletion.",
     deleteAccountUnsyncedWarning: {
       one: "You have %{count} unsynced change that will be lost.",
       other: "You have %{count} unsynced changes that will be lost.",
     },
-    deleteAccountConfirm: "Delete My Account",
+    deleteAccountConfirm: "Delete my account",
     profileTitle: "Profile",
-    logout: "Log Out",
-    logoutConfirmTitle: "Log Out",
-    logoutConfirmMessage: "Are you sure you want to log out?",
+    logout: "Log out",
+    logoutConfirmTitle: "Log out?",
+    logoutConfirmMessage: "You will need to sign in again to sync or restore backups.",
+    staySignedIn: "Stay signed in",
     localQaTitle: "Local QA",
     localQaDescription: "Reset or switch local-only QA scenarios without touching a real account.",
     localQaReset: "Reset current scenario",
@@ -727,9 +729,9 @@ const en = {
   },
 
   privateBackup: {
-    title: "Private Backup",
+    title: "Private backup",
     status: {
-      notSetUp: "Private Backup off",
+      notSetUp: "Private backup off",
       recoveryKeyNotConfirmed: "Save Recovery Key",
       ready: "Recovery Key saved",
       backupFailed: "Backup needs retry",
@@ -739,10 +741,10 @@ const en = {
       "Fidy can save a backup that only your Recovery Key or a trusted device can unlock.",
     confirmTitle: "Save your Recovery Key now",
     confirmBody:
-      "Same-device restore can stay quiet, but a new phone needs your saved Recovery Key. Fidy cannot recreate it later.",
+      "This device can restore without asking for the key, but a new phone needs your saved Recovery Key. Fidy cannot recreate it later.",
     readyTitle: "Your backup is healthy",
     readyBody:
-      "This device can restore quietly, and a new phone can unlock the same backup with your saved Recovery Key.",
+      "This device can restore without asking for the key, and a new phone can unlock the same backup with your saved Recovery Key.",
     failedTitle: "Backup upload failed",
     failedBody: "Your current phone still has your data. Retry when your connection is steady.",
     recoveryKeyLabel: "Recovery Key",
@@ -752,7 +754,7 @@ const en = {
     saveKey: "Save Recovery Key",
     savingBackup: "Saving backup...",
     finishLater: "Finish later",
-    setUp: "Set up Private Backup",
+    setUp: "Set up private backup",
     retryBackup: "Retry backup",
     viewKey: "View key",
     rotateKey: "Rotate key",
@@ -782,6 +784,12 @@ const en = {
     body: "We can share this redacted format to improve future parsing:\n\n%{template}\n\nAmounts, merchants, dates, names, and cards are removed first.",
     share: "Share redacted format",
     notNow: "Not now",
+  },
+
+  errorFallback: {
+    title: "Fidy could not load this screen",
+    body: "Close and reopen the app. If it keeps happening, your local data is still on this device.",
+    restart: "Restart app",
   },
 
   qaTools: {
@@ -868,11 +876,11 @@ const en = {
 
   // Notification Capture
   notificationCapture: {
-    title: "Notification Capture",
+    title: "Notification capture",
     description: "Automatically capture transactions from your bank app notifications.",
     listening: "Listening",
     permissionRequired: "Permission required",
-    grantAccess: "Grant Access",
+    grantAccess: "Grant access",
   },
 
   // Apple Pay / SMS
@@ -938,7 +946,7 @@ const en = {
     welcome: {
       hero: "Your finances, on autopilot",
       subtitle: "Connect your email and let Fidy capture your transactions automatically.",
-      getStarted: "Get Started",
+      getStarted: "Get started",
       alreadyHaveAccount: "I already have an account",
     },
     connectEmail: {
@@ -969,14 +977,14 @@ const en = {
       subtitle: "Based on your recent spending",
       perMonth: "/month",
       basedOnSpending: "Based on last month's spending",
-      saveBudgets: "Save Budgets",
+      saveBudgets: "Save budgets",
       skipForNow: "Skip for now",
       noSuggestions: "No spending data yet — you can set budgets later from the Budgets tab.",
     },
     complete: {
       title: "You're all set!",
       stats: "We found %{transactionCount} transactions and set up %{budgetCount} budgets for you.",
-      goToDashboard: "Go to Dashboard",
+      goToDashboard: "Go to dashboard",
     },
   },
 
@@ -1077,11 +1085,11 @@ const en = {
 
     // Pre-permission screen
     enableNotifications: {
-      title: "Stay on Top of Your Finances",
+      title: "Stay on top of your finances",
       description:
         "Fidy can alert you when you're approaching your budget limit, celebrate your goal milestones, and send a weekly summary of your finances.",
-      enable: "Enable Notifications",
-      notNow: "Not Now",
+      enable: "Enable notifications",
+      notNow: "Not now",
     },
   },
 

--- a/apps/mobile/shared/i18n/locales/en.ts
+++ b/apps/mobile/shared/i18n/locales/en.ts
@@ -391,7 +391,7 @@ const en = {
       saveChanges: "Save changes",
       deleteGoal: "Delete goal",
       deleteConfirmTitle: 'Delete "%{goalName}"?',
-      deleteConfirmMessage: "This will remove the goal and its contribution history.",
+      deleteConfirmMessage: "This will remove the goal from your active goals.",
       keepGoal: "Keep goal",
     },
     card: {

--- a/apps/mobile/shared/i18n/locales/es.ts
+++ b/apps/mobile/shared/i18n/locales/es.ts
@@ -107,25 +107,25 @@ const es = {
     expense: "Gasto",
     income: "Ingreso",
     saved: "Transacción guardada",
-    saveTransaction: "Guardar Transacción",
+    saveTransaction: "Guardar transacción",
     descriptionOptional: "Descripción (opcional)",
     noTransactionsYet: "Aún no hay transacciones",
-    noTransactionsHint:
-      "Conecta una cuenta de correo o agrega transacciones manualmente para comenzar",
-    deleteConfirmTitle: "Eliminar Transacción",
-    deleteConfirmMessage: "¿Estás seguro de que quieres eliminar esta transacción?",
-    editTransaction: "Editar Transacción",
-    deleteTransaction: "Eliminar",
+    noTransactionsHint: "Conecta un correo o agrega tu primera transacción.",
+    deleteConfirmTitle: "¿Eliminar transacción?",
+    deleteConfirmMessage: "Ya no contará en tus gastos, presupuestos ni reportes.",
+    keepTransaction: "Conservar transacción",
+    deleteTransaction: "Eliminar transacción",
+    editTransaction: "Editar transacción",
     convertToTransfer: "Convertir en transferencia",
-    updateFailed: "No se pudo actualizar la transacción",
-    deleteFailed: "No se pudo eliminar la transacción",
+    updateFailed: "La transacción no se actualizó. Revisa los datos e intenta de nuevo.",
+    deleteFailed: "La transacción no se eliminó. Revisa tu conexión e intenta de nuevo.",
   },
 
   transfers: {
     title: "Nueva transferencia",
     reclassifyTitle: "Convertir en transferencia",
     subtitle:
-      "Las transferencias mueven dinero entre cuentas o entre una cuenta rastreada y un lado explícito fuera de Fidy.",
+      "Las transferencias mueven dinero entre cuentas rastreadas, efectivo u otra cuenta sin seguimiento.",
     reclassifySubtitle:
       "Reemplaza esta transacción capturada por la transferencia que realmente representa, sin perder la evidencia original.",
     outsideSubtitle:
@@ -137,14 +137,14 @@ const es = {
     toLabel: "Hacia",
     dateLabel: "Fecha de transferencia",
     chooseSide: "Elegir lado",
-    chooseSideHint: "Elige una cuenta o Fuera de Fidy",
+    chooseSideHint: "Elige una cuenta, efectivo u otra cuenta sin seguimiento",
     chooseDifferentSide: "Elige otro lado",
     saved: "Transferencia guardada",
     save: "Registrar transferencia",
     outsideFidy: "Fuera de Fidy",
-    outsideFidyDescription: "Efectivo u otro lado no rastreado",
+    outsideFidyDescription: "Efectivo u otra cuenta sin seguimiento",
     outsideHint:
-      "¿Necesitas efectivo u otro lado no rastreado? Elígelo explícitamente en el selector en lugar de guardar un gasto falso.",
+      "¿Necesitas efectivo u otra cuenta sin seguimiento? Elígela explícitamente en lugar de guardar un gasto falso.",
     reclassifyHint:
       "Al guardar se sustituirá la transacción original, la evidencia de captura seguirá adjunta y el registro viejo dejará de contar como gasto.",
     outsideSelectedHint:
@@ -153,7 +153,7 @@ const es = {
       "Elige dos lados distintos. Una transferencia no puede empezar y terminar en la misma cuenta financiera.",
     pickerTitle: "Elige el lado de la transferencia",
     pickerSubtitle:
-      "Elige una cuenta financiera rastreada, o selecciona explícitamente un lado fuera de Fidy para efectivo o fondos externos.",
+      "Elige una cuenta financiera rastreada, o elige Fuera de Fidy para efectivo o fondos externos.",
     a11y: {
       amountField: "Editar monto de la transferencia",
       selectSide: "Seleccionar lado %{side}",
@@ -165,7 +165,7 @@ const es = {
       trackedAccountRequired: "Al menos un lado debe ser una cuenta rastreada",
       distinctSidesRequired: "Elige dos lados distintos",
       reclassifyFailed: "No se pudo convertir esta transacción en transferencia",
-      saveFailed: "No se pudo guardar la transferencia",
+      saveFailed: "La transferencia no se guardó. Revisa ambos lados e intenta de nuevo.",
     },
     reclassifySave: "Convertir en transferencia",
     activity: {
@@ -196,7 +196,7 @@ const es = {
       settingsRow: "Cuentas financieras",
       title: "Cuentas financieras",
       subtitle:
-        "Crea y edita las cuentas que usas para saldos, transferencias y registro manual. Las fuentes de captura siguen en Cuentas conectadas.",
+        "Crea y edita las cuentas que usas para saldos, transferencias y registro manual. La captura de correos y notificaciones sigue en Cuentas conectadas.",
       regularSection: "Efectivo y bancos",
       creditSection: "Tarjetas de crédito",
       emptyTitle: "Aún no hay cuentas financieras",
@@ -222,7 +222,7 @@ const es = {
       editCta: "Editar cuenta",
       billingGapTitle: "Faltan fechas del ciclo",
       billingGapBody:
-        "Las funciones de tarjetas por ciclo seguirán apagadas hasta que agregues fecha de corte y fecha limite de pago.",
+        "Las funciones de tarjetas por ciclo seguirán apagadas hasta que agregues el día de corte y el día límite de pago.",
     },
     form: {
       createTitle: "Agregar cuenta",
@@ -238,7 +238,7 @@ const es = {
       datePlaceholder: "Elige una fecha",
       dayPlaceholder: "Día",
       billingHint:
-        "Opcional. Agrega fecha de corte y fecha limite de pago después si todavía no las tienes.",
+        "Opcional. Agrega el día de corte y el día límite de pago después si todavía no los tienes.",
       statementClosingDay: "Fecha de corte",
       paymentDueDay: "Fecha limite de pago",
       saveCreate: "Crear cuenta",
@@ -251,7 +251,7 @@ const es = {
       invalidOpeningBalance:
         "Agrega monto y fecha efectiva al mismo tiempo, o deja ambos campos vacíos.",
       invalidBillingDay: "Ingresa un día entre 1 y 31.",
-      saveFailed: "No se pudo guardar la cuenta",
+      saveFailed: "La cuenta no se guardó. Revisa los datos e intenta de nuevo.",
     },
     identifierSheet: {
       title: "Agregar identificador",
@@ -260,20 +260,21 @@ const es = {
       placeholder: "ej. Visa gold",
       note: "Mantenlo corto y estable. Puedes agregar más pistas después.",
       save: "Guardar identificador",
-      saveFailed: "No se pudo guardar el identificador",
+      saveFailed: "El identificador no se guardó. Intenta de nuevo.",
     },
   },
 
   // Bills / Calendar
   bills: {
-    addBill: "Agregar Gasto Fijo",
-    editBill: "Editar Gasto Fijo",
+    addBill: "Agregar gasto fijo",
+    editBill: "Editar gasto fijo",
     frequency: "Frecuencia",
     startDate: "Fecha de inicio",
-    saveChanges: "Guardar Cambios",
+    saveChanges: "Guardar cambios",
     add: "Agregar",
-    deleteBill: "Eliminar Gasto Fijo",
-    deleteBillConfirm: '¿Estás seguro de que quieres eliminar "%{billName}"?',
+    deleteBill: "Eliminar gasto fijo",
+    deleteBillConfirm:
+      '¿Eliminar "%{billName}"? Se detendrán los recordatorios futuros de este gasto fijo.',
     noBillsOnDay: "No hay gastos fijos este día",
     weekly: "Semanal",
     biweekly: "Quincenal",
@@ -316,7 +317,7 @@ const es = {
       nameTooLong: "El nombre debe tener menos de 32 caracteres",
       iconRequired: "Por favor selecciona un ícono",
       colorRequired: "Por favor selecciona un color",
-      saveFailed: "No se pudo guardar la categoría",
+      saveFailed: "La categoría no se guardó. Elige nombre, ícono y color, e intenta de nuevo.",
     },
   },
 
@@ -330,13 +331,13 @@ const es = {
       createManually: "Crear manualmente",
     },
     create: {
-      title: "Crear Presupuesto",
+      title: "Crear presupuesto",
       selectCategory: "Selecciona una categoría",
       enterAmount: "Monto del presupuesto mensual",
       lastMonthHint: "Gastaste %{amount} en %{category} el mes pasado",
     },
     edit: {
-      title: "Editar Presupuesto",
+      title: "Editar presupuesto",
     },
     card: {
       remaining: "%{amount} restante",
@@ -344,7 +345,7 @@ const es = {
       used: "%{percent}% usado",
     },
     summary: {
-      totalBudget: "Presupuesto Total",
+      totalBudget: "Presupuesto total",
       used: "%{percent}% usado",
     },
     alerts: {
@@ -354,14 +355,14 @@ const es = {
       overBudget: "%{category} excedió el presupuesto al %{percent}%",
     },
     autoSuggest: {
-      title: "Configurar Presupuestos",
+      title: "Configurar presupuestos",
       subtitle: "Basado en los gastos del mes pasado",
       skipAll: "Omitir",
       acceptSelected: "Aceptar seleccionados",
       noSuggestions: "Sin datos de gastos del mes pasado",
     },
     upcomingBills: {
-      title: "Próximos Gastos Fijos",
+      title: "Próximos gastos fijos",
       seeAll: "Ver todos",
       noBills: "No hay gastos fijos próximos",
     },
@@ -381,7 +382,7 @@ const es = {
       createGoal: "Crear una meta",
     },
     create: {
-      title: "Crear Meta",
+      title: "Crear meta",
       goalName: "Nombre de la meta",
       goalNamePlaceholder: "ej., Viaje a Holanda",
       targetAmount: "Monto objetivo",
@@ -393,17 +394,18 @@ const es = {
       noProjectionHint: "Agrega transacciones de ingreso para una proyección",
     },
     edit: {
-      title: "Editar Meta",
-      saveChanges: "Guardar Cambios",
-      deleteGoal: "Eliminar Meta",
-      deleteConfirmTitle: "Eliminar Meta",
-      deleteConfirmMessage: '¿Estás seguro de que quieres eliminar "%{goalName}"?',
+      title: "Editar meta",
+      saveChanges: "Guardar cambios",
+      deleteGoal: "Eliminar meta",
+      deleteConfirmTitle: '¿Eliminar "%{goalName}"?',
+      deleteConfirmMessage: "Esto eliminará la meta y su historial de contribuciones.",
+      keepGoal: "Conservar meta",
     },
     card: {
       installments: "%{current}/%{total}",
       almostThere: "¡Ya casi!",
       completed: "¡Completado!",
-      addPayment: "+ Agregar Pago",
+      addPayment: "+ Agregar pago",
       paceAhead: "↑ Adelantado %{amount}",
       paceBehind: "↓ Atrasado %{amount}",
       startSaving: "Empieza a ahorrar",
@@ -419,7 +421,7 @@ const es = {
       paymentTooLow: "El pago no cubre los intereses",
       progress: "%{percent}% completado",
       remaining: "%{amount} restante",
-      addPayment: "Agregar Pago",
+      addPayment: "Agregar pago",
       noContributions: "Aún no hay contribuciones",
       contributionNote: "Nota: %{note}",
       recommendation: "Recomendación de Fidy",
@@ -429,8 +431,8 @@ const es = {
       manualPayment: "Pago manual",
     },
     payment: {
-      title: "Agregar Pago",
-      addPaymentCta: "+ Agregar Pago",
+      title: "Agregar pago",
+      addPaymentCta: "+ Agregar pago",
       amount: "Monto",
       noteOptional: "Nota (opcional)",
       notePlaceholder: "ej., Ahorro mensual",
@@ -482,7 +484,7 @@ const es = {
 
   // Connected Accounts
   connectedAccounts: {
-    title: "Cuentas Conectadas",
+    title: "Cuentas conectadas",
     subtitle:
       "Administra tus cuentas conectadas y fuentes de captura para el seguimiento automático de transacciones.",
     connected: "Conectado",
@@ -666,7 +668,7 @@ const es = {
     language: "Idioma",
     languageEnglish: "English",
     languageSpanish: "Español",
-    connectedEmails: "Correos Conectados",
+    connectedEmails: "Correos conectados",
     connectedEmailsCount: {
       one: "%{count} cuenta",
       other: "%{count} cuentas",
@@ -684,25 +686,27 @@ const es = {
     },
     on: "Activadas",
     off: "Desactivadas",
-    helpSupport: "Ayuda y Soporte",
-    privacyPolicy: "Política de Privacidad",
-    termsOfService: "Términos de Servicio",
+    helpSupport: "Ayuda y soporte",
+    privacyPolicy: "Política de privacidad",
+    termsOfService: "Términos de servicio",
     designSystem: "Sistema de diseño",
     designSystemSubtitle: "Previsualiza componentes compartidos",
     version: "Versión",
-    deleteAccount: "Eliminar Cuenta",
-    deleteAccountTitle: "Eliminar Cuenta",
+    deleteAccount: "Eliminar cuenta",
+    deleteAccountTitle: "Eliminar cuenta",
     deleteAccountWarning:
       "Esto eliminará permanentemente tu cuenta, tus copias privadas y todos tus datos remotos. Las copias privadas anteriores no se podrán recuperar después.",
     deleteAccountUnsyncedWarning: {
       one: "Tienes %{count} cambio sin sincronizar que se perderá.",
       other: "Tienes %{count} cambios sin sincronizar que se perderán.",
     },
-    deleteAccountConfirm: "Eliminar Mi Cuenta",
+    deleteAccountConfirm: "Eliminar mi cuenta",
     profileTitle: "Perfil",
-    logout: "Cerrar Sesión",
-    logoutConfirmTitle: "Cerrar Sesión",
-    logoutConfirmMessage: "¿Estás seguro de que quieres cerrar sesión?",
+    logout: "Cerrar sesión",
+    logoutConfirmTitle: "¿Cerrar sesión?",
+    logoutConfirmMessage:
+      "Tendrás que iniciar sesión de nuevo para sincronizar o restaurar copias.",
+    staySignedIn: "Seguir conectado",
     localQaTitle: "QA local",
     localQaDescription:
       "Reinicia o cambia escenarios de QA solo locales sin tocar una cuenta real.",
@@ -748,10 +752,10 @@ const es = {
       "Fidy puede guardar una copia que solo tu Llave de recuperación o un dispositivo confiable pueden abrir.",
     confirmTitle: "Guarda tu Llave de recuperación ahora",
     confirmBody:
-      "Este celular puede restaurar en silencio, pero un celular nuevo necesita tu Llave de recuperación guardada. Fidy no puede recrearla después.",
+      "Este celular puede restaurar sin pedir la llave, pero un celular nuevo necesita tu Llave de recuperación guardada. Fidy no puede recrearla después.",
     readyTitle: "Tu copia está saludable",
     readyBody:
-      "Este dispositivo puede restaurar en silencio, y un celular nuevo puede abrir la misma copia con tu Llave de recuperación guardada.",
+      "Este dispositivo puede restaurar sin pedir la llave, y un celular nuevo puede abrir la misma copia con tu Llave de recuperación guardada.",
     failedTitle: "Falló la subida de la copia",
     failedBody:
       "Tu celular actual todavía tiene tus datos. Reintenta cuando la conexión esté estable.",
@@ -762,7 +766,7 @@ const es = {
     saveKey: "Guardar Llave",
     savingBackup: "Guardando copia...",
     finishLater: "Terminar después",
-    setUp: "Configurar Copia privada",
+    setUp: "Configurar copia privada",
     retryBackup: "Reintentar copia",
     viewKey: "Ver llave",
     rotateKey: "Rotar llave",
@@ -795,6 +799,12 @@ const es = {
     body: "Podemos compartir este formato redactado para mejorar futuras lecturas:\n\n%{template}\n\nPrimero se quitan montos, comercios, fechas, nombres y tarjetas.",
     share: "Compartir formato redactado",
     notNow: "Ahora no",
+  },
+
+  errorFallback: {
+    title: "Fidy no pudo cargar esta pantalla",
+    body: "Cierra y vuelve a abrir la app. Si sigue pasando, tus datos locales siguen en este dispositivo.",
+    restart: "Reiniciar app",
   },
 
   qaTools: {
@@ -885,11 +895,11 @@ const es = {
 
   // Notification Capture
   notificationCapture: {
-    title: "Captura de Notificaciones",
+    title: "Captura de notificaciones",
     description: "Captura automáticamente transacciones de las notificaciones de tu app bancaria.",
     listening: "Escuchando",
     permissionRequired: "Permiso requerido",
-    grantAccess: "Conceder Acceso",
+    grantAccess: "Conceder acceso",
   },
 
   // Apple Pay / SMS (already Spanish)
@@ -986,7 +996,7 @@ const es = {
       subtitle: "Basado en tus gastos recientes",
       perMonth: "/mes",
       basedOnSpending: "Basado en los gastos del mes pasado",
-      saveBudgets: "Guardar Presupuestos",
+      saveBudgets: "Guardar presupuestos",
       skipForNow: "Omitir por ahora",
       noSuggestions:
         "Aún no hay datos de gastos — puedes configurar presupuestos después desde la pestaña de Presupuestos.",
@@ -995,7 +1005,7 @@ const es = {
       title: "¡Todo listo!",
       stats:
         "Encontramos %{transactionCount} transacciones y configuramos %{budgetCount} presupuestos para ti.",
-      goToDashboard: "Ir al Panel",
+      goToDashboard: "Ir al panel",
     },
   },
 
@@ -1096,11 +1106,11 @@ const es = {
 
     // Pantalla de pre-permiso
     enableNotifications: {
-      title: "Mantente al Día con tus Finanzas",
+      title: "Mantente al día con tus finanzas",
       description:
         "Fidy puede alertarte cuando te acerques a tu límite de presupuesto, celebrar los hitos de tus metas, y enviarte un resumen semanal de tus finanzas.",
-      enable: "Activar Notificaciones",
-      notNow: "Ahora No",
+      enable: "Activar notificaciones",
+      notNow: "Ahora no",
     },
   },
 

--- a/apps/mobile/shared/i18n/locales/es.ts
+++ b/apps/mobile/shared/i18n/locales/es.ts
@@ -398,7 +398,7 @@ const es = {
       saveChanges: "Guardar cambios",
       deleteGoal: "Eliminar meta",
       deleteConfirmTitle: '¿Eliminar "%{goalName}"?',
-      deleteConfirmMessage: "Esto eliminará la meta y su historial de contribuciones.",
+      deleteConfirmMessage: "Esto quitará la meta de tus metas activas.",
       keepGoal: "Conservar meta",
     },
     card: {


### PR DESCRIPTION
- clarify high-stakes app copy

- use specific dialog actions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sharpens mobile UX copy and localizes the crash fallback to reduce confusion and prevent mistakes in destructive flows. Replaces generic labels with safer, specific actions and improves EN/ES strings across the app.

- **Refactors**
  - Localized `ErrorFallback` via `t("errorFallback.*")` (title/body/restart); updated tests to assert i18n usage.
  - Replaced generic dialog actions with explicit choices: keep/delete transaction, keep/delete goal (title shows goal name), and stay signed in/log out.
  - Revised EN/ES copy across transactions, transfers, bills, budgets, goals, settings, onboarding, backup, and notifications for clarity and consistent casing.

<sup>Written for commit 305719407d5f2be7b576a8aba3dfac4b818cf5f5. Summary will update on new commits. <a href="https://cubic.dev/pr/B4rz99/fidy/pull/476?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

