### PR TITLE
fix(mobile): simplify home chart

### DIFF
--- a/apps/mobile/features/dashboard/components/ChartSection.tsx
+++ b/apps/mobile/features/dashboard/components/ChartSection.tsx
@@ -1,34 +1,18 @@
-import { useCallback, useState } from "react";
 import { CATEGORY_MAP } from "@/shared/categories";
-import {
-  type LayoutChangeEvent,
-  type NativeScrollEvent,
-  type NativeSyntheticEvent,
-  Pressable,
-  ScrollView,
-  Text,
-  View,
-} from "@/shared/components/rn";
-import { useThemeColor, useTranslation } from "@/shared/hooks";
+import { Pressable, View } from "@/shared/components/rn";
+import { useTranslation } from "@/shared/hooks";
 import { getCategoryLabel } from "@/shared/i18n";
 import { formatMoney } from "@/shared/lib";
 import { CategoryRow } from "./CategoryRow";
 import { DonutChart } from "./DonutChart";
-import { SpendingLineChart } from "./SpendingLineChart";
 
 type CategorySpendingItem = {
   readonly categoryId: string;
   readonly total: number;
 };
 
-type DailySpendingItem = {
-  readonly date: string;
-  readonly total: number;
-};
-
 type ChartSectionProps = {
   readonly categorySpending: readonly CategorySpendingItem[];
-  readonly dailySpending: readonly DailySpendingItem[];
   readonly totalSpent: number;
   readonly onPress?: () => void;
 };
