### PR TITLE
fix(mobile): refresh budget suggestions

### DIFF
--- a/apps/mobile/__tests__/onboarding/budget-setup-step.test.ts
+++ b/apps/mobile/__tests__/onboarding/budget-setup-step.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { shouldRefreshBudgetSuggestions } from "@/features/onboarding/components/BudgetSetupStep.helpers";
+
+const snapshot = ({
+  isFetching = true,
+}: {
+  readonly isFetching?: boolean;
+} = {}) => ({
+  isFetching,
+});
+
+describe("BudgetSetupStep suggestion refresh", () => {
+  it("refreshes when email sync finishes without a larger progress count", () => {
+    expect(
+      shouldRefreshBudgetSuggestions(
+        snapshot({ isFetching: true }),
+        snapshot({ isFetching: false })
+      )
+    ).toBe(true);
+  });
+
+  it("does not refresh for incremental progress updates while sync is running", () => {
+    expect(
+      shouldRefreshBudgetSuggestions(snapshot({ isFetching: true }), snapshot({ isFetching: true }))
+    ).toBe(false);
+  });
+
+  it("does not refresh after sync has already finished", () => {
+    expect(
+      shouldRefreshBudgetSuggestions(
+        snapshot({ isFetching: false }),
+        snapshot({ isFetching: false })
+      )
+    ).toBe(false);
+  });
+});

--- a/apps/mobile/features/onboarding/components/BudgetSetupStep.helpers.ts
+++ b/apps/mobile/features/onboarding/components/BudgetSetupStep.helpers.ts
@@ -1,0 +1,10 @@
+type EmailSyncSnapshot = {
+  readonly isFetching: boolean;
+};
+
+export function shouldRefreshBudgetSuggestions(
+  previous: EmailSyncSnapshot,
+  next: EmailSyncSnapshot
+): boolean {
+  return previous.isFetching && !next.isFetching;
+}

--- a/apps/mobile/features/onboarding/components/BudgetSetupStep.tsx
+++ b/apps/mobile/features/onboarding/components/BudgetSetupStep.tsx
@@ -5,6 +5,7 @@ import {
   loadBudgetAutoSuggestions,
   useBudgetStore,
 } from "@/features/budget/public";
+import { useEmailCaptureStore } from "@/features/email-capture/public";
 import { CATEGORY_MAP } from "@/shared/categories";
 import {
   Pressable,
@@ -21,6 +22,7 @@ import { getCategoryLabel } from "@/shared/i18n";
 import { formatMoney } from "@/shared/lib";
 import { logOnboardingEvent, trackOnboardingEvent } from "../lib/telemetry";
 import { useOnboardingStore } from "../store";
+import { shouldRefreshBudgetSuggestions } from "./BudgetSetupStep.helpers";
 
 export function BudgetSetupStep() {
   const { t, locale } = useTranslation();
@@ -38,13 +40,23 @@ export function BudgetSetupStep() {
 
   const { isBusy, run: guardedRun } = useAsyncGuard();
 
-  // Load suggestions on mount
   useMountEffect(() => {
     if (!userId || !db) return;
-    logOnboardingEvent("budget_suggestions_load_start");
-    loadBudgetAutoSuggestions(db, userId);
-    trackOnboardingEvent("budget_suggestions_loaded", {
-      suggestionCount: useBudgetStore.getState().autoSuggestions.length,
+    const loadSuggestions = (trackLoaded: boolean) => {
+      if (trackLoaded) {
+        logOnboardingEvent("budget_suggestions_load_start");
+      }
+      loadBudgetAutoSuggestions(db, userId);
+      if (!trackLoaded) return;
+      trackOnboardingEvent("budget_suggestions_loaded", {
+        suggestionCount: useBudgetStore.getState().autoSuggestions.length,
+      });
+    };
+    loadSuggestions(true);
+
+    return useEmailCaptureStore.subscribe((state, previousState) => {
+      if (!shouldRefreshBudgetSuggestions(previousState, state)) return;
+      loadSuggestions(false);
     });
   });
 


### PR DESCRIPTION
- reload suggestions during onboarding sync

- cover refresh trigger decisions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes budget suggestions during onboarding when email sync finishes, so users see current suggestions. Adds a helper to decide when to reload, with unit tests, and skips duplicate tracking on refresh.

- **Bug Fixes**
  - Load suggestions on mount; subscribe to `useEmailCaptureStore` to reload once when `isFetching` goes from true to false, without emitting tracking events.
  - Gate reloads with `shouldRefreshBudgetSuggestions`; tests cover refresh and no-refresh cases.

<sup>Written for commit 4e915d01edf05bce1b82a254464a6334cf37fe6c. Summary will update on new commits. <a href="https://cubic.dev/pr/B4rz99/fidy/pull/481?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

