### PR TITLE
feat(mobile): improve email regex capture

### DIFF
--- a/apps/mobile/__tests__/background-fetch/task.test.ts
+++ b/apps/mobile/__tests__/background-fetch/task.test.ts
@@ -43,7 +43,11 @@ describe("background email fetch task", () => {
       "gmail-client",
       "outlook-client",
       undefined,
-      { parseProfile: "background", shareParseImprovementSamples: true }
+      {
+        parseProfile: "background",
+        shareParseImprovementSamples: true,
+        isShareParseImprovementSamplesEnabled: expect.any(Function),
+      }
     );
   });
 });

--- a/apps/mobile/__tests__/capture-sources/notification-parse-improvement.test.ts
+++ b/apps/mobile/__tests__/capture-sources/notification-parse-improvement.test.ts
@@ -190,4 +190,42 @@ describe("notification parse improvement samples", () => {
       },
     });
   });
+
+  it("sanitizes prebuilt parser templates before storing opted-in email samples", async () => {
+    await shareNotificationParseImprovementSample({
+      consent: true,
+      userId: "user-1",
+      parserTemplate: "Compra EXITO por 50000 con tarjeta 1234.",
+      rawText: "Compra EXITO por $50,000 con tarjeta *1234.",
+      senderDomain: "davibank.com",
+      source: "email_gmail",
+      status: "failed",
+      confidence: null,
+      parseMethod: "regex",
+    });
+
+    expect(mockInsertNotificationParseImprovementSample).toHaveBeenCalledWith({
+      userId: "user-1",
+      sample: {
+        template: "Compra [MERCHANT] por [AMOUNT] con tarjeta [CARD].",
+        senderDomain: "davibank.com",
+        source: "email_gmail",
+        status: "failed",
+        confidenceBucket: "none",
+        parseMethod: "regex",
+      },
+    });
+  });
+
+  it("clamps oversized templates to the remote table limit", () => {
+    const sample = buildNotificationParseImprovementSample({
+      rawText: "Compra ".repeat(300),
+      source: "email_gmail",
+      status: "failed",
+      confidence: null,
+      parseMethod: "regex",
+    });
+
+    expect(sample.template.length).toBeLessThanOrEqual(1000);
+  });
 });

--- a/apps/mobile/__tests__/email-capture/bank-email-parser.test.ts
+++ b/apps/mobile/__tests__/email-capture/bank-email-parser.test.ts
@@ -37,6 +37,23 @@ describe("known bank email parser", () => {
     });
   });
 
+  it("does not interpret Colombian full dates as US month-day-year dates", () => {
+    const result = parseKnownBankEmail(
+      makeEmail({
+        from: "Alertas Davibank <alertas@davibank.com>",
+        body: "Compra aprobada en EXITO COLOMBIA por $50.000 el 05/18/2026 con tarjeta **** 1234.",
+      })
+    );
+
+    expect(result).toEqual({
+      kind: "failed",
+      parserKey: "davibank",
+      request: expect.objectContaining({
+        status: "failed",
+      }),
+    });
+  });
+
   it("returns a redacted regex failure request for known banks with unknown templates", () => {
     const result = parseKnownBankEmail(
       makeEmail({
@@ -82,5 +99,228 @@ describe("known bank email parser", () => {
     );
 
     expect(result.kind).toBe("parsed");
+  });
+
+  it("extracts BBVA reference amount and establishment details", () => {
+    const result = parseKnownBankEmail(
+      makeEmail({
+        from: "BBVA <bbva@bbvanet.com.co>",
+        subject: "BBVA - Notificacion Ref: $125.900",
+        body: "Estamos contigo en BBVA. Operacion: Pago Restaurante Central Tarjeta terminada en: 1234 Fecha de operacion: 18/05/2026 Establecimiento: Restaurante Central. Ref: $125.900",
+      })
+    );
+
+    expect(result).toEqual({
+      kind: "parsed",
+      parserKey: "bbva:purchase",
+      parsed: {
+        type: "expense",
+        amount: 125900,
+        categoryId: "other",
+        description: "Restaurante Central",
+        counterpartyHint: "Restaurante Central",
+        date: "2026-05-18",
+        confidence: 0.86,
+        cardProductHint: "tarjeta 1234",
+      },
+    });
+  });
+
+  it("extracts ISO BBVA dates without treating them as Colombian slash dates", () => {
+    const result = parseKnownBankEmail(
+      makeEmail({
+        from: "BBVA <bbva@bbvanet.com.co>",
+        receivedAt: "2026-05-19T19:04:59.000Z",
+        subject: "BBVA - Notificacion Ref: $125.900",
+        body: "Operacion: Pago Restaurante Central Tarjeta terminada en: 1234 Fecha de operacion: 2026-05-18 Establecimiento: Restaurante Central. Ref: $125.900",
+      })
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: "parsed",
+        parsed: expect.objectContaining({
+          date: "2026-05-18",
+        }),
+      })
+    );
+  });
+
+  it("keeps dotted BBVA establishment names intact", () => {
+    const result = parseKnownBankEmail(
+      makeEmail({
+        from: "BBVA <bbva@bbvanet.com.co>",
+        subject: "BBVA - Notificacion Ref: $45.900",
+        body: "Operacion: Pago NETFLIX.COM Tarjeta terminada en: 1234 Fecha de operacion: 18/05/2026 Establecimiento: NETFLIX.COM. Ref: $45.900",
+      })
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: "parsed",
+        parsed: expect.objectContaining({
+          description: "NETFLIX.COM",
+          counterpartyHint: "NETFLIX.COM",
+        }),
+      })
+    );
+  });
+
+  it("stops BBVA establishment capture before HTML-entity disclaimer labels", () => {
+    const result = parseKnownBankEmail(
+      makeEmail({
+        from: "BBVA <bbva@bbvanet.com.co>",
+        subject: "BBVA - Notificacion Ref: $45.900",
+        body: "Operacion: Pago NETFLIX.COM Tarjeta terminada en: 1234 Fecha de operacion: 18/05/2026 Establecimiento: NETFLIX.COM c&oacute;digos de seguridad nunca seran solicitados. Ref: $45.900",
+      })
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: "parsed",
+        parsed: expect.objectContaining({
+          description: "NETFLIX.COM",
+        }),
+      })
+    );
+  });
+
+  it("extracts Davibank transaction-line amount and date", () => {
+    const result = parseKnownBankEmail(
+      makeEmail({
+        from: "Davibank <davibankinforma@davibank.com>",
+        receivedAt: "2026-05-19T19:04:59.000Z",
+        body: "Compraste en Tienda Norte el dia 18/05 con tu tarjeta. La siguiente transaccion o compra Tienda Norte. $88.500 $88.500/18/05 14:22:10",
+      })
+    );
+
+    expect(result).toEqual({
+      kind: "parsed",
+      parserKey: "davibank:purchase",
+      parsed: {
+        type: "expense",
+        amount: 88500,
+        categoryId: "other",
+        description: "Tienda Norte",
+        counterpartyHint: "Tienda Norte",
+        date: "2026-05-18",
+        confidence: 0.88,
+      },
+    });
+  });
+
+  it("uses the previous year for partial Davibank dates received in January", () => {
+    const result = parseKnownBankEmail(
+      makeEmail({
+        from: "Davibank <davibankinforma@davibank.com>",
+        receivedAt: "2026-01-01T01:04:59.000Z",
+        body: "Compraste en Tienda Norte el dia 31/12 con tu tarjeta. La siguiente transaccion o compra Tienda Norte. $88.500 $88.500/31/12 23:22:10",
+      })
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: "parsed",
+        parsed: expect.objectContaining({
+          date: "2025-12-31",
+        }),
+      })
+    );
+  });
+
+  it("does not shift partial Davibank dates into the next year", () => {
+    const result = parseKnownBankEmail(
+      makeEmail({
+        from: "Davibank <davibankinforma@davibank.com>",
+        receivedAt: "2026-12-31T23:04:59.000Z",
+        body: "Compraste en Tienda Norte el dia 01/01 con tu tarjeta. La siguiente transaccion o compra Tienda Norte. $88.500 $88.500/01/01 00:22:10",
+      })
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: "parsed",
+        parsed: expect.objectContaining({
+          date: "2026-01-01",
+        }),
+      })
+    );
+  });
+
+  it("falls back to received date when Davibank partial dates are malformed", () => {
+    const result = parseKnownBankEmail(
+      makeEmail({
+        from: "Davibank <davibankinforma@davibank.com>",
+        body: "Compraste en Tienda Norte el dia 18/05 con tu tarjeta. La siguiente transaccion o compra Tienda Norte. $88.500 $88.500/13/40 14:22:10",
+      })
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: "parsed",
+        parsed: expect.objectContaining({
+          date: "2026-05-18",
+        }),
+      })
+    );
+  });
+
+  it("extracts Davibank short purchase alerts", () => {
+    const result = parseKnownBankEmail(
+      makeEmail({
+        from: "Davibank <davibankinforma@davibank.com>",
+        body: "Compra en Cafe Local el $22.300 . Si no lo hiciste comunicate a la linea.",
+      })
+    );
+
+    expect(result).toEqual({
+      kind: "parsed",
+      parserKey: "davibank:purchase",
+      parsed: {
+        type: "expense",
+        amount: 22300,
+        categoryId: "other",
+        description: "Cafe Local",
+        counterpartyHint: "Cafe Local",
+        date: "2026-05-18",
+        confidence: 0.86,
+      },
+    });
+  });
+
+  it("extracts Davibank short purchase alerts with HTML entity accents", () => {
+    const result = parseKnownBankEmail(
+      makeEmail({
+        from: "Davibank <davibankinforma@davibank.com>",
+        body: "Compra en Cafe Local el $22.300 . s&iacute; no lo hiciste comunicate a la linea.",
+      })
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: "parsed",
+        parsed: expect.objectContaining({
+          description: "Cafe Local",
+        }),
+      })
+    );
+  });
+
+  it("does not parse generic Davibank content as a short purchase alert", () => {
+    const result = parseKnownBankEmail(
+      makeEmail({
+        from: "Davibank <davibankinforma@davibank.com>",
+        subject: "Actualizacion de canales",
+        body: "Consulta tus extractos en Davibank el $22.300 . Revisa terminos y condiciones.",
+      })
+    );
+
+    expect(result).toEqual({
+      kind: "failed",
+      parserKey: "davibank",
+      request: expect.objectContaining({
+        status: "failed",
+      }),
+    });
   });
 });

