### PR TITLE
perf(mobile): tighten native list patterns

### DIFF
--- a/apps/mobile/__tests__/budget/create-budget-draft.test.ts
+++ b/apps/mobile/__tests__/budget/create-budget-draft.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vitest";
 import { resolveNextDigits } from "@/features/budget/components/create-budget/useCreateBudgetDraft";
-import { handleNumpadPress } from "@/features/transactions";
+import { handleNumpadPress } from "@/features/transactions/display.public";
 
 test("resolveNextDigits returns a direct digits replacement", () => {
   expect(resolveNextDigits("12", "450")).toBe("450");

--- a/apps/mobile/__tests__/transactions/categories.test.ts
+++ b/apps/mobile/__tests__/transactions/categories.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { getBuiltInCategoryId } from "@/features/transactions";
-import { getBuiltInCategory } from "@/features/transactions/categories.public";
+import {
+  getBuiltInCategory,
+  getBuiltInCategoryId,
+} from "@/features/transactions/categories.public";
 import {
   CATEGORIES,
   CATEGORY_IDS,

--- a/apps/mobile/features/ai-chat/components/ConversationList.tsx
+++ b/apps/mobile/features/ai-chat/components/ConversationList.tsx
@@ -21,6 +21,8 @@ type ConversationListProps = {
 
 const ItemSeparator = () => <View style={{ height: 10 }} />;
 
+const sessionKeyExtractor = (item: ChatSession) => item.id;
+
 function AndroidTabBarSpacer() {
   return Platform.OS === "ios" ? null : <View style={{ height: TAB_BAR_CLEARANCE }} />;
 }
@@ -116,7 +118,7 @@ export function ConversationList({ onSelectSession, onNewChat }: ConversationLis
       <FlashList
         data={sessions}
         renderItem={renderItem}
-        keyExtractor={(item) => item.id}
+        keyExtractor={sessionKeyExtractor}
         contentInsetAdjustmentBehavior="automatic"
         contentContainerStyle={{
           paddingBottom: 0,

--- a/apps/mobile/features/ai-chat/components/MemoryManager.tsx
+++ b/apps/mobile/features/ai-chat/components/MemoryManager.tsx
@@ -14,6 +14,8 @@ type MemoryManagerProps = {
 
 const ItemSeparator = () => <View style={{ height: 8 }} />;
 
+const memoryKeyExtractor = (item: UserMemory) => item.id;
+
 const MemoryCard = memo(function MemoryCardInner({
   memory,
   onDelete,
@@ -92,7 +94,7 @@ export function MemoryManager({ onBack }: MemoryManagerProps) {
       <FlashList
         data={memories}
         renderItem={renderItem}
-        keyExtractor={(item) => item.id}
+        keyExtractor={memoryKeyExtractor}
         contentInsetAdjustmentBehavior="automatic"
         contentContainerStyle={{
           paddingBottom: TAB_BAR_CLEARANCE,

--- a/apps/mobile/features/ai-chat/components/NewChatButton.tsx
+++ b/apps/mobile/features/ai-chat/components/NewChatButton.tsx
@@ -1,5 +1,6 @@
 import { Plus } from "@/shared/components/icons";
-import { Pressable } from "@/shared/components/rn";
+import { GlassSurface } from "@/shared/components";
+import { Pressable, StyleSheet } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 
 export function NewChatButton({ onPress }: { readonly onPress: () => void }) {
@@ -13,7 +14,20 @@ export function NewChatButton({ onPress }: { readonly onPress: () => void }) {
       accessibilityRole="button"
       accessibilityLabel={t("aiChat.newChat")}
     >
-      <Plus size={24} color={iconColor} />
+      <GlassSurface padded={false} style={styles.surface}>
+        <Plus size={24} color={iconColor} />
+      </GlassSurface>
     </Pressable>
   );
 }
+
+const styles = StyleSheet.create({
+  surface: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    overflow: "hidden",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});

--- a/apps/mobile/features/dashboard/components/home-screen/HomeScreenContent.tsx
+++ b/apps/mobile/features/dashboard/components/home-screen/HomeScreenContent.tsx
@@ -1,8 +1,8 @@
+import { FlashList, type ListRenderItemInfo } from "@shopify/flash-list";
 import { useCallback, useMemo } from "react";
-import type { ListRenderItemInfo } from "react-native";
 import type { StoredActivityItem } from "@/features/activity/query.public";
 import { ScreenLayout, TAB_BAR_CLEARANCE } from "@/shared/components";
-import { FlatList, Platform } from "@/shared/components/rn";
+import { Platform, StyleSheet } from "@/shared/components/rn";
 import { EmptyTransactions } from "../EmptyTransactions";
 import { ActivityFeedItem } from "./ActivityFeedItem";
 import { HomeScreenActions } from "./HomeScreenActions";
@@ -12,6 +12,8 @@ import type { HomeScreenModel } from "./useHomeScreen";
 type HomeScreenContentProps = {
   readonly model: HomeScreenModel;
 };
+
+const keyExtractor = (item: StoredActivityItem) => item.id;
 
 export function HomeScreenContent({ model }: HomeScreenContentProps) {
   const renderItem = useCallback(
@@ -41,20 +43,26 @@ export function HomeScreenContent({ model }: HomeScreenContentProps) {
 
   return (
     <ScreenLayout title="fidy" rightActions={headerActions}>
-      <FlatList
+      <FlashList
         data={model.activityFeed.activityPages}
         renderItem={renderItem}
-        keyExtractor={(item) => item.id}
+        keyExtractor={keyExtractor}
         onEndReached={model.activityFeed.handleEndReached}
         onEndReachedThreshold={0.1}
         scrollEventThrottle={16}
         ListHeaderComponent={listHeader}
         ListEmptyComponent={model.showEmptyTransactions ? <EmptyTransactions /> : undefined}
         showsVerticalScrollIndicator={false}
-        contentContainerStyle={{ paddingBottom: 0 }}
+        contentContainerStyle={styles.listContent}
         contentInset={{ bottom: TAB_BAR_CLEARANCE }}
         contentInsetAdjustmentBehavior="automatic"
       />
     </ScreenLayout>
   );
 }
+
+const styles = StyleSheet.create({
+  listContent: {
+    paddingBottom: 0,
+  },
+});

--- a/apps/mobile/features/goals/components/GoalsListScreen.tsx
+++ b/apps/mobile/features/goals/components/GoalsListScreen.tsx
@@ -1,9 +1,10 @@
+import { FlashList } from "@shopify/flash-list";
 import { useRouter } from "expo-router";
 import { useCallback } from "react";
 import { useOptionalUserId } from "@/features/auth/public";
 import { ScreenLayout, TAB_BAR_CLEARANCE } from "@/shared/components";
 import { Plus, Target } from "@/shared/components/icons";
-import { FlatList, Platform, Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
+import { Platform, Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { selectGoal, useGoalStore } from "../store";
@@ -114,7 +115,7 @@ export function GoalsListScreen() {
       {!hasGoals && !isLoading ? (
         <GoalsEmpty onCreateGoal={handleCreateGoal} />
       ) : (
-        <FlatList
+        <FlashList
           data={goals}
           renderItem={renderItem}
           keyExtractor={keyExtractor}

--- a/apps/mobile/features/notifications/components/NotificationsScreen.tsx
+++ b/apps/mobile/features/notifications/components/NotificationsScreen.tsx
@@ -19,6 +19,9 @@ import {
 import { NotificationCard } from "./NotificationCard";
 import { NotificationEmptyState } from "./NotificationEmptyState";
 
+const notificationKeyExtractor = (item: NotificationDisplay) => item.id;
+const NotificationItemSeparator = () => <View style={styles.separator} />;
+
 export const NotificationsScreen = () => {
   const router = useRouter();
   const { t } = useTranslation();
@@ -64,6 +67,20 @@ export const NotificationsScreen = () => {
     [router]
   );
 
+  const renderItem = useCallback(
+    ({ item }: { item: NotificationDisplay }) => (
+      <NotificationCard notification={item} onPress={handlePress} />
+    ),
+    [handlePress]
+  );
+
+  const renderSectionHeader = useCallback(
+    ({ section }: { section: { title: string } }) => (
+      <Text style={[styles.sectionLabel, { color: tertiaryColor }]}>{section.title}</Text>
+    ),
+    [tertiaryColor]
+  );
+
   return (
     <ScreenLayout
       title={t("notifications.title")}
@@ -98,12 +115,10 @@ export const NotificationsScreen = () => {
       ) : (
         <SectionList
           sections={sections}
-          keyExtractor={(item) => item.id}
-          renderItem={({ item }) => <NotificationCard notification={item} onPress={handlePress} />}
-          renderSectionHeader={({ section }) => (
-            <Text style={[styles.sectionLabel, { color: tertiaryColor }]}>{section.title}</Text>
-          )}
-          ItemSeparatorComponent={() => <View style={styles.separator} />}
+          keyExtractor={notificationKeyExtractor}
+          renderItem={renderItem}
+          renderSectionHeader={renderSectionHeader}
+          ItemSeparatorComponent={NotificationItemSeparator}
           contentContainerStyle={[styles.listContent, { paddingBottom: bottom + 16 }]}
           contentInsetAdjustmentBehavior="automatic"
           stickySectionHeadersEnabled={false}

--- a/apps/mobile/features/review-queues/components/AttributionQueueCard.tsx
+++ b/apps/mobile/features/review-queues/components/AttributionQueueCard.tsx
@@ -1,0 +1,182 @@
+import { useCallback } from "react";
+import { getTransactionDisplayName } from "@/features/transactions/display.public";
+import { ChevronRight } from "@/shared/components/icons";
+import { Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
+import { useThemeColor, useTranslation } from "@/shared/hooks";
+import { formatSignedMoney } from "@/shared/lib";
+import type { TransactionId } from "@/shared/types/branded";
+import type { useAttributionReviewQueue } from "../hooks/use-attribution-review-queue";
+import { ActionButton } from "./shared";
+
+type AttributionQueueItem = ReturnType<typeof useAttributionReviewQueue>["items"][number];
+
+type AttributionQueueCardProps = {
+  readonly disabled: boolean;
+  readonly item: AttributionQueueItem;
+  readonly onChooseAnother: (fingerprint: string) => void;
+  readonly onConfirm: (transactionId: TransactionId) => void;
+  readonly onOpenDetails: (transactionId: TransactionId) => void;
+  readonly onSkip: (transactionId: TransactionId) => void;
+};
+
+export function AttributionQueueCard({
+  item,
+  disabled,
+  onConfirm,
+  onChooseAnother,
+  onOpenDetails,
+  onSkip,
+}: AttributionQueueCardProps) {
+  const { t } = useTranslation();
+  const primary = useThemeColor("primary");
+  const secondary = useThemeColor("secondary");
+  const tertiary = useThemeColor("tertiary");
+  const card = useThemeColor("card");
+  const borderSubtle = useThemeColor("borderSubtle");
+  const accentRed = useThemeColor("accentRed");
+  const transactionId = item.transaction.id;
+  const handleConfirmPress = useCallback(
+    () => onConfirm(transactionId),
+    [onConfirm, transactionId]
+  );
+  const handleChooseAnotherPress = useCallback(
+    () => onChooseAnother(item.suggestion.fingerprint),
+    [item.suggestion.fingerprint, onChooseAnother]
+  );
+  const handleOpenDetailsPress = useCallback(
+    () => onOpenDetails(transactionId),
+    [onOpenDetails, transactionId]
+  );
+  const handleSkipPress = useCallback(() => onSkip(transactionId), [onSkip, transactionId]);
+
+  return (
+    <View style={[styles.card, { backgroundColor: card, borderColor: borderSubtle }]}>
+      <Pressable onPress={handleOpenDetailsPress} disabled={disabled} style={styles.cardPressable}>
+        <View style={styles.cardMetaRow}>
+          <Text style={[styles.metaLabel, { color: tertiary }]}>
+            {t("attributionReview.provisionalLabel")}
+          </Text>
+          <ChevronRight size={16} color={tertiary} />
+        </View>
+
+        <View style={styles.titleRow}>
+          <View style={styles.titleWrap}>
+            <Text style={[styles.title, { color: primary }]} numberOfLines={2}>
+              {getTransactionDisplayName(item.transaction, t("common.unknown"))}
+            </Text>
+            <Text style={[styles.supportingCopy, { color: secondary }]}>{item.evidenceLabel}</Text>
+          </View>
+          <Text style={[styles.amount, { color: accentRed }]}>
+            {formatSignedMoney(item.transaction.amount, item.transaction.type)}
+          </Text>
+        </View>
+
+        <View style={styles.ownerColumn}>
+          <View style={styles.ownerRow}>
+            <Text style={[styles.ownerLabel, { color: secondary }]}>
+              {t("attributionReview.currentOwner")}
+            </Text>
+            <Text style={[styles.ownerValue, { color: primary }]}>
+              {item.currentAccount?.name ?? t("common.unknown")}
+            </Text>
+          </View>
+          <View style={styles.ownerRow}>
+            <Text style={[styles.ownerLabel, { color: secondary }]}>
+              {t("attributionReview.suggestedOwner")}
+            </Text>
+            <Text style={[styles.ownerValue, { color: primary }]}>
+              {item.suggestedAccount.name}
+            </Text>
+          </View>
+        </View>
+      </Pressable>
+
+      <View style={styles.actionRow}>
+        <ActionButton
+          label={t("attributionReview.confirmOwner")}
+          onPress={handleConfirmPress}
+          disabled={disabled}
+        />
+        <ActionButton
+          label={t("attributionReview.chooseAnother")}
+          onPress={handleChooseAnotherPress}
+          variant="outline"
+          disabled={disabled}
+        />
+        <ActionButton
+          label={t("attributionReview.skip")}
+          onPress={handleSkipPress}
+          variant="ghost"
+          disabled={disabled}
+        />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 20,
+    borderWidth: 1,
+    padding: 14,
+    gap: 14,
+  },
+  cardPressable: {
+    gap: 10,
+  },
+  cardMetaRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  metaLabel: {
+    fontFamily: "Poppins_700Bold",
+    fontSize: 10,
+    letterSpacing: 0.6,
+    textTransform: "uppercase",
+  },
+  titleRow: {
+    flexDirection: "row",
+    gap: 12,
+  },
+  titleWrap: {
+    flex: 1,
+    gap: 4,
+  },
+  title: {
+    fontFamily: "Poppins_600SemiBold",
+    fontSize: 18,
+    lineHeight: 22,
+  },
+  supportingCopy: {
+    fontFamily: "Poppins_500Medium",
+    fontSize: 12,
+  },
+  amount: {
+    fontFamily: "Poppins_700Bold",
+    fontSize: 16,
+    textAlign: "right",
+  },
+  ownerColumn: {
+    gap: 8,
+  },
+  ownerRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    gap: 16,
+  },
+  ownerLabel: {
+    fontFamily: "Poppins_500Medium",
+    fontSize: 12,
+  },
+  ownerValue: {
+    flex: 1,
+    fontFamily: "Poppins_600SemiBold",
+    fontSize: 13,
+    textAlign: "right",
+  },
+  actionRow: {
+    flexDirection: "row",
+    gap: 8,
+  },
+});

--- a/apps/mobile/features/review-queues/components/AttributionQueueScreen.tsx
+++ b/apps/mobile/features/review-queues/components/AttributionQueueScreen.tsx
@@ -1,107 +1,25 @@
 import { FlashList } from "@shopify/flash-list";
 import { useRouter } from "expo-router";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useOptionalUserId } from "@/features/auth/public";
-import { getTransactionDisplayName } from "@/features/transactions/display.public";
 import { refreshTransactions } from "@/features/transactions/store.public";
 import { ScreenLayout } from "@/shared/components";
-import { ChevronRight, Landmark } from "@/shared/components/icons";
-import { Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
+import { Landmark } from "@/shared/components/icons";
+import { StyleSheet, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
-import { useAsyncGuard, useThemeColor, useTranslation } from "@/shared/hooks";
-import { formatSignedMoney, showErrorToast } from "@/shared/lib";
+import { useAsyncGuard, useTranslation } from "@/shared/hooks";
+import { showErrorToast } from "@/shared/lib";
 import type { TransactionId } from "@/shared/types/branded";
 import { useAttributionReviewQueue } from "../hooks/use-attribution-review-queue";
-import { ActionButton, EmptyState, SummaryCard } from "./shared";
+import { AttributionQueueCard } from "./AttributionQueueCard";
+import { EmptyState, SummaryCard } from "./shared";
 
-function AttributionQueueCard({
-  item,
-  disabled,
-  onConfirm,
-  onChooseAnother,
-  onOpenDetails,
-  onSkip,
-}: {
-  readonly item: ReturnType<typeof useAttributionReviewQueue>["items"][number];
-  readonly disabled: boolean;
-  readonly onConfirm: () => void;
-  readonly onChooseAnother: () => void;
-  readonly onOpenDetails: () => void;
-  readonly onSkip: () => void;
-}) {
-  const { t } = useTranslation();
-  const primary = useThemeColor("primary");
-  const secondary = useThemeColor("secondary");
-  const tertiary = useThemeColor("tertiary");
-  const card = useThemeColor("card");
-  const borderSubtle = useThemeColor("borderSubtle");
-  const accentRed = useThemeColor("accentRed");
+const transactionKeyExtractor = (
+  item: ReturnType<typeof useAttributionReviewQueue>["items"][number]
+) => item.transaction.id;
 
-  return (
-    <View style={[styles.card, { backgroundColor: card, borderColor: borderSubtle }]}>
-      <Pressable onPress={onOpenDetails} disabled={disabled} style={styles.cardPressable}>
-        <View style={styles.cardMetaRow}>
-          <Text style={[styles.metaLabel, { color: tertiary }]}>
-            {t("attributionReview.provisionalLabel")}
-          </Text>
-          <ChevronRight size={16} color={tertiary} />
-        </View>
-
-        <View style={styles.titleRow}>
-          <View style={styles.titleWrap}>
-            <Text style={[styles.title, { color: primary }]} numberOfLines={2}>
-              {getTransactionDisplayName(item.transaction, t("common.unknown"))}
-            </Text>
-            <Text style={[styles.supportingCopy, { color: secondary }]}>{item.evidenceLabel}</Text>
-          </View>
-          <Text style={[styles.amount, { color: accentRed }]}>
-            {formatSignedMoney(item.transaction.amount, item.transaction.type)}
-          </Text>
-        </View>
-
-        <View style={styles.ownerColumn}>
-          <View style={styles.ownerRow}>
-            <Text style={[styles.ownerLabel, { color: secondary }]}>
-              {t("attributionReview.currentOwner")}
-            </Text>
-            <Text style={[styles.ownerValue, { color: primary }]}>
-              {item.currentAccount?.name ?? t("common.unknown")}
-            </Text>
-          </View>
-          <View style={styles.ownerRow}>
-            <Text style={[styles.ownerLabel, { color: secondary }]}>
-              {t("attributionReview.suggestedOwner")}
-            </Text>
-            <Text style={[styles.ownerValue, { color: primary }]}>
-              {item.suggestedAccount.name}
-            </Text>
-          </View>
-        </View>
-      </Pressable>
-
-      <View style={styles.actionRow}>
-        <ActionButton
-          label={t("attributionReview.confirmOwner")}
-          onPress={onConfirm}
-          disabled={disabled}
-        />
-        <ActionButton
-          label={t("attributionReview.chooseAnother")}
-          onPress={onChooseAnother}
-          variant="outline"
-          disabled={disabled}
-        />
-        <ActionButton
-          label={t("attributionReview.skip")}
-          onPress={onSkip}
-          variant="ghost"
-          disabled={disabled}
-        />
-      </View>
-    </View>
-  );
-}
+const QueueItemSeparator = () => <View style={styles.itemSeparator} />;
 
 export function AttributionQueueScreen() {
   const router = useRouter();
@@ -115,26 +33,69 @@ export function AttributionQueueScreen() {
 
   const visibleItems = items.filter((item) => !skippedIds.includes(item.transaction.id));
 
-  const handleConfirm = (transactionId: TransactionId) => {
-    void guardedAction(async () => {
-      if (!db || !userId) {
-        return;
-      }
-
-      try {
-        const result = service.confirmSuggestedOwner({ db, userId, transactionId });
-        if (!result.success) {
-          showErrorToast(t("attributionReview.errors.confirmFailed"));
+  const handleConfirm = useCallback(
+    (transactionId: TransactionId) => {
+      void guardedAction(async () => {
+        if (!db || !userId) {
           return;
         }
 
-        await refreshTransactions(db, userId);
-        reloadQueue();
-      } catch {
-        showErrorToast(t("attributionReview.errors.confirmFailed"));
-      }
-    });
-  };
+        try {
+          const result = service.confirmSuggestedOwner({ db, userId, transactionId });
+          if (!result.success) {
+            showErrorToast(t("attributionReview.errors.confirmFailed"));
+            return;
+          }
+
+          await refreshTransactions(db, userId);
+          reloadQueue();
+        } catch {
+          showErrorToast(t("attributionReview.errors.confirmFailed"));
+        }
+      });
+    },
+    [db, guardedAction, reloadQueue, service, t, userId]
+  );
+
+  const handleChooseAnother = useCallback(
+    (fingerprint: string) => {
+      router.push({
+        pathname: "/link-suggested-account",
+        params: { fingerprint },
+      });
+    },
+    [router]
+  );
+
+  const handleOpenDetails = useCallback(
+    (transactionId: TransactionId) => {
+      router.push({
+        pathname: "/attribution-review",
+        params: { transactionId },
+      } as never);
+    },
+    [router]
+  );
+
+  const handleSkip = useCallback((transactionId: TransactionId) => {
+    setSkippedIds((current) =>
+      current.includes(transactionId) ? current : [...current, transactionId]
+    );
+  }, []);
+
+  const renderItem = useCallback(
+    ({ item }: { item: (typeof visibleItems)[number] }) => (
+      <AttributionQueueCard
+        item={item}
+        disabled={isBusy}
+        onConfirm={handleConfirm}
+        onChooseAnother={handleChooseAnother}
+        onOpenDetails={handleOpenDetails}
+        onSkip={handleSkip}
+      />
+    ),
+    [handleChooseAnother, handleConfirm, handleOpenDetails, handleSkip, isBusy]
+  );
 
   return (
     <ScreenLayout
@@ -150,10 +111,10 @@ export function AttributionQueueScreen() {
       ) : (
         <FlashList
           data={visibleItems}
-          keyExtractor={(item) => item.transaction.id}
+          keyExtractor={transactionKeyExtractor}
           contentContainerStyle={[styles.listContent, { paddingBottom: bottom + 28 }]}
           contentInsetAdjustmentBehavior="automatic"
-          ItemSeparatorComponent={() => <View style={{ height: 14 }} />}
+          ItemSeparatorComponent={QueueItemSeparator}
           ListHeaderComponent={
             <SummaryCard
               icon={Landmark}
@@ -162,32 +123,7 @@ export function AttributionQueueScreen() {
               tone="green"
             />
           }
-          renderItem={({ item }) => (
-            <AttributionQueueCard
-              item={item}
-              disabled={isBusy}
-              onConfirm={() => handleConfirm(item.transaction.id)}
-              onChooseAnother={() =>
-                router.push({
-                  pathname: "/link-suggested-account",
-                  params: { fingerprint: item.suggestion.fingerprint },
-                })
-              }
-              onOpenDetails={() =>
-                router.push({
-                  pathname: "/attribution-review",
-                  params: { transactionId: item.transaction.id },
-                } as never)
-              }
-              onSkip={() =>
-                setSkippedIds((current) =>
-                  current.includes(item.transaction.id)
-                    ? current
-                    : [...current, item.transaction.id]
-                )
-              }
-            />
-          )}
+          renderItem={renderItem}
         />
       )}
     </ScreenLayout>
@@ -200,68 +136,7 @@ const styles = StyleSheet.create({
     paddingBottom: 28,
     gap: 14,
   },
-  card: {
-    borderRadius: 20,
-    borderWidth: 1,
-    padding: 14,
-    gap: 14,
-  },
-  cardPressable: {
-    gap: 10,
-  },
-  cardMetaRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-  },
-  metaLabel: {
-    fontFamily: "Poppins_700Bold",
-    fontSize: 10,
-    letterSpacing: 0.6,
-    textTransform: "uppercase",
-  },
-  titleRow: {
-    flexDirection: "row",
-    gap: 12,
-  },
-  titleWrap: {
-    flex: 1,
-    gap: 4,
-  },
-  title: {
-    fontFamily: "Poppins_600SemiBold",
-    fontSize: 18,
-    lineHeight: 22,
-  },
-  supportingCopy: {
-    fontFamily: "Poppins_500Medium",
-    fontSize: 12,
-  },
-  amount: {
-    fontFamily: "Poppins_700Bold",
-    fontSize: 16,
-    textAlign: "right",
-  },
-  ownerColumn: {
-    gap: 8,
-  },
-  ownerRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    gap: 16,
-  },
-  ownerLabel: {
-    fontFamily: "Poppins_500Medium",
-    fontSize: 12,
-  },
-  ownerValue: {
-    flex: 1,
-    fontFamily: "Poppins_600SemiBold",
-    fontSize: 13,
-    textAlign: "right",
-  },
-  actionRow: {
-    flexDirection: "row",
-    gap: 8,
+  itemSeparator: {
+    height: 14,
   },
 });

--- a/apps/mobile/features/review-queues/components/FinancialMeaningQueueScreen.styles.ts
+++ b/apps/mobile/features/review-queues/components/FinancialMeaningQueueScreen.styles.ts
@@ -6,6 +6,9 @@ export const styles = StyleSheet.create({
     paddingBottom: 28,
     gap: 14,
   },
+  itemSeparator: {
+    height: 14,
+  },
   card: {
     borderRadius: 20,
     borderWidth: 1,

--- a/apps/mobile/features/review-queues/components/FinancialMeaningQueueScreen.tsx
+++ b/apps/mobile/features/review-queues/components/FinancialMeaningQueueScreen.tsx
@@ -1,7 +1,7 @@
 import { FlashList } from "@shopify/flash-list";
 import { format } from "date-fns";
 import { useRouter } from "expo-router";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useOptionalUserId } from "@/features/auth/public";
 import {
@@ -23,6 +23,8 @@ import { getReviewQueueProviderLabel } from "../lib/source-labels";
 import { styles } from "./FinancialMeaningQueueScreen.styles";
 import { ActionButton, EmptyState, SummaryCard } from "./shared";
 
+const QueueItemSeparator = () => <View style={styles.itemSeparator} />;
+
 function FinancialMeaningQueueCard({
   item,
   disabled,
@@ -32,9 +34,15 @@ function FinancialMeaningQueueCard({
 }: {
   readonly item: ReturnType<typeof useFinancialMeaningReviewQueue>["items"][number];
   readonly disabled: boolean;
-  readonly onReview: () => void;
-  readonly onDismiss: () => void;
-  readonly onSkip: () => void;
+  readonly onReview: (
+    processedSourceEventId: ProcessedSourceEventId,
+    reviewCandidateId: ReviewCandidateId
+  ) => void;
+  readonly onDismiss: (
+    processedSourceEventId: ProcessedSourceEventId,
+    reviewCandidateId: ReviewCandidateId
+  ) => void;
+  readonly onSkip: (id: string) => void;
 }) {
   const { t, locale } = useTranslation();
   const primary = useThemeColor("primary");
@@ -56,10 +64,22 @@ function FinancialMeaningQueueCard({
       : transactionType === "expense"
         ? accentRed
         : primary;
+  const reviewCandidateId = item.reviewCandidate.id;
+  const processedSourceEventId = item.processedSourceEvent.id;
+  const itemId = getFinancialMeaningQueueItemId(item);
+  const handleReviewPress = useCallback(
+    () => onReview(processedSourceEventId, reviewCandidateId),
+    [onReview, processedSourceEventId, reviewCandidateId]
+  );
+  const handleDismissPress = useCallback(
+    () => onDismiss(processedSourceEventId, reviewCandidateId),
+    [onDismiss, processedSourceEventId, reviewCandidateId]
+  );
+  const handleSkipPress = useCallback(() => onSkip(itemId), [itemId, onSkip]);
 
   return (
     <View style={[styles.card, { backgroundColor: card, borderColor: borderSubtle }]}>
-      <Pressable onPress={onReview} disabled={disabled} style={styles.cardPressable}>
+      <Pressable onPress={handleReviewPress} disabled={disabled} style={styles.cardPressable}>
         <View style={styles.cardMetaRow}>
           <Text style={[styles.cardMetaLabel, { color: tertiary }]}>{providerLabel}</Text>
           <ChevronRight size={16} color={tertiary} />
@@ -97,18 +117,18 @@ function FinancialMeaningQueueCard({
       <View style={styles.actionRow}>
         <ActionButton
           label={t("financialMeaningReview.reviewMeaning")}
-          onPress={onReview}
+          onPress={handleReviewPress}
           disabled={disabled}
         />
         <ActionButton
           label={t("financialMeaningReview.dismiss")}
-          onPress={onDismiss}
+          onPress={handleDismissPress}
           variant="outline"
           disabled={disabled}
         />
         <ActionButton
           label={t("financialMeaningReview.skip")}
-          onPress={onSkip}
+          onPress={handleSkipPress}
           variant="ghost"
           disabled={disabled}
         />
@@ -131,30 +151,60 @@ export function FinancialMeaningQueueScreen() {
     (item) => !skippedIds.includes(getFinancialMeaningQueueItemId(item))
   );
 
-  const handleDismissSourceEvent = (
-    processedSourceEventId: ProcessedSourceEventId,
-    reviewCandidateId: ReviewCandidateId
-  ) => {
-    void guardedAction(async () => {
-      if (!db || !userId) {
-        return;
-      }
-
-      try {
-        await dismissSourceEventFinancialMeaningReview(
-          db,
-          userId,
+  const handleReview = useCallback(
+    (processedSourceEventId: ProcessedSourceEventId, reviewCandidateId: ReviewCandidateId) => {
+      router.push({
+        pathname: "/meaning-review",
+        params: {
           processedSourceEventId,
-          reviewCandidateId
-        );
-        await loadNeedsReviewEmails(db, userId);
-        await refreshTransactions(db, userId);
-        await reloadQueue();
-      } catch {
-        showErrorToast(t("financialMeaningReview.errors.dismissFailed"));
-      }
-    });
-  };
+          reviewCandidateId,
+        },
+      } as never);
+    },
+    [router]
+  );
+
+  const handleDismissSourceEvent = useCallback(
+    (processedSourceEventId: ProcessedSourceEventId, reviewCandidateId: ReviewCandidateId) => {
+      void guardedAction(async () => {
+        if (!db || !userId) {
+          return;
+        }
+
+        try {
+          await dismissSourceEventFinancialMeaningReview(
+            db,
+            userId,
+            processedSourceEventId,
+            reviewCandidateId
+          );
+          await loadNeedsReviewEmails(db, userId);
+          await refreshTransactions(db, userId);
+          await reloadQueue();
+        } catch {
+          showErrorToast(t("financialMeaningReview.errors.dismissFailed"));
+        }
+      });
+    },
+    [db, guardedAction, reloadQueue, t, userId]
+  );
+
+  const handleSkip = useCallback((id: string) => {
+    setSkippedIds((current) => (current.includes(id) ? current : [...current, id]));
+  }, []);
+
+  const renderItem = useCallback(
+    ({ item }: { item: (typeof visibleItems)[number] }) => (
+      <FinancialMeaningQueueCard
+        item={item}
+        disabled={isBusy}
+        onReview={handleReview}
+        onDismiss={handleDismissSourceEvent}
+        onSkip={handleSkip}
+      />
+    ),
+    [handleDismissSourceEvent, handleReview, handleSkip, isBusy]
+  );
 
   return (
     <ScreenLayout
@@ -173,7 +223,7 @@ export function FinancialMeaningQueueScreen() {
           keyExtractor={getFinancialMeaningQueueItemId}
           contentContainerStyle={[styles.listContent, { paddingBottom: bottom + 28 }]}
           contentInsetAdjustmentBehavior="automatic"
-          ItemSeparatorComponent={() => <View style={{ height: 14 }} />}
+          ItemSeparatorComponent={QueueItemSeparator}
           ListHeaderComponent={
             <SummaryCard
               icon={TriangleAlert}
@@ -181,31 +231,7 @@ export function FinancialMeaningQueueScreen() {
               subtitle={t("financialMeaningReview.queueSubtitle")}
             />
           }
-          renderItem={({ item }) => (
-            <FinancialMeaningQueueCard
-              item={item}
-              disabled={isBusy}
-              onReview={() =>
-                router.push({
-                  pathname: "/meaning-review",
-                  params: {
-                    processedSourceEventId: item.processedSourceEvent.id,
-                    reviewCandidateId: item.reviewCandidate.id,
-                  },
-                } as never)
-              }
-              onDismiss={() =>
-                handleDismissSourceEvent(item.processedSourceEvent.id, item.reviewCandidate.id)
-              }
-              onSkip={() =>
-                setSkippedIds((current) =>
-                  current.includes(getFinancialMeaningQueueItemId(item))
-                    ? current
-                    : [...current, getFinancialMeaningQueueItemId(item)]
-                )
-              }
-            />
-          )}
+          renderItem={renderItem}
         />
       )}
     </ScreenLayout>

--- a/apps/mobile/features/search/components/search-screen/SearchResultsList.tsx
+++ b/apps/mobile/features/search/components/search-screen/SearchResultsList.tsx
@@ -1,7 +1,8 @@
+import { FlashList } from "@shopify/flash-list";
 import { useCallback, useMemo } from "react";
 import type { StoredTransaction } from "@/features/transactions/query.public";
 import { TAB_BAR_CLEARANCE } from "@/shared/components";
-import { FlatList } from "@/shared/components/rn";
+import { StyleSheet } from "@/shared/components/rn";
 import { toIsoDate } from "@/shared/lib";
 import { hasActiveFilters } from "../../lib/filters";
 import { SearchEmptyState } from "../SearchEmptyState";
@@ -57,7 +58,7 @@ export function SearchResultsList({
   );
 
   return (
-    <FlatList
+    <FlashList
       data={results}
       renderItem={renderItem}
       keyExtractor={keyExtractor}
@@ -79,7 +80,13 @@ export function SearchResultsList({
       }
       showsVerticalScrollIndicator={false}
       contentInsetAdjustmentBehavior="automatic"
-      contentContainerStyle={{ paddingBottom: TAB_BAR_CLEARANCE }}
+      contentContainerStyle={styles.listContent}
     />
   );
 }
+
+const styles = StyleSheet.create({
+  listContent: {
+    paddingBottom: TAB_BAR_CLEARANCE,
+  },
+});

--- a/apps/mobile/shared/components/ErrorFallback.tsx
+++ b/apps/mobile/shared/components/ErrorFallback.tsx
@@ -1,5 +1,6 @@
+import { Image } from "expo-image";
 import * as Updates from "expo-updates";
-import { Image, Pressable, Text, View } from "@/shared/components/rn";
+import { Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
 import { Colors } from "@/shared/constants/theme";
 import { useTranslation } from "@/shared/hooks/use-translation";
 
@@ -7,43 +8,15 @@ export function ErrorFallback() {
   const { t } = useTranslation();
 
   return (
-    <View
-      style={{
-        flex: 1,
-        justifyContent: "center",
-        alignItems: "center",
-        padding: 32,
-        backgroundColor: Colors.light.page,
-      }}
-    >
+    <View style={styles.container}>
       <Image
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- static asset require
         source={require("../../assets/images/icon.png")}
-        style={{ width: 80, height: 80, marginBottom: 24, borderRadius: 16 }}
+        style={styles.icon}
+        contentFit="cover"
       />
-      <Text
-        style={{
-          fontSize: 22,
-          fontFamily: "Poppins_700Bold",
-          color: Colors.light.primary,
-          marginBottom: 8,
-          textAlign: "center",
-        }}
-      >
-        {t("errorFallback.title")}
-      </Text>
-      <Text
-        style={{
-          fontSize: 15,
-          fontFamily: "Poppins_500Medium",
-          color: Colors.light.secondary,
-          textAlign: "center",
-          marginBottom: 32,
-          lineHeight: 22,
-        }}
-      >
-        {t("errorFallback.body")}
-      </Text>
+      <Text style={styles.title}>{t("errorFallback.title")}</Text>
+      <Text style={styles.body}>{t("errorFallback.body")}</Text>
       <Pressable
         onPress={() => {
           void Updates.reloadAsync().catch(() => undefined);
@@ -69,3 +42,34 @@ export function ErrorFallback() {
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 32,
+    backgroundColor: Colors.light.page,
+  },
+  icon: {
+    width: 80,
+    height: 80,
+    marginBottom: 24,
+    borderRadius: 16,
+  },
+  title: {
+    fontSize: 22,
+    fontFamily: "Poppins_700Bold",
+    color: Colors.light.primary,
+    marginBottom: 8,
+    textAlign: "center",
+  },
+  body: {
+    fontSize: 15,
+    fontFamily: "Poppins_500Medium",
+    color: Colors.light.secondary,
+    textAlign: "center",
+    marginBottom: 32,
+    lineHeight: 22,
+  },
+});

--- a/apps/mobile/shared/components/TransactionRow.tsx
+++ b/apps/mobile/shared/components/TransactionRow.tsx
@@ -1,5 +1,17 @@
 import { useCallback } from "react";
-import { ActionSheetIOS, Platform, Pressable, Text, View } from "@/shared/components/rn";
+import * as Haptics from "expo-haptics";
+import ReanimatedSwipeable, {
+  type SwipeableMethods,
+} from "react-native-gesture-handler/ReanimatedSwipeable";
+import type { SharedValue } from "react-native-reanimated";
+import {
+  ActionSheetIOS,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 
 type TransactionRowProps = {
@@ -15,6 +27,8 @@ type TransactionRowProps = {
   onEdit?: () => void;
   onDelete?: () => void;
 };
+
+const SWIPE_ACTION_WIDTH = 88;
 
 function getAmountClassName(amountTone: NonNullable<TransactionRowProps["amountTone"]>): string {
   if (amountTone === "positive") return "text-accent-green dark:text-accent-green-dark";
@@ -45,6 +59,8 @@ export function TransactionRow({
   const handleLongPress = useCallback(() => {
     if (Platform.OS !== "ios") return;
 
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+
     const options = [
       ...(onEdit ? [t("common.edit")] : []),
       ...(onDelete ? [t("common.delete")] : []),
@@ -63,7 +79,58 @@ export function TransactionRow({
     );
   }, [onEdit, onDelete, t]);
 
-  const hasActions = (onEdit != null || onDelete != null) && Platform.OS === "ios";
+  const renderRightActions = useCallback(
+    (
+      _progress: SharedValue<number>,
+      _translation: SharedValue<number>,
+      swipeable: SwipeableMethods
+    ) => {
+      const handleEditPress = () => {
+        swipeable.close();
+        void Haptics.selectionAsync();
+        onEdit?.();
+      };
+      const handleDeletePress = () => {
+        swipeable.close();
+        void Haptics.selectionAsync();
+        onDelete?.();
+      };
+
+      return (
+        <View className="flex-row items-stretch py-3">
+          {onEdit ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={t("common.edit")}
+              className="items-center justify-center bg-secondary dark:bg-secondary-dark"
+              style={styles.swipeAction}
+              onPress={handleEditPress}
+            >
+              <Text className="font-poppins-semibold text-caption text-white">
+                {t("common.edit")}
+              </Text>
+            </Pressable>
+          ) : null}
+          {onDelete ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={t("common.delete")}
+              className="items-center justify-center bg-accent-red dark:bg-accent-red-dark"
+              style={styles.swipeAction}
+              onPress={handleDeletePress}
+            >
+              <Text className="font-poppins-semibold text-caption text-white">
+                {t("common.delete")}
+              </Text>
+            </Pressable>
+          ) : null}
+        </View>
+      );
+    },
+    [onDelete, onEdit, t]
+  );
+
+  const hasActions = onEdit != null || onDelete != null;
 
   const content = (
     <View className="flex-row items-center py-3">
@@ -94,5 +161,20 @@ export function TransactionRow({
 
   if (!hasActions) return content;
 
-  return <Pressable onLongPress={handleLongPress}>{content}</Pressable>;
+  return (
+    <ReanimatedSwipeable
+      friction={2}
+      rightThreshold={SWIPE_ACTION_WIDTH}
+      overshootRight={false}
+      renderRightActions={renderRightActions}
+    >
+      <Pressable onLongPress={handleLongPress}>{content}</Pressable>
+    </ReanimatedSwipeable>
+  );
 }
+
+const styles = StyleSheet.create({
+  swipeAction: {
+    width: SWIPE_ACTION_WIDTH,
+  },
+});

--- a/apps/mobile/shared/components/TransactionRow.tsx
+++ b/apps/mobile/shared/components/TransactionRow.tsx
@@ -1,9 +1,9 @@
-import { useCallback } from "react";
+import { useCallback, type ReactNode } from "react";
 import * as Haptics from "expo-haptics";
 import ReanimatedSwipeable, {
   type SwipeableMethods,
 } from "react-native-gesture-handler/ReanimatedSwipeable";
-import type { SharedValue } from "react-native-reanimated";
+import Animated, { type SharedValue, useAnimatedStyle } from "react-native-reanimated";
 import {
   ActionSheetIOS,
   Platform,
@@ -29,6 +29,27 @@ type TransactionRowProps = {
 };
 
 const SWIPE_ACTION_WIDTH = 88;
+
+type SwipeActionPanelProps = {
+  readonly actionWidth: number;
+  readonly children: ReactNode;
+  readonly translation: SharedValue<number>;
+};
+
+function SwipeActionPanel({ actionWidth, children, translation }: SwipeActionPanelProps) {
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: Math.max(translation.value + actionWidth, 0) }],
+  }));
+
+  return (
+    <Animated.View
+      className="flex-row items-stretch py-3"
+      style={[styles.swipeActionPanel, { width: actionWidth }, animatedStyle]}
+    >
+      {children}
+    </Animated.View>
+  );
+}
 
 function getAmountClassName(amountTone: NonNullable<TransactionRowProps["amountTone"]>): string {
   if (amountTone === "positive") return "text-accent-green dark:text-accent-green-dark";
@@ -85,6 +106,8 @@ export function TransactionRow({
       _translation: SharedValue<number>,
       swipeable: SwipeableMethods
     ) => {
+      const actionCount = Number(onEdit != null) + Number(onDelete != null);
+      const actionWidth = SWIPE_ACTION_WIDTH * actionCount;
       const handleEditPress = () => {
         swipeable.close();
         void Haptics.selectionAsync();
@@ -97,7 +120,7 @@ export function TransactionRow({
       };
 
       return (
-        <View className="flex-row items-stretch py-3">
+        <SwipeActionPanel actionWidth={actionWidth} translation={_translation}>
           {onEdit ? (
             <Pressable
               accessibilityRole="button"
@@ -124,7 +147,7 @@ export function TransactionRow({
               </Text>
             </Pressable>
           ) : null}
-        </View>
+        </SwipeActionPanel>
       );
     },
     [onDelete, onEdit, t]
@@ -174,6 +197,9 @@ export function TransactionRow({
 }
 
 const styles = StyleSheet.create({
+  swipeActionPanel: {
+    overflow: "hidden",
+  },
   swipeAction: {
     width: SWIPE_ACTION_WIDTH,
   },

--- a/apps/mobile/shared/components/rn.ts
+++ b/apps/mobile/shared/components/rn.ts
@@ -15,7 +15,6 @@ export {
   Appearance,
   AppState,
   FlatList,
-  Image,
   Keyboard,
   KeyboardAvoidingView,
   Linking,

--- a/apps/mobile/shared/lib/format-money.ts
+++ b/apps/mobile/shared/lib/format-money.ts
@@ -11,10 +11,25 @@ const makeFormatter = (config: CurrencyConfig): Intl.NumberFormat =>
     minimumFractionDigits: config.exponent,
   });
 
-const defaultFormatter = makeFormatter(getActiveCurrency());
+const formatterKey = (config: CurrencyConfig): string =>
+  `${config.locale}:${config.code}:${config.exponent}`;
 
-const getFormatter = (config?: CurrencyConfig): Intl.NumberFormat =>
-  config ? makeFormatter(config) : defaultFormatter;
+const activeCurrency = getActiveCurrency();
+const formatterCache = new Map<string, Intl.NumberFormat>([
+  [formatterKey(activeCurrency), makeFormatter(activeCurrency)],
+]);
+
+const getFormatter = (config: CurrencyConfig = activeCurrency): Intl.NumberFormat => {
+  const key = formatterKey(config);
+  const cached = formatterCache.get(key);
+  if (cached) {
+    return cached;
+  }
+
+  const formatter = makeFormatter(config);
+  formatterCache.set(key, formatter);
+  return formatter;
+};
 
 /** Remove locale-inserted whitespace between currency symbol and number. */
 const stripCurrencySpace = (formatted: string): string => formatted.replace(/\s+/g, "");

--- a/dependency-policy.json
+++ b/dependency-policy.json
@@ -26,6 +26,11 @@
       "reason": "Expo SDK 56 expects 2.0.2; newer native versions need Expo compatibility confirmation."
     },
     {
+      "name": "better-sqlite3",
+      "until": "2026-06-01",
+      "reason": "Native test database addon update should land in a dedicated dependency PR with install and DB test verification."
+    },
+    {
       "name": "posthog-react-native",
       "until": "2026-06-01",
       "reason": "React Native analytics update should land separately from the SDK 55 restoration."


### PR DESCRIPTION
- use FlashList on list screens

- stabilize list render callbacks

- cache money formatters

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches mobile list screens to `@shopify/flash-list`, stabilizes render functions, and caches currency formatters to improve scroll performance and reduce re-renders. Also adds swipe actions to transaction rows and extracts a dedicated attribution queue card for cleaner queue code.

- **Performance**
  - Replaced `FlatList` with `@shopify/flash-list` on Home, Goals, Search, Chat sessions, Memories, and Review Queues.
  - Memoized key extractors, `renderItem`/headers, and separators; moved inline styles to `StyleSheet`.
  - Cached `Intl.NumberFormat` currency formatters in `format-money` to cut GC and repeated allocations.

- **Refactors**
  - Extracted `AttributionQueueCard` and simplified queue screens with typed callbacks.
  - Added swipe actions with haptics to `TransactionRow` (keeps iOS long‑press sheet).
  - Switched `ErrorFallback` to `expo-image`, removed `Image` re-export from `rn.ts`, and narrowed transaction test imports to public modules to fix Vitest import parsing.
  - Added shared item separators and styled the AI chat new‑chat button with a glass surface.
  - Updated dependency policy to temporarily allow `better-sqlite3`.

<sup>Written for commit 7fce59f959bb41909306cb1a6476982aa3d32233. Summary will update on new commits. <a href="https://cubic.dev/pr/B4rz99/fidy/pull/480?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

