### PR TITLE
feat(mobile): improve wait feedback

### DIFF
--- a/apps/mobile/__tests__/transactions/add-screen-source.test.ts
+++ b/apps/mobile/__tests__/transactions/add-screen-source.test.ts
@@ -74,6 +74,26 @@ test("Pencil entry scaffold matches the requested layout structure", () => {
   expect(scaffoldSource).toContain("$0");
 });
 
+test("Pencil entry numpad keeps the final row aligned to three columns", () => {
+  expect(scaffoldSource).toContain('["000", "0", "delete"]');
+  expect(scaffoldSource).toContain("<View key={key} style={styles.rightColumn}>");
+  expect(scaffoldSource).not.toContain("style={({ pressed })");
+  expect(scaffoldStylesSource).toContain("rightColumn: {");
+  expect(scaffoldStylesSource).toContain("flex: 1");
+  expect(scaffoldStylesSource).not.toContain("flex: 2");
+  expect(scaffoldStylesSource).not.toContain("flexBasis");
+  expect(scaffoldStylesSource).not.toContain("minWidth");
+});
+
+test("Pencil entry numpad feedback does not own layout styles", () => {
+  expect(scaffoldSource).toContain("PencilNumpadButton");
+  expect(scaffoldSource).toContain("Haptics.impactAsync");
+  expect(scaffoldSource).toContain("android_ripple");
+  expect(scaffoldSource).toContain("styles.keyFeedback");
+  expect(scaffoldStylesSource).toContain("keyFeedback");
+  expect(scaffoldStylesSource).not.toContain("keyPressed");
+});
+
 test("Pencil entry tab indicator uses a centered pill instead of an underline", () => {
   expect(scaffoldSource).toContain("animatedTabPillStyle");
   expect(scaffoldSource).toContain("animatedTabPillX");

--- a/apps/mobile/features/onboarding/components/SyncImportProgress.tsx
+++ b/apps/mobile/features/onboarding/components/SyncImportProgress.tsx
@@ -1,0 +1,35 @@
+import { ProgressBar } from "@/shared/components";
+import { Text, View } from "@/shared/components/rn";
+import { useThemeColor, useTranslation } from "@/shared/hooks";
+import { styles } from "./SyncProgressStep.styles";
+
+type SyncImportProgressProps = {
+  readonly importComplete: boolean;
+  readonly isWaiting: boolean;
+  readonly savedCount: number;
+  readonly percent: number;
+};
+
+export function SyncImportProgress({
+  importComplete,
+  isWaiting,
+  savedCount,
+  percent,
+}: SyncImportProgressProps) {
+  const { t } = useTranslation();
+  const accentGreen = useThemeColor("accentGreen");
+
+  return (
+    <View style={styles.progressSection}>
+      <ProgressBar
+        percent={percent}
+        height={10}
+        completeTone="success"
+        shimmering={isWaiting && !importComplete}
+      />
+      <Text style={[styles.counter, { color: accentGreen }]}>
+        {t("onboarding.syncing.transactionsFound", { count: savedCount })}
+      </Text>
+    </View>
+  );
+}

--- a/apps/mobile/features/onboarding/components/SyncProgressStep.tsx
+++ b/apps/mobile/features/onboarding/components/SyncProgressStep.tsx
@@ -10,7 +10,6 @@ import {
 } from "@/features/email-capture/public";
 import { useSettingsStore } from "@/features/settings/hooks.public";
 import { refreshTransactions, useTransactionStore } from "@/features/transactions/store.public";
-import { ProgressBar } from "@/shared/components";
 import { Pressable, Text, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
 import { useMountEffect, useThemeColor, useTranslation } from "@/shared/hooks";
@@ -23,6 +22,7 @@ import {
   type SyncOutcome,
 } from "./SyncProgressStep.helpers";
 import { styles } from "./SyncProgressStep.styles";
+import { SyncImportProgress } from "./SyncImportProgress";
 import { SyncTransactionPreview } from "./SyncTransactionPreview";
 
 export function SyncProgressStep() {
@@ -247,12 +247,12 @@ export function SyncProgressStep() {
           {t("onboarding.syncing.processing")}
         </Text>
 
-        <View style={styles.progressSection}>
-          <ProgressBar percent={percent} height={10} />
-          <Text style={[styles.counter, { color: accentGreen }]}>
-            {t("onboarding.syncing.transactionsFound", { count: savedCount })}
-          </Text>
-        </View>
+        <SyncImportProgress
+          importComplete={importComplete}
+          isWaiting={syncOutcome === null}
+          percent={percent}
+          savedCount={savedCount}
+        />
 
         <SyncTransactionPreview
           fallbackLabel={t("common.transaction")}

--- a/apps/mobile/shared/components/PencilEntryScaffold.styles.ts
+++ b/apps/mobile/shared/components/PencilEntryScaffold.styles.ts
@@ -52,6 +52,11 @@ export const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "center",
   },
+  keyFeedback: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "rgba(255, 255, 255, 0.42)",
+    borderRadius: 14,
+  },
   keyText: {
     fontFamily: "Poppins_600SemiBold",
     fontSize: 19,

--- a/apps/mobile/shared/components/PencilEntryScaffold.tsx
+++ b/apps/mobile/shared/components/PencilEntryScaffold.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import * as Haptics from "expo-haptics";
 import Animated, {
   useAnimatedStyle,
   useDerivedValue,
@@ -12,9 +13,11 @@ import {
   Keyboard,
   Platform,
   Pressable,
+  type StyleProp,
   Text,
   useWindowDimensions,
   View,
+  type ViewStyle,
 } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { styles } from "./PencilEntryScaffold.styles";
@@ -46,6 +49,7 @@ const ANDROID_TAB_BAR_HEIGHT = 64;
 const PENCIL_ENTRY_HORIZONTAL_PADDING = 16;
 const SWIPE_TAB_THRESHOLD = 56;
 const TAB_GAP = 8;
+const NUMPAD_RIPPLE_COLOR = "rgba(255, 255, 255, 0.42)";
 
 function getTabIndicatorColor(input: {
   readonly accentGreen: string;
@@ -56,6 +60,54 @@ function getTabIndicatorColor(input: {
   if (input.tab === "expense") return input.accentRed;
   if (input.tab === "income") return input.accentGreen;
   return input.tertiary;
+}
+
+type PencilNumpadButtonProps = {
+  readonly accessibilityLabel?: string;
+  readonly children: ReactNode;
+  readonly disabled?: boolean;
+  readonly onPress?: () => void;
+  readonly style: StyleProp<ViewStyle>;
+  readonly testID?: string;
+};
+
+function PencilNumpadButton({
+  accessibilityLabel,
+  children,
+  disabled = false,
+  onPress,
+  style,
+  testID,
+}: PencilNumpadButtonProps) {
+  const feedback = useSharedValue(0);
+  const feedbackStyle = useAnimatedStyle(() => ({
+    opacity: feedback.value,
+    transform: [{ scale: 0.88 + feedback.value * 0.12 }],
+  }));
+  const showFeedback = () => {
+    if (disabled) return;
+    feedback.value = withTiming(1, { duration: 80 });
+  };
+  const hideFeedback = () => {
+    feedback.value = withTiming(0, { duration: 180 });
+  };
+
+  return (
+    <Pressable
+      testID={testID}
+      style={style}
+      android_ripple={{ color: NUMPAD_RIPPLE_COLOR, borderless: false }}
+      disabled={disabled}
+      onPress={onPress}
+      onPressIn={showFeedback}
+      onPressOut={hideFeedback}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+    >
+      <Animated.View pointerEvents="none" style={[styles.keyFeedback, feedbackStyle]} />
+      {children}
+    </Pressable>
+  );
 }
 
 export function PencilEntryScaffold({
@@ -103,6 +155,14 @@ export function PencilEntryScaffold({
       transform: [{ translateX: animatedTabPillX.value }],
     };
   });
+  const handleKeyPress = (key: string) => {
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    onKeyPress(key);
+  };
+  const handleConfirmPress = () => {
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    onConfirm();
+  };
   const tabSwipe = Gesture.Pan()
     .runOnJS(true)
     .activeOffsetX([-16, 16])
@@ -184,15 +244,14 @@ export function PencilEntryScaffold({
                   if (key === "delete") {
                     return (
                       <View key={key} style={styles.rightColumn}>
-                        <Pressable
+                        <PencilNumpadButton
                           style={[styles.key, { backgroundColor: specialKeyBg }]}
-                          onPress={() => onKeyPress(key)}
-                          accessibilityRole="button"
+                          onPress={() => handleKeyPress(key)}
                           accessibilityLabel={t("common.delete")}
                         >
                           <Delete size={20} color={tertiary} />
-                        </Pressable>
-                        <Pressable
+                        </PencilNumpadButton>
+                        <PencilNumpadButton
                           testID="keyConfirm"
                           style={[
                             styles.key,
@@ -202,25 +261,23 @@ export function PencilEntryScaffold({
                             },
                           ]}
                           disabled={isConfirmDisabled}
-                          onPress={isConfirmDisabled ? undefined : onConfirm}
-                          accessibilityRole="button"
+                          onPress={isConfirmDisabled ? undefined : handleConfirmPress}
                         >
                           <Check size={22} color={onAccent} />
-                        </Pressable>
+                        </PencilNumpadButton>
                       </View>
                     );
                   }
 
                   return (
-                    <Pressable
+                    <PencilNumpadButton
                       key={key}
                       style={[styles.key, { backgroundColor: keyBg }]}
-                      onPress={() => onKeyPress(key)}
-                      accessibilityRole="button"
+                      onPress={() => handleKeyPress(key)}
                       accessibilityLabel={key}
                     >
                       <Text style={[styles.keyText, { color: primary }]}>{key}</Text>
-                    </Pressable>
+                    </PencilNumpadButton>
                   );
                 })}
               </View>

--- a/apps/mobile/shared/components/ProgressBar.tsx
+++ b/apps/mobile/shared/components/ProgressBar.tsx
@@ -1,20 +1,63 @@
-import Animated, { type AnimatedStyle } from "react-native-reanimated";
-import { StyleSheet, View, type ViewStyle } from "@/shared/components/rn";
+import { useEffect } from "react";
+import Animated, {
+  type AnimatedStyle,
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from "react-native-reanimated";
+import { StyleSheet, useWindowDimensions, View, type ViewStyle } from "@/shared/components/rn";
 import { useAnimatedProgress, useThemeColor } from "@/shared/hooks";
 
 type Props = {
   readonly percent: number;
   readonly height?: number;
+  readonly completeTone?: "danger" | "success";
+  readonly shimmering?: boolean;
 };
 
-export function ProgressBar({ percent, height = 8 }: Props) {
+const SHIMMER_WIDTH = 72;
+
+export function ProgressBar({
+  percent,
+  height = 8,
+  completeTone = "danger",
+  shimmering = false,
+}: Props) {
+  const { width } = useWindowDimensions();
   const accentGreen = useThemeColor("accentGreen");
   const accentRed = useThemeColor("accentRed");
   const borderColor = useThemeColor("borderSubtle");
+  const shimmerX = useSharedValue(-SHIMMER_WIDTH);
 
   const { animatedStyle } = useAnimatedProgress(Math.min(percent, 100) / 100, 600);
 
-  const barColor = percent >= 100 ? accentRed : accentGreen;
+  useEffect(() => {
+    if (!shimmering) {
+      shimmerX.value = -SHIMMER_WIDTH;
+      return;
+    }
+
+    shimmerX.value = withRepeat(
+      withSequence(
+        withTiming(width + SHIMMER_WIDTH, {
+          duration: 1300,
+          easing: Easing.inOut(Easing.quad),
+        }),
+        withTiming(-SHIMMER_WIDTH, { duration: 0 })
+      ),
+      -1,
+      false
+    );
+  }, [shimmerX, shimmering, width]);
+
+  const shimmerStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: shimmerX.value }],
+  }));
+
+  const barColor = percent >= 100 && completeTone === "danger" ? accentRed : accentGreen;
 
   return (
     <View style={[styles.track, { height, backgroundColor: borderColor }]}>
@@ -25,11 +68,23 @@ export function ProgressBar({ percent, height = 8 }: Props) {
           animatedStyle as AnimatedStyle<ViewStyle>,
         ]}
       />
+      {shimmering ? (
+        <Animated.View
+          pointerEvents="none"
+          style={[styles.shimmer, { height, width: SHIMMER_WIDTH }, shimmerStyle]}
+        />
+      ) : null}
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  track: { borderRadius: 4, overflow: "hidden" },
+  track: { borderRadius: 4, overflow: "hidden", position: "relative" },
   fill: { borderRadius: 4 },
+  shimmer: {
+    backgroundColor: "rgba(255, 255, 255, 0.42)",
+    borderRadius: 4,
+    position: "absolute",
+    top: 0,
+  },
 });


### PR DESCRIPTION
- add numpad haptics and press feedback
- shimmer onboarding import progress
- keep import completion green


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves wait feedback on mobile: adds tactile press on the pencil numpad and a shimmering progress bar during onboarding sync. Progress stays green on import completion for a clear success signal.

- New Features
  - Numpad keys now provide haptic feedback via `expo-haptics` and visual press cues (animated overlay + Android ripple), while keeping the 3-column layout.
  - Onboarding import shows a shimmering progress bar while waiting; completion remains green.

- Refactors
  - Extracted SyncImportProgress and extended ProgressBar props (completeTone, shimmering); updated tests for numpad layout and feedback.

<sup>Written for commit 5cb9ab7fb45eb7b1d0bdca5a60091e2857564b96. Summary will update on new commits. <a href="https://cubic.dev/pr/B4rz99/fidy/pull/479?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