--- a/apps/mobile/__tests__/email-capture/parse-improvement-outbox.test.ts
+++ b/apps/mobile/__tests__/email-capture/parse-improvement-outbox.test.ts
@@ -1,0 +1,517 @@
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { eq } from "drizzle-orm";
+import { resolve } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  countPendingEmailParseImprovementSamples,
+  enqueueEmailParseImprovementRequests,
+  flushPendingEmailParseImprovementSamples,
+  pruneStaleFailedEmailSourceEvents,
+} from "@/features/email-capture/services/email-parse-improvement-outbox";
+import { recordProcessedCaptureSourceEventWithLocalLedger } from "@/infrastructure/local-ledger/public";
+import { emailParseImprovementSamples, processedSourceEvents } from "@/shared/db/schema";
+import type { AnyDb } from "@/shared/db";
+import type { IsoDateTime, UserId } from "@/shared/types/branded";
+
+const { mockShareCaptureParseImprovementSample } = vi.hoisted(() => ({
+  mockShareCaptureParseImprovementSample: vi.fn<(sample: unknown) => Promise<void>>(() =>
+    Promise.resolve()
+  ),
+}));
+
+vi.mock("@/features/capture-sources/diagnostics.public", () => ({
+  buildNotificationParseImprovementSample: (input: {
+    readonly parserTemplate?: string;
+    readonly senderDomain?: string | null;
+    readonly source: string;
+    readonly status: "failed" | "needs_review";
+    readonly confidence: number | null;
+    readonly parseMethod: "regex" | "llm";
+    readonly rawText: string;
+  }) => ({
+    template: input.parserTemplate ?? input.rawText,
+    senderDomain: input.senderDomain ?? undefined,
+    source: input.source,
+    status: input.status,
+    confidenceBucket: input.confidence == null ? "none" : "medium",
+    parseMethod: input.parseMethod,
+  }),
+  shareCaptureParseImprovementSample: (sample: unknown) =>
+    mockShareCaptureParseImprovementSample(sample),
+}));
+
+const USER_ID = "user-1" as UserId;
+const NOW = new Date("2026-05-19T10:00:00.000Z");
+
+function createDb() {
+  const sqlite = new Database(":memory:");
+  const db = drizzle(sqlite);
+  migrate(db, { migrationsFolder: resolve(__dirname, "../../drizzle") });
+  return { db: db as unknown as AnyDb, sqlite };
+}
+
+const request = {
+  parserTemplate: "Compra en [MERCHANT] por [AMOUNT]",
+  rawText: "Compra en Comercio por $123",
+  senderDomain: "davibank.com",
+  source: "email_gmail" as const,
+  status: "failed" as const,
+  confidence: null,
+  parseMethod: "regex" as const,
+};
+
+describe("email parse improvement outbox", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    mockShareCaptureParseImprovementSample.mockResolvedValue(undefined);
+  });
+
+  it("skips enqueue work when there are no requests", () => {
+    const { db, sqlite } = createDb();
+
+    expect(
+      enqueueEmailParseImprovementRequests({
+        db,
+        userId: USER_ID,
+        requests: [],
+        now: NOW,
+      })
+    ).toBe(0);
+
+    expect(countPendingEmailParseImprovementSamples({ db, userId: USER_ID })).toBe(0);
+    sqlite.close();
+  });
+
+  it("stores anonymized templates and deduplicates repeats", () => {
+    const { db, sqlite } = createDb();
+
+    expect(
+      enqueueEmailParseImprovementRequests({
+        db,
+        userId: USER_ID,
+        requests: [request, request],
+        now: NOW,
+      })
+    ).toBe(1);
+
+    expect(db.select().from(emailParseImprovementSamples).all()).toEqual([
+      expect.objectContaining({
+        userId: USER_ID,
+        template: "Compra en [MERCHANT] por [AMOUNT]",
+        senderDomain: "davibank.com",
+        source: "email_gmail",
+        status: "failed",
+        parseMethod: "regex",
+        sharedAt: null,
+      }),
+    ]);
+    expect(countPendingEmailParseImprovementSamples({ db, userId: USER_ID })).toBe(1);
+    sqlite.close();
+  });
+
+  it("deduplicates samples without sender domains", () => {
+    const { db, sqlite } = createDb();
+    const noDomainRequest = { ...request, senderDomain: null };
+
+    expect(
+      enqueueEmailParseImprovementRequests({
+        db,
+        userId: USER_ID,
+        requests: [noDomainRequest],
+        now: NOW,
+      })
+    ).toBe(1);
+    expect(
+      enqueueEmailParseImprovementRequests({
+        db,
+        userId: USER_ID,
+        requests: [noDomainRequest],
+        now: NOW,
+      })
+    ).toBe(0);
+
+    expect(countPendingEmailParseImprovementSamples({ db, userId: USER_ID })).toBe(1);
+    sqlite.close();
+  });
+
+  it("keeps bank-specific templates with the same shape", () => {
+    const { db, sqlite } = createDb();
+
+    expect(
+      enqueueEmailParseImprovementRequests({
+        db,
+        userId: USER_ID,
+        requests: [
+          request,
+          {
+            ...request,
+            senderDomain: "bbvanet.com.co",
+            rawText: "Compra en Otro Comercio por $123",
+          },
+        ],
+        now: NOW,
+      })
+    ).toBe(2);
+
+    expect(
+      db
+        .select()
+        .from(emailParseImprovementSamples)
+        .all()
+        .map((sample) => sample.senderDomain)
+        .sort()
+    ).toEqual(["bbvanet.com.co", "davibank.com"]);
+    sqlite.close();
+  });
+
+  it("logs enqueue summaries when debug logging is enabled", () => {
+    const { db, sqlite } = createDb();
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.stubEnv("EXPO_PUBLIC_EMAIL_CAPTURE_DEBUG", "1");
+
+    enqueueEmailParseImprovementRequests({
+      db,
+      userId: USER_ID,
+      requests: [request],
+      now: NOW,
+    });
+
+    expect(consoleLog).toHaveBeenCalledWith("[email-capture] parse-improvement.enqueue", {
+      requestCount: 1,
+      enqueued: 1,
+    });
+
+    consoleLog.mockRestore();
+    sqlite.close();
+  });
+
+  it("flushes pending templates and marks them shared", async () => {
+    const { db, sqlite } = createDb();
+    enqueueEmailParseImprovementRequests({ db, userId: USER_ID, requests: [request], now: NOW });
+
+    await expect(
+      flushPendingEmailParseImprovementSamples({ db, userId: USER_ID, now: NOW })
+    ).resolves.toMatchObject({ shared: 1, failed: 0 });
+
+    expect(mockShareCaptureParseImprovementSample).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parserTemplate: "Compra en [MERCHANT] por [AMOUNT]",
+        rawText: "Compra en [MERCHANT] por [AMOUNT]",
+        consent: true,
+        userId: USER_ID,
+      })
+    );
+    expect(db.select().from(emailParseImprovementSamples).all()[0]?.sharedAt).toBe(
+      "2026-05-19T10:00:00.000Z"
+    );
+    sqlite.close();
+  });
+
+  it("releases the per-user flush guard when startup counting fails", async () => {
+    const { db, sqlite } = createDb();
+    enqueueEmailParseImprovementRequests({ db, userId: USER_ID, requests: [request], now: NOW });
+    const select = vi.spyOn(db, "select").mockImplementationOnce(() => {
+      throw new Error("count failed");
+    });
+
+    await expect(
+      flushPendingEmailParseImprovementSamples({ db, userId: USER_ID, now: NOW })
+    ).rejects.toThrow("count failed");
+    select.mockRestore();
+
+    await expect(
+      flushPendingEmailParseImprovementSamples({ db, userId: USER_ID, now: NOW })
+    ).resolves.toMatchObject({ shared: 1, failed: 0 });
+    sqlite.close();
+  });
+
+  it("leaves failed flushes pending and logs failure diagnostics", async () => {
+    const { db, sqlite } = createDb();
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.stubEnv("EXPO_PUBLIC_EMAIL_CAPTURE_DEBUG", "1");
+    enqueueEmailParseImprovementRequests({ db, userId: USER_ID, requests: [request], now: NOW });
+    mockShareCaptureParseImprovementSample.mockRejectedValueOnce({
+      code: "23514",
+      reason: "privacy",
+    });
+
+    await expect(
+      flushPendingEmailParseImprovementSamples({ db, userId: USER_ID, now: NOW })
+    ).resolves.toMatchObject({
+      shared: 0,
+      failed: 1,
+      failureTypes: ["unknown"],
+    });
+
+    expect(db.select().from(emailParseImprovementSamples).all()[0]?.sharedAt).toBeNull();
+    expect(consoleLog).toHaveBeenCalledWith("[email-capture] parse-improvement.flush.start", {
+      pending: 1,
+    });
+    expect(consoleLog).toHaveBeenCalledWith("[email-capture] parse-improvement.flush.failure", {
+      errorType: "unknown",
+      errorCode: "23514",
+      privacyReason: "privacy",
+      permanent: false,
+    });
+
+    consoleLog.mockRestore();
+    sqlite.close();
+  });
+
+  it("logs error flush failures without code or privacy reason", async () => {
+    const { db, sqlite } = createDb();
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.stubEnv("EXPO_PUBLIC_EMAIL_CAPTURE_DEBUG", "1");
+    enqueueEmailParseImprovementRequests({ db, userId: USER_ID, requests: [request], now: NOW });
+    mockShareCaptureParseImprovementSample.mockRejectedValueOnce(new ReferenceError("missing"));
+
+    await expect(
+      flushPendingEmailParseImprovementSamples({ db, userId: USER_ID, now: NOW })
+    ).resolves.toMatchObject({
+      shared: 0,
+      failed: 1,
+      failureTypes: ["ReferenceError"],
+    });
+
+    expect(consoleLog).toHaveBeenCalledWith("[email-capture] parse-improvement.flush.failure", {
+      errorType: "ReferenceError",
+      errorCode: null,
+      privacyReason: null,
+      permanent: false,
+    });
+
+    consoleLog.mockRestore();
+    sqlite.close();
+  });
+
+  it("dead-letters privacy failures instead of retrying them forever", async () => {
+    const { db, sqlite } = createDb();
+    enqueueEmailParseImprovementRequests({ db, userId: USER_ID, requests: [request], now: NOW });
+    const error = new Error("privacy");
+    error.name = "ParseImprovementSamplePrivacyError";
+    Object.assign(error, { reason: "sensitive_value_pattern" });
+    mockShareCaptureParseImprovementSample.mockRejectedValueOnce(error);
+
+    await expect(
+      flushPendingEmailParseImprovementSamples({ db, userId: USER_ID, now: NOW })
+    ).resolves.toMatchObject({ shared: 0, failed: 1 });
+
+    const [sample] = db.select().from(emailParseImprovementSamples).all();
+    expect(sample?.sharedAt).toBeNull();
+    expect(sample?.deletedAt).toBe("2026-05-19T10:00:00.000Z");
+    expect(countPendingEmailParseImprovementSamples({ db, userId: USER_ID })).toBe(0);
+    expect(enqueueEmailParseImprovementRequests({ db, userId: USER_ID, requests: [request] })).toBe(
+      0
+    );
+    sqlite.close();
+  });
+
+  it("dead-letters non-retryable insert failures", async () => {
+    const { db, sqlite } = createDb();
+    enqueueEmailParseImprovementRequests({ db, userId: USER_ID, requests: [request], now: NOW });
+    const error = new Error("constraint");
+    error.name = "ParseImprovementSampleInsertError";
+    Object.assign(error, { code: "23514" });
+    mockShareCaptureParseImprovementSample.mockRejectedValueOnce(error);
+
+    await expect(
+      flushPendingEmailParseImprovementSamples({ db, userId: USER_ID, now: NOW })
+    ).resolves.toMatchObject({ shared: 0, failed: 1 });
+
+    expect(db.select().from(emailParseImprovementSamples).all()[0]?.deletedAt).toBe(
+      "2026-05-19T10:00:00.000Z"
+    );
+    sqlite.close();
+  });
+
+  it("flushes pending templates in bounded batches", async () => {
+    const { db, sqlite } = createDb();
+    const requests = Array.from({ length: 11 }, (_, index) => ({
+      ...request,
+      parserTemplate: `Compra ${index} en [MERCHANT] por [AMOUNT]`,
+      rawText: `Compra ${index} en Comercio por $123`,
+    }));
+    enqueueEmailParseImprovementRequests({ db, userId: USER_ID, requests, now: NOW });
+    let inFlight = 0;
+    let maxInFlight = 0;
+    mockShareCaptureParseImprovementSample.mockImplementation(async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await Promise.resolve();
+      inFlight -= 1;
+    });
+
+    await expect(
+      flushPendingEmailParseImprovementSamples({ db, userId: USER_ID, now: NOW })
+    ).resolves.toMatchObject({ shared: 11, failed: 0 });
+
+    expect(maxInFlight).toBeLessThanOrEqual(10);
+    sqlite.close();
+  });
+
+  it("continues past transient failures so newer pending templates can flush", async () => {
+    const { db, sqlite } = createDb();
+    const requests = Array.from({ length: 21 }, (_, index) => ({
+      ...request,
+      parserTemplate: `Compra ${index} en [MERCHANT] por [AMOUNT]`,
+      rawText: `Compra ${index} en Comercio por $123`,
+    }));
+    enqueueEmailParseImprovementRequests({ db, userId: USER_ID, requests, now: NOW });
+    mockShareCaptureParseImprovementSample.mockRejectedValueOnce(new ReferenceError("network"));
+
+    await expect(
+      flushPendingEmailParseImprovementSamples({ db, userId: USER_ID, now: NOW })
+    ).resolves.toMatchObject({ shared: 20, failed: 1 });
+
+    expect(countPendingEmailParseImprovementSamples({ db, userId: USER_ID })).toBe(1);
+    sqlite.close();
+  });
+
+  it("stops after marking the in-flight share when consent is revoked mid-flush", async () => {
+    const { db, sqlite } = createDb();
+    const requests = Array.from({ length: 3 }, (_, index) => ({
+      ...request,
+      parserTemplate: `Compra ${index} en [MERCHANT] por [AMOUNT]`,
+      rawText: `Compra ${index} en Comercio por $123`,
+    }));
+    let isSharingEnabled = true;
+    enqueueEmailParseImprovementRequests({ db, userId: USER_ID, requests, now: NOW });
+    mockShareCaptureParseImprovementSample.mockImplementation(async () => {
+      isSharingEnabled = false;
+    });
+
+    await expect(
+      flushPendingEmailParseImprovementSamples({
+        db,
+        userId: USER_ID,
+        now: NOW,
+        isSharingEnabled: () => isSharingEnabled,
+      })
+    ).resolves.toMatchObject({ shared: 1, failed: 0 });
+
+    expect(mockShareCaptureParseImprovementSample).toHaveBeenCalledTimes(1);
+    expect(countPendingEmailParseImprovementSamples({ db, userId: USER_ID })).toBe(2);
+    sqlite.close();
+  });
+
+  it("does not advance the continuation cursor past unprocessed rows", async () => {
+    const { db, sqlite } = createDb();
+    const requests = Array.from({ length: 12 }, (_, index) => ({
+      ...request,
+      parserTemplate: `Compra ${index} en [MERCHANT] por [AMOUNT]`,
+      rawText: `Compra ${index} en Comercio por $123`,
+    }));
+    let consentChecks = 0;
+    enqueueEmailParseImprovementRequests({ db, userId: USER_ID, requests, now: NOW });
+
+    await expect(
+      flushPendingEmailParseImprovementSamples({
+        db,
+        userId: USER_ID,
+        now: NOW,
+        isSharingEnabled: () => {
+          consentChecks += 1;
+          return consentChecks !== 3;
+        },
+      })
+    ).resolves.toMatchObject({ shared: 1, failed: 0 });
+
+    expect(mockShareCaptureParseImprovementSample).toHaveBeenCalledTimes(1);
+    expect(countPendingEmailParseImprovementSamples({ db, userId: USER_ID })).toBe(11);
+    sqlite.close();
+  });
+
+  it("coalesces concurrent flush callers onto the active flush result", async () => {
+    const { db, sqlite } = createDb();
+    enqueueEmailParseImprovementRequests({ db, userId: USER_ID, requests: [request], now: NOW });
+    mockShareCaptureParseImprovementSample.mockImplementationOnce(async () => {
+      enqueueEmailParseImprovementRequests({
+        db,
+        userId: USER_ID,
+        requests: [
+          {
+            ...request,
+            parserTemplate: "Pago en [MERCHANT] por [AMOUNT]",
+            rawText: "Pago en Comercio por $456",
+          },
+        ],
+        now: NOW,
+      });
+    });
+
+    const [firstFlush, secondFlush] = await Promise.all([
+      flushPendingEmailParseImprovementSamples({ db, userId: USER_ID, now: NOW }),
+      flushPendingEmailParseImprovementSamples({ db, userId: USER_ID, now: NOW }),
+    ]);
+
+    expect(firstFlush).toMatchObject({ shared: 1, failed: 0 });
+    expect(secondFlush).toMatchObject({ shared: 1, failed: 0 });
+    expect(mockShareCaptureParseImprovementSample).toHaveBeenCalledTimes(1);
+    expect(countPendingEmailParseImprovementSamples({ db, userId: USER_ID })).toBe(1);
+    sqlite.close();
+  });
+
+  it("soft-deletes failed email source events older than retention", () => {
+    const { db, sqlite } = createDb();
+    recordProcessedCaptureSourceEventWithLocalLedger({
+      db,
+      ...sourceEventInput("old-failed", "failed", "2026-05-01T10:00:00.000Z" as IsoDateTime),
+    });
+    recordProcessedCaptureSourceEventWithLocalLedger({
+      db,
+      ...sourceEventInput("recent-failed", "failed", "2026-05-18T10:00:00.000Z" as IsoDateTime),
+    });
+    recordProcessedCaptureSourceEventWithLocalLedger({
+      db,
+      ...sourceEventInput("freshly-processed", "failed", "2026-05-01T10:00:00.000Z" as IsoDateTime),
+      processedAt: "2026-05-18T10:00:00.000Z" as IsoDateTime,
+    });
+
+    expect(pruneStaleFailedEmailSourceEvents({ db, userId: USER_ID, now: NOW })).toBe(1);
+
+    expect(
+      db
+        .select({ deletedAt: processedSourceEvents.deletedAt })
+        .from(processedSourceEvents)
+        .where(eq(processedSourceEvents.sourceEventId, "old-failed"))
+        .all()[0]?.deletedAt
+    ).toBe("2026-05-19T10:00:00.000Z");
+    expect(
+      db
+        .select({ deletedAt: processedSourceEvents.deletedAt })
+        .from(processedSourceEvents)
+        .where(eq(processedSourceEvents.sourceEventId, "recent-failed"))
+        .all()[0]?.deletedAt
+    ).toBeNull();
+    expect(
+      db
+        .select({ deletedAt: processedSourceEvents.deletedAt })
+        .from(processedSourceEvents)
+        .where(eq(processedSourceEvents.sourceEventId, "freshly-processed"))
+        .all()[0]?.deletedAt
+    ).toBeNull();
+    sqlite.close();
+  });
+});
+
+function sourceEventInput(
+  sourceEventId: string,
+  status: string,
+  updatedAt: IsoDateTime
+): Omit<Parameters<typeof recordProcessedCaptureSourceEventWithLocalLedger>[0], "db"> {
+  return {
+    userId: USER_ID,
+    sourceFamily: "email",
+    sourceId: "email_gmail",
+    sourceEventId,
+    status: status as Parameters<
+      typeof recordProcessedCaptureSourceEventWithLocalLedger
+    >[0]["status"],
+    failureReason: null,
+    receivedAt: updatedAt,
+    processedAt: updatedAt,
+  };
+}

--- a/apps/mobile/__tests__/email-capture/parse-improvement-sharing.test.ts
+++ b/apps/mobile/__tests__/email-capture/parse-improvement-sharing.test.ts
@@ -1,23 +1,38 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { shareEmailParseImprovementRequests } from "@/features/email-capture/services/email-parse-improvement-sharing";
+import type { AnyDb } from "@/shared/db";
 import type { UserId } from "@/shared/types/branded";
 