@@ -55,38 +39,9 @@ const toCategoryRows = (categories: readonly CategorySpendingItem[], locale: str
 
 const MAX_VISIBLE_CATEGORIES = 5;
 const OTHERS_COLOR = "#6B6B6B";
-const LINE_CHART_WIDTH = 140;
 
-const CarouselDots = ({ activeIndex }: { readonly activeIndex: number }) => {
-  const primaryColor = useThemeColor("primary");
-
-  return (
-    <View className="flex-row items-center justify-center gap-2 pt-3">
-      {[0, 1].map((i) => (
-        <View
-          key={i}
-          style={{
-            width: activeIndex === i ? 8 : 6,
-            height: activeIndex === i ? 8 : 6,
-            borderRadius: 4,
-            backgroundColor: activeIndex === i ? primaryColor : "#C4A882",
-          }}
-        />
-      ))}
-    </View>
-  );
-};
-
-export const ChartSection = ({
-  categorySpending,
-  dailySpending,
-  totalSpent,
-  onPress,
-}: ChartSectionProps) => {
+export const ChartSection = ({ categorySpending, totalSpent, onPress }: ChartSectionProps) => {
   const { t, locale } = useTranslation();
-  const [activeIndex, setActiveIndex] = useState(0);
-  const [slideWidth, setSlideWidth] = useState(0);
-  const secondaryColor = useThemeColor("secondary");
 
   const visible = categorySpending.slice(0, MAX_VISIBLE_CATEGORIES);
   const remaining = categorySpending.slice(MAX_VISIBLE_CATEGORIES);
@@ -105,101 +60,32 @@ export const ChartSection = ({
       : visibleSegments;
   const rows = toCategoryRows(visible, locale);
 
-  const dailyTotal = dailySpending.reduce((sum, d) => sum + d.total, 0);
-  const dayCount = dailySpending.length === 0 ? 1 : dailySpending.length;
-  const avgPerDay = Math.round(dailyTotal / dayCount);
-
-  const handleLayout = useCallback((e: LayoutChangeEvent) => {
-    setSlideWidth(e.nativeEvent.layout.width);
-  }, []);
-
-  const handleScrollEnd = useCallback(
-    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
-      if (slideWidth === 0) return;
-      const page = Math.round(e.nativeEvent.contentOffset.x / slideWidth);
-      setActiveIndex(page);
-    },
-    [slideWidth]
-  );
-
   return (
     <Pressable onPress={onPress} className="rounded-chart bg-chart-bg p-4 dark:bg-chart-bg-dark">
-      <View onLayout={handleLayout}>
-        {slideWidth > 0 && (
-          <ScrollView
-            horizontal
-            pagingEnabled
-            showsHorizontalScrollIndicator={false}
-            onMomentumScrollEnd={handleScrollEnd}
-            decelerationRate="fast"
-          >
-            {/* Slide 1: Donut Chart */}
-            <View style={{ width: slideWidth }} className="flex-row gap-4">
-              <DonutChart
-                segments={segments}
-                centerLabel={formatMoney(totalSpent)}
-                centerSubLabel={t("chart.spent")}
-              />
-              <View className="flex-1 justify-center gap-2.5">
-                {rows.map((row) => (
-                  <CategoryRow
-                    key={row.categoryId}
-                    color={row.color}
-                    name={row.name}
-                    amount={row.amount}
-                  />
-                ))}
-                {remaining.length > 0 && (
-                  <CategoryRow
-                    color={OTHERS_COLOR}
-                    name={t("chart.moreCategories", { count: remaining.length })}
-                    amount={formatMoney(remainingTotal)}
-                  />
-                )}
-              </View>
-            </View>
-
-            {/* Slide 2: Line Chart */}
-            <View style={{ width: slideWidth }} className="flex-row gap-4">
-              <SpendingLineChart data={dailySpending} width={LINE_CHART_WIDTH} height={100} />
-              <View className="flex-1 justify-center gap-1.5">
-                <Text className="font-poppins-bold text-body text-primary dark:text-primary-dark">
-                  {t("chart.dailySpending")}
-                </Text>
-                <Text
-                  className="font-poppins-medium text-caption"
-                  style={{ color: secondaryColor }}
-                >
-                  {t("chart.last30Days")}
-                </Text>
-                <View className="mt-2 gap-1">
-                  <Text
-                    className="font-poppins-medium text-caption"
-                    style={{ color: secondaryColor }}
-                  >
-                    {t("chart.avgPerDay")}
-                  </Text>
-                  <Text className="font-poppins-bold text-body text-primary dark:text-primary-dark">
-                    {formatMoney(avgPerDay)}
-                  </Text>
-                </View>
-                <View className="mt-1 gap-1">
-                  <Text
-                    className="font-poppins-medium text-caption"
-                    style={{ color: secondaryColor }}
-                  >
-                    {t("chart.thisMonthTotal")}
-                  </Text>
-                  <Text className="font-poppins-bold text-body text-primary dark:text-primary-dark">
-                    {formatMoney(totalSpent)}
-                  </Text>
-                </View>
-              </View>
-            </View>
-          </ScrollView>
-        )}
+      <View className="flex-row gap-4">
+        <DonutChart
+          segments={segments}
+          centerLabel={formatMoney(totalSpent)}
+          centerSubLabel={t("chart.spent")}
+        />
+        <View className="flex-1 justify-center gap-2.5">
+          {rows.map((row) => (
+            <CategoryRow
+              key={row.categoryId}
+              color={row.color}
+              name={row.name}
+              amount={row.amount}
+            />
+          ))}
+          {remaining.length > 0 && (
+            <CategoryRow
+              color={OTHERS_COLOR}
+              name={t("chart.moreCategories", { count: remaining.length })}
+              amount={formatMoney(remainingTotal)}
+            />
+          )}
+        </View>
       </View>
-      <CarouselDots activeIndex={activeIndex} />
     </Pressable>
   );
 };

--- a/apps/mobile/features/dashboard/components/home-screen/HomeScreenContent.tsx
+++ b/apps/mobile/features/dashboard/components/home-screen/HomeScreenContent.tsx
@@ -28,14 +28,8 @@ export function HomeScreenContent({ model }: HomeScreenContentProps) {
   );
 
   const listHeader = useMemo(
-    () => (
-      <HomeScreenHeader
-        balance={model.balance}
-        categorySpending={model.categorySpending}
-        dailySpending={model.dailySpending}
-      />
-    ),
-    [model.balance, model.categorySpending, model.dailySpending]
+    () => <HomeScreenHeader balance={model.balance} categorySpending={model.categorySpending} />,
+    [model.balance, model.categorySpending]
   );
 
   const headerActions =

--- a/apps/mobile/features/dashboard/components/home-screen/HomeScreenHeader.tsx
+++ b/apps/mobile/features/dashboard/components/home-screen/HomeScreenHeader.tsx
@@ -17,19 +17,14 @@ import { AttributionReviewBanner } from "../AttributionReviewBanner";
 import { BalanceSection } from "../BalanceSection";
 import { ChartSection } from "../ChartSection";
 import { NeedsReviewBanner } from "../NeedsReviewBanner";
-import type { CategorySpendingItem, DailySpendingItem } from "./useHomeScreen";
+import type { CategorySpendingItem } from "./useHomeScreen";
 
 type HomeScreenHeaderProps = {
   readonly balance: number;
   readonly categorySpending: readonly CategorySpendingItem[];
-  readonly dailySpending: readonly DailySpendingItem[];
 };
 
-export function HomeScreenHeader({
-  balance,
-  categorySpending,
-  dailySpending,
-}: HomeScreenHeaderProps) {
+export function HomeScreenHeader({ balance, categorySpending }: HomeScreenHeaderProps) {
   const { push } = useRouter();
   const userId = useOptionalUserId();
   const db = userId ? tryGetDb(userId) : null;
@@ -58,7 +53,6 @@ export function HomeScreenHeader({
       <BalanceSection balance={balance} />
       <ChartSection
         categorySpending={categorySpending}
-        dailySpending={dailySpending}
         totalSpent={balance}
         onPress={() => push("/analytics" as never)}
       />

--- a/apps/mobile/features/dashboard/components/home-screen/useHomeScreen.ts
+++ b/apps/mobile/features/dashboard/components/home-screen/useHomeScreen.ts
@@ -9,16 +9,10 @@ export type CategorySpendingItem = {
   readonly total: number;
 };
 
-export type DailySpendingItem = {
-  readonly date: string;
-  readonly total: number;
-};
-
 export type HomeScreenModel = {
   readonly activityFeed: HomeActivityFeedModel;
   readonly balance: number;
   readonly categorySpending: readonly CategorySpendingItem[];
-  readonly dailySpending: readonly DailySpendingItem[];
   readonly showEmptyTransactions: boolean;
 };
 
@@ -27,7 +21,6 @@ export function useHomeScreen(): HomeScreenModel {
   const db = userId ? tryGetDb(userId) : null;
   const balance = useTransactionStore((state) => state.balance);
   const categorySpending = useTransactionStore((state) => state.categorySpending);
-  const dailySpending = useTransactionStore((state) => state.dailySpending);
   const dataRevision = useTransactionStore((state) => state.dataRevision);
   const phase = useEmailCaptureStore((state) => state.phase);
 
@@ -35,7 +28,6 @@ export function useHomeScreen(): HomeScreenModel {
     activityFeed: useHomeActivityFeed({ dataRevision, db, userId }),
     balance,
     categorySpending,
-    dailySpending,
     showEmptyTransactions: phase === null,
   };
 }


### PR DESCRIPTION
- remove line chart slide
- keep donut chart only


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the mobile Home chart to show only the donut chart. Removed the line chart slide and related state to reduce UI complexity.

- **Refactors**
  - Removed carousel logic and `SpendingLineChart` from `ChartSection`; donut chart only.
  - Dropped `dailySpending` from the model and components (`useHomeScreen`, `HomeScreenHeader`, `HomeScreenContent`).

<sup>Written for commit 8887401b407614ddd132e66fcaa25a07f02e9100. Summary will update on new commits. <a href="https://cubic.dev/pr/B4rz99/fidy/pull/477?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