-const { mockCaptureError, mockShareCaptureParseImprovementSample } = vi.hoisted(() => ({
-  mockCaptureError: vi.fn<(...args: any[]) => any>((_error: unknown) => undefined),
-  mockShareCaptureParseImprovementSample: vi.fn<(...args: any[]) => any>((_sample: unknown) =>
-    Promise.resolve()
+const {
+  mockCaptureError,
+  mockCaptureWarning,
+  mockEnqueueEmailParseImprovementRequests,
+  mockFlushPendingEmailParseImprovementSamples,
+} = vi.hoisted(() => ({
+  mockCaptureError: vi.fn<(error: unknown) => void>((_error) => undefined),
+  mockCaptureWarning: vi.fn<(message: string, context?: unknown) => void>(
+    (_message, _context) => undefined
   ),
+  mockEnqueueEmailParseImprovementRequests: vi.fn<(input: unknown) => number>(() => 1),
+  mockFlushPendingEmailParseImprovementSamples: vi.fn<
+    (input: unknown) => Promise<{ readonly shared: number; readonly failed: number }>
+  >(() => Promise.resolve({ shared: 1, failed: 0 })),
 }));
 
-vi.mock("@/features/capture-sources/diagnostics.public", () => ({
-  shareCaptureParseImprovementSample: (sample: unknown) =>
-    mockShareCaptureParseImprovementSample(sample),
+vi.mock("@/features/email-capture/services/email-parse-improvement-outbox", () => ({
+  enqueueEmailParseImprovementRequests: (input: unknown) =>
+    mockEnqueueEmailParseImprovementRequests(input),
+  flushPendingEmailParseImprovementSamples: (input: unknown) =>
+    mockFlushPendingEmailParseImprovementSamples(input),
 }));
 
 vi.mock("@/shared/lib", () => ({
   captureError: (error: unknown) => mockCaptureError(error),
+  captureWarning: (message: string, context?: unknown) => mockCaptureWarning(message, context),
 }));
 
+const db = {} as AnyDb;
+const userId = "user-1" as UserId;
 const request = {
   parserTemplate: "Subject Body",
   rawText: "Subject\n\nBody",
@@ -31,45 +46,276 @@ const request = {
 describe("shareEmailParseImprovementRequests", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockShareCaptureParseImprovementSample.mockResolvedValue(undefined);
+    vi.unstubAllEnvs();
+    mockEnqueueEmailParseImprovementRequests.mockReturnValue(1);
+    mockFlushPendingEmailParseImprovementSamples.mockResolvedValue({ shared: 1, failed: 0 });
   });
 
-  it("does not share samples when sharing is disabled", async () => {
+  it("does not enqueue or flush samples when sharing is disabled", async () => {
     await shareEmailParseImprovementRequests({
+      db,
       enabled: false,
-      userId: "user-1" as UserId,
+      userId,
       requests: [request],
     });
 
-    expect(mockShareCaptureParseImprovementSample).not.toHaveBeenCalled();
+    expect(mockEnqueueEmailParseImprovementRequests).not.toHaveBeenCalled();
+    expect(mockFlushPendingEmailParseImprovementSamples).not.toHaveBeenCalled();
   });
 
-  it("shares enabled samples with user consent", async () => {
+  it("logs disabled sharing summaries when debug logging is enabled", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.stubEnv("EXPO_PUBLIC_EMAIL_CAPTURE_DEBUG", "1");
+
     await shareEmailParseImprovementRequests({
-      enabled: true,
-      userId: "user-1" as UserId,
+      db,
+      enabled: false,
+      userId,
       requests: [request],
     });
 
-    expect(mockShareCaptureParseImprovementSample).toHaveBeenCalledWith({
-      ...request,
-      userId: "user-1",
-      consent: true,
+    expect(consoleLog).toHaveBeenCalledWith("[email-capture] parse-improvement.summary", {
+      enabled: false,
+      requestCount: 1,
+      enqueued: 0,
+      shared: 0,
+      failed: 0,
+    });
+
+    consoleLog.mockRestore();
+  });
+
+  it("flushes pending samples when sharing is enabled", async () => {
+    await shareEmailParseImprovementRequests({
+      db,
+      enabled: true,
+      userId,
+      requests: [request],
+    });
+
+    expect(mockEnqueueEmailParseImprovementRequests).toHaveBeenCalledWith({
+      db,
+      userId,
+      requests: [request],
+    });
+    expect(mockFlushPendingEmailParseImprovementSamples).toHaveBeenCalledWith({ db, userId });
+  });
+
+  it("passes live sharing consent through to the outbox flush", async () => {
+    const isSharingEnabled = () => true;
+
+    await shareEmailParseImprovementRequests({
+      db,
+      enabled: true,
+      userId,
+      requests: [request],
+      isSharingEnabled,
+    });
+
+    expect(mockFlushPendingEmailParseImprovementSamples).toHaveBeenCalledWith({
+      db,
+      userId,
+      isSharingEnabled,
     });
   });
 
-  it("captures individual sharing failures without rejecting the batch", async () => {
-    const error = new Error("share failed");
-    mockShareCaptureParseImprovementSample.mockRejectedValueOnce(error);
+  it("does not enqueue samples when live sharing consent has already been revoked", async () => {
+    await shareEmailParseImprovementRequests({
+      db,
+      enabled: true,
+      userId,
+      requests: [request],
+      isSharingEnabled: () => false,
+    });
+
+    expect(mockEnqueueEmailParseImprovementRequests).not.toHaveBeenCalled();
+    expect(mockFlushPendingEmailParseImprovementSamples).not.toHaveBeenCalled();
+  });
+
+  it("logs revoked live sharing consent as disabled when debug logging is enabled", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.stubEnv("EXPO_PUBLIC_EMAIL_CAPTURE_DEBUG", "1");
+
+    await shareEmailParseImprovementRequests({
+      db,
+      enabled: true,
+      userId,
+      requests: [request],
+      isSharingEnabled: () => false,
+    });
+
+    expect(consoleLog).toHaveBeenCalledWith("[email-capture] parse-improvement.summary", {
+      enabled: false,
+      requestCount: 1,
+      enqueued: 0,
+      shared: 0,
+      failed: 0,
+    });
+
+    consoleLog.mockRestore();
+  });
+
+  it("captures enqueue failures without rejecting the batch", async () => {
+    const error = new Error("enqueue failed");
+    mockEnqueueEmailParseImprovementRequests.mockImplementationOnce(() => {
+      throw error;
+    });
 
     await expect(
       shareEmailParseImprovementRequests({
+        db,
         enabled: true,
-        userId: "user-1" as UserId,
+        userId,
         requests: [request],
       })
     ).resolves.toBeUndefined();
 
     expect(mockCaptureError).toHaveBeenCalledWith(error);
+    expect(mockCaptureWarning).toHaveBeenCalledWith(
+      "email_parse_improvement_sample_enqueue_failed",
+      { errorType: "Error" }
+    );
+  });
+
+  it("handles enqueue failures per request without dropping the whole invocation", async () => {
+    const error = new Error("enqueue failed");
+    mockEnqueueEmailParseImprovementRequests
+      .mockImplementationOnce(() => {
+        throw error;
+      })
+      .mockReturnValueOnce(1);
+
+    await shareEmailParseImprovementRequests({
+      db,
+      enabled: true,
+      userId,
+      requests: [
+        request,
+        {
+          ...request,
+          parserTemplate: "Pago en [MERCHANT] por [AMOUNT]",
+          rawText: "Pago en Comercio por $123",
+        },
+      ],
+    });
+
+    expect(mockEnqueueEmailParseImprovementRequests).toHaveBeenCalledTimes(2);
+    expect(mockFlushPendingEmailParseImprovementSamples).toHaveBeenCalledWith({ db, userId });
+    expect(mockCaptureError).toHaveBeenCalledWith(error);
+  });
+
+  it("captures non-error enqueue failures as unknown", async () => {
+    mockEnqueueEmailParseImprovementRequests.mockImplementationOnce(() => {
+      throw "enqueue failed";
+    });
+
+    await shareEmailParseImprovementRequests({
+      db,
+      enabled: true,
+      userId,
+      requests: [request],
+    });
+
+    expect(mockCaptureWarning).toHaveBeenCalledWith(
+      "email_parse_improvement_sample_enqueue_failed",
+      { errorType: "unknown" }
+    );
+  });
+
+  it("logs enabled sharing summaries when debug logging is enabled", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.stubEnv("EXPO_PUBLIC_EMAIL_CAPTURE_DEBUG", "1");
+    mockEnqueueEmailParseImprovementRequests.mockReturnValueOnce(2);
+    mockFlushPendingEmailParseImprovementSamples.mockResolvedValueOnce({ shared: 1, failed: 1 });
+
+    await shareEmailParseImprovementRequests({
+      db,
+      enabled: true,
+      userId,
+      requests: [request],
+    });
+
+    expect(consoleLog).toHaveBeenCalledWith("[email-capture] parse-improvement.summary", {
+      enabled: true,
+      requestCount: 1,
+      enqueued: 2,
+      shared: 1,
+      failed: 1,
+    });
+
+    consoleLog.mockRestore();
+  });
+
+  it("captures outbox flush failures without rejecting the batch", async () => {
+    const error = new Error("share failed");
+    mockFlushPendingEmailParseImprovementSamples.mockRejectedValueOnce(error);
+
+    await expect(
+      shareEmailParseImprovementRequests({
+        db,
+        enabled: true,
+        userId,
+        requests: [request],
+      })
+    ).resolves.toBeUndefined();
+
+    expect(mockCaptureError).toHaveBeenCalledWith(error);
+    expect(mockCaptureWarning).toHaveBeenCalledWith("email_parse_improvement_sample_share_failed", {
+      errorType: "Error",
+    });
+  });
+
+  it("does not report newly enqueued rows as failed when a full outbox flush throws", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.stubEnv("EXPO_PUBLIC_EMAIL_CAPTURE_DEBUG", "1");
+    mockEnqueueEmailParseImprovementRequests.mockReturnValueOnce(3);
+    mockFlushPendingEmailParseImprovementSamples.mockRejectedValueOnce(new Error("share failed"));
+
+    await shareEmailParseImprovementRequests({
+      db,
+      enabled: true,
+      userId,
+      requests: [request],
+    });
+
+    expect(consoleLog).toHaveBeenCalledWith("[email-capture] parse-improvement.summary", {
+      enabled: true,
+      requestCount: 1,
+      enqueued: 3,
+      shared: 0,
+      failed: 0,
+    });
+
+    consoleLog.mockRestore();
+  });
+
+  it("captures non-error outbox flush failures as unknown", async () => {
+    mockFlushPendingEmailParseImprovementSamples.mockRejectedValueOnce("share failed");
+
+    await shareEmailParseImprovementRequests({
+      db,
+      enabled: true,
+      userId,
+      requests: [request],
+    });
+
+    expect(mockCaptureWarning).toHaveBeenCalledWith("email_parse_improvement_sample_share_failed", {
+      errorType: "unknown",
+    });
+  });
+
+  it("warns when individual pending samples fail to flush", async () => {
+    mockFlushPendingEmailParseImprovementSamples.mockResolvedValueOnce({ shared: 0, failed: 1 });
+
+    await shareEmailParseImprovementRequests({
+      db,
+      enabled: true,
+      userId,
+      requests: [request],
+    });
+
+    expect(mockCaptureWarning).toHaveBeenCalledWith("email_parse_improvement_sample_share_failed", {
+      errorType: "unknown",
+    });
   });
 });

--- a/apps/mobile/__tests__/email-capture/store-orchestration.test.ts
+++ b/apps/mobile/__tests__/email-capture/store-orchestration.test.ts
@@ -286,6 +286,94 @@ describe("email capture store orchestration", () => {
     expect(mocks.captureError).toHaveBeenCalledWith(expect.any(Error));
   });
 
+  it("counts skipped emails when reporting per-account fetch progress", async () => {
+    const store = await loadStoreModule();
+    const progressCalls: Array<{
+      readonly total: number;
+      readonly completed: number;
+      readonly saved: number;
+      readonly failed: number;
+      readonly needsReview: number;
+    }> = [];
+    store.useEmailCaptureStore
+      .getState()
+      .setAccounts([
+        account({ id: "ea-1" as EmailAccountId }),
+        account({ id: "ea-2" as EmailAccountId, email: "second@gmail.com" }),
+      ]);
+    mocks.fetchEmailAccountBatch.mockResolvedValueOnce({
+      showProgress: true,
+      fetchResults: [
+        {
+          account: account({ id: "ea-1" as EmailAccountId }),
+          fetchOk: true,
+          rawEmails: [{ id: "email-1", receivedAt: NOW }],
+        },
+        {
+          account: account({ id: "ea-2" as EmailAccountId, email: "second@gmail.com" }),
+          fetchOk: true,
+          rawEmails: [
+            { id: "email-2", receivedAt: NOW },
+            { id: "email-3", receivedAt: NOW },
+          ],
+        },
+      ],
+    });
+    mocks.ingestFetchedEmails
+      .mockImplementationOnce(async (input) => {
+        input.onProgress?.({ total: 1, completed: 1, saved: 1, failed: 0, needsReview: 0 });
+        return { saved: 1, needsReview: 0, failed: 0, parseImprovementRequests: [] };
+      })
+      .mockImplementationOnce(async (input) => {
+        input.onProgress?.({ total: 0, completed: 0, saved: 0, failed: 0, needsReview: 0 });
+        return { saved: 0, needsReview: 0, failed: 0, parseImprovementRequests: [] };
+      });
+    store.useEmailCaptureStore.subscribe((state) => {
+      if (state.progress) progressCalls.push(state.progress);
+    });
+
+    await store.fetchAndProcessEmails(db, USER_ID, "gmail-client", "outlook-client");
+
+    expect(progressCalls).toContainEqual({
+      total: 3,
+      completed: 3,
+      saved: 1,
+      failed: 0,
+      needsReview: 0,
+    });
+  });
+
+  it("persists account cursors when queue refresh fails after processing", async () => {
+    const store = await loadStoreModule();
+    store.useEmailCaptureStore.getState().setAccounts([account()]);
+    mocks.fetchEmailAccountBatch.mockResolvedValueOnce({
+      showProgress: true,
+      fetchResults: [
+        {
+          account: account(),
+          fetchOk: true,
+          rawEmails: [{ id: "email-1", receivedAt: NOW }],
+        },
+      ],
+    });
+    mocks.ingestFetchedEmails.mockResolvedValueOnce({
+      saved: 0,
+      needsReview: 1,
+      failed: 0,
+      parseImprovementRequests: [],
+    });
+    mocks.loadEmailCaptureQueues.mockRejectedValueOnce(new Error("queue failed"));
+
+    await expect(
+      store.fetchAndProcessEmails(db, USER_ID, "gmail-client", "outlook-client")
+    ).resolves.toEqual({ status: "completed", savedCount: 0, needsReviewCount: 1, failedCount: 0 });
+
+    expect(mocks.captureWarning).toHaveBeenCalledWith("email_capture_queue_refresh_failed", {
+      errorType: "Error",
+    });
+    expect(mocks.persistFetchedAccounts).toHaveBeenCalled();
+  });
+
   it("connects managed email accounts and reports account connection failures", async () => {
     const store = await loadStoreModule();
     const adapter = {

--- a/apps/mobile/__tests__/email-capture/store-state.test.ts
+++ b/apps/mobile/__tests__/email-capture/store-state.test.ts
@@ -298,6 +298,31 @@ describe("email capture store runtime", () => {
     expect(runtimeState().progress).toBeNull();
   });
 
+  it("clears queue slices when fetch outcome queue refresh fails", async () => {
+    const refreshTransactions = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const account = makeAccount();
+    runtimeState().setAccounts([account]);
+    runtimeState().setFailedEmailSourceEvents([sourceEvent("stale-failed")]);
+    runtimeState().setNeedsReviewEmailSourceEvents([sourceEvent("stale-review")]);
+    const start = beginEmailCaptureFetchRun(USER_ID);
+    expect(start.kind).toBe("ready");
+    if (start.kind !== "ready") return;
+
+    await applyEmailCaptureFetchOutcome({
+      run: start.run,
+      showProgress: true,
+      persistedAccounts: {
+        updatedAccountIds: new Set([account.id]),
+        fetchedAt: NOW,
+      },
+      queues: null,
+      refreshTransactions,
+    });
+
+    expect(runtimeState().failedEmailSourceEvents).toEqual([]);
+    expect(runtimeState().needsReviewEmailSourceEvents).toEqual([]);
+  });
+
   it("clears non-complete fetch state immediately and ignores stale runs", () => {
     const start = beginEmailCaptureFetchRun(USER_ID);
     expect(start.kind).toBe("ready");

--- a/apps/mobile/__tests__/email-capture/use-email-capture.test.ts
+++ b/apps/mobile/__tests__/email-capture/use-email-capture.test.ts
@@ -4,11 +4,17 @@ import { requireUserId } from "@/shared/types/assertions";
 
 const mockDb = {} as any;
 const mockRefreshTransactions = vi.fn<(...args: any[]) => any>();
+const mockHydrateSettings = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
 const mockUseSettingsStore = Object.assign(
   vi.fn<(...args: any[]) => any>((selector: any) =>
     selector({ shareAnonymizedParseSamples: false })
   ),
-  { getState: () => ({ shareAnonymizedParseSamples: false }) }
+  {
+    getState: () => ({
+      hydrate: mockHydrateSettings,
+      shareAnonymizedParseSamples: false,
+    }),
+  }
 );
 const mockInitializeEmailCaptureSession = vi.fn<(...args: any[]) => any>();
 const mockLoadEmailAccounts = vi.fn<(...args: any[]) => any>();
@@ -20,6 +26,7 @@ describe("useEmailCapture", () => {
     vi.resetModules();
     vi.clearAllMocks();
     mockLoadEmailAccounts.mockResolvedValue(undefined);
+    mockHydrateSettings.mockResolvedValue(undefined);
     mockFetchAndProcessEmails.mockResolvedValue({
       status: "completed",
       savedCount: 0,
@@ -43,16 +50,20 @@ describe("useEmailCapture", () => {
     const userId = requireUserId("user-1");
 
     useEmailCapture(mockDb, userId);
-    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(calls).toEqual(["init", "loadAccounts", "fetch"]);
+    expect(mockHydrateSettings).not.toHaveBeenCalled();
     expect(mockFetchAndProcessEmails).toHaveBeenCalledWith(
       mockDb,
       userId,
       "gmail-client-id",
       "outlook-client-id",
       expect.any(Function),
-      { shareParseImprovementSamples: false }
+      {
+        shareParseImprovementSamples: false,
+        isShareParseImprovementSamplesEnabled: expect.any(Function),
+      }
     );
   });
 });

--- a/apps/mobile/__tests__/navigation/root-layout-local-qa.test.ts
+++ b/apps/mobile/__tests__/navigation/root-layout-local-qa.test.ts
@@ -6,7 +6,7 @@ describe("Root layout local QA gating", () => {
   const source = readFileSync(resolve(__dirname, "../../app/_layout.tsx"), "utf-8");
 
   test("disables remote capture hooks when remote effects are off", () => {
-    expect(source).toContain("enableRemoteEffects ? userId : null");
+    expect(source).toContain("enableRemoteEffects && onboardingComplete ? userId : null");
   });
 
   test("passes auth mode through to AuthenticatedShell", () => {

--- a/apps/mobile/__tests__/settings/parse-improvement-sharing-toggle.test.ts
+++ b/apps/mobile/__tests__/settings/parse-improvement-sharing-toggle.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { applyParseImprovementSharingToggle } from "@/features/settings/components/parse-improvement-sharing-toggle";
+import type { UserId } from "@/shared/types/branded";
+
+const {
+  mockCaptureError,
+  mockCaptureWarning,
+  mockCountPendingEmailParseImprovementSamples,
+  mockFlushPendingEmailParseImprovementSamples,
+  mockGetDb,
+  mockIsEmailCaptureDebugEnabled,
+  mockSettingsState,
+} = vi.hoisted(() => ({
+  mockCaptureError: vi.fn<(error: unknown) => void>(),
+  mockCaptureWarning: vi.fn<(message: string, context?: unknown) => void>(),
+  mockCountPendingEmailParseImprovementSamples: vi.fn<(...args: unknown[]) => number>(() => 1),
+  mockFlushPendingEmailParseImprovementSamples: vi.fn<(...args: unknown[]) => Promise<unknown>>(
+    () => Promise.resolve({ shared: 0, failed: 0 })
+  ),
+  mockGetDb: vi.fn<(...args: unknown[]) => unknown>(() => ({})),
+  mockIsEmailCaptureDebugEnabled: vi.fn<() => boolean>(() => false),
+  mockSettingsState: { shareAnonymizedParseSamples: true },
+}));
+
+vi.mock("@/features/email-capture/parse-improvement.public", () => ({
+  countPendingEmailParseImprovementSamples: (...args: unknown[]) =>
+    mockCountPendingEmailParseImprovementSamples(...args),
+  flushPendingEmailParseImprovementSamples: (...args: unknown[]) =>
+    mockFlushPendingEmailParseImprovementSamples(...args),
+  isEmailCaptureDebugEnabled: () => mockIsEmailCaptureDebugEnabled(),
+}));
+
+vi.mock("@/shared/db", () => ({
+  getDb: (...args: unknown[]) => mockGetDb(...args),
+}));
+
+vi.mock("@/shared/lib", () => ({
+  captureError: (error: unknown) => mockCaptureError(error),
+  captureWarning: (message: string, context?: unknown) => mockCaptureWarning(message, context),
+}));
+
+vi.mock("@/features/settings/store", () => ({
+  useSettingsStore: {
+    getState: () => mockSettingsState,
+  },
+}));
+
+const flushPromises = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+describe("applyParseImprovementSharingToggle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsEmailCaptureDebugEnabled.mockReturnValue(false);
+    mockSettingsState.shareAnonymizedParseSamples = true;
+  });
+
+  it("only counts pending samples for debug logging", async () => {
+    applyParseImprovementSharingToggle({
+      enabled: false,
+      userId: "user-1" as UserId,
+      setShareAnonymizedParseSamples: vi.fn(),
+    });
+
+    expect(mockCountPendingEmailParseImprovementSamples).not.toHaveBeenCalled();
+
+    mockIsEmailCaptureDebugEnabled.mockReturnValue(true);
+    applyParseImprovementSharingToggle({
+      enabled: false,
+      userId: "user-1" as UserId,
+      setShareAnonymizedParseSamples: vi.fn(),
+    });
+
+    expect(mockCountPendingEmailParseImprovementSamples).toHaveBeenCalledTimes(1);
+  });
+
+  it("captures flush failures returned from toggle-triggered sharing", async () => {
+    mockFlushPendingEmailParseImprovementSamples.mockResolvedValueOnce({
+      shared: 0,
+      failed: 2,
+      failureTypes: ["ParseImprovementSampleInsertError"],
+    });
+
+    applyParseImprovementSharingToggle({
+      enabled: true,
+      userId: "user-1" as UserId,
+      setShareAnonymizedParseSamples: vi.fn(),
+    });
+    await flushPromises();
+
+    expect(mockCaptureWarning).toHaveBeenCalledWith("email_parse_improvement_sample_share_failed", {
+      errorType: "ParseImprovementSampleInsertError",
+    });
+  });
+
+  it("captures empty flush failure types as unknown", async () => {
+    mockFlushPendingEmailParseImprovementSamples.mockResolvedValueOnce({
+      shared: 0,
+      failed: 1,
+      failureTypes: [],
+    });
+
+    applyParseImprovementSharingToggle({
+      enabled: true,
+      userId: "user-1" as UserId,
+      setShareAnonymizedParseSamples: vi.fn(),
+    });
+    await flushPromises();
+
+    expect(mockCaptureWarning).toHaveBeenCalledWith("email_parse_improvement_sample_share_failed", {
+      errorType: "unknown",
+    });
+  });
+
+  it("captures rejected toggle-triggered flushes as share warnings", async () => {
+    const error = new Error("flush failed");
+    mockFlushPendingEmailParseImprovementSamples.mockRejectedValueOnce(error);
+
+    applyParseImprovementSharingToggle({
+      enabled: true,
+      userId: "user-1" as UserId,
+      setShareAnonymizedParseSamples: vi.fn(),
+    });
+    await flushPromises();
+
+    expect(mockCaptureError).toHaveBeenCalledWith(error);
+    expect(mockCaptureWarning).toHaveBeenCalledWith("email_parse_improvement_sample_share_failed", {
+      errorType: "Error",
+    });
+  });
+
+  it("queues a re-enabled flush behind an in-flight toggle flush", async () => {
+    let resolveFirstFlush: () => void = () => undefined;
+    mockFlushPendingEmailParseImprovementSamples
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFirstFlush = () => resolve({ shared: 0, failed: 0 });
+        })
+      )
+      .mockResolvedValueOnce({ shared: 1, failed: 0 });
+    const setShareAnonymizedParseSamples = vi.fn((enabled: boolean) => {
+      mockSettingsState.shareAnonymizedParseSamples = enabled;
+    });
+    const userId = "user-1" as UserId;
+
+    applyParseImprovementSharingToggle({ enabled: true, userId, setShareAnonymizedParseSamples });
+    await flushPromises();
+    applyParseImprovementSharingToggle({ enabled: false, userId, setShareAnonymizedParseSamples });
+    applyParseImprovementSharingToggle({ enabled: true, userId, setShareAnonymizedParseSamples });
+
+    expect(mockFlushPendingEmailParseImprovementSamples).toHaveBeenCalledTimes(1);
+    resolveFirstFlush?.();
+    await flushPromises();
+
+    expect(mockFlushPendingEmailParseImprovementSamples).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/mobile/__tests__/setup.ts
+++ b/apps/mobile/__tests__/setup.ts
@@ -267,6 +267,8 @@ vi.mock("expo-secure-store", () => ({
 
 // Mock expo-crypto
 vi.mock("expo-crypto", () => ({
+  CryptoDigestAlgorithm: { SHA256: "SHA-256" },
+  digest: createMock(() => Promise.resolve(new Uint8Array(32))),
   getRandomBytes: createMock(() => new Uint8Array(32)),
 }));
 

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -16,6 +16,7 @@ import { useCallback } from "react";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import {
   runAuthenticatedBootstrap,
+  runAuthenticatedMaintenanceBootstrap,
   subscribeAuthenticatedTransactionRefreshes,
   useAuthenticatedCapturePipelines,
   useAuthenticatedNotificationBootstrap,
@@ -68,30 +69,42 @@ function AuthenticatedShell({
   db,
   userId,
   enableRemoteEffects,
+  onboardingComplete,
 }: {
   db: AnyDb;
   userId: UserId;
   enableRemoteEffects: boolean;
+  onboardingComplete: boolean;
 }) {
   const { push } = useRouter();
   const { success: migrationsReady, error: migrationsError } = useMigrations(db, migrations);
 
   useSubscription(
     () => {
-      void runAuthenticatedBootstrap({ db, enableRemoteEffects, userId }).catch(captureError);
+      void runAuthenticatedMaintenanceBootstrap({ db, enableRemoteEffects, userId }).catch(
+        captureError
+      );
     },
     [db, enableRemoteEffects, userId],
     migrationsReady
   );
 
   useSubscription(
-    () => subscribeAuthenticatedTransactionRefreshes({ db, enableRemoteEffects, userId }),
-    [db, enableRemoteEffects, userId],
-    migrationsReady
+    () => {
+      void runAuthenticatedBootstrap({ db, enableRemoteEffects, userId }).catch(captureError);
+    },
+    [db, enableRemoteEffects, onboardingComplete, userId],
+    migrationsReady && onboardingComplete
   );
 
-  const captureDb = enableRemoteEffects && migrationsReady ? db : null;
-  const captureUserId = enableRemoteEffects ? userId : null;
+  useSubscription(
+    () => subscribeAuthenticatedTransactionRefreshes({ db, enableRemoteEffects, userId }),
+    [db, enableRemoteEffects, onboardingComplete, userId],
+    migrationsReady && onboardingComplete
+  );
+
+  const captureDb = enableRemoteEffects && migrationsReady && onboardingComplete ? db : null;
+  const captureUserId = enableRemoteEffects && onboardingComplete ? userId : null;
   const navigateToRoute = useCallback(
     (route: string) => {
       const href = route as unknown as Parameters<typeof push>[0];
@@ -101,7 +114,7 @@ function AuthenticatedShell({
   );
   useAuthenticatedCapturePipelines({ db: captureDb, userId: captureUserId });
   useAuthenticatedNotificationBootstrap({
-    enableRemoteEffects,
+    enableRemoteEffects: enableRemoteEffects && onboardingComplete,
     navigateToRoute,
     userId,
   });
@@ -271,11 +284,12 @@ function RootLayout() {
               <Stack.Screen name="qa-transfer-conflict" options={{ headerShown: false }} />
             ) : null}
           </Stack>
-          {db && userId && onboardingComplete && (
+          {db && userId && (
             <AuthenticatedShell
               db={db}
               userId={userId}
               enableRemoteEffects={authMode === "remote"}
+              onboardingComplete={onboardingComplete}
             />
           )}
         </QueryProvider>

--- a/apps/mobile/bootstrap/authenticated-shell.ts
+++ b/apps/mobile/bootstrap/authenticated-shell.ts
@@ -14,7 +14,10 @@ import {
   useCaptureSourcesBootstrap,
 } from "@/features/capture-sources/bootstrap";
 import { categoriesBootstrapTask } from "@/features/categories/bootstrap";
-import { useEmailCaptureBootstrap } from "@/features/email-capture/bootstrap";
+import {
+  emailCaptureMaintenanceBootstrapTask,
+  useEmailCaptureBootstrap,
+} from "@/features/email-capture/bootstrap";
 import { goalsBootstrapTask, goalsTransactionSubscriptionTask } from "@/features/goals/bootstrap";
 import {
   notificationsBootstrapTask,
@@ -43,6 +46,8 @@ const AUTHENTICATED_BOOTSTRAP_TASKS = [
   backgroundFetchBootstrapTask,
 ] as const;
 
+const AUTHENTICATED_MAINTENANCE_BOOTSTRAP_TASKS = [emailCaptureMaintenanceBootstrapTask] as const;
+
 const AUTHENTICATED_TRANSACTION_SUBSCRIPTIONS = [
   budgetTransactionSubscriptionTask,
   goalsTransactionSubscriptionTask,
@@ -51,6 +56,10 @@ const AUTHENTICATED_TRANSACTION_SUBSCRIPTIONS = [
 
 export const runAuthenticatedBootstrap = (context: AuthenticatedBootstrapContext): Promise<void> =>
   runBootstrapTasks(context, AUTHENTICATED_BOOTSTRAP_TASKS);
+
+export const runAuthenticatedMaintenanceBootstrap = (
+  context: AuthenticatedBootstrapContext
+): Promise<void> => runBootstrapTasks(context, AUTHENTICATED_MAINTENANCE_BOOTSTRAP_TASKS);
 
 export const subscribeAuthenticatedTransactionRefreshes = (
   context: AuthenticatedBootstrapContext

--- a/apps/mobile/drizzle/0030_email_parse_improvement_outbox.sql
+++ b/apps/mobile/drizzle/0030_email_parse_improvement_outbox.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `email_parse_improvement_samples` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`template` text NOT NULL,
+	`sender_domain` text,
+	`source` text NOT NULL,
+	`status` text NOT NULL,
+	`confidence` real,
+	`parse_method` text NOT NULL,
+	`created_at` text NOT NULL,
+	`shared_at` text,
+	`deleted_at` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_email_parse_improvement_sample` ON `email_parse_improvement_samples` (`user_id`,`source`,`status`,`parse_method`,coalesce(`sender_domain`,''),`template`);
+--> statement-breakpoint
+CREATE INDEX `idx_email_parse_improvement_samples_pending` ON `email_parse_improvement_samples` (`user_id`,`shared_at`,`deleted_at`,`created_at`,`id`);

--- a/apps/mobile/drizzle/meta/_journal.json
+++ b/apps/mobile/drizzle/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1778976000000,
       "tag": "0029_retire_legacy_processed_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "6",
+      "when": 1779062400000,
+      "tag": "0030_email_parse_improvement_outbox",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/mobile/drizzle/migrations.js
+++ b/apps/mobile/drizzle/migrations.js
@@ -29,6 +29,7 @@ import m0026 from "./0026_align_transaction_domain.sql";
 import m0027 from "./0027_transfer_source.sql";
 import m0028 from "./0028_email_source_event_status.sql";
 import m0029 from "./0029_retire_legacy_processed_tables.sql";
+import m0030 from "./0030_email_parse_improvement_outbox.sql";
 import journal from "./meta/_journal.json";
 
 export default {
@@ -64,5 +65,6 @@ export default {
     m0027,
     m0028,
     m0029,
+    m0030,
   },
 };

--- a/apps/mobile/features/background-fetch/task.ts
+++ b/apps/mobile/features/background-fetch/task.ts
@@ -30,6 +30,8 @@ TaskManager.defineTask(BACKGROUND_TASK_NAME, async () => {
     await fetchAndProcessEmails(db, userId, getGmailClientId(), getOutlookClientId(), undefined, {
       parseProfile: "background",
       shareParseImprovementSamples: useSettingsStore.getState().shareAnonymizedParseSamples,
+      isShareParseImprovementSamplesEnabled: () =>
+        useSettingsStore.getState().shareAnonymizedParseSamples,
     });
     return BackgroundTask.BackgroundTaskResult.Success;
   } catch (error) {

--- a/apps/mobile/features/capture-sources/lib/notification-parse-improvement-repository.ts
+++ b/apps/mobile/features/capture-sources/lib/notification-parse-improvement-repository.ts
@@ -1,3 +1,4 @@
+import { CryptoDigestAlgorithm, digest } from "expo-crypto";
 import { getSupabase } from "@/shared/db";
 
 export type PersistedNotificationParseImprovementSample = {
@@ -9,14 +10,36 @@ export type PersistedNotificationParseImprovementSample = {
   readonly parseMethod: "regex" | "llm";
 };
 
+export class ParseImprovementSampleInsertError extends Error {
+  readonly code: string | null;
+  readonly details: string | null;
+
+  constructor(input: { readonly code?: string; readonly details?: string }) {
+    super("Unable to store parse improvement sample");
+    this.name = "ParseImprovementSampleInsertError";
+    this.code = input.code ?? null;
+    this.details = input.details ?? null;
+  }
+}
+
+export class ParseImprovementSamplePrivacyError extends Error {
+  readonly reason: string;
+
+  constructor(reason: string) {
+    super("Parse improvement sample still contains sensitive values");
+    this.name = "ParseImprovementSamplePrivacyError";
+    this.reason = reason;
+  }
+}
+
 type InsertNotificationParseImprovementSampleInput = {
   readonly userId: string;
   readonly sample: PersistedNotificationParseImprovementSample;
 };
 
 async function sha256Hex(value: string): Promise<string> {
-  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
-  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+  const hash = await digest(CryptoDigestAlgorithm.SHA256, new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(hash), (byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
 const SENSITIVE_TEMPLATE_PATTERNS = [
@@ -70,13 +93,17 @@ const hasResidualTitleEntity = (template: string): boolean =>
   );
 
 function assertTemplateIsAnonymized(template: string): void {
-  if (
-    SENSITIVE_TEMPLATE_PATTERNS.some((pattern) => pattern.test(template)) ||
-    LOWERCASE_COUNTERPARTY_PATTERN.test(template) ||
-    RESIDUAL_ENTITY_PATTERN.test(template) ||
-    hasResidualTitleEntity(template)
-  ) {
-    throw new Error("Parse improvement sample still contains sensitive values");
+  if (SENSITIVE_TEMPLATE_PATTERNS.some((pattern) => pattern.test(template))) {
+    throw new ParseImprovementSamplePrivacyError("sensitive_value_pattern");
+  }
+  if (LOWERCASE_COUNTERPARTY_PATTERN.test(template)) {
+    throw new ParseImprovementSamplePrivacyError("lowercase_counterparty_pattern");
+  }
+  if (RESIDUAL_ENTITY_PATTERN.test(template)) {
+    throw new ParseImprovementSamplePrivacyError("residual_entity_pattern");
+  }
+  if (hasResidualTitleEntity(template)) {
+    throw new ParseImprovementSamplePrivacyError("residual_title_entity");
   }
 }
 
@@ -100,6 +127,9 @@ export async function insertNotificationParseImprovementSample(
     });
 
   if (error != null) {
-    throw new Error("Unable to store parse improvement sample");
+    throw new ParseImprovementSampleInsertError({
+      code: error.code,
+      details: error.details,
+    });
   }
 }

--- a/apps/mobile/features/capture-sources/lib/notification-parse-improvement.ts
+++ b/apps/mobile/features/capture-sources/lib/notification-parse-improvement.ts
@@ -21,6 +21,8 @@ export type ShareParseImprovementInput = ParseImprovementInput & {
   readonly userId: string;
 };
 
+const MAX_PARSE_IMPROVEMENT_TEMPLATE_LENGTH = 1000;
+
 type RedactionRule = {
   readonly pattern: RegExp;
   readonly replacement: string;
@@ -139,8 +141,12 @@ export function anonymizeNotificationParseSample(rawText: string): string {
 }
 
 export function buildNotificationParseImprovementSample(input: ParseImprovementInput) {
+  const template = clampParseImprovementTemplate(
+    anonymizeNotificationParseSample(input.parserTemplate ?? input.rawText)
+  );
+
   return {
-    template: input.parserTemplate ?? anonymizeNotificationParseSample(input.rawText),
+    template,
     ...(input.senderDomain ? { senderDomain: input.senderDomain } : {}),
     source: input.source,
     status: input.status,
@@ -159,6 +165,11 @@ const LENGTH_BUCKETS = [
 
 const lengthBucket = (value: string): string =>
   LENGTH_BUCKETS.find((bucket) => value.length < bucket.max)?.label ?? "500_plus";
+
+const clampParseImprovementTemplate = (template: string): string =>
+  template.length <= MAX_PARSE_IMPROVEMENT_TEMPLATE_LENGTH
+    ? template
+    : template.slice(0, MAX_PARSE_IMPROVEMENT_TEMPLATE_LENGTH).trim();
 
 export async function shareNotificationParseImprovementSample(
   input: ShareParseImprovementInput

--- a/apps/mobile/features/email-capture/bootstrap.ts
+++ b/apps/mobile/features/email-capture/bootstrap.ts
@@ -1,6 +1,55 @@
-import type { CapturePipelineContext } from "@/shared/bootstrap/types";
+import * as SecureStore from "expo-secure-store";
+import type { BootstrapTask } from "@/shared/bootstrap/registry";
+import type {
+  AuthenticatedBootstrapContext,
+  CapturePipelineContext,
+} from "@/shared/bootstrap/types";
+import { captureError, captureWarning, toIsoDate } from "@/shared/lib";
 import { useEmailCapture } from "./hooks/useEmailCapture";
+import { pruneStaleFailedEmailSourceEvents } from "./services/email-parse-improvement-outbox";
+
+const toSecureStoreKeyFragment = (value: string): string =>
+  Array.from(value)
+    .map((char) => char.charCodeAt(0).toString(16).padStart(4, "0"))
+    .join("");
+
+const createEmailCapturePruneDateKey = (userId: string): string =>
+  `email_capture_last_pruned_on_${toSecureStoreKeyFragment(userId)}`;
+
+const captureMaintenanceFailure =
+  (message: string) =>
+  (error: unknown): void => {
+    captureError(error);
+    captureWarning("email_capture_maintenance_failed", {
+      errorType: error instanceof Error ? error.name : "unknown",
+      operation: message,
+    });
+  };
 
 export const useEmailCaptureBootstrap = ({ db, userId }: CapturePipelineContext): void => {
   useEmailCapture(db, userId);
+};
+
+export const emailCaptureMaintenanceBootstrapTask: BootstrapTask<AuthenticatedBootstrapContext> = {
+  id: "email-capture-maintenance",
+  run: async ({ db, userId }) => {
+    const today = toIsoDate(new Date());
+    const pruneDateKey = createEmailCapturePruneDateKey(userId);
+    const lastPrunedOn = await SecureStore.getItemAsync(pruneDateKey).catch((error) => {
+      captureMaintenanceFailure("read_prune_date")(error);
+      return null;
+    });
+    if (lastPrunedOn === today) return;
+
+    try {
+      pruneStaleFailedEmailSourceEvents({ db, userId });
+    } catch (error) {
+      captureMaintenanceFailure("prune_stale_failures")(error);
+      return;
+    }
+
+    await SecureStore.setItemAsync(pruneDateKey, today).catch(
+      captureMaintenanceFailure("persist_prune_date")
+    );
+  },
 };

--- a/apps/mobile/features/email-capture/hooks/useEmailCapture.ts
+++ b/apps/mobile/features/email-capture/hooks/useEmailCapture.ts
@@ -15,7 +15,7 @@ export function useEmailCapture(db: AnyDb | null, userId: UserId | null) {
       initializeEmailCaptureSession(userId);
 
       const runFetch = () => {
-        fetchAndProcessEmails(
+        void fetchAndProcessEmails(
           db,
           userId,
           getGmailClientId(),
@@ -23,6 +23,8 @@ export function useEmailCapture(db: AnyDb | null, userId: UserId | null) {
           () => refreshTransactions(db, userId),
           {
             shareParseImprovementSamples: useSettingsStore.getState().shareAnonymizedParseSamples,
+            isShareParseImprovementSamplesEnabled: () =>
+              useSettingsStore.getState().shareAnonymizedParseSamples,
           }
         ).catch(handleRecoverableError("Email sync failed"));
       };

--- a/apps/mobile/features/email-capture/parse-improvement.public.ts
+++ b/apps/mobile/features/email-capture/parse-improvement.public.ts
@@ -1,0 +1,5 @@
+export {
+  countPendingEmailParseImprovementSamples,
+  flushPendingEmailParseImprovementSamples,
+} from "./services/email-parse-improvement-outbox";
+export { isEmailCaptureDebugEnabled } from "./services/email-capture-debug";

--- a/apps/mobile/features/email-capture/services/bank-email-parser.ts
+++ b/apps/mobile/features/email-capture/services/bank-email-parser.ts
@@ -33,6 +33,23 @@ const KNOWN_BANK_DOMAINS = [
 const PURCHASE_PATTERN =
   /\b(?:compra|purchase|pago|payment)\b(?:\s+aprobada|\s+aprobado|\s+realizada|\s+exitos[ao])?\s+(?:en|at)\s+(.+?)\s+(?:por|for)\s+(?:\$|COP)?\s*([\d.,]+)(?:\s+(?:el|on)\s+(\d{1,2}[/-]\d{1,2}[/-]\d{2,4}))?/i;
 
+const BBVA_PAYMENT_PATTERN =
+  /\b(?:operaci[oó]n|operaci&oacute;n)\s*:\s*pago\s+(.+?)\s+(?:tarjeta\s+terminada\s+en\s*:?\s*(?:[*xX\s-]*)?(\d{4}).*?)?(?:fecha\s+de\s+(?:operaci[oó]n|operaci&oacute;n)\s*:\s*(\d{4}-\d{1,2}-\d{1,2}|\d{1,2}[/-]\d{1,2}[/-]\d{2,4})).*?establecimiento\s*:\s*(.+?)(?=\s*[.;]?\s+(?:si\s+necesitas|c[oó]digos?|c&oacute;digos?|recuerda|ref(?:erencia)?\s*:)|$)/i;
+
+const BBVA_REFERENCE_AMOUNT_PATTERN = /\b(?:ref|referencia)\s*:\s*(?:\$|COP)?\s*([\d.,]+)/i;
+
+const BBVA_DATE_PATTERN =
+  /\b(?:fecha|fecha\s+de\s+(?:operaci[oó]n|operaci&oacute;n))\s*:\s*(\d{4}-\d{1,2}-\d{1,2}|\d{1,2}[/-]\d{1,2}[/-]\d{2,4})/i;
+
+const BBVA_ESTABLISHMENT_PATTERN =
+  /\bestablecimiento\s*:\s*(.+?)(?=\s*[.;]?\s+(?:si\s+necesitas|c[oó]digos?|c&oacute;digos?|recuerda|ref(?:erencia)?\s*:)|$)/i;
+
+const DAVIBANK_TRANSACTION_LINE_PATTERN =
+  /\b(?:transacci[oó]n|transacci&oacute;n)\s+o\s+compra\s+(.+?)[./]\s*(?:\$|COP)?\s*([\d.,]+)(?:\s+(?:\$|COP)?\s*[\d.,]+)?(?:[/-](\d{1,2})[/-](\d{1,2}))?/i;
+
+const DAVIBANK_SHORT_PURCHASE_PATTERN =
+  /\bcompra\s+en\s+(.+?)\s+el\s+(?:\$|COP)?\s*([\d.,]+)\s*(?:[.;]|$)(?=.*\b(?:s[ií]|s&iacute;)\s+no\s+lo\s+hiciste\b)/i;
+
 export const buildEmailParseImprovementRawText = (email: RawEmail): string =>
   [email.subject, email.body].filter((part) => part.trim().length > 0).join("\n\n");
 
@@ -55,32 +72,185 @@ const parseCopAmount = (rawAmount: string): number | null => {
   return Number.isSafeInteger(amount) && amount > 0 ? amount : null;
 };
 
-const parseDate = (rawDate: string): string | null => {
-  const match = rawDate.match(/^(\d{1,2})[/-](\d{1,2})[/-](\d{2}|\d{4})$/);
-  if (!match) return null;
-  const rawDay = match[1];
-  const rawMonth = match[2];
-  const rawYear = match[3];
-  if (!rawDay || !rawMonth || !rawYear) return null;
-  const year = rawYear.length === 2 ? `20${rawYear}` : rawYear;
-  const month = rawMonth.padStart(2, "0");
-  const day = rawDay.padStart(2, "0");
-  return `${year}-${month}-${day}`;
-};
-
 const getReceivedDate = (email: RawEmail): string | null =>
   email.receivedAt.match(/^(\d{4}-\d{2}-\d{2})/)?.[1] ?? null;
+
+const toIsoDateIfValid = (input: {
+  readonly year: number;
+  readonly month: number;
+  readonly day: number;
+}): string | null => {
+  const date = new Date(Date.UTC(input.year, input.month - 1, input.day));
+  const isValid =
+    date.getUTCFullYear() === input.year &&
+    date.getUTCMonth() === input.month - 1 &&
+    date.getUTCDate() === input.day;
+  const year = String(input.year).padStart(4, "0");
+  const month = String(input.month).padStart(2, "0");
+  const day = String(input.day).padStart(2, "0");
+  return isValid ? `${year}-${month}-${day}` : null;
+};
+
+const parseIsoBankDate = (rawDate: string): string | null => {
+  const match = rawDate.match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/);
+  if (!match?.[1] || !match[2] || !match[3]) return null;
+  return toIsoDateIfValid({
+    year: Number(match[1]),
+    month: Number(match[2]),
+    day: Number(match[3]),
+  });
+};
+
+const parseColombianDayMonthYearDate = (rawDate: string): string | null => {
+  const match = rawDate.match(/^(\d{1,2})[/-](\d{1,2})[/-](\d{2}|\d{4})$/);
+  if (!match?.[1] || !match[2] || !match[3]) return null;
+  const year = Number(match[3].length === 2 ? `20${match[3]}` : match[3]);
+  return toIsoDateIfValid({
+    year,
+    month: Number(match[2]),
+    day: Number(match[1]),
+  });
+};
+
+const parseColombianBankDate = (rawDate: string): string | null =>
+  parseIsoBankDate(rawDate) ?? parseColombianDayMonthYearDate(rawDate);
 
 const parseCardProductHint = (text: string): string | undefined => {
   const last4 = text.match(/\b(?:tarjeta|card)\s+(?:[*xX]+\s*)?(\d{4})\b/i)?.[1];
   return last4 ? `tarjeta ${last4}` : undefined;
 };
 
+const cleanMerchant = (merchant: string): string =>
+  merchant
+    .replace(/\s+/g, " ")
+    .replace(/\s*[:;,.]+$/g, "")
+    .trim();
+
+const inferPartialDateYear = (input: {
+  readonly receivedYear: number;
+  readonly receivedMonth: number;
+  readonly parsedMonth: number;
+}): number => {
+  if (input.receivedMonth === 1 && input.parsedMonth === 12) return input.receivedYear - 1;
+  return input.receivedYear;
+};
+
+const isMonthDayInRange = (month: number, day: number): boolean =>
+  Number.isSafeInteger(month) &&
+  Number.isSafeInteger(day) &&
+  month >= 1 &&
+  month <= 12 &&
+  day >= 1 &&
+  day <= 31;
+
+const parseMonthDayDate = (
+  rawMonth: string | undefined,
+  rawDay: string | undefined,
+  email: RawEmail
+): string | null => {
+  const receivedDate = getReceivedDate(email);
+  if (!rawMonth || !rawDay || !receivedDate) return null;
+  const receivedYear = Number(receivedDate.slice(0, 4));
+  const receivedMonth = Number(receivedDate.slice(5, 7));
+  const parsedMonth = Number(rawMonth);
+  const parsedDay = Number(rawDay);
+  if (!Number.isSafeInteger(receivedYear) || !isMonthDayInRange(parsedMonth, parsedDay)) {
+    return null;
+  }
+  const year = inferPartialDateYear({ receivedYear, receivedMonth, parsedMonth });
+  return toIsoDateIfValid({ year, month: parsedMonth, day: parsedDay });
+};
+
+const buildParsedPurchase = (input: {
+  readonly merchant: string | undefined;
+  readonly amount: string | undefined;
+  readonly date: string | null;
+  readonly confidence: number;
+  readonly cardLast4?: string;
+}): LlmParsedTransaction | null => {
+  const merchant = input.merchant ? cleanMerchant(input.merchant) : "";
+  const amount = input.amount ? parseCopAmount(input.amount) : null;
+  return merchant && amount && input.date
+    ? {
+        type: "expense",
+        amount,
+        categoryId: "other",
+        description: merchant,
+        counterpartyHint: merchant,
+        date: input.date,
+        confidence: input.confidence,
+        ...(input.cardLast4 ? { cardProductHint: `tarjeta ${input.cardLast4}` } : {}),
+      }
+    : null;
+};
+
+const parseBbvaPurchase = (text: string, email: RawEmail): LlmParsedTransaction | null => {
+  const paymentMatch = text.match(BBVA_PAYMENT_PATTERN);
+  if (paymentMatch) {
+    const amount = text.match(BBVA_REFERENCE_AMOUNT_PATTERN)?.[1];
+    const parsed = buildParsedPurchase({
+      merchant: paymentMatch[4] ?? paymentMatch[1],
+      amount,
+      date: paymentMatch[3] ? parseColombianBankDate(paymentMatch[3]) : getReceivedDate(email),
+      confidence: 0.86,
+      cardLast4: paymentMatch[2],
+    });
+    if (parsed) return parsed;
+  }
+
+  const amount = text.match(BBVA_REFERENCE_AMOUNT_PATTERN)?.[1];
+  const date = text.match(BBVA_DATE_PATTERN)?.[1];
+  const establishment = text.match(BBVA_ESTABLISHMENT_PATTERN)?.[1];
+  return amount
+    ? buildParsedPurchase({
+        merchant: establishment,
+        amount,
+        date: date ? parseColombianBankDate(date) : getReceivedDate(email),
+        confidence: 0.84,
+      })
+    : null;
+};
+
+const parseDavibankPurchase = (text: string, email: RawEmail): LlmParsedTransaction | null => {
+  const shortMatch = text.match(DAVIBANK_SHORT_PURCHASE_PATTERN);
+  if (shortMatch) {
+    return buildParsedPurchase({
+      merchant: shortMatch[1],
+      amount: shortMatch[2],
+      date: getReceivedDate(email),
+      confidence: 0.86,
+    });
+  }
+
+  const transactionMatch = text.match(DAVIBANK_TRANSACTION_LINE_PATTERN);
+  if (transactionMatch) {
+    return buildParsedPurchase({
+      merchant: transactionMatch[1],
+      amount: transactionMatch[2],
+      date:
+        parseMonthDayDate(transactionMatch[4], transactionMatch[3], email) ??
+        getReceivedDate(email),
+      confidence: 0.88,
+    });
+  }
+  return null;
+};
+
+const parseBankPurchase = (
+  parserKey: string,
+  text: string,
+  email: RawEmail
+): LlmParsedTransaction | null => {
+  if (parserKey === "bbva") return parseBbvaPurchase(text, email);
+  if (parserKey === "davibank") return parseDavibankPurchase(text, email);
+  return null;
+};
+
 const parsePurchase = (text: string, email: RawEmail): LlmParsedTransaction | null => {
   const match = text.match(PURCHASE_PATTERN);
   const merchant = match?.[1]?.trim();
   const amount = match?.[2] ? parseCopAmount(match[2]) : null;
-  const date = match?.[3] ? parseDate(match[3]) : getReceivedDate(email);
+  const date = match?.[3] ? parseColombianBankDate(match[3]) : getReceivedDate(email);
   const cardProductHint = parseCardProductHint(text);
   return merchant && amount && date
     ? {
@@ -117,7 +287,8 @@ export const parseKnownBankEmail = (email: RawEmail): BankEmailParseResult => {
   if (!bank) return { kind: "unsupported" };
 
   const text = normalizeEmailParserText(buildEmailParseImprovementRawText(email));
-  const parsed = parsePurchase(text, email);
+  const bankParsed = parseBankPurchase(bank.parserKey, text, email);
+  const parsed = bankParsed ?? parsePurchase(text, email);
   return parsed
     ? { kind: "parsed", parserKey: `${bank.parserKey}:purchase`, parsed }
     : {

--- a/apps/mobile/features/email-capture/services/email-capture-debug.ts
+++ b/apps/mobile/features/email-capture/services/email-capture-debug.ts
@@ -1,0 +1,2 @@
+export const isEmailCaptureDebugEnabled = (): boolean =>
+  process.env.EXPO_PUBLIC_EMAIL_CAPTURE_DEBUG === "1";

--- a/apps/mobile/features/email-capture/services/email-parse-improvement-dedupe.ts
+++ b/apps/mobile/features/email-capture/services/email-parse-improvement-dedupe.ts
@@ -1,0 +1,49 @@
+import { and, eq, sql } from "drizzle-orm";
+import type { AnyDb } from "@/shared/db";
+import { emailParseImprovementSamples } from "@/shared/db/schema";
+import type { UserId } from "@/shared/types/branded";
+
+type EmailParseImprovementSampleDedupeInput = {
+  readonly senderDomain: string | null | undefined;
+  readonly source: string;
+  readonly status: string;
+  readonly parseMethod: string;
+  readonly template: string;
+};
+
+export const getEmailParseImprovementSampleDedupeKey = (
+  sample: EmailParseImprovementSampleDedupeInput
+): string =>
+  [
+    sample.senderDomain ?? "",
+    sample.source,
+    sample.status,
+    sample.parseMethod,
+    sample.template,
+  ].join("\u001f");
+
+export function hasEmailParseImprovementSample(input: {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly sample: EmailParseImprovementSampleDedupeInput;
+}): boolean {
+  return Boolean(
+    input.db
+      .select({ id: emailParseImprovementSamples.id })
+      .from(emailParseImprovementSamples)
+      .where(
+        and(
+          eq(emailParseImprovementSamples.userId, input.userId),
+          eq(emailParseImprovementSamples.source, input.sample.source),
+          eq(emailParseImprovementSamples.status, input.sample.status),
+          eq(emailParseImprovementSamples.parseMethod, input.sample.parseMethod),
+          sql`coalesce(${emailParseImprovementSamples.senderDomain}, '') = ${
+            input.sample.senderDomain ?? ""
+          }`,
+          eq(emailParseImprovementSamples.template, input.sample.template)
+        )
+      )
+      .limit(1)
+      .get()
+  );
+}

--- a/apps/mobile/features/email-capture/services/email-parse-improvement-outbox.ts
+++ b/apps/mobile/features/email-capture/services/email-parse-improvement-outbox.ts
@@ -1,0 +1,288 @@
+import { and, asc, count, eq, gt, isNull, or } from "drizzle-orm";
+import {
+  buildNotificationParseImprovementSample,
+  shareCaptureParseImprovementSample,
+} from "@/features/capture-sources/diagnostics.public";
+import type { AnyDb } from "@/shared/db";
+import { emailParseImprovementSamples } from "@/shared/db/schema";
+import { generateEmailParseImprovementSampleId } from "@/shared/lib/generate-id";
+import { toIsoDateTime } from "@/shared/lib";
+import type { EmailParseImprovementSampleId, IsoDateTime, UserId } from "@/shared/types/branded";
+import { isEmailCaptureDebugEnabled } from "./email-capture-debug";
+import {
+  getEmailParseImprovementSampleDedupeKey,
+  hasEmailParseImprovementSample,
+} from "./email-parse-improvement-dedupe";
+export { pruneStaleFailedEmailSourceEvents } from "./email-parse-improvement-prune";
+import type { EmailParseImprovementRequest } from "./email-pipeline-service/types";
+
+const FLUSH_BATCH_SIZE = 10;
+const PERMANENT_INSERT_ERROR_CODES = new Set(["22P02", "23502", "23505", "23514"]);
+const activeFlushesByUserId = new Map<UserId, Promise<FlushResult>>();
+
+type FlushCursor = {
+  readonly createdAt: IsoDateTime;
+  readonly id: EmailParseImprovementSampleId;
+};
+
+type FlushResult = {
+  readonly shared: number;
+  readonly failed: number;
+  readonly failureTypes?: readonly string[];
+};
+
+const logParseImprovementOutboxForDebug = (
+  event: string,
+  payload: Record<string, number | string | boolean | null>
+): void => {
+  if (!isEmailCaptureDebugEnabled()) return;
+
+  // eslint-disable-next-line no-console
+  console.log(`[email-capture] parse-improvement.${event}`, payload);
+};
+
+const getErrorName = (error: unknown): string => (error instanceof Error ? error.name : "unknown");
+
+const getErrorCode = (error: unknown): string | null =>
+  error != null && typeof error === "object" && "code" in error ? String(error.code) : null;
+
+const getPrivacyReason = (error: unknown): string | null =>
+  error != null && typeof error === "object" && "reason" in error ? String(error.reason) : null;
+
+const isPermanentShareFailure = (error: unknown): boolean => {
+  if (getErrorName(error) === "ParseImprovementSamplePrivacyError") return true;
+  const code = getErrorCode(error);
+  return getErrorName(error) === "ParseImprovementSampleInsertError" && code !== null
+    ? PERMANENT_INSERT_ERROR_CODES.has(code)
+    : false;
+};
+
+export function countPendingEmailParseImprovementSamples(input: {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+}): number {
+  return (
+    input.db
+      .select({ count: count() })
+      .from(emailParseImprovementSamples)
+      .where(
+        and(
+          eq(emailParseImprovementSamples.userId, input.userId),
+          isNull(emailParseImprovementSamples.sharedAt),
+          isNull(emailParseImprovementSamples.deletedAt)
+        )
+      )
+      .get()?.count ?? 0
+  );
+}
+
+export function enqueueEmailParseImprovementRequests(input: {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly requests: readonly EmailParseImprovementRequest[];
+  readonly now?: Date;
+}): number {
+  if (input.requests.length === 0) return 0;
+
+  const createdAt = toIsoDateTime(input.now ?? new Date());
+  const seen = new Set<string>();
+  const rows = input.requests
+    .map((request) => {
+      const sample = buildNotificationParseImprovementSample(request);
+      return {
+        id: generateEmailParseImprovementSampleId(),
+        userId: input.userId,
+        template: sample.template,
+        senderDomain: sample.senderDomain ?? null,
+        source: sample.source,
+        status: sample.status,
+        confidence: request.confidence,
+        parseMethod: sample.parseMethod,
+        createdAt,
+        sharedAt: null,
+        deletedAt: null,
+      };
+    })
+    .filter((row) => {
+      const key = getEmailParseImprovementSampleDedupeKey(row);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return !hasEmailParseImprovementSample({ db: input.db, userId: input.userId, sample: row });
+    });
+
+  if (rows.length === 0) return 0;
+
+  const enqueued = input.db
+    .insert(emailParseImprovementSamples)
+    .values(rows)
+    .onConflictDoNothing()
+    .run().changes;
+  logParseImprovementOutboxForDebug("enqueue", {
+    requestCount: input.requests.length,
+    enqueued,
+  });
+  return enqueued;
+}
+
+export async function flushPendingEmailParseImprovementSamples(input: {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly now?: Date;
+  readonly isSharingEnabled?: () => boolean;
+}): Promise<FlushResult> {
+  const activeFlush = activeFlushesByUserId.get(input.userId);
+  if (activeFlush) return activeFlush;
+
+  const flush = (async (): Promise<FlushResult> => {
+    const isSharingEnabled = input.isSharingEnabled ?? (() => true);
+    if (!isSharingEnabled()) return { shared: 0, failed: 0 };
+
+    const sharedAt = toIsoDateTime(input.now ?? new Date());
+    if (isEmailCaptureDebugEnabled()) {
+      logParseImprovementOutboxForDebug("flush.start", {
+        pending: countPendingEmailParseImprovementSamples(input),
+      });
+    }
+
+    const flushBatch = async (
+      cursor: FlushCursor | null
+    ): Promise<{
+      shared: number;
+      failed: number;
+      failureTypes: readonly string[];
+      cursor: FlushCursor | null;
+      shouldContinue: boolean;
+    }> => {
+      const cursorFilter =
+        cursor === null
+          ? undefined
+          : or(
+              gt(emailParseImprovementSamples.createdAt, cursor.createdAt),
+              and(
+                eq(emailParseImprovementSamples.createdAt, cursor.createdAt),
+                gt(emailParseImprovementSamples.id, cursor.id)
+              )
+            );
+      const pending = await input.db
+        .select()
+        .from(emailParseImprovementSamples)
+        .where(
+          and(
+            eq(emailParseImprovementSamples.userId, input.userId),
+            isNull(emailParseImprovementSamples.sharedAt),
+            isNull(emailParseImprovementSamples.deletedAt),
+            cursorFilter
+          )
+        )
+        .orderBy(asc(emailParseImprovementSamples.createdAt), asc(emailParseImprovementSamples.id))
+        .limit(FLUSH_BATCH_SIZE);
+      if (pending.length === 0) {
+        return { shared: 0, failed: 0, failureTypes: [], cursor: null, shouldContinue: false };
+      }
+
+      const results = [];
+      const processedSamples: typeof pending = [];
+      for (const sample of pending) {
+        if (!isSharingEnabled()) break;
+        processedSamples.push(sample);
+        results.push(
+          await (async () => {
+            try {
+              await shareCaptureParseImprovementSample({
+                rawText: sample.template,
+                parserTemplate: sample.template,
+                senderDomain: sample.senderDomain,
+                source: sample.source,
+                status: sample.status as "failed" | "needs_review",
+                confidence: sample.confidence,
+                parseMethod: sample.parseMethod as "regex" | "llm",
+                consent: true,
+                userId: input.userId,
+              }).catch((error) => {
+                if (isPermanentShareFailure(error)) {
+                  input.db
+                    .update(emailParseImprovementSamples)
+                    .set({ deletedAt: sharedAt })
+                    .where(
+                      and(
+                        eq(emailParseImprovementSamples.id, sample.id),
+                        isNull(emailParseImprovementSamples.sharedAt),
+                        isNull(emailParseImprovementSamples.deletedAt)
+                      )
+                    )
+                    .run();
+                }
+                throw error;
+              });
+
+              const value =
+                input.db
+                  .update(emailParseImprovementSamples)
+                  .set({ sharedAt })
+                  .where(
+                    and(
+                      eq(emailParseImprovementSamples.id, sample.id),
+                      isNull(emailParseImprovementSamples.sharedAt),
+                      isNull(emailParseImprovementSamples.deletedAt)
+                    )
+                  )
+                  .run().changes === 1;
+              return { status: "fulfilled" as const, value };
+            } catch (reason) {
+              return { status: "rejected" as const, reason };
+            }
+          })()
+        );
+        if (!isSharingEnabled()) break;
+      }
+      const failedResults = results.filter((result) => result.status === "rejected");
+      const failureTypes = failedResults.map((result) => getErrorName(result.reason));
+      failedResults.forEach((result) => {
+        const reason = result.reason;
+        logParseImprovementOutboxForDebug("flush.failure", {
+          errorType: getErrorName(reason),
+          errorCode: getErrorCode(reason),
+          privacyReason: getPrivacyReason(reason),
+          permanent: isPermanentShareFailure(reason),
+        });
+      });
+
+      const shared = results.filter(
+        (result) => result.status === "fulfilled" && result.value
+      ).length;
+      const lastSample = processedSamples.at(-1);
+      return {
+        shared,
+        failed: failedResults.length,
+        failureTypes,
+        cursor: lastSample ? { createdAt: lastSample.createdAt, id: lastSample.id } : null,
+        shouldContinue: isSharingEnabled() && processedSamples.length === FLUSH_BATCH_SIZE,
+      };
+    };
+
+    const flushAll = async (
+      cursor: FlushCursor | null,
+      totals: FlushResult = { shared: 0, failed: 0 }
+    ): Promise<FlushResult> => {
+      const result = await flushBatch(cursor);
+      const nextTotals = {
+        shared: totals.shared + result.shared,
+        failed: totals.failed + result.failed,
+        failureTypes: [...(totals.failureTypes ?? []), ...result.failureTypes],
+      };
+      return result.shouldContinue && result.cursor
+        ? flushAll(result.cursor, nextTotals)
+        : nextTotals;
+    };
+
+    return await flushAll(null);
+  })();
+  activeFlushesByUserId.set(input.userId, flush);
+  try {
+    return await flush;
+  } finally {
+    if (activeFlushesByUserId.get(input.userId) === flush) {
+      activeFlushesByUserId.delete(input.userId);
+    }
+  }
+}

--- a/apps/mobile/features/email-capture/services/email-parse-improvement-prune.ts
+++ b/apps/mobile/features/email-capture/services/email-parse-improvement-prune.ts
@@ -1,0 +1,30 @@
+import { pruneStaleCaptureSourceEventsWithLocalLedger } from "@/infrastructure/local-ledger/public";
+import type { AnyDb } from "@/shared/db";
+import { toIsoDateTime } from "@/shared/lib";
+import type { IsoDateTime, UserId } from "@/shared/types/branded";
+
+const FAILED_EMAIL_SOURCE_EVENT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+
+const toRetentionBoundary = (now: Date, retentionMs: number): IsoDateTime =>
+  toIsoDateTime(new Date(now.getTime() - retentionMs));
+
+export function pruneStaleFailedEmailSourceEvents(input: {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly now?: Date;
+}): number {
+  const deletedAt = toIsoDateTime(input.now ?? new Date());
+  const retentionBoundary = toRetentionBoundary(
+    input.now ?? new Date(),
+    FAILED_EMAIL_SOURCE_EVENT_RETENTION_MS
+  );
+
+  return pruneStaleCaptureSourceEventsWithLocalLedger({
+    db: input.db,
+    userId: input.userId,
+    sourceFamily: "email",
+    status: "failed",
+    retentionBoundary,
+    deletedAt,
+  });
+}

--- a/apps/mobile/features/email-capture/services/email-parse-improvement-sharing.ts
+++ b/apps/mobile/features/email-capture/services/email-parse-improvement-sharing.ts
@@ -1,20 +1,96 @@
-import { shareCaptureParseImprovementSample } from "@/features/capture-sources/diagnostics.public";
-import { captureError } from "@/shared/lib";
+import type { AnyDb } from "@/shared/db";
+import { captureError, captureWarning } from "@/shared/lib";
 import type { UserId } from "@/shared/types/branded";
+import { isEmailCaptureDebugEnabled } from "./email-capture-debug";
 import type { EmailParseImprovementRequest } from "./email-pipeline-service/types";
+import {
+  enqueueEmailParseImprovementRequests,
+  flushPendingEmailParseImprovementSamples,
+} from "./email-parse-improvement-outbox";
+
+const getErrorName = (error: unknown): string => (error instanceof Error ? error.name : "unknown");
+
+const logParseImprovementSharingForDebug = (input: {
+  readonly enabled: boolean;
+  readonly requestCount: number;
+  readonly enqueued: number;
+  readonly shared: number;
+  readonly failed: number;
+}): void => {
+  if (!isEmailCaptureDebugEnabled()) return;
+
+  // eslint-disable-next-line no-console
+  console.log("[email-capture] parse-improvement.summary", input);
+};
 
 export async function shareEmailParseImprovementRequests(input: {
+  readonly db: AnyDb;
   readonly enabled: boolean;
   readonly userId: UserId;
   readonly requests: readonly EmailParseImprovementRequest[];
+  readonly isSharingEnabled?: () => boolean;
 }): Promise<void> {
-  if (!input.enabled) return;
+  if (!input.enabled) {
+    logParseImprovementSharingForDebug({
+      enabled: false,
+      requestCount: input.requests.length,
+      enqueued: 0,
+      shared: 0,
+      failed: 0,
+    });
+    return;
+  }
 
-  await Promise.all(
-    input.requests.map((request) =>
-      shareCaptureParseImprovementSample({ ...request, userId: input.userId, consent: true }).catch(
-        captureError
-      )
-    )
-  );
+  if (input.isSharingEnabled && !input.isSharingEnabled()) {
+    logParseImprovementSharingForDebug({
+      enabled: false,
+      requestCount: input.requests.length,
+      enqueued: 0,
+      shared: 0,
+      failed: 0,
+    });
+    return;
+  }
+
+  const enqueueRequest = (request: EmailParseImprovementRequest): number => {
+    try {
+      return enqueueEmailParseImprovementRequests({
+        db: input.db,
+        userId: input.userId,
+        requests: [request],
+      });
+    } catch (error) {
+      captureError(error);
+      captureWarning("email_parse_improvement_sample_enqueue_failed", {
+        errorType: getErrorName(error),
+      });
+      return 0;
+    }
+  };
+  const enqueued = input.requests.reduce((total, request) => total + enqueueRequest(request), 0);
+
+  const result = await flushPendingEmailParseImprovementSamples({
+    db: input.db,
+    userId: input.userId,
+    ...(input.isSharingEnabled ? { isSharingEnabled: input.isSharingEnabled } : {}),
+  }).catch((error) => {
+    captureError(error);
+    captureWarning("email_parse_improvement_sample_share_failed", {
+      errorType: getErrorName(error),
+    });
+    return { shared: 0, failed: 0, warningCaptured: true };
+  });
+  if (result.failed > 0 && !("warningCaptured" in result)) {
+    captureWarning("email_parse_improvement_sample_share_failed", {
+      errorType: result.failureTypes?.join(",") ?? "unknown",
+    });
+  }
+
+  logParseImprovementSharingForDebug({
+    enabled: true,
+    requestCount: input.requests.length,
+    enqueued,
+    shared: result.shared,
+    failed: result.failed,
+  });
 }

--- a/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-batch.ts
+++ b/apps/mobile/features/email-capture/services/email-pipeline-service/incoming-batch.ts
@@ -1,5 +1,6 @@
 import type { AnyDb } from "@/shared/db";
 import { capturePipelineEventEffect } from "@/shared/effect/telemetry";
+import { isEmailCaptureDebugEnabled } from "../email-capture-debug";
 import { buildEmailPipelineBatchTelemetry } from "./email-telemetry";
 import { processIncomingEmail } from "./incoming-email";
 import { getProcessedEmailSourceEventIdsEffect } from "./runtime";
@@ -46,9 +47,6 @@ type RegexParseAccumulator = {
 };
 
 const nowMs = (): number => Date.now();
-
-const isEmailCaptureDebugEnabled = (): boolean =>
-  process.env.EXPO_PUBLIC_EMAIL_CAPTURE_DEBUG === "1";
 
 const logRegexSummaryForDebug = (input: {
   readonly emailCount: number;

--- a/apps/mobile/features/email-capture/store.ts
+++ b/apps/mobile/features/email-capture/store.ts
@@ -1,5 +1,5 @@
 import type { AnyDb } from "@/shared/db";
-import { captureError, captureWarning, toIsoDateTime } from "@/shared/lib";
+import { captureError, captureWarning } from "@/shared/lib";
 import type { UserId } from "@/shared/types/branded";
 import {
   getEmailAccounts,
@@ -14,12 +14,8 @@ import {
   type EmailCaptureParseProfile,
   fetchEmailAccountBatch,
   ingestFetchedEmails,
-  type ProcessedEmailAccountFetchResult,
-  persistFetchedAccounts,
   resolveEmailCaptureSyncPolicy,
-  sortFetchResultsByNewestEmail,
 } from "./services/email-capture-fetch-service";
-import { loadEmailCaptureQueues } from "./services/email-capture-queues";
 import { aggregatePipelineResults } from "./services/email-capture-result";
 import {
   applyEmailCaptureFetchSummary,
@@ -34,7 +30,10 @@ import {
   registerEmailCaptureStoreRuntime,
 } from "./services/email-capture-store-runtime";
 import {
-  applyEmailCaptureFetchOutcome,
+  processFetchedAccountResults,
+  refreshEmailCaptureQueuesAndOutcome,
+} from "./store/fetch-processing";
+import {
   type RefreshTransactions,
   useEmailCaptureStore,
   warnFetchMissingContext,
@@ -142,6 +141,7 @@ export async function fetchAndProcessEmails(
   options: {
     readonly parseProfile?: EmailCaptureParseProfile;
     readonly shareParseImprovementSamples?: boolean;
+    readonly isShareParseImprovementSamplesEnabled?: () => boolean;
   } = {}
 ): Promise<EmailCaptureFetchOutcome> {
   const fetchStart = beginEmailCaptureFetchRun(userId);
@@ -177,36 +177,14 @@ export async function fetchAndProcessEmails(
       emailCount: allEmails.length,
     });
     const onProgress = createEmailCaptureFetchProgressHandler(run, refreshTransactions);
-    const processedFetchResults = await sortFetchResultsByNewestEmail(fetchResults).reduce(
-      async (processedPromise, fetchResult) => {
-        const processed = await processedPromise;
-        if (!fetchResult.fetchOk) return processed;
-        const previousResult = aggregatePipelineResults(
-          processed.map((result) => result.processingResult)
-        );
-        const completedBefore = processed.reduce(
-          (completed, result) => completed + result.rawEmails.length,
-          0
-        );
-        const processingResult = await ingestFetchedEmails({
-          db,
-          userId,
-          emails: fetchResult.rawEmails,
-          onProgress: (progress) =>
-            onProgress({
-              total: allEmails.length,
-              completed: completedBefore + progress.completed,
-              saved: previousResult.saved + progress.saved,
-              failed: previousResult.failed + progress.failed,
-              needsReview: previousResult.needsReview + progress.needsReview,
-            }),
-          runRetries: false,
-          parseProfile: syncPolicy.parseProfile,
-        });
-        return [...processed, { ...fetchResult, processingResult }];
-      },
-      Promise.resolve([] as ProcessedEmailAccountFetchResult[])
-    );
+    const processedFetchResults = await processFetchedAccountResults({
+      db,
+      userId,
+      fetchResults,
+      allEmails,
+      onProgress,
+      parseProfile: syncPolicy.parseProfile,
+    });
     if (syncPolicy.runRetries) {
       await ingestFetchedEmails({ db, userId, emails: [], parseProfile: syncPolicy.parseProfile });
     }
@@ -214,31 +192,19 @@ export async function fetchAndProcessEmails(
       processedFetchResults.map((result) => result.processingResult)
     );
     await shareEmailParseImprovementRequests({
+      db,
       enabled: options.shareParseImprovementSamples === true,
       userId,
       requests: processingResult.parseImprovementRequests,
+      isSharingEnabled: options.isShareParseImprovementSamplesEnabled,
     });
-    const queues = await loadEmailCaptureQueues(db, userId).catch((error) => {
-      captureWarning("email_capture_queue_refresh_failed", {
-        errorType: error instanceof Error ? error.name : "unknown",
-      });
-      const currentQueues = useEmailCaptureStore.getState();
-      return {
-        failedEmailSourceEvents: [...currentQueues.failedEmailSourceEvents],
-        needsReviewEmailSourceEvents: [...currentQueues.needsReviewEmailSourceEvents],
-      };
-    });
-    await applyEmailCaptureFetchOutcome({
+    await refreshEmailCaptureQueuesAndOutcome({
+      db,
+      userId,
       run,
       showProgress,
-      persistedAccounts: syncPolicy.advancesLastFetchedAt
-        ? await persistFetchedAccounts({
-            db,
-            userId,
-            fetchResults: processedFetchResults,
-          })
-        : { fetchedAt: toIsoDateTime(new Date()), updatedAccountIds: new Set() },
-      queues,
+      syncPolicy,
+      processedFetchResults,
       refreshTransactions,
     });
     return {

--- a/apps/mobile/features/email-capture/store/fetch-processing.ts
+++ b/apps/mobile/features/email-capture/store/fetch-processing.ts
@@ -1,0 +1,148 @@
+import type { AnyDb } from "@/shared/db";
+import { captureWarning, toIsoDateTime } from "@/shared/lib";
+import type { EmailAccountId, UserId } from "@/shared/types/branded";
+import {
+  type EmailAccountFetchResult,
+  type EmailCaptureParseProfile,
+  ingestFetchedEmails,
+  type ProcessedEmailAccountFetchResult,
+  persistFetchedAccounts,
+  resolveEmailCaptureSyncPolicy,
+  sortFetchResultsByNewestEmail,
+} from "../services/email-capture-fetch-service";
+import { loadEmailCaptureQueues } from "../services/email-capture-queues";
+import { aggregatePipelineResults } from "../services/email-capture-result";
+import {
+  createEmailCaptureFetchProgressHandler,
+  type EmailCaptureFetchRun,
+  isCurrentEmailCaptureFetchRun,
+} from "../services/email-capture-store-runtime";
+import { applyEmailCaptureFetchOutcome, type RefreshTransactions } from "./state";
+
+type FetchAccountResultsInput = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly fetchResults: readonly EmailAccountFetchResult[];
+  readonly allEmails: Parameters<typeof ingestFetchedEmails>[0]["emails"];
+  readonly onProgress: ReturnType<typeof createEmailCaptureFetchProgressHandler>;
+  readonly parseProfile: EmailCaptureParseProfile;
+};
+type ProcessFetchResultInput = Omit<FetchAccountResultsInput, "fetchResults"> & {
+  readonly fetchResult: EmailAccountFetchResult;
+  readonly processed: readonly ProcessedEmailAccountFetchResult[];
+};
+type RefreshFetchOutcomeInput = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly run: EmailCaptureFetchRun;
+  readonly showProgress: boolean;
+  readonly syncPolicy: ReturnType<typeof resolveEmailCaptureSyncPolicy>;
+  readonly processedFetchResults: readonly ProcessedEmailAccountFetchResult[];
+  readonly refreshTransactions: RefreshTransactions;
+};
+type EmailCaptureQueues = Awaited<ReturnType<typeof loadEmailCaptureQueues>>;
+
+function createFetchedEmailProgress(input: ProcessFetchResultInput) {
+  const previous = aggregatePipelineResults(
+    input.processed.map((result) => result.processingResult)
+  );
+  const completedBefore = input.processed.reduce(
+    (completed, result) => completed + result.rawEmails.length,
+    0
+  );
+  return (
+    progress: Parameters<NonNullable<Parameters<typeof ingestFetchedEmails>[0]["onProgress"]>>[0]
+  ) =>
+    input.onProgress({
+      total: input.allEmails.length,
+      completed:
+        completedBefore +
+        (input.fetchResult.rawEmails.length - progress.total) +
+        progress.completed,
+      saved: previous.saved + progress.saved,
+      failed: previous.failed + progress.failed,
+      needsReview: previous.needsReview + progress.needsReview,
+    });
+}
+
+async function processFetchedAccountResult(
+  input: ProcessFetchResultInput
+): Promise<ProcessedEmailAccountFetchResult> {
+  const processingResult = await ingestFetchedEmails({
+    db: input.db,
+    userId: input.userId,
+    emails: input.fetchResult.rawEmails,
+    onProgress: createFetchedEmailProgress(input),
+    runRetries: false,
+    parseProfile: input.parseProfile,
+  });
+  return { ...input.fetchResult, processingResult };
+}
+
+export async function processFetchedAccountResults(
+  input: FetchAccountResultsInput
+): Promise<ProcessedEmailAccountFetchResult[]> {
+  const processed: ProcessedEmailAccountFetchResult[] = [];
+
+  for (const fetchResult of sortFetchResultsByNewestEmail(input.fetchResults)) {
+    if (!fetchResult.fetchOk) continue;
+    processed.push(
+      await processFetchedAccountResult({
+        db: input.db,
+        userId: input.userId,
+        fetchResult,
+        processed,
+        allEmails: input.allEmails,
+        onProgress: input.onProgress,
+        parseProfile: input.parseProfile,
+      })
+    );
+  }
+
+  return processed;
+}
+
+async function loadEmailCaptureQueuesWithFallback(
+  db: AnyDb,
+  userId: UserId
+): Promise<EmailCaptureQueues | null> {
+  return loadEmailCaptureQueues(db, userId).catch((error) => {
+    captureWarning("email_capture_queue_refresh_failed", {
+      errorType: error instanceof Error ? error.name : "unknown",
+    });
+    return null;
+  });
+}
+
+async function createPersistedFetchAccounts(input: RefreshFetchOutcomeInput) {
+  if (!input.syncPolicy.advancesLastFetchedAt) {
+    return { fetchedAt: toIsoDateTime(new Date()), updatedAccountIds: new Set<EmailAccountId>() };
+  }
+  return persistFetchedAccounts({
+    db: input.db,
+    userId: input.userId,
+    fetchResults: input.processedFetchResults,
+  });
+}
+
+async function prepareCurrentFetchOutcome(input: RefreshFetchOutcomeInput) {
+  const isCurrentRun = () => isCurrentEmailCaptureFetchRun(input.run);
+  const persistedAccounts = await createPersistedFetchAccounts(input);
+  if (!isCurrentRun()) return null;
+  const queues = await loadEmailCaptureQueuesWithFallback(input.db, input.userId);
+  return isCurrentRun() ? { persistedAccounts, queues } : null;
+}
+
+export async function refreshEmailCaptureQueuesAndOutcome(
+  input: RefreshFetchOutcomeInput
+): Promise<void> {
+  const outcome = await prepareCurrentFetchOutcome(input);
+  if (!outcome) return;
+  await applyEmailCaptureFetchOutcome({
+    run: input.run,
+    showProgress: input.showProgress,
+    persistedAccounts: outcome.persistedAccounts,
+    queues: outcome.queues,
+    refreshTransactions: input.refreshTransactions,
+  });
+}

--- a/apps/mobile/features/email-capture/store/state.ts
+++ b/apps/mobile/features/email-capture/store/state.ts
@@ -133,7 +133,7 @@ export async function applyEmailCaptureFetchOutcome(input: {
   readonly run: EmailCaptureFetchRun;
   readonly showProgress: boolean;
   readonly persistedAccounts: PersistedFetchedAccounts;
-  readonly queues: EmailCaptureQueues;
+  readonly queues: EmailCaptureQueues | null;
   readonly refreshTransactions: RefreshTransactions;
 }): Promise<void> {
   if (!isCurrentEmailCaptureFetchRun(input.run)) return;
@@ -143,8 +143,8 @@ export async function applyEmailCaptureFetchOutcome(input: {
     input.persistedAccounts.updatedAccountIds,
     input.persistedAccounts.fetchedAt
   );
-  state.setFailedEmailSourceEvents(input.queues.failedEmailSourceEvents);
-  state.setNeedsReviewEmailSourceEvents(input.queues.needsReviewEmailSourceEvents);
+  state.setFailedEmailSourceEvents(input.queues?.failedEmailSourceEvents ?? []);
+  state.setNeedsReviewEmailSourceEvents(input.queues?.needsReviewEmailSourceEvents ?? []);
   if (input.showProgress) state.setPhase("complete");
   await input.refreshTransactions();
 }

--- a/apps/mobile/features/onboarding/components/SyncProgressStep.tsx
+++ b/apps/mobile/features/onboarding/components/SyncProgressStep.tsx
@@ -24,7 +24,6 @@ import {
 import { styles } from "./SyncProgressStep.styles";
 import { SyncImportProgress } from "./SyncImportProgress";
 import { SyncTransactionPreview } from "./SyncTransactionPreview";
-
 export function SyncProgressStep() {
   const { t } = useTranslation();
   const userId = useOptionalUserId();
@@ -60,7 +59,6 @@ export function SyncProgressStep() {
       resolveIdle?.(shouldRetry);
       resolveIdle = null;
     };
-
     const getHasAccountSuggestions = () =>
       Boolean(
         db &&
@@ -180,6 +178,8 @@ export function SyncProgressStep() {
           {
             parseProfile: "initial_sync",
             shareParseImprovementSamples: shareAnonymizedParseSamples,
+            isShareParseImprovementSamplesEnabled: () =>
+              useSettingsStore.getState().shareAnonymizedParseSamples,
           }
         );
 

--- a/apps/mobile/features/settings/components/SettingsScreen.tsx
+++ b/apps/mobile/features/settings/components/SettingsScreen.tsx
@@ -3,7 +3,7 @@ import { Image } from "expo-image";
 import { Stack, useRouter } from "expo-router";
 import { useState } from "react";
 import { openBrowserAsync } from "expo-web-browser";
-import { useAuthIdentity } from "@/features/auth/public";
+import { useAuthIdentity, useOptionalUserId } from "@/features/auth/public";
 import type { PrivateBackupHealthStatus } from "@/features/backup/public";
 import { useEmailCaptureStore } from "@/features/email-capture/public";
 import { ScreenLayout, SettingsSection, TAB_BAR_CLEARANCE } from "@/shared/components";
@@ -28,6 +28,7 @@ import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { deriveProfileAvatar } from "../lib/profile-avatar";
 import { buildPrivacyUrl, buildTermsUrl, buildWhatsAppUrl } from "../lib/settings-links";
 import { useSettingsStore } from "../store";
+import { applyParseImprovementSharingToggle } from "./parse-improvement-sharing-toggle";
 import { SettingsRow } from "./SettingsRow";
 
 const THEME_LABEL_KEYS: Record<string, string> = {
@@ -54,6 +55,7 @@ export function SettingsScreen() {
   const { t, locale } = useTranslation();
 
   const { fullName, email, profileImageUrl } = useAuthIdentity();
+  const userId = useOptionalUserId();
   const [failedImageUrl, setFailedImageUrl] = useState<string | null>(null);
   const avatar = deriveProfileAvatar({
     fullName,
@@ -80,6 +82,12 @@ export function SettingsScreen() {
     : t("settings.languageEnglish");
 
   const version = Constants.expoConfig?.version ?? "0.0.1";
+  const handleParseImprovementSharingChange = (enabled: boolean) =>
+    applyParseImprovementSharingToggle({
+      enabled,
+      userId,
+      setShareAnonymizedParseSamples,
+    });
 
   return (
     <ScreenLayout variant="sub" title={t("settings.title")} onBack={back}>
@@ -201,7 +209,7 @@ export function SettingsScreen() {
             subtitle={t("settings.parseImprovementSharingSubtitle")}
             accessory="switch"
             switchValue={shareAnonymizedParseSamples}
-            onSwitchChange={setShareAnonymizedParseSamples}
+            onSwitchChange={handleParseImprovementSharingChange}
             isLast
           />
         </SettingsSection>
@@ -234,7 +242,7 @@ export function SettingsScreen() {
               icon={Wrench}
               label={t("settings.designSystem")}
               subtitle={t("settings.designSystemSubtitle")}
-              onPress={() => push("/design-system" as never)}
+              onPress={() => push("/design-system")}
             />
           ) : null}
           <SettingsRow

--- a/apps/mobile/features/settings/components/parse-improvement-sharing-toggle.ts
+++ b/apps/mobile/features/settings/components/parse-improvement-sharing-toggle.ts
@@ -1,0 +1,92 @@
+import {
+  countPendingEmailParseImprovementSamples,
+  flushPendingEmailParseImprovementSamples,
+  isEmailCaptureDebugEnabled,
+} from "@/features/email-capture/parse-improvement.public";
+import { getDb } from "@/shared/db";
+import { captureError, captureWarning } from "@/shared/lib";
+import type { UserId } from "@/shared/types/branded";
+import { useSettingsStore } from "../store";
+
+const logParseImprovementToggleForDebug = (
+  payload: Record<string, number | string | boolean | null>
+): void => {
+  if (!isEmailCaptureDebugEnabled()) return;
+
+  // eslint-disable-next-line no-console
+  console.log("[email-capture] parse-improvement.toggle", payload);
+};
+
+const toggleFlushesByUserId = new Map<UserId, Promise<void>>();
+
+const getErrorName = (error: unknown): string => (error instanceof Error ? error.name : "unknown");
+
+const captureFlushFailureWarning = (failureTypes?: readonly string[]): void => {
+  captureWarning("email_parse_improvement_sample_share_failed", {
+    errorType: failureTypes && failureTypes.length > 0 ? failureTypes.join(",") : "unknown",
+  });
+};
+
+export function applyParseImprovementSharingToggle(input: {
+  readonly enabled: boolean;
+  readonly userId: UserId | null;
+  readonly setShareAnonymizedParseSamples: (enabled: boolean) => void;
+}): void {
+  input.setShareAnonymizedParseSamples(input.enabled);
+  if (!input.userId) {
+    logParseImprovementToggleForDebug({ enabled: input.enabled, hasUserId: false, pending: null });
+    return;
+  }
+  const userId = input.userId;
+
+  let pending: number | null = null;
+  let db: ReturnType<typeof getDb>;
+  try {
+    db = getDb(userId);
+  } catch (error) {
+    captureError(error);
+    logParseImprovementToggleForDebug({ enabled: input.enabled, hasUserId: true, pending: null });
+    return;
+  }
+
+  if (isEmailCaptureDebugEnabled()) {
+    try {
+      pending = countPendingEmailParseImprovementSamples({ db, userId });
+    } catch (error) {
+      captureError(error);
+    }
+  }
+
+  logParseImprovementToggleForDebug({ enabled: input.enabled, hasUserId: true, pending });
+  if (!input.enabled) return;
+
+  const previousFlush = toggleFlushesByUserId.get(userId) ?? Promise.resolve();
+  const flush = previousFlush
+    .catch(() => undefined)
+    .then(async () => {
+      if (!useSettingsStore.getState().shareAnonymizedParseSamples) return;
+      const result = await flushPendingEmailParseImprovementSamples({
+        db,
+        userId,
+        isSharingEnabled: () => useSettingsStore.getState().shareAnonymizedParseSamples,
+      });
+      if (result.failed > 0) captureFlushFailureWarning(result.failureTypes);
+      logParseImprovementToggleForDebug({
+        enabled: input.enabled,
+        hasUserId: true,
+        pending,
+        shared: result.shared,
+        failed: result.failed,
+      });
+    })
+    .catch((error) => {
+      captureError(error);
+      captureFlushFailureWarning([getErrorName(error)]);
+    })
+    .finally(() => {
+      if (toggleFlushesByUserId.get(userId) === flush) {
+        toggleFlushesByUserId.delete(userId);
+      }
+    });
+  toggleFlushesByUserId.set(userId, flush);
+}

--- a/apps/mobile/infrastructure/local-ledger/capture-source-events.ts
+++ b/apps/mobile/infrastructure/local-ledger/capture-source-events.ts
@@ -1,5 +1,6 @@
 export {
   persistCommittedCaptureSourceEvent as recordCommittedCaptureSourceEventWithLocalLedger,
+  pruneStaleCaptureSourceEventsWithLocalLedger,
   persistCommittedCaptureSourceEventInTransaction as recordCommittedCaptureSourceEventInTransactionWithLocalLedger,
   persistProcessedSourceEvent as recordProcessedCaptureSourceEventWithLocalLedger,
 } from "./source-events";

--- a/apps/mobile/infrastructure/local-ledger/public.ts
+++ b/apps/mobile/infrastructure/local-ledger/public.ts
@@ -18,6 +18,7 @@ export {
   type ReclassifyTransactionsAsTransferResult,
 } from "./transfer-reclassification";
 export {
+  pruneStaleCaptureSourceEventsWithLocalLedger,
   recordCommittedCaptureSourceEventInTransactionWithLocalLedger,
   recordCommittedCaptureSourceEventWithLocalLedger,
   recordProcessedCaptureSourceEventWithLocalLedger,

--- a/apps/mobile/infrastructure/local-ledger/source-events.ts
+++ b/apps/mobile/infrastructure/local-ledger/source-events.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, isNull, lt } from "drizzle-orm";
 import type { CaptureEvidenceSeed } from "@/shared/capture-evidence/types";
 import type { AnyDb } from "@/shared/db";
 import { captureEvidence, processedSourceEvents } from "@/shared/db/schema";
@@ -34,6 +34,15 @@ type SourceEventInput = {
 
 type PersistSourceEventInput = SourceEventInput & {
   readonly db: AnyDb;
+};
+
+type PruneStaleCaptureSourceEventsInput = {
+  readonly db: AnyDb;
+  readonly userId: UserId;
+  readonly sourceFamily: string;
+  readonly status: SourceEventStatus;
+  readonly retentionBoundary: IsoDateTime;
+  readonly deletedAt: IsoDateTime;
 };
 
 type PersistCommittedCaptureInput = PersistSourceEventInput & {
@@ -185,3 +194,20 @@ export const persistCommittedCaptureSourceEvent = (
     persistCommittedCaptureSourceEventInTransaction(tx, input);
   });
 };
+
+export const pruneStaleCaptureSourceEventsWithLocalLedger = (
+  input: PruneStaleCaptureSourceEventsInput
+): number =>
+  input.db
+    .update(processedSourceEvents)
+    .set({ deletedAt: input.deletedAt, updatedAt: input.deletedAt })
+    .where(
+      and(
+        eq(processedSourceEvents.userId, input.userId),
+        eq(processedSourceEvents.sourceFamily, input.sourceFamily),
+        eq(processedSourceEvents.status, input.status),
+        lt(processedSourceEvents.processedAt, input.retentionBoundary),
+        isNull(processedSourceEvents.deletedAt)
+      )
+    )
+    .run().changes;

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -94,7 +94,7 @@
     "@vitest/coverage-v8": "^4.0.18",
     "babel-plugin-inline-import": "3.0.0",
     "babel-preset-expo": "~55.0.8",
-    "better-sqlite3": "12.9.0",
+    "better-sqlite3": "12.10.0",
     "drizzle-kit": "0.31.9",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~55.0.1",

--- a/apps/mobile/shared/db/schema.ts
+++ b/apps/mobile/shared/db/schema.ts
@@ -21,6 +21,7 @@ import type {
   CopAmount,
   DetectedSmsEventId,
   EmailAccountId,
+  EmailParseImprovementSampleId,
   FinancialAccountId,
   FinancialAccountIdentifierId,
   IsoDate,
@@ -259,6 +260,40 @@ export const processedSourceEvents = sqliteTable(
       table.nextRetryAt
     ),
     index("idx_processed_source_events_user_updated").on(table.userId, table.updatedAt),
+  ]
+);
+
+export const emailParseImprovementSamples = sqliteTable(
+  "email_parse_improvement_samples",
+  {
+    id: text("id").$type<EmailParseImprovementSampleId>().primaryKey(),
+    userId: text("user_id").$type<UserId>().notNull(),
+    template: text("template").notNull(),
+    senderDomain: text("sender_domain"),
+    source: text("source").notNull(),
+    status: text("status").notNull(),
+    confidence: real("confidence"),
+    parseMethod: text("parse_method").notNull(),
+    createdAt: text("created_at").$type<IsoDateTime>().notNull(),
+    sharedAt: text("shared_at").$type<IsoDateTime>(),
+    deletedAt: text("deleted_at").$type<IsoDateTime>(),
+  },
+  (table) => [
+    uniqueIndex("uq_email_parse_improvement_sample").on(
+      table.userId,
+      table.source,
+      table.status,
+      table.parseMethod,
+      sql`coalesce(${table.senderDomain}, '')`,
+      table.template
+    ),
+    index("idx_email_parse_improvement_samples_pending").on(
+      table.userId,
+      table.sharedAt,
+      table.deletedAt,
+      table.createdAt,
+      table.id
+    ),
   ]
 );
 

--- a/apps/mobile/shared/lib/generate-id.ts
+++ b/apps/mobile/shared/lib/generate-id.ts
@@ -9,6 +9,7 @@ import type {
   ChatSessionId,
   DetectedSmsEventId,
   EmailAccountId,
+  EmailParseImprovementSampleId,
   FinancialAccountId,
   FinancialAccountIdentifierId,
   MerchantRuleId,
@@ -78,6 +79,10 @@ export function generateUserMemoryId(): UserMemoryId {
 
 export function generateEmailAccountId(): EmailAccountId {
   return generateId("ea") as EmailAccountId;
+}
+
+export function generateEmailParseImprovementSampleId(): EmailParseImprovementSampleId {
+  return generateId("epis") as EmailParseImprovementSampleId;
 }
 
 export function generateFinancialAccountId(): FinancialAccountId {

--- a/apps/mobile/shared/types/branded.ts
+++ b/apps/mobile/shared/types/branded.ts
@@ -15,6 +15,7 @@ export type ChatSessionId = Brand<string, "ChatSessionId">;
 export type ChatMessageId = Brand<string, "ChatMessageId">;
 export type UserMemoryId = Brand<string, "UserMemoryId">;
 export type EmailAccountId = Brand<string, "EmailAccountId">;
+export type EmailParseImprovementSampleId = Brand<string, "EmailParseImprovementSampleId">;
 export type TransferId = Brand<string, "TransferId">;
 export type MerchantRuleId = Brand<string, "MerchantRuleId">;
 export type NotificationSourceId = Brand<string, "NotificationSourceId">;

--- a/bun.lock
+++ b/bun.lock
@@ -94,7 +94,7 @@
         "@vitest/coverage-v8": "^4.0.18",
         "babel-plugin-inline-import": "3.0.0",
         "babel-preset-expo": "~55.0.8",
-        "better-sqlite3": "12.9.0",
+        "better-sqlite3": "12.10.0",
         "drizzle-kit": "0.31.9",
         "eslint": "^9.25.0",
         "eslint-config-expo": "~55.0.1",
@@ -1173,7 +1173,7 @@
 
     "better-opn": ["better-opn@3.0.2", "", { "dependencies": { "open": "^8.0.4" } }, "sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ=="],
 
-    "better-sqlite3": ["better-sqlite3@12.9.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ=="],
+    "better-sqlite3": ["better-sqlite3@12.10.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ=="],
 
     "big-integer": ["big-integer@1.6.52", "", {}, "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg=="],
 

--- a/dependency-policy.json
+++ b/dependency-policy.json
@@ -71,6 +71,126 @@
       "reason": "Minor dependency update should land in a dedicated tooling PR so architecture reports can be reviewed separately."
     },
     {
+      "name": "babel-preset-expo",
+      "until": "2026-06-01",
+      "reason": "Held to the Expo SDK 55-compatible version; SDK 56 belongs in a dedicated Expo migration PR."
+    },
+    {
+      "name": "eslint-config-expo",
+      "until": "2026-06-01",
+      "reason": "Held to the Expo SDK 55-compatible version; SDK 56 belongs in a dedicated Expo migration PR."
+    },
+    {
+      "name": "expo-background-task",
+      "until": "2026-06-01",
+      "reason": "Held to the Expo SDK 55-compatible version; SDK 56 belongs in a dedicated Expo migration PR."
+    },
+    {
+      "name": "expo-blur",
+      "until": "2026-06-01",
+      "reason": "Held to the Expo SDK 55-compatible version; SDK 56 belongs in a dedicated Expo migration PR."
+    },
+    {
+      "name": "expo-constants",
+      "until": "2026-06-01",
+      "reason": "Held to the Expo SDK 55-compatible version; SDK 56 belongs in a dedicated Expo migration PR."
+    },
+    {
+      "name": "expo-crypto",
+      "until": "2026-06-01",
+      "reason": "Held to the Expo SDK 55-compatible version; SDK 56 belongs in a dedicated Expo migration PR."
+    },
+    {
+      "name": "expo-dev-client",
+      "until": "2026-06-01",
+      "reason": "Held to the Expo SDK 55-compatible version; SDK 56 belongs in a dedicated Expo migration PR."
+    },
+    {
+      "name": "expo-font",
+      "until": "2026-06-01",
+      "reason": "Held to the Expo SDK 55-compatible version; SDK 56 belongs in a dedicated Expo migration PR."
+    },
+    {
+      "name": "expo-glass-effect",
+      "until": "2026-06-01",
+      "reason": "Held to the Expo SDK 55-compatible version; SDK 56 belongs in a dedicated Expo migration PR."
+    },
+    {
+      "name": "expo-haptics",
+      "until": "2026-06-01",
+      "reason": "Held to the Expo SDK 55-compatible version; SDK 56 belongs in a dedicated Expo migration PR."
+    },
+    {
+      "name": "expo-image",
+      "until": "2026-06-01",
+      "reason": "Held to the Expo SDK 55-compatible version; SDK 56 belongs in a dedicated Expo migration PR."
+    },
+    {
+      "name": "expo-linking",
+      "until": "2026-06-01",
+      "reason": "Held to the Expo SDK 55-compatible version; SDK 56 belongs in a dedicated Expo migration PR."
+    },
+    {
+      "name": "expo-localization",
+      "until": "2026-06-01",
+      "reason": "Held to the Expo SDK 55-compatible version; SDK 56 belongs in a dedicated Expo migration PR."
+    },
+    {
+      "name": "expo-notifications",
+      "until": "2026-06-01",
+      "reason": "Held to the Expo SDK 55-compatible version; SDK 56 belongs in a dedicated Expo migration PR."
+    },
+    {
+      "name": "expo-router",
+      "until": "2026-06-01",
+      "reason": "Held to the Expo SDK 55-compatible version; SDK 56 belongs in a dedicated Expo migration PR."
+    },
+    {
+      "name": "expo-secure-store",
+      "until": "2026-06-01",
+      "reason": "Held to the Expo SDK 55-compatible version; SDK 56 belongs in a dedicated Expo migration PR."
+    },
+    {
+      "name": "expo-splash-screen",
+      "until": "2026-06-01",
+      "reason": "Held to the Expo SDK 55-compatible version; SDK 56 belongs in a dedicated Expo migration PR."
+    },
+    {
+      "name": "expo-sqlite",
+      "until": "2026-06-01",
+      "reason": "Held to the Expo SDK 55-compatible version; SDK 56 belongs in a dedicated Expo migration PR."
+    },
+    {
+      "name": "expo-status-bar",
+      "until": "2026-06-01",
+      "reason": "Held to the Expo SDK 55-compatible version; SDK 56 belongs in a dedicated Expo migration PR."
+    },
+    {
+      "name": "expo-symbols",
+      "until": "2026-06-01",
+      "reason": "Held to the Expo SDK 55-compatible version; SDK 56 belongs in a dedicated Expo migration PR."
+    },
+    {
+      "name": "expo-system-ui",
+      "until": "2026-06-01",
+      "reason": "Held to the Expo SDK 55-compatible version; SDK 56 belongs in a dedicated Expo migration PR."
+    },
+    {
+      "name": "expo-task-manager",
+      "until": "2026-06-01",
+      "reason": "Held to the Expo SDK 55-compatible version; SDK 56 belongs in a dedicated Expo migration PR."
+    },
+    {
+      "name": "expo-updates",
+      "until": "2026-06-01",
+      "reason": "Held to the Expo SDK 55-compatible version; SDK 56 belongs in a dedicated Expo migration PR."
+    },
+    {
+      "name": "expo-web-browser",
+      "until": "2026-06-01",
+      "reason": "Held to the Expo SDK 55-compatible version; SDK 56 belongs in a dedicated Expo migration PR."
+    },
+    {
       "name": "eslint",
       "until": "2026-06-01",
       "reason": "ESLint 10 should wait for eslint-config-expo compatibility confirmation."


### PR DESCRIPTION
- add parse-improvement outbox

- add BBVA and Davibank regex patterns

- prune stale failed email events

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt‑in outbox for anonymized email‑parse samples with batched, consent‑aware sharing and debug logs, plus improved BBVA/Davibank regex parsing. Adds a maintenance task that prunes stale failed email events.

- **New Features**
  - Outbox for parse samples: unique‑key de‑dupe, batch size 10, single in‑flight flush per user, sets `sharedAt`, stops if consent is revoked, dead‑letters privacy/non‑retryable insert errors, routes all sharing through the outbox, and sanitizes/clamps templates to 1000 chars.
  - Debug/consent: debug summaries behind `EXPO_PUBLIC_EMAIL_CAPTURE_DEBUG`; uses live consent checker (`isShareParseImprovementSamplesEnabled`) across background, initial, and onboarding; settings toggle shows pending count and flushes on enable; enqueue/flush failures captured as warnings (non‑Error => “unknown”).
  - Maintenance: daily job prunes 7‑day‑old failed email source events, tracks last run in `SecureStore`, and runs in the authenticated maintenance bootstrap.
  - Bank parsers: prevent US‑style misreads of Colombian dates; add BBVA reference amount/establishment/date/card last4 extraction; improve Davibank parsing with a false‑positive guard and partial date handling.
  - Reliability: hydrate settings before email sync; progress includes skipped emails per account; clear stale queues if queue refresh fails; gate remote capture effects on onboarding completion.
  - Dependencies: bump `better-sqlite3` to 12.10.0; add Expo SDK 55 dependency holds in `dependency-policy.json`.

- **Migration**
  - Apply `0030_email_parse_improvement_outbox.sql`.

<sup>Written for commit 4c34e248d05c70ed5fcb06e74105d4fea640018b. Summary will update on new commits. <a href="https://cubic.dev/pr/B4rz99/fidy/pull/478?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

