### PR TITLE
feat(mobile): polish chat interactions

### DIFF
--- a/apps/mobile/__tests__/ai-chat/chat-composer.test.ts
+++ b/apps/mobile/__tests__/ai-chat/chat-composer.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { resolveChatComposerSend } from "@/features/ai-chat/lib/chat-composer";
+
+describe("AI chat composer", () => {
+  it("trims message text and clears the input after a send", () => {
+    expect(resolveChatComposerSend({ text: "  comida este mes  ", disabled: false })).toEqual({
+      canSend: true,
+      message: "comida este mes",
+      nextText: "",
+    });
+  });
+
+  it("does not send empty or disabled messages", () => {
+    expect(resolveChatComposerSend({ text: "   ", disabled: false })).toEqual({
+      canSend: false,
+      message: null,
+      nextText: "   ",
+    });
+    expect(resolveChatComposerSend({ text: "hello", disabled: true })).toEqual({
+      canSend: false,
+      message: null,
+      nextText: "hello",
+    });
+  });
+});

--- a/apps/mobile/__tests__/ai-chat/chat-shell-layout.test.ts
+++ b/apps/mobile/__tests__/ai-chat/chat-shell-layout.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  getChatComposerBottomOffset,
+  getChatShellBottomInset,
+  getScrollButtonBottomOffset,
+  shouldRenderScrollToBottom,
+} from "@/features/ai-chat/lib/chat-shell-layout";
+
+describe("AI chat shell layout", () => {
+  it("reserves space below the list for the floating composer", () => {
+    expect(getChatShellBottomInset({ composerHeight: 64, safeBottom: 24 })).toBe(104);
+  });
+
+  it("positions scroll affordance above the floating composer", () => {
+    expect(getScrollButtonBottomOffset({ composerHeight: 64, safeBottom: 24 })).toBe(116);
+  });
+
+  it("keeps the composer above the home indicator when the keyboard is closed", () => {
+    expect(getChatComposerBottomOffset({ keyboardVisible: false, safeBottom: 24 })).toBe(24);
+  });
+
+  it("anchors the composer flush to the keyboard when the keyboard is open", () => {
+    expect(getChatComposerBottomOffset({ keyboardVisible: true, safeBottom: 24 })).toBe(0);
+  });
+
+  it("does not show the scroll affordance while a response is streaming", () => {
+    expect(
+      shouldRenderScrollToBottom({
+        hasListContent: true,
+        isStreaming: true,
+        isAwayFromBottom: true,
+      })
+    ).toBe(false);
+  });
+
+  it("does not show the scroll affordance without list content", () => {
+    expect(
+      shouldRenderScrollToBottom({
+        hasListContent: false,
+        isStreaming: false,
+        isAwayFromBottom: true,
+      })
+    ).toBe(false);
+  });
+});

--- a/apps/mobile/__tests__/ai-chat/conversation-scroll.test.ts
+++ b/apps/mobile/__tests__/ai-chat/conversation-scroll.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  shouldAutoScrollForContentChange,
+  shouldShowScrollToBottom,
+} from "@/features/ai-chat/lib/conversation-scroll";
+
+describe("AI chat conversation scroll policy", () => {
+  it("auto-scrolls when content grows while the reader is near the bottom", () => {
+    expect(
+      shouldAutoScrollForContentChange({
+        previousContentHeight: 900,
+        nextContentHeight: 960,
+        viewportHeight: 500,
+        scrollOffsetY: 430,
+        bottomInset: 80,
+      })
+    ).toBe(true);
+  });
+
+  it("preserves scroll position when content grows while reading older messages", () => {
+    expect(
+      shouldAutoScrollForContentChange({
+        previousContentHeight: 900,
+        nextContentHeight: 960,
+        viewportHeight: 500,
+        scrollOffsetY: 100,
+        bottomInset: 80,
+      })
+    ).toBe(false);
+  });
+
+  it("shows a scroll-to-bottom affordance only away from the bottom", () => {
+    expect(
+      shouldShowScrollToBottom({
+        contentHeight: 1200,
+        viewportHeight: 500,
+        scrollOffsetY: 300,
+        bottomInset: 80,
+      })
+    ).toBe(true);
+
+    expect(
+      shouldShowScrollToBottom({
+        contentHeight: 1200,
+        viewportHeight: 500,
+        scrollOffsetY: 730,
+        bottomInset: 80,
+      })
+    ).toBe(false);
+  });
+
+  it("does not double count list bottom inset already included in content height", () => {
+    expect(
+      shouldShowScrollToBottom({
+        contentHeight: 1200,
+        viewportHeight: 500,
+        scrollOffsetY: 660,
+        bottomInset: 80,
+      })
+    ).toBe(false);
+  });
+});

--- a/apps/mobile/__tests__/ai-chat/message-content.test.ts
+++ b/apps/mobile/__tests__/ai-chat/message-content.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  getAssistantDisplayBlocks,
+  getPlainMessageText,
+} from "@/features/ai-chat/lib/message-content";
+
+describe("AI chat message content", () => {
+  it("removes action payloads from visible message text", () => {
+    expect(getPlainMessageText('Added it.\n\n[ACTION]{"type":"add"}[/ACTION]')).toBe("Added it.");
+  });
+
+  it("turns assistant markdown into display blocks without raw markdown markers", () => {
+    expect(getAssistantDisplayBlocks("You spent **120,000 COP**.\n\n- Food\n- Transport")).toEqual([
+      {
+        key: "paragraph-0-0",
+        type: "paragraph",
+        segments: [
+          { key: "text-0-0", text: "You spent ", strong: false },
+          { key: "strong-0-1", text: "120,000 COP", strong: true },
+          { key: "text-0-2", text: ".", strong: false },
+        ],
+      },
+      { key: "list-1-0", type: "bullet", text: "Food" },
+      { key: "list-1-1", type: "bullet", text: "Transport" },
+    ]);
+  });
+
+  it("keeps non-markdown asterisks in visible assistant text", () => {
+    expect(getAssistantDisplayBlocks("The formula is 2 * 3 * 4.")[0]).toEqual({
+      key: "paragraph-0-0",
+      type: "paragraph",
+      segments: [{ key: "text-0-0", text: "The formula is 2 * 3 * 4.", strong: false }],
+    });
+  });
+
+  it("strips nested inline markers from bold segments", () => {
+    expect(getAssistantDisplayBlocks("You spent **`120,000 COP`** today.")[0]).toEqual({
+      key: "paragraph-0-0",
+      type: "paragraph",
+      segments: [
+        { key: "text-0-0", text: "You spent ", strong: false },
+        { key: "strong-0-1", text: "120,000 COP", strong: true },
+        { key: "text-0-2", text: " today.", strong: false },
+      ],
+    });
+  });
+
+  it("preserves mixed paragraphs and bullets in order", () => {
+    expect(
+      getAssistantDisplayBlocks("Here are the categories:\n- Food\n- Transport\nDone.")
+    ).toEqual([
+      {
+        key: "paragraph-0-0",
+        type: "paragraph",
+        segments: [{ key: "text-0-0", text: "Here are the categories:", strong: false }],
+      },
+      { key: "list-0-1", type: "bullet", text: "Food" },
+      { key: "list-0-2", type: "bullet", text: "Transport" },
+      {
+        key: "paragraph-0-3",
+        type: "paragraph",
+        segments: [{ key: "text-3-0", text: "Done.", strong: false }],
+      },
+    ]);
+  });
+});

--- a/apps/mobile/__tests__/ai-chat/streaming-bubble-display.test.ts
+++ b/apps/mobile/__tests__/ai-chat/streaming-bubble-display.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { getStreamingBubbleDisplay } from "@/features/ai-chat/lib/streaming-bubble-display";
+
+describe("AI chat streaming bubble display", () => {
+  it("shows a thinking state before the first streamed token", () => {
+    expect(getStreamingBubbleDisplay("", "Fidy is thinking")).toEqual({
+      phase: "waiting",
+      label: "Fidy is thinking",
+    });
+  });
+
+  it("shows streamed content after tokens arrive", () => {
+    expect(getStreamingBubbleDisplay("Here is your answer", "Fidy is thinking")).toEqual({
+      phase: "streaming",
+      content: "Here is your answer",
+    });
+  });
+});

--- a/apps/mobile/__tests__/ai-chat/streaming-text-store.test.ts
+++ b/apps/mobile/__tests__/ai-chat/streaming-text-store.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+import { createStreamingTextStore } from "@/features/ai-chat/services/streaming-text-store";
+
+describe("streaming text store", () => {
+  it("notifies subscribers when streaming text changes", () => {
+    const store = createStreamingTextStore();
+    const listener = vi.fn();
+
+    const unsubscribe = store.subscribe(listener);
+    store.set("hello");
+
+    expect(store.getSnapshot()).toBe("hello");
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    store.set("ignored");
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the streaming text", () => {
+    const store = createStreamingTextStore("partial");
+
+    store.clear();
+
+    expect(store.getSnapshot()).toBe("");
+  });
+});

--- a/apps/mobile/__tests__/budget/create-budget-screen.test.ts
+++ b/apps/mobile/__tests__/budget/create-budget-screen.test.ts
@@ -24,9 +24,12 @@ const submitSource = readSource(
   "../../features/budget/components/create-budget/useCreateBudgetSubmit.ts"
 );
 
-test("create-budget is registered in root layout as formSheet", () => {
+test("create-budget is registered in root layout as a dialog modal", () => {
   expect(layoutSource).toContain('"create-budget"');
-  expect(layoutSource).toContain("formSheet");
+  expect(routeSource).toContain("DialogRouteFrame");
+  const createBudgetBlock = layoutSource.slice(layoutSource.indexOf('name="create-budget"'));
+  expect(createBudgetBlock.slice(0, 140)).toContain("DIALOG_MODAL");
+  expect(layoutSource).not.toContain("formSheet");
 });
 
 test("create-budget route uses the budget public route surface", () => {

--- a/apps/mobile/__tests__/calendar/add-bill-screen.test.ts
+++ b/apps/mobile/__tests__/calendar/add-bill-screen.test.ts
@@ -18,9 +18,12 @@ const authFormSource = readSource(
 );
 const submitSource = readSource("../../features/calendar/components/add-bill/useAddBillSubmit.ts");
 
-test("add-bill is registered in root layout as formSheet", () => {
+test("add-bill is registered in root layout as a dialog modal", () => {
   expect(layoutSource).toContain('name="add-bill"');
-  expect(layoutSource).toContain("formSheet");
+  expect(routeSource).toContain("DialogRouteFrame");
+  const addBillBlock = layoutSource.slice(layoutSource.indexOf('name="add-bill"'));
+  expect(addBillBlock.slice(0, 140)).toContain("DIALOG_MODAL");
+  expect(layoutSource).not.toContain("formSheet");
 });
 
 test("add-bill routes through the extracted screen module", () => {

--- a/apps/mobile/__tests__/calendar/day-detail-screen.test.ts
+++ b/apps/mobile/__tests__/calendar/day-detail-screen.test.ts
@@ -5,10 +5,13 @@ import { describe, expect, test } from "vitest";
 const source = readFileSync(resolve(__dirname, "../../app/day-detail.tsx"), "utf-8");
 const layoutSource = readFileSync(resolve(__dirname, "../../app/_layout.tsx"), "utf-8");
 
-describe("day-detail formSheet screen", () => {
-  test("is registered in root layout as formSheet", () => {
+describe("day-detail dialog modal screen", () => {
+  test("is registered in root layout as a dialog modal", () => {
     expect(layoutSource).toContain('name="day-detail"');
-    expect(layoutSource).toContain("formSheet");
+    expect(source).toContain("DialogRouteFrame");
+    const dayDetailBlock = layoutSource.slice(layoutSource.indexOf('name="day-detail"'));
+    expect(dayDetailBlock.slice(0, 140)).toContain("DIALOG_MODAL");
+    expect(layoutSource).not.toContain("formSheet");
   });
 
   test("accepts date param via useLocalSearchParams", () => {

--- a/apps/mobile/__tests__/navigation/root-layout-headers.test.ts
+++ b/apps/mobile/__tests__/navigation/root-layout-headers.test.ts
@@ -17,13 +17,16 @@ describe("Root layout native headers", () => {
     expect(source).toContain("theme.page");
   });
 
-  test("formSheet modals use SHEET constant with headerShown: false", () => {
-    expect(source).toContain(
-      'const SHEET = { headerShown: false, presentation: "formSheet" } as const'
-    );
+  test("dialog modal routes use DIALOG_MODAL without sheet detents", () => {
+    expect(source).toContain("const DIALOG_MODAL = {");
+    expect(source).toContain('presentation: "transparentModal"');
+    expect(source).toContain('animation: "fade"');
+    expect(source).toContain('contentStyle: { backgroundColor: "transparent" }');
+    expect(source).not.toContain("formSheet");
+    expect(source).not.toContain("sheetAllowedDetents");
     expect(source).toContain('name="add-bill"');
-    // add-bill options must spread SHEET
+    // add-bill options must use the shared dialog modal presentation.
     const addBillBlock = source.slice(source.indexOf('name="add-bill"'));
-    expect(addBillBlock.slice(0, 200)).toContain("...SHEET");
+    expect(addBillBlock.slice(0, 200)).toContain("DIALOG_MODAL");
   });
 });

--- a/apps/mobile/__tests__/transactions/add-screen-source.test.ts
+++ b/apps/mobile/__tests__/transactions/add-screen-source.test.ts
@@ -129,10 +129,15 @@ test("Pencil entry dismisses the description keyboard from outside taps", () => 
 test("Pencil entry picker backdrops are translucent and do not slide the screen", () => {
   expect(themeSource).toContain('modalBackdrop: "#000000"');
   expect(transactionSheetsSource).toContain("backgroundColor: `${modalBackdrop}40`");
+  expect(transactionSheetsSource).toContain('justifyContent: "center"');
+  expect(transactionSheetsSource).toContain("maxWidth: 480");
   expect(pencilTransferEntrySource).toContain("backgroundColor: `${modalBackdrop}40`");
+  expect(pencilTransferEntrySource).toContain('justifyContent: "center"');
+  expect(pencilTransferEntrySource).toContain("maxWidth: 480");
   expect(transferSidePickerSource).toContain('animationType="fade"');
   expect(transferSidePickerSource).not.toContain('animationType="slide"');
   expect(transferSidePickerSource).toContain("backgroundColor: `${modalBackdrop}40`");
+  expect(transferSidePickerSource).toContain("styles.pickerSheet");
 });
 
 test("Pencil transaction entry supports expense income transfer and calendar", () => {

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -46,7 +46,12 @@ import { QueryProvider } from "@/shared/query";
 import type { UserId } from "@/shared/types/branded";
 import migrations from "../drizzle/migrations";
 
-const SHEET = { headerShown: false, presentation: "formSheet" } as const;
+const DIALOG_MODAL = {
+  animation: "fade",
+  contentStyle: { backgroundColor: "transparent" },
+  headerShown: false,
+  presentation: "transparentModal",
+} as const;
 const ONBOARDING_ALLOWED_ROUTES = new Set(["create-financial-account", "link-suggested-account"]);
 
 // Init locale synchronously before first render
@@ -209,24 +214,21 @@ function RootLayout() {
             {localQaAvailable ? <Stack.Screen name="qa-open" options={iosHeaderOptions} /> : null}
             <Stack.Screen
               name="add-bill"
-              options={{ ...SHEET, sheetAllowedDetents: "fitToContents" }}
+              options={DIALOG_MODAL}
             />
             <Stack.Screen
               name="day-detail"
-              options={{ ...SHEET, sheetAllowedDetents: "fitToContents" }}
+              options={DIALOG_MODAL}
             />
-            <Stack.Screen name="theme-picker" options={{ ...SHEET, sheetAllowedDetents: [0.24] }} />
-            <Stack.Screen
-              name="language-picker"
-              options={{ ...SHEET, sheetAllowedDetents: [0.18] }}
-            />
+            <Stack.Screen name="theme-picker" options={DIALOG_MODAL} />
+            <Stack.Screen name="language-picker" options={DIALOG_MODAL} />
             <Stack.Screen
               name="delete-account"
-              options={{ ...SHEET, sheetAllowedDetents: "fitToContents" }}
+              options={DIALOG_MODAL}
             />
             <Stack.Screen
               name="enable-notifications"
-              options={{ ...SHEET, sheetAllowedDetents: "fitToContents" }}
+              options={DIALOG_MODAL}
             />
             <Stack.Screen name="analytics" options={iosHeaderOptions} />
             <Stack.Screen name="notifications" options={iosHeaderOptions} />
@@ -242,38 +244,37 @@ function RootLayout() {
             {__DEV__ ? <Stack.Screen name="design-system" options={iosHeaderOptions} /> : null}
             <Stack.Screen
               name="financial-account-identifier"
-              options={{ ...SHEET, ...iosHeaderOptions, sheetAllowedDetents: [0.62] }}
+              options={{ ...DIALOG_MODAL, ...iosHeaderOptions }}
             />
             <Stack.Screen
               name="link-suggested-account"
-              options={{ ...SHEET, ...iosHeaderOptions, sheetAllowedDetents: [0.8] }}
+              options={{ ...DIALOG_MODAL, ...iosHeaderOptions }}
             />
             <Stack.Screen
               name="create-budget"
-              options={{ presentation: "formSheet", sheetAllowedDetents: "fitToContents" }}
+              options={DIALOG_MODAL}
             />
             <Stack.Screen
               name="auto-suggest-budgets"
-              options={{ presentation: "formSheet", sheetAllowedDetents: "fitToContents" }}
+              options={DIALOG_MODAL}
             />
             <Stack.Screen name="goal-detail" options={iosHeaderOptions} />
             <Stack.Screen
               name="create-goal"
-              options={{ presentation: "formSheet", sheetAllowedDetents: "fitToContents" }}
+              options={DIALOG_MODAL}
             />
             <Stack.Screen
               name="add-payment"
-              options={{ presentation: "formSheet", sheetAllowedDetents: "fitToContents" }}
+              options={DIALOG_MODAL}
             />
             <Stack.Screen
               name="edit-goal"
-              options={{ presentation: "formSheet", sheetAllowedDetents: "fitToContents" }}
+              options={DIALOG_MODAL}
             />
             <Stack.Screen
               name="add-transaction"
               options={{
-                ...SHEET,
-                sheetAllowedDetents: [0.65],
+                ...DIALOG_MODAL,
                 gestureEnabled: false,
                 sheetGrabberVisible: false,
               }}
@@ -285,13 +286,12 @@ function RootLayout() {
             <Stack.Screen name="categories" options={iosHeaderOptions} />
             <Stack.Screen
               name="create-category"
-              options={{ presentation: "formSheet", sheetAllowedDetents: "fitToContents" }}
+              options={DIALOG_MODAL}
             />
             <Stack.Screen
               name="edit-transaction"
               options={{
-                ...SHEET,
-                sheetAllowedDetents: [0.65],
+                ...DIALOG_MODAL,
                 gestureEnabled: false,
                 sheetGrabberVisible: false,
               }}

--- a/apps/mobile/app/add-bill.tsx
+++ b/apps/mobile/app/add-bill.tsx
@@ -1,5 +1,10 @@
 import { AddBillScreen } from "@/features/calendar/routes.public";
+import { DialogRouteFrame } from "@/shared/components";
 
 export default function AddBillRoute() {
-  return <AddBillScreen />;
+  return (
+    <DialogRouteFrame>
+      <AddBillScreen />
+    </DialogRouteFrame>
+  );
 }

--- a/apps/mobile/app/add-payment.tsx
+++ b/apps/mobile/app/add-payment.tsx
@@ -1,5 +1,10 @@
 import { AddPaymentSheet } from "@/features/goals/ui.public";
+import { DialogRouteFrame } from "@/shared/components";
 
 export default function AddPaymentRoute() {
-  return <AddPaymentSheet />;
+  return (
+    <DialogRouteFrame>
+      <AddPaymentSheet />
+    </DialogRouteFrame>
+  );
 }

--- a/apps/mobile/app/add-transaction.tsx
+++ b/apps/mobile/app/add-transaction.tsx
@@ -1,11 +1,14 @@
 import { Stack } from "expo-router";
 import { PencilTransactionEntryScreen } from "@/features/transactions/routes.public";
+import { DialogRouteFrame } from "@/shared/components";
 
 export default function AddTransactionRoute() {
   return (
     <>
       <Stack.Screen options={{ gestureEnabled: true }} />
-      <PencilTransactionEntryScreen includesNativeHeader={false} />
+      <DialogRouteFrame>
+        <PencilTransactionEntryScreen includesNativeHeader={false} />
+      </DialogRouteFrame>
     </>
   );
 }

--- a/apps/mobile/app/add-transfer.tsx
+++ b/apps/mobile/app/add-transfer.tsx
@@ -1,5 +1,6 @@
 import { Stack, useRouter } from "expo-router";
 import { PencilTransferEntryScreen } from "@/features/transfers/routes.public";
+import { DialogRouteFrame } from "@/shared/components";
 
 export default function AddTransferRoute() {
   const { replace } = useRouter();
@@ -11,7 +12,9 @@ export default function AddTransferRoute() {
   return (
     <>
       <Stack.Screen options={{ gestureEnabled: true }} />
-      <PencilTransferEntryScreen onTransactionTabSelect={handleTransactionTabSelect} />
+      <DialogRouteFrame>
+        <PencilTransferEntryScreen onTransactionTabSelect={handleTransactionTabSelect} />
+      </DialogRouteFrame>
     </>
   );
 }

--- a/apps/mobile/app/auto-suggest-budgets.tsx
+++ b/apps/mobile/app/auto-suggest-budgets.tsx
@@ -7,6 +7,7 @@ import {
   useSuggestionSelection,
 } from "@/features/budget/hooks.public";
 import { CATEGORY_MAP } from "@/features/transactions";
+import { DialogRouteFrame } from "@/shared/components";
 import {
   KeyboardAvoidingView,
   Platform,
@@ -69,16 +70,17 @@ export default function AutoSuggestBudgetsScreen() {
   };
 
   return (
-    <KeyboardAvoidingView
-      style={styles.flex}
-      behavior={Platform.OS === "ios" ? "padding" : "height"}
-    >
-      <ScrollView
-        style={[styles.container, { backgroundColor: cardBg }]}
-        contentContainerStyle={[styles.scrollContent, { paddingBottom: bottom + 24 }]}
-        contentInsetAdjustmentBehavior="automatic"
-        keyboardShouldPersistTaps="handled"
+    <DialogRouteFrame>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
       >
+        <ScrollView
+          style={[styles.container, { backgroundColor: cardBg }]}
+          contentContainerStyle={[styles.scrollContent, { paddingBottom: bottom + 24 }]}
+          contentInsetAdjustmentBehavior="automatic"
+          keyboardShouldPersistTaps="handled"
+        >
         <Text style={[styles.title, { color: primaryColor }]}>
           {t("budgets.autoSuggest.title")}
         </Text>
@@ -159,8 +161,9 @@ export default function AutoSuggestBudgetsScreen() {
             </Text>
           </Pressable>
         </View>
-      </ScrollView>
-    </KeyboardAvoidingView>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </DialogRouteFrame>
   );
 }
 

--- a/apps/mobile/app/create-budget.tsx
+++ b/apps/mobile/app/create-budget.tsx
@@ -1,1 +1,10 @@
-export { CreateBudgetScreen as default } from "@/features/budget/routes.public";
+import { CreateBudgetScreen } from "@/features/budget/routes.public";
+import { DialogRouteFrame } from "@/shared/components";
+
+export default function CreateBudgetRoute() {
+  return (
+    <DialogRouteFrame>
+      <CreateBudgetScreen />
+    </DialogRouteFrame>
+  );
+}

--- a/apps/mobile/app/create-category.tsx
+++ b/apps/mobile/app/create-category.tsx
@@ -1,5 +1,10 @@
 import { CreateCategorySheet } from "@/features/categories";
+import { DialogRouteFrame } from "@/shared/components";
 
 export default function CreateCategoryRoute() {
-  return <CreateCategorySheet />;
+  return (
+    <DialogRouteFrame>
+      <CreateCategorySheet />
+    </DialogRouteFrame>
+  );
 }

--- a/apps/mobile/app/create-goal.tsx
+++ b/apps/mobile/app/create-goal.tsx
@@ -1,5 +1,10 @@
 import { GoalCreateSheet } from "@/features/goals/ui.public";
+import { DialogRouteFrame } from "@/shared/components";
 
 export default function CreateGoalRoute() {
-  return <GoalCreateSheet />;
+  return (
+    <DialogRouteFrame>
+      <GoalCreateSheet />
+    </DialogRouteFrame>
+  );
 }

--- a/apps/mobile/app/day-detail.tsx
+++ b/apps/mobile/app/day-detail.tsx
@@ -10,6 +10,7 @@ import {
   unmarkBillPaid,
   useCalendarStore,
 } from "@/features/calendar";
+import { DialogRouteFrame } from "@/shared/components";
 import { Check, Pencil, Trash2 } from "@/shared/components/icons";
 import { Alert, Pressable, ScrollView, StyleSheet, Text, View } from "@/shared/components/rn";
 import { getDb } from "@/shared/db";
@@ -74,14 +75,15 @@ export default function DayDetailScreen() {
   };
 
   return (
-    <ScrollView
-      style={[styles.container, { backgroundColor: cardBg }]}
-      contentContainerStyle={[styles.content, { paddingBottom: bottom + 24 }]}
-      contentInsetAdjustmentBehavior="automatic"
-    >
-      <Text style={[styles.title, { color: primaryColor }]}>
-        {format(dateObj, "EEEE, PP", { locale: getDateFnsLocale(locale) })}
-      </Text>
+    <DialogRouteFrame>
+      <ScrollView
+        style={[styles.container, { backgroundColor: cardBg }]}
+        contentContainerStyle={[styles.content, { paddingBottom: bottom + 24 }]}
+        contentInsetAdjustmentBehavior="automatic"
+      >
+        <Text style={[styles.title, { color: primaryColor }]}>
+          {format(dateObj, "EEEE, PP", { locale: getDateFnsLocale(locale) })}
+        </Text>
 
       {billsForDate.length === 0 ? (
         <View style={styles.emptyState}>
@@ -146,7 +148,8 @@ export default function DayDetailScreen() {
           })}
         </View>
       )}
-    </ScrollView>
+      </ScrollView>
+    </DialogRouteFrame>
   );
 }
 

--- a/apps/mobile/app/delete-account.tsx
+++ b/apps/mobile/app/delete-account.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from "expo-router";
 import { useAuthStore } from "@/features/auth/hooks.public";
 import { useDeleteAccountMutation } from "@/features/settings/hooks.public";
+import { DialogRouteFrame } from "@/shared/components";
 import { TriangleAlert } from "@/shared/components/icons";
 import { ActivityIndicator, Alert, Pressable, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
@@ -23,76 +24,78 @@ export default function DeleteAccountSheet() {
   };
 
   return (
-    <View
-      className="flex-1 bg-card dark:bg-card-dark"
-      style={{ paddingHorizontal: 24, paddingTop: 24, alignItems: "center", gap: 16 }}
-    >
+    <DialogRouteFrame>
       <View
-        style={{
-          width: 64,
-          height: 64,
-          borderRadius: 32,
-          alignItems: "center",
-          justifyContent: "center",
-          backgroundColor: `${accentRed}1A`,
-        }}
+        className="bg-card dark:bg-card-dark"
+        style={{ padding: 24, alignItems: "center", gap: 16 }}
       >
-        <TriangleAlert size={32} color={accentRed} />
-      </View>
-      <Text
-        className="font-poppins-semibold text-primary dark:text-primary-dark"
-        style={{ fontSize: 16 }}
-      >
-        {t("settings.deleteAccountTitle")}
-      </Text>
-      <Text
-        className="font-poppins text-secondary dark:text-secondary-dark"
-        style={{ fontSize: 13, lineHeight: 20, textAlign: "center" }}
-      >
-        {t("settings.deleteAccountWarning")}
-      </Text>
-      <View style={{ width: "100%", gap: 12, marginTop: 8 }}>
-        <Pressable
-          onPress={() => router.back()}
+        <View
           style={{
-            height: 48,
-            borderRadius: 16,
-            borderWidth: 1,
-            borderColor,
+            width: 64,
+            height: 64,
+            borderRadius: 32,
             alignItems: "center",
             justifyContent: "center",
+            backgroundColor: `${accentRed}1A`,
           }}
         >
-          <Text
-            className="font-poppins-semibold text-primary dark:text-primary-dark"
-            style={{ fontSize: 15 }}
+          <TriangleAlert size={32} color={accentRed} />
+        </View>
+        <Text
+          className="font-poppins-semibold text-primary dark:text-primary-dark"
+          style={{ fontSize: 16 }}
+        >
+          {t("settings.deleteAccountTitle")}
+        </Text>
+        <Text
+          className="font-poppins text-secondary dark:text-secondary-dark"
+          style={{ fontSize: 13, lineHeight: 20, textAlign: "center" }}
+        >
+          {t("settings.deleteAccountWarning")}
+        </Text>
+        <View style={{ width: "100%", gap: 12, marginTop: 8 }}>
+          <Pressable
+            onPress={() => router.back()}
+            style={{
+              height: 48,
+              borderRadius: 16,
+              borderWidth: 1,
+              borderColor,
+              alignItems: "center",
+              justifyContent: "center",
+            }}
           >
-            {t("common.cancel")}
-          </Text>
-        </Pressable>
-        <Pressable
-          onPress={() => {
-            void handleDelete();
-          }}
-          disabled={deleteAccount.isPending}
-          style={{
-            height: 48,
-            borderRadius: 16,
-            backgroundColor: accentRed,
-            alignItems: "center",
-            justifyContent: "center",
-            opacity: deleteAccount.isPending ? 0.6 : 1,
-          }}
-        >
-          {deleteAccount.isPending ? (
-            <ActivityIndicator color="#FFFFFF" />
-          ) : (
-            <Text className="font-poppins-semibold" style={{ fontSize: 15, color: "#FFFFFF" }}>
-              {t("settings.deleteAccountConfirm")}
+            <Text
+              className="font-poppins-semibold text-primary dark:text-primary-dark"
+              style={{ fontSize: 15 }}
+            >
+              {t("common.cancel")}
             </Text>
-          )}
-        </Pressable>
+          </Pressable>
+          <Pressable
+            onPress={() => {
+              void handleDelete();
+            }}
+            disabled={deleteAccount.isPending}
+            style={{
+              height: 48,
+              borderRadius: 16,
+              backgroundColor: accentRed,
+              alignItems: "center",
+              justifyContent: "center",
+              opacity: deleteAccount.isPending ? 0.6 : 1,
+            }}
+          >
+            {deleteAccount.isPending ? (
+              <ActivityIndicator color="#FFFFFF" />
+            ) : (
+              <Text className="font-poppins-semibold" style={{ fontSize: 15, color: "#FFFFFF" }}>
+                {t("settings.deleteAccountConfirm")}
+              </Text>
+            )}
+          </Pressable>
+        </View>
       </View>
-    </View>
+    </DialogRouteFrame>
   );
 }

--- a/apps/mobile/app/edit-goal.tsx
+++ b/apps/mobile/app/edit-goal.tsx
@@ -1,5 +1,10 @@
 import { GoalEditSheet } from "@/features/goals/ui.public";
+import { DialogRouteFrame } from "@/shared/components";
 
 export default function EditGoalRoute() {
-  return <GoalEditSheet />;
+  return (
+    <DialogRouteFrame>
+      <GoalEditSheet />
+    </DialogRouteFrame>
+  );
 }

--- a/apps/mobile/app/edit-transaction.tsx
+++ b/apps/mobile/app/edit-transaction.tsx
@@ -14,6 +14,7 @@ import {
   TransactionForm,
   updateTransactionDirect,
 } from "@/features/transactions";
+import { DialogRouteFrame } from "@/shared/components";
 import { tryGetDb } from "@/shared/db";
 import { useAsyncGuard, useMountEffect, useTranslation } from "@/shared/hooks";
 import { clampDateToToday, showErrorToast, waitForNavigationTransition } from "@/shared/lib";
@@ -169,36 +170,42 @@ export default function EditTransactionScreen() {
   if (!loadedRef.current) return null;
 
   return (
-    <TransactionForm
-      type={draft.type}
-      digits={draft.digits}
-      categoryId={draft.categoryId}
-      accounts={accounts}
-      accountId={draft.accountId}
-      description={draft.description}
-      date={draft.date}
-      saveLabel={t("common.save")}
-      isSaving={isSaving}
-      onTypeChange={(type) => setDraft({ type: "update", update: { type } })}
-      onDigitsChange={(digits) => setDraft({ type: "setDigits", digits })}
-      onCategoryChange={(categoryId) => setDraft({ type: "update", update: { categoryId } })}
-      onAccountChange={(accountId) => setDraft({ type: "update", update: { accountId } })}
-      onDescriptionChange={(description) => setDraft({ type: "update", update: { description } })}
-      onSave={handleSave}
-      onDelete={handleDelete}
-      onClose={back}
-      extraActionLabel={draft.source === "manual" ? undefined : t("transactions.convertToTransfer")}
-      onExtraAction={
-        draft.source === "manual" || transactionId == null
-          ? undefined
-          : () =>
-              push({
-                pathname: "/reclassify-transaction",
-                params: {
-                  transactionId,
-                },
-              })
-      }
-    />
+    <DialogRouteFrame>
+      <TransactionForm
+        type={draft.type}
+        digits={draft.digits}
+        categoryId={draft.categoryId}
+        accounts={accounts}
+        accountId={draft.accountId}
+        description={draft.description}
+        date={draft.date}
+        saveLabel={t("common.save")}
+        isSaving={isSaving}
+        onTypeChange={(type) => setDraft({ type: "update", update: { type } })}
+        onDigitsChange={(digits) => setDraft({ type: "setDigits", digits })}
+        onCategoryChange={(categoryId) => setDraft({ type: "update", update: { categoryId } })}
+        onAccountChange={(accountId) => setDraft({ type: "update", update: { accountId } })}
+        onDescriptionChange={(description) =>
+          setDraft({ type: "update", update: { description } })
+        }
+        onSave={handleSave}
+        onDelete={handleDelete}
+        onClose={back}
+        extraActionLabel={
+          draft.source === "manual" ? undefined : t("transactions.convertToTransfer")
+        }
+        onExtraAction={
+          draft.source === "manual" || transactionId == null
+            ? undefined
+            : () =>
+                push({
+                  pathname: "/reclassify-transaction",
+                  params: {
+                    transactionId,
+                  },
+                })
+        }
+      />
+    </DialogRouteFrame>
   );
 }

--- a/apps/mobile/app/enable-notifications.tsx
+++ b/apps/mobile/app/enable-notifications.tsx
@@ -9,6 +9,7 @@ import {
   registerPushToken,
   requestNotificationPermissionStatus,
 } from "@/features/notifications/hooks.public";
+import { DialogRouteFrame } from "@/shared/components";
 import { Bell } from "@/shared/components/icons";
 import { ActivityIndicator, Pressable, ScrollView, Text, View } from "@/shared/components/rn";
 import { useMountEffect, useThemeColor, useTranslation } from "@/shared/hooks";
@@ -84,85 +85,87 @@ export default function EnableNotificationsSheet() {
   };
 
   return (
-    <ScrollView
-      className="flex-1 bg-card dark:bg-card-dark"
-      contentContainerStyle={{
-        padding: 24,
-        paddingBottom: 24,
-        alignItems: "center",
-        gap: 16,
-      }}
-      contentInset={{ bottom }}
-      contentInsetAdjustmentBehavior="automatic"
-    >
-      <View
-        style={{
-          width: 64,
-          height: 64,
-          borderRadius: 32,
+    <DialogRouteFrame>
+      <ScrollView
+        className="bg-card dark:bg-card-dark"
+        contentContainerStyle={{
+          padding: 24,
+          paddingBottom: 24,
           alignItems: "center",
-          justifyContent: "center",
-          backgroundColor: `${accentGreen}1A`,
+          gap: 16,
         }}
+        contentInset={{ bottom }}
+        contentInsetAdjustmentBehavior="automatic"
       >
-        <Bell size={32} color={accentGreen} />
-      </View>
-      <Text
-        className="font-poppins-semibold text-primary dark:text-primary-dark"
-        style={{ fontSize: 16 }}
-      >
-        {t("notifications.enableNotifications.title")}
-      </Text>
-      <Text
-        className="font-poppins text-secondary dark:text-secondary-dark"
-        style={{ fontSize: 13, lineHeight: 20, textAlign: "center" }}
-      >
-        {t("notifications.enableNotifications.description")}
-      </Text>
-      <View style={{ width: "100%", gap: 12 }}>
-        <Pressable
-          onPress={() => {
-            void handleEnable();
-          }}
-          disabled={isRequesting}
+        <View
           style={{
-            height: 48,
-            borderRadius: 16,
-            backgroundColor: accentGreen,
+            width: 64,
+            height: 64,
+            borderRadius: 32,
             alignItems: "center",
             justifyContent: "center",
-            opacity: isRequesting ? 0.6 : 1,
+            backgroundColor: `${accentGreen}1A`,
           }}
         >
-          {isRequesting ? (
-            <ActivityIndicator color="#FFFFFF" />
-          ) : (
-            <Text className="font-poppins-semibold" style={{ fontSize: 15, color: "#FFFFFF" }}>
-              {t("notifications.enableNotifications.enable")}
-            </Text>
-          )}
-        </Pressable>
-        <Pressable
-          onPress={() => {
-            void handleNotNow();
-          }}
-          style={{
-            height: 48,
-            borderRadius: 16,
-            borderWidth: 1,
-            borderColor,
-            alignItems: "center",
-            justifyContent: "center",
-          }}
+          <Bell size={32} color={accentGreen} />
+        </View>
+        <Text
+          className="font-poppins-semibold text-primary dark:text-primary-dark"
+          style={{ fontSize: 16 }}
         >
-          <Text
-            className="font-poppins-semibold text-primary dark:text-primary-dark"
-            style={{ fontSize: 15 }}
+          {t("notifications.enableNotifications.title")}
+        </Text>
+        <Text
+          className="font-poppins text-secondary dark:text-secondary-dark"
+          style={{ fontSize: 13, lineHeight: 20, textAlign: "center" }}
+        >
+          {t("notifications.enableNotifications.description")}
+        </Text>
+        <View style={{ width: "100%", gap: 12 }}>
+          <Pressable
+            onPress={() => {
+              void handleEnable();
+            }}
+            disabled={isRequesting}
+            style={{
+              height: 48,
+              borderRadius: 16,
+              backgroundColor: accentGreen,
+              alignItems: "center",
+              justifyContent: "center",
+              opacity: isRequesting ? 0.6 : 1,
+            }}
           >
-            {t("notifications.enableNotifications.notNow")}
-          </Text>
-        </Pressable>
-      </View>
-    </ScrollView>
+            {isRequesting ? (
+              <ActivityIndicator color="#FFFFFF" />
+            ) : (
+              <Text className="font-poppins-semibold" style={{ fontSize: 15, color: "#FFFFFF" }}>
+                {t("notifications.enableNotifications.enable")}
+              </Text>
+            )}
+          </Pressable>
+          <Pressable
+            onPress={() => {
+              void handleNotNow();
+            }}
+            style={{
+              height: 48,
+              borderRadius: 16,
+              borderWidth: 1,
+              borderColor,
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <Text
+              className="font-poppins-semibold text-primary dark:text-primary-dark"
+              style={{ fontSize: 15 }}
+            >
+              {t("notifications.enableNotifications.notNow")}
+            </Text>
+          </Pressable>
+        </View>
+      </ScrollView>
+    </DialogRouteFrame>
   );
 }

--- a/apps/mobile/app/financial-account-identifier.tsx
+++ b/apps/mobile/app/financial-account-identifier.tsx
@@ -1,1 +1,10 @@
-export { FinancialAccountIdentifierSheet as default } from "@/features/financial-accounts/routes.public";
+import { FinancialAccountIdentifierSheet } from "@/features/financial-accounts/routes.public";
+import { DialogRouteFrame } from "@/shared/components";
+
+export default function FinancialAccountIdentifierRoute() {
+  return (
+    <DialogRouteFrame>
+      <FinancialAccountIdentifierSheet />
+    </DialogRouteFrame>
+  );
+}

--- a/apps/mobile/app/language-picker.tsx
+++ b/apps/mobile/app/language-picker.tsx
@@ -1,4 +1,5 @@
 import { useRouter } from "expo-router";
+import { DialogRouteFrame } from "@/shared/components";
 import { Check } from "@/shared/components/icons";
 import { Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
@@ -22,39 +23,38 @@ export default function LanguagePickerSheet() {
   };
 
   return (
-    <View
-      className="flex-1 bg-card dark:bg-card-dark"
-      style={{ paddingHorizontal: 24, paddingTop: 24 }}
-    >
-      <Text
-        className="font-poppins-semibold text-primary dark:text-primary-dark"
-        style={{ fontSize: 16, textAlign: "center", marginBottom: 20 }}
-      >
-        {t("settings.language")}
-      </Text>
-      {OPTIONS.map((option, index) => (
-        <Pressable
-          key={option.locale}
-          onPress={() => handleSelect(option.locale)}
-          style={{
-            flexDirection: "row",
-            alignItems: "center",
-            justifyContent: "space-between",
-            height: 52,
-            paddingHorizontal: 4,
-            borderBottomWidth: index < OPTIONS.length - 1 ? StyleSheet.hairlineWidth : 0,
-            borderBottomColor: borderColor,
-          }}
+    <DialogRouteFrame>
+      <View className="bg-card dark:bg-card-dark" style={{ padding: 24 }}>
+        <Text
+          className="font-poppins-semibold text-primary dark:text-primary-dark"
+          style={{ fontSize: 16, textAlign: "center", marginBottom: 20 }}
         >
-          <Text
-            className="font-poppins-medium text-primary dark:text-primary-dark"
-            style={{ fontSize: 15 }}
+          {t("settings.language")}
+        </Text>
+        {OPTIONS.map((option, index) => (
+          <Pressable
+            key={option.locale}
+            onPress={() => handleSelect(option.locale)}
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              justifyContent: "space-between",
+              height: 52,
+              paddingHorizontal: 4,
+              borderBottomWidth: index < OPTIONS.length - 1 ? StyleSheet.hairlineWidth : 0,
+              borderBottomColor: borderColor,
+            }}
           >
-            {option.label}
-          </Text>
-          {locale.startsWith(option.locale) ? <Check size={22} color={accentGreen} /> : null}
-        </Pressable>
-      ))}
-    </View>
+            <Text
+              className="font-poppins-medium text-primary dark:text-primary-dark"
+              style={{ fontSize: 15 }}
+            >
+              {option.label}
+            </Text>
+            {locale.startsWith(option.locale) ? <Check size={22} color={accentGreen} /> : null}
+          </Pressable>
+        ))}
+      </View>
+    </DialogRouteFrame>
   );
 }

--- a/apps/mobile/app/link-suggested-account.tsx
+++ b/apps/mobile/app/link-suggested-account.tsx
@@ -1,1 +1,10 @@
-export { LinkSuggestedAccountScreen as default } from "@/features/account-suggestions/routes.public";
+import { LinkSuggestedAccountScreen } from "@/features/account-suggestions/routes.public";
+import { DialogRouteFrame } from "@/shared/components";
+
+export default function LinkSuggestedAccountRoute() {
+  return (
+    <DialogRouteFrame>
+      <LinkSuggestedAccountScreen />
+    </DialogRouteFrame>
+  );
+}

--- a/apps/mobile/app/theme-picker.tsx
+++ b/apps/mobile/app/theme-picker.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from "expo-router";
 import { type ThemePreference, useSettingsStore } from "@/features/settings/hooks.public";
+import { DialogRouteFrame } from "@/shared/components";
 import { Check } from "@/shared/components/icons";
 import { Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
@@ -24,39 +25,38 @@ export default function ThemePickerSheet() {
   };
 
   return (
-    <View
-      className="flex-1 bg-card dark:bg-card-dark"
-      style={{ paddingHorizontal: 24, paddingTop: 24 }}
-    >
-      <Text
-        className="font-poppins-semibold text-primary dark:text-primary-dark"
-        style={{ fontSize: 16, textAlign: "center", marginBottom: 20 }}
-      >
-        {t("settings.theme")}
-      </Text>
-      {OPTIONS.map((option, index) => (
-        <Pressable
-          key={option.key}
-          onPress={() => handleSelect(option.key)}
-          style={{
-            flexDirection: "row",
-            alignItems: "center",
-            justifyContent: "space-between",
-            height: 52,
-            paddingHorizontal: 4,
-            borderBottomWidth: index < OPTIONS.length - 1 ? StyleSheet.hairlineWidth : 0,
-            borderBottomColor: borderColor,
-          }}
+    <DialogRouteFrame>
+      <View className="bg-card dark:bg-card-dark" style={{ padding: 24 }}>
+        <Text
+          className="font-poppins-semibold text-primary dark:text-primary-dark"
+          style={{ fontSize: 16, textAlign: "center", marginBottom: 20 }}
         >
-          <Text
-            className="font-poppins-medium text-primary dark:text-primary-dark"
-            style={{ fontSize: 15 }}
+          {t("settings.theme")}
+        </Text>
+        {OPTIONS.map((option, index) => (
+          <Pressable
+            key={option.key}
+            onPress={() => handleSelect(option.key)}
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              justifyContent: "space-between",
+              height: 52,
+              paddingHorizontal: 4,
+              borderBottomWidth: index < OPTIONS.length - 1 ? StyleSheet.hairlineWidth : 0,
+              borderBottomColor: borderColor,
+            }}
           >
-            {t(option.labelKey)}
-          </Text>
-          {current === option.key ? <Check size={22} color={accentGreen} /> : null}
-        </Pressable>
-      ))}
-    </View>
+            <Text
+              className="font-poppins-medium text-primary dark:text-primary-dark"
+              style={{ fontSize: 15 }}
+            >
+              {t(option.labelKey)}
+            </Text>
+            {current === option.key ? <Check size={22} color={accentGreen} /> : null}
+          </Pressable>
+        ))}
+      </View>
+    </DialogRouteFrame>
   );
 }

--- a/apps/mobile/features/account-suggestions/components/AccountSuggestionCard.tsx
+++ b/apps/mobile/features/account-suggestions/components/AccountSuggestionCard.tsx
@@ -1,3 +1,4 @@
+import { memo, useCallback } from "react";
 import { Building2, CreditCard, Sparkles, Wallet } from "@/shared/components/icons";
 import { Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
@@ -37,7 +38,7 @@ function getAccountIcon(kind: string) {
   return Building2;
 }
 
-export function AccountSuggestionCard({
+function AccountSuggestionCardInner({
   suggestion,
   onCreate,
   onLink,
@@ -55,6 +56,9 @@ export function AccountSuggestionCard({
   const accentGreenLight = useThemeColor("accentGreenLight");
   const peachLight = useThemeColor("peachLight");
   const AccountIcon = getAccountIcon(draft.kind);
+  const handleCreate = useCallback(() => onCreate(suggestion), [onCreate, suggestion]);
+  const handleLink = useCallback(() => onLink(suggestion), [onLink, suggestion]);
+  const handleSkip = useCallback(() => onSkip(suggestion), [onSkip, suggestion]);
 
   return (
     <View style={[styles.card, { backgroundColor: card, borderColor: borderSubtle }]}>
@@ -97,19 +101,19 @@ export function AccountSuggestionCard({
       <View style={styles.actionsRow}>
         <Pressable
           style={[styles.primaryAction, { backgroundColor: accentGreen }]}
-          onPress={() => onCreate(suggestion)}
+          onPress={handleCreate}
         >
           <Text style={styles.primaryActionText}>{t("accountSuggestions.card.create")}</Text>
         </Pressable>
         <Pressable
           style={[styles.secondaryAction, { backgroundColor: peachLight }]}
-          onPress={() => onLink(suggestion)}
+          onPress={handleLink}
         >
           <Text style={[styles.secondaryActionText, { color: primary }]}>
             {t("accountSuggestions.card.linkExisting")}
           </Text>
         </Pressable>
-        <Pressable style={styles.skipAction} onPress={() => onSkip(suggestion)}>
+        <Pressable style={styles.skipAction} onPress={handleSkip}>
           <Text style={[styles.skipActionText, { color: secondary }]}>
             {t("accountSuggestions.card.skipForNow")}
           </Text>
@@ -118,6 +122,8 @@ export function AccountSuggestionCard({
     </View>
   );
 }
+
+export const AccountSuggestionCard = memo(AccountSuggestionCardInner);
 
 const styles = StyleSheet.create({
   card: {

--- a/apps/mobile/features/account-suggestions/components/AccountSuggestionReviewScreen.tsx
+++ b/apps/mobile/features/account-suggestions/components/AccountSuggestionReviewScreen.tsx
@@ -1,15 +1,20 @@
+import { FlashList, type ListRenderItemInfo } from "@shopify/flash-list";
 import { useRouter } from "expo-router";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useOptionalUserId } from "@/features/auth/public";
 import { ScreenLayout } from "@/shared/components";
-import { ScrollView, StyleSheet, Text, View } from "@/shared/components/rn";
+import { StyleSheet, Text, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
 import { useAsyncGuard, useThemeColor, useTranslation } from "@/shared/hooks";
 import { showErrorToast } from "@/shared/lib";
 import { useAccountSuggestions } from "../hooks/use-account-suggestions";
+import type { AccountCreationSuggestion } from "../lib/derive-account-suggestions";
 import { createAccountSuggestionService } from "../services/create-account-suggestion-service";
 import { AccountSuggestionCard } from "./AccountSuggestionCard";
+
+const suggestionKeyExtractor = (item: AccountCreationSuggestion) => item.fingerprint;
+const SuggestionItemSeparator = () => <View style={styles.itemSeparator} />;
 
 export function AccountSuggestionReviewScreen() {
   const router = useRouter();
@@ -26,35 +31,92 @@ export function AccountSuggestionReviewScreen() {
   const secondary = useThemeColor("secondary");
   const { run: guardedMutation } = useAsyncGuard();
 
-  const handleCreate = (fingerprint: string) => {
-    router.push({
-      pathname: "/create-financial-account",
-      params: { fingerprint },
-    } as never);
-  };
+  const handleCreate = useCallback(
+    (fingerprint: string) => {
+      router.push({
+        pathname: "/create-financial-account",
+        params: { fingerprint },
+      } as never);
+    },
+    [router]
+  );
 
-  const handleLink = (fingerprint: string) => {
-    router.push({
-      pathname: "/link-suggested-account",
-      params: { fingerprint },
-    } as never);
-  };
+  const handleLink = useCallback(
+    (fingerprint: string) => {
+      router.push({
+        pathname: "/link-suggested-account",
+        params: { fingerprint },
+      } as never);
+    },
+    [router]
+  );
 
-  const handleSkip = (fingerprint: string) => {
-    const suggestion = suggestions.find((item) => item.fingerprint === fingerprint);
-    if (!db || !userId || !suggestion) {
-      return;
-    }
-
-    void guardedMutation(async () => {
-      try {
-        service.dismissSuggestion({ db, userId, suggestion });
-        reloadSuggestions();
-      } catch {
-        showErrorToast(t("accountSuggestions.review.dismissFailed"));
+  const handleSkip = useCallback(
+    (fingerprint: string) => {
+      const suggestion = suggestions.find((item) => item.fingerprint === fingerprint);
+      if (!db || !userId || !suggestion) {
+        return;
       }
-    });
-  };
+
+      void guardedMutation(async () => {
+        try {
+          service.dismissSuggestion({ db, userId, suggestion });
+          reloadSuggestions();
+        } catch {
+          showErrorToast(t("accountSuggestions.review.dismissFailed"));
+        }
+      });
+    },
+    [db, guardedMutation, reloadSuggestions, service, suggestions, t, userId]
+  );
+
+  const handleCreateSuggestion = useCallback(
+    (suggestion: AccountCreationSuggestion) => handleCreate(suggestion.fingerprint),
+    [handleCreate]
+  );
+
+  const handleLinkSuggestion = useCallback(
+    (suggestion: AccountCreationSuggestion) => handleLink(suggestion.fingerprint),
+    [handleLink]
+  );
+
+  const handleSkipSuggestion = useCallback(
+    (suggestion: AccountCreationSuggestion) => handleSkip(suggestion.fingerprint),
+    [handleSkip]
+  );
+
+  const renderSuggestion = useCallback(
+    ({ item }: ListRenderItemInfo<AccountCreationSuggestion>) => (
+      <AccountSuggestionCard
+        suggestion={item}
+        onCreate={handleCreateSuggestion}
+        onLink={handleLinkSuggestion}
+        onSkip={handleSkipSuggestion}
+      />
+    ),
+    [handleCreateSuggestion, handleLinkSuggestion, handleSkipSuggestion]
+  );
+
+  const listHeader = useMemo(
+    () => (
+      <Text style={[styles.subtitle, { color: secondary }]}>
+        {t("accountSuggestions.review.subtitle")}
+      </Text>
+    ),
+    [secondary, t]
+  );
+
+  const emptyState =
+    hasLoadedSuggestions && suggestions.length === 0 ? (
+      <View style={styles.emptyState}>
+        <Text style={[styles.emptyTitle, { color: primary }]}>
+          {t("accountSuggestions.review.emptyTitle")}
+        </Text>
+        <Text style={[styles.emptySubtitle, { color: secondary }]}>
+          {t("accountSuggestions.review.emptySubtitle")}
+        </Text>
+      </View>
+    ) : null;
 
   return (
     <ScreenLayout
@@ -62,36 +124,17 @@ export function AccountSuggestionReviewScreen() {
       variant="sub"
       onBack={() => router.back()}
     >
-      <ScrollView
+      <FlashList
+        data={suggestions}
+        renderItem={renderSuggestion}
+        keyExtractor={suggestionKeyExtractor}
+        ListHeaderComponent={listHeader}
+        ListEmptyComponent={emptyState}
+        ItemSeparatorComponent={SuggestionItemSeparator}
         contentInsetAdjustmentBehavior="automatic"
         contentContainerStyle={[styles.content, { paddingBottom: bottom + 32 }]}
         showsVerticalScrollIndicator={false}
-      >
-        <Text style={[styles.subtitle, { color: secondary }]}>
-          {t("accountSuggestions.review.subtitle")}
-        </Text>
-
-        {hasLoadedSuggestions && suggestions.length === 0 ? (
-          <View style={styles.emptyState}>
-            <Text style={[styles.emptyTitle, { color: primary }]}>
-              {t("accountSuggestions.review.emptyTitle")}
-            </Text>
-            <Text style={[styles.emptySubtitle, { color: secondary }]}>
-              {t("accountSuggestions.review.emptySubtitle")}
-            </Text>
-          </View>
-        ) : (
-          suggestions.map((suggestion) => (
-            <AccountSuggestionCard
-              key={suggestion.fingerprint}
-              suggestion={suggestion}
-              onCreate={(item) => handleCreate(item.fingerprint)}
-              onLink={(item) => handleLink(item.fingerprint)}
-              onSkip={(item) => handleSkip(item.fingerprint)}
-            />
-          ))
-        )}
-      </ScrollView>
+      />
     </ScreenLayout>
   );
 }
@@ -100,12 +143,15 @@ const styles = StyleSheet.create({
   content: {
     paddingHorizontal: 16,
     paddingBottom: 32,
-    gap: 16,
+  },
+  itemSeparator: {
+    height: 16,
   },
   subtitle: {
     fontFamily: "Poppins_500Medium",
     fontSize: 13,
     lineHeight: 18,
+    marginBottom: 16,
   },
   emptyState: {
     flex: 1,

--- a/apps/mobile/features/ai-chat/components/ChatConversationShell.tsx
+++ b/apps/mobile/features/ai-chat/components/ChatConversationShell.tsx
@@ -1,0 +1,207 @@
+import type { FlashListRef } from "@shopify/flash-list";
+import { FlashList } from "@shopify/flash-list";
+import type { ReactElement, ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { ChevronLeft } from "@/shared/components/icons";
+import {
+  Keyboard,
+  Platform,
+  Pressable,
+  View,
+  type LayoutChangeEvent,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+} from "@/shared/components/rn";
+import {
+  getChatComposerBottomOffset,
+  getChatShellBottomInset,
+  getScrollButtonBottomOffset,
+  shouldRenderScrollToBottom,
+} from "../lib/chat-shell-layout";
+import {
+  shouldAutoScrollForContentChange,
+  shouldShowScrollToBottom,
+} from "../lib/conversation-scroll";
+import type { ChatMessage } from "../schema";
+
+type ChatConversationShellProps = {
+  readonly messages: readonly ChatMessage[];
+  readonly renderMessage: (info: { item: ChatMessage }) => ReactElement;
+  readonly keyExtractor: (item: ChatMessage) => string;
+  readonly isStreaming: boolean;
+  readonly streamingBubble: ReactElement;
+  readonly emptyState: ReactNode;
+  readonly composer: ReactNode;
+  readonly scrollToBottomLabel: string;
+};
+
+export function ChatConversationShell({
+  messages,
+  renderMessage,
+  keyExtractor,
+  isStreaming,
+  streamingBubble,
+  emptyState,
+  composer,
+  scrollToBottomLabel,
+}: ChatConversationShellProps) {
+  const listRef = useRef<FlashListRef<ChatMessage>>(null);
+  const { bottom: safeBottom } = useSafeAreaInsets();
+  const [composerHeight, setComposerHeight] = useState(64);
+  const [keyboardVisible, setKeyboardVisible] = useState(false);
+  const [showScrollToBottom, setShowScrollToBottom] = useState(false);
+  const bottomInset = getChatShellBottomInset({ composerHeight, safeBottom });
+  const scrollButtonBottom = getScrollButtonBottomOffset({ composerHeight, safeBottom });
+  const scrollMetricsRef = useRef({
+    contentHeight: 0,
+    viewportHeight: 0,
+    scrollOffsetY: 0,
+    bottomInset,
+  });
+
+  const scrollToBottom = useCallback((animated = true) => {
+    listRef.current?.scrollToEnd({ animated });
+  }, []);
+
+  const updateScrollButton = useCallback(() => {
+    setShowScrollToBottom(shouldShowScrollToBottom(scrollMetricsRef.current));
+  }, []);
+
+  const handleComposerLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      const nextHeight = event.nativeEvent.layout.height;
+      const nextBottomInset = getChatShellBottomInset({
+        composerHeight: nextHeight,
+        safeBottom,
+      });
+      setComposerHeight(nextHeight);
+      scrollMetricsRef.current = {
+        ...scrollMetricsRef.current,
+        bottomInset: nextBottomInset,
+      };
+    },
+    [safeBottom]
+  );
+
+  const handleScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      scrollMetricsRef.current = {
+        ...scrollMetricsRef.current,
+        scrollOffsetY: event.nativeEvent.contentOffset.y,
+        viewportHeight: event.nativeEvent.layoutMeasurement.height,
+        bottomInset,
+      };
+      updateScrollButton();
+    },
+    [bottomInset, updateScrollButton]
+  );
+
+  const handleListLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      scrollMetricsRef.current = {
+        ...scrollMetricsRef.current,
+        viewportHeight: event.nativeEvent.layout.height,
+        bottomInset,
+      };
+      updateScrollButton();
+    },
+    [bottomInset, updateScrollButton]
+  );
+
+  const handleContentSizeChange = useCallback(
+    (_width: number, height: number) => {
+      const metrics = { ...scrollMetricsRef.current, bottomInset };
+      const shouldScroll = shouldAutoScrollForContentChange({
+        previousContentHeight: metrics.contentHeight,
+        nextContentHeight: height,
+        viewportHeight: metrics.viewportHeight,
+        scrollOffsetY: metrics.scrollOffsetY,
+        bottomInset,
+      });
+      scrollMetricsRef.current = { ...metrics, contentHeight: height };
+      updateScrollButton();
+      if (shouldScroll) {
+        requestAnimationFrame(() => scrollToBottom(false));
+      }
+    },
+    [bottomInset, scrollToBottom, updateScrollButton]
+  );
+
+  useEffect(() => {
+    const showEvent = Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow";
+    const hideEvent = Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide";
+    const showSub = Keyboard.addListener(showEvent, () => setKeyboardVisible(true));
+    const hideSub = Keyboard.addListener(hideEvent, () => setKeyboardVisible(false));
+    return () => {
+      showSub.remove();
+      hideSub.remove();
+    };
+  }, []);
+
+  return (
+    <View style={{ flex: 1 }}>
+      {messages.length === 0 && !isStreaming ? (
+        emptyState
+      ) : (
+        <FlashList
+          ref={listRef}
+          data={messages}
+          renderItem={renderMessage}
+          keyExtractor={keyExtractor}
+          keyboardDismissMode="on-drag"
+          keyboardShouldPersistTaps="handled"
+          contentContainerStyle={{
+            paddingHorizontal: 16,
+            paddingTop: 12,
+            paddingBottom: bottomInset,
+          }}
+          contentInsetAdjustmentBehavior="automatic"
+          showsVerticalScrollIndicator={false}
+          onLayout={handleListLayout}
+          onScroll={handleScroll}
+          scrollEventThrottle={16}
+          onContentSizeChange={handleContentSizeChange}
+          ListFooterComponent={isStreaming ? streamingBubble : null}
+        />
+      )}
+
+      {shouldRenderScrollToBottom({
+        hasListContent: messages.length > 0 || isStreaming,
+        isStreaming,
+        isAwayFromBottom: showScrollToBottom,
+      }) ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={scrollToBottomLabel}
+          onPress={() => scrollToBottom()}
+          style={{
+            position: "absolute",
+            right: 16,
+            bottom: scrollButtonBottom,
+            width: 40,
+            height: 40,
+            borderRadius: 20,
+            backgroundColor: "rgba(0,0,0,0.64)",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <ChevronLeft size={20} color="#fff" style={{ transform: [{ rotate: "-90deg" }] }} />
+        </Pressable>
+      ) : null}
+
+      <View
+        onLayout={handleComposerLayout}
+        style={{
+          position: "absolute",
+          left: 0,
+          right: 0,
+          bottom: getChatComposerBottomOffset({ keyboardVisible, safeBottom }),
+        }}
+      >
+        {composer}
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/features/ai-chat/components/ChatInput.tsx
+++ b/apps/mobile/features/ai-chat/components/ChatInput.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useState } from "react";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { SendHorizonal } from "@/shared/components/icons";
-import { Keyboard, Platform, Pressable, TextInput, View } from "@/shared/components/rn";
-import { useSubscription, useThemeColor, useTranslation } from "@/shared/hooks";
+import { Pressable, TextInput, View } from "@/shared/components/rn";
+import { useThemeColor, useTranslation } from "@/shared/hooks";
+import { resolveChatComposerSend } from "../lib/chat-composer";
 
 type ChatInputProps = {
   readonly onSend: (text: string) => void;
@@ -12,41 +12,34 @@ type ChatInputProps = {
 export function ChatInput({ onSend, disabled = false }: ChatInputProps) {
   const { t } = useTranslation();
   const [text, setText] = useState("");
-  const [keyboardVisible, setKeyboardVisible] = useState(false);
-  const { bottom: safeBottom } = useSafeAreaInsets();
   const borderSubtle = useThemeColor("borderSubtle");
   const tertiary = useThemeColor("tertiary");
   const accentGreen = useThemeColor("accentGreen");
 
-  useSubscription(() => {
-    const showEvent = Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow";
-    const hideEvent = Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide";
-    const showSub = Keyboard.addListener(showEvent, () => setKeyboardVisible(true));
-    const hideSub = Keyboard.addListener(hideEvent, () => setKeyboardVisible(false));
-    return () => {
-      showSub.remove();
-      hideSub.remove();
-    };
-  }, []);
-
   const handleSend = useCallback(() => {
-    const trimmed = text.trim();
-    if (!trimmed || disabled) return;
-    onSend(trimmed);
-    setText("");
+    const result = resolveChatComposerSend({ text, disabled });
+    if (!result.canSend || !result.message) return;
+    onSend(result.message);
+    setText(result.nextText);
   }, [text, disabled, onSend]);
 
   const canSend = !disabled && text.trim().length > 0;
 
   return (
     <View
-      className="flex-row items-center gap-2 bg-card dark:bg-card-dark"
+      className="flex-row items-end gap-2 bg-card dark:bg-card-dark"
       style={{
-        paddingTop: 8,
-        paddingBottom: keyboardVisible ? 8 : Math.max(safeBottom, 8),
-        paddingHorizontal: 16,
-        borderTopWidth: 1,
+        marginHorizontal: 12,
+        padding: 10,
+        borderRadius: 24,
+        borderWidth: 1,
         borderTopColor: borderSubtle,
+        borderColor: borderSubtle,
+        shadowColor: "#000",
+        shadowOpacity: 0.12,
+        shadowRadius: 12,
+        shadowOffset: { width: 0, height: 4 },
+        elevation: 4,
       }}
     >
       <View

--- a/apps/mobile/features/ai-chat/components/ChatScreen.tsx
+++ b/apps/mobile/features/ai-chat/components/ChatScreen.tsx
@@ -1,6 +1,4 @@
-import type { FlashListRef } from "@shopify/flash-list";
-import { FlashList } from "@shopify/flash-list";
-import { memo, useCallback, useRef } from "react";
+import { memo, useCallback } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useOptionalUserId } from "@/features/auth/public";
 import { removeTransaction } from "@/features/transactions/store.public";
@@ -13,6 +11,7 @@ import type { ChatMessageId } from "@/shared/types/branded";
 import { useStreamingChat } from "../hooks/use-streaming-chat";
 import type { ActionStatus, ChatMessage } from "../schema";
 import { updateChatActionStatus, useChatStore } from "../store";
+import { ChatConversationShell } from "./ChatConversationShell";
 import { ChatInput } from "./ChatInput";
 import { MessageBubble } from "./MessageBubble";
 import { NewChatButton } from "./NewChatButton";
@@ -44,7 +43,6 @@ export function ChatScreen({ onBack, onNewChat }: ChatScreenProps) {
   const { t } = useTranslation();
   useMountEffect(() => trackAiChatOpened());
   const userId = useOptionalUserId();
-  const listRef = useRef<FlashListRef<ChatMessage>>(null);
   const { top: safeTop } = useSafeAreaInsets();
   const db = userId ? tryGetDb(userId) : null;
 
@@ -105,9 +103,6 @@ export function ChatScreen({ onBack, onNewChat }: ChatScreenProps) {
   const handleSend = useCallback(
     (text: string) => {
       void sendMessage(text);
-      setTimeout(() => {
-        listRef.current?.scrollToEnd({ animated: true });
-      }, 100);
     },
     [sendMessage]
   );
@@ -118,8 +113,6 @@ export function ChatScreen({ onBack, onNewChat }: ChatScreenProps) {
     },
     [handleSend]
   );
-
-  const isEmpty = messages.length === 0 && !isStreaming;
 
   return (
     <ScreenLayout
@@ -134,41 +127,26 @@ export function ChatScreen({ onBack, onNewChat }: ChatScreenProps) {
         behavior={Platform.OS === "ios" ? "padding" : undefined}
         keyboardVerticalOffset={Platform.OS === "ios" ? safeTop + HEADER_HEIGHT : HEADER_HEIGHT}
       >
-        {isEmpty ? (
-          <View
-            style={{ flex: 1 }}
-            onStartShouldSetResponder={() => {
-              Keyboard.dismiss();
-              return false;
-            }}
-          >
-            <StarterSuggestions onSelect={handleSuggestionSelect} />
-          </View>
-        ) : (
-          <FlashList
-            ref={listRef}
-            data={messages}
-            renderItem={renderItem}
-            keyExtractor={keyExtractor}
-            keyboardDismissMode="on-drag"
-            keyboardShouldPersistTaps="handled"
-            contentContainerStyle={{
-              paddingHorizontal: 16,
-              paddingTop: 12,
-              paddingBottom: 12,
-            }}
-            contentInsetAdjustmentBehavior="automatic"
-            showsVerticalScrollIndicator={false}
-            onContentSizeChange={() => {
-              listRef.current?.scrollToEnd({ animated: false });
-            }}
-            ListFooterComponent={
-              isStreaming ? <StreamingBubble content={streamingContent} /> : null
-            }
-          />
-        )}
-
-        <ChatInput onSend={handleSend} disabled={isStreaming} />
+        <ChatConversationShell
+          messages={messages}
+          renderMessage={renderItem}
+          keyExtractor={keyExtractor}
+          isStreaming={isStreaming}
+          streamingBubble={<StreamingBubble content={streamingContent} />}
+          scrollToBottomLabel={t("aiChat.scrollToBottom")}
+          composer={<ChatInput onSend={handleSend} disabled={isStreaming} />}
+          emptyState={
+            <View
+              style={{ flex: 1 }}
+              onStartShouldSetResponder={() => {
+                Keyboard.dismiss();
+                return false;
+              }}
+            >
+              <StarterSuggestions onSelect={handleSuggestionSelect} />
+            </View>
+          }
+        />
       </KeyboardAvoidingView>
     </ScreenLayout>
   );

--- a/apps/mobile/features/ai-chat/components/MessageBubble.tsx
+++ b/apps/mobile/features/ai-chat/components/MessageBubble.tsx
@@ -3,7 +3,7 @@ import { CircleCheck, Sparkles } from "@/shared/components/icons";
 import { Text, View } from "@/shared/components/rn";
 import { useThemeColor } from "@/shared/hooks";
 import type { ChatMessageId } from "@/shared/types/branded";
-import { ACTION_BLOCK_REGEX } from "../lib/parse-action";
+import { getAssistantDisplayBlocks, getPlainMessageText } from "../lib/message-content";
 import type { ChatMessage } from "../schema";
 import { ActionCard } from "./ActionCard";
 
@@ -23,7 +23,8 @@ function MessageBubbleInner({ message, onConfirmAction, onDismissAction }: Messa
 
   const isUser = message.role === "user";
 
-  const contentWithoutAction = message.content.replace(ACTION_BLOCK_REGEX, "").trim();
+  const contentWithoutAction = getPlainMessageText(message.content);
+  const assistantBlocks = isUser ? [] : getAssistantDisplayBlocks(message.content);
 
   return (
     <View style={{ marginBottom: 4 }}>
@@ -69,9 +70,44 @@ function MessageBubbleInner({ message, onConfirmAction, onDismissAction }: Messa
                 paddingHorizontal: 14,
               }}
             >
-              <Text className="font-poppins-medium text-body" style={{ color: chatAssistantText }}>
-                {contentWithoutAction}
-              </Text>
+              {assistantBlocks.map((block) =>
+                block.type === "bullet" ? (
+                  <View key={block.key} style={{ flexDirection: "row", gap: 8, marginBottom: 4 }}>
+                    <Text
+                      className="font-poppins-medium text-body"
+                      style={{ color: chatAssistantText }}
+                    >
+                      -
+                    </Text>
+                    <Text
+                      className="font-poppins-medium text-body"
+                      style={{ color: chatAssistantText, flex: 1 }}
+                    >
+                      {block.text}
+                    </Text>
+                  </View>
+                ) : (
+                  <Text
+                    key={block.key}
+                    className="font-poppins-medium text-body"
+                    style={{ color: chatAssistantText, marginBottom: 4 }}
+                  >
+                    {block.segments.map((segment) => (
+                      <Text
+                        key={segment.key}
+                        className={
+                          segment.strong
+                            ? "font-poppins-semibold text-body"
+                            : "font-poppins-medium text-body"
+                        }
+                        style={{ color: chatAssistantText }}
+                      >
+                        {segment.text}
+                      </Text>
+                    ))}
+                  </Text>
+                )
+              )}
             </View>
           </View>
         </View>

--- a/apps/mobile/features/ai-chat/components/StreamingBubble.tsx
+++ b/apps/mobile/features/ai-chat/components/StreamingBubble.tsx
@@ -1,16 +1,47 @@
-import { memo } from "react";
+import { memo, useEffect, useState } from "react";
 import { Sparkles } from "@/shared/components/icons";
 import { Text, View } from "@/shared/components/rn";
-import { useThemeColor } from "@/shared/hooks";
+import { useThemeColor, useTranslation } from "@/shared/hooks";
+import { getStreamingBubbleDisplay } from "../lib/streaming-bubble-display";
 
 type StreamingBubbleProps = {
   readonly content: string;
 };
 
+function ThinkingDots({ color }: { readonly color: string }) {
+  const [activeDot, setActiveDot] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setActiveDot((dot) => (dot + 1) % 3);
+    }, 260);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <View style={{ flexDirection: "row", gap: 4, paddingTop: 2 }}>
+      {[0, 1, 2].map((dot) => (
+        <View
+          key={dot}
+          style={{
+            width: 5,
+            height: 5,
+            borderRadius: 2.5,
+            backgroundColor: color,
+            opacity: dot === activeDot ? 1 : 0.28,
+          }}
+        />
+      ))}
+    </View>
+  );
+}
+
 function StreamingBubbleInner({ content }: StreamingBubbleProps) {
+  const { t } = useTranslation();
   const accentGreen = useThemeColor("accentGreen");
   const chatAssistantBubble = useThemeColor("chatAssistantBubble");
   const chatAssistantText = useThemeColor("chatAssistantText");
+  const display = getStreamingBubbleDisplay(content, t("aiChat.thinking"));
 
   return (
     <View style={{ flexDirection: "row", alignItems: "flex-start", gap: 8, marginBottom: 4 }}>
@@ -37,9 +68,19 @@ function StreamingBubbleInner({ content }: StreamingBubbleProps) {
             paddingHorizontal: 14,
           }}
         >
-          <Text className="font-poppins-medium text-body" style={{ color: chatAssistantText }}>
-            {content || "..."}
-          </Text>
+          {display.phase === "waiting" ? (
+            <View style={{ flexDirection: "row", alignItems: "center", gap: 8 }}>
+              <Text className="font-poppins-medium text-body" style={{ color: chatAssistantText }}>
+                {display.label}
+              </Text>
+              <ThinkingDots color={chatAssistantText} />
+            </View>
+          ) : (
+            <Text className="font-poppins-medium text-body" style={{ color: chatAssistantText }}>
+              {display.content}
+              <Text style={{ color: chatAssistantText, opacity: 0.45 }}> |</Text>
+            </Text>
+          )}
         </View>
       </View>
     </View>

--- a/apps/mobile/features/ai-chat/hooks/use-streaming-chat.ts
+++ b/apps/mobile/features/ai-chat/hooks/use-streaming-chat.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 import { buildFinancialContextPacket } from "@/features/advisor/public";
 import { useOptionalUserId } from "@/features/auth/public";
 import { saveCurrentTransaction, useTransactionStore } from "@/features/transactions/store.public";
@@ -6,6 +6,7 @@ import { tryGetDb } from "@/shared/db";
 import { parseIsoDate, trackAiMessageSent, trackTransactionCreated } from "@/shared/lib";
 import { listUserMemories } from "../data/user-memories";
 import { parseActionFromResponse } from "../lib/parse-action";
+import { createStreamingTextStore } from "../services/streaming-text-store";
 import type { ChatAction } from "../schema";
 import { streamChat } from "../services/ai-chat-api";
 import { createStreamingChatService } from "../services/create-streaming-chat-service";
@@ -17,6 +18,7 @@ import {
 } from "../store";
 
 const MAX_CONTEXT_MEMORIES = 20;
+const streamingTextStore = createStreamingTextStore();
 
 const streamingChatService = createStreamingChatService({
   getState: () => {
@@ -28,7 +30,9 @@ const streamingChatService = createStreamingChatService({
     };
   },
   setStreaming: (isStreaming) => useChatStore.getState().setStreaming(isStreaming),
-  setStreamingContent: (content) => useChatStore.getState().setStreamingContent(content),
+  setStreamingContent: (content) => {
+    streamingTextStore.set(content);
+  },
   streamChat,
   buildFinancialContextPacket: async (input) => {
     const [packet, memories] = await Promise.all([
@@ -100,7 +104,11 @@ export function useStreamingChat() {
   const userId = useOptionalUserId();
   const db = userId ? tryGetDb(userId) : null;
   const isStreaming = useChatStore((s) => s.isStreaming);
-  const streamingContent = useChatStore((s) => s.streamingContent);
+  const streamingContent = useSyncExternalStore(
+    streamingTextStore.subscribe,
+    streamingTextStore.getSnapshot,
+    streamingTextStore.getSnapshot
+  );
 
   const executeAction = useCallback(
     async (action: ChatAction) => {

--- a/apps/mobile/features/ai-chat/lib/chat-composer.ts
+++ b/apps/mobile/features/ai-chat/lib/chat-composer.ts
@@ -1,0 +1,22 @@
+type ResolveChatComposerSendInput = {
+  readonly text: string;
+  readonly disabled: boolean;
+};
+
+export type ChatComposerSendResolution = {
+  readonly canSend: boolean;
+  readonly message: string | null;
+  readonly nextText: string;
+};
+
+export const resolveChatComposerSend = ({
+  text,
+  disabled,
+}: ResolveChatComposerSendInput): ChatComposerSendResolution => {
+  const message = text.trim();
+  if (!message || disabled) {
+    return { canSend: false, message: null, nextText: text };
+  }
+
+  return { canSend: true, message, nextText: "" };
+};

--- a/apps/mobile/features/ai-chat/lib/chat-shell-layout.ts
+++ b/apps/mobile/features/ai-chat/lib/chat-shell-layout.ts
@@ -1,0 +1,42 @@
+type ChatShellInsetInput = {
+  readonly composerHeight: number;
+  readonly safeBottom: number;
+};
+
+type ChatComposerBottomOffsetInput = {
+  readonly keyboardVisible: boolean;
+  readonly safeBottom: number;
+};
+
+type ScrollToBottomVisibilityInput = {
+  readonly isStreaming: boolean;
+  readonly isAwayFromBottom: boolean;
+  readonly hasListContent: boolean;
+};
+
+const MIN_COMPOSER_HEIGHT = 56;
+const LIST_COMPOSER_GAP = 16;
+const SCROLL_BUTTON_GAP = 12;
+
+export const getChatShellBottomInset = ({
+  composerHeight,
+  safeBottom,
+}: ChatShellInsetInput): number =>
+  Math.max(composerHeight, MIN_COMPOSER_HEIGHT) + safeBottom + LIST_COMPOSER_GAP;
+
+export const getScrollButtonBottomOffset = ({
+  composerHeight,
+  safeBottom,
+}: ChatShellInsetInput): number =>
+  getChatShellBottomInset({ composerHeight, safeBottom }) + SCROLL_BUTTON_GAP;
+
+export const getChatComposerBottomOffset = ({
+  keyboardVisible,
+  safeBottom,
+}: ChatComposerBottomOffsetInput): number => (keyboardVisible ? 0 : safeBottom);
+
+export const shouldRenderScrollToBottom = ({
+  hasListContent,
+  isStreaming,
+  isAwayFromBottom,
+}: ScrollToBottomVisibilityInput): boolean => hasListContent && !isStreaming && isAwayFromBottom;

--- a/apps/mobile/features/ai-chat/lib/conversation-scroll.ts
+++ b/apps/mobile/features/ai-chat/lib/conversation-scroll.ts
@@ -1,0 +1,40 @@
+type ScrollMetrics = {
+  readonly viewportHeight: number;
+  readonly scrollOffsetY: number;
+  readonly bottomInset: number;
+};
+
+type ContentChangeMetrics = ScrollMetrics & {
+  readonly previousContentHeight: number;
+  readonly nextContentHeight: number;
+};
+
+type CurrentScrollMetrics = ScrollMetrics & {
+  readonly contentHeight: number;
+};
+
+const NEAR_BOTTOM_THRESHOLD = 64;
+
+const distanceFromBottom = ({
+  contentHeight,
+  viewportHeight,
+  scrollOffsetY,
+}: CurrentScrollMetrics): number => Math.max(0, contentHeight - viewportHeight - scrollOffsetY);
+
+export const shouldShowScrollToBottom = (metrics: CurrentScrollMetrics): boolean =>
+  distanceFromBottom(metrics) > NEAR_BOTTOM_THRESHOLD;
+
+export const shouldAutoScrollForContentChange = ({
+  previousContentHeight,
+  nextContentHeight,
+  viewportHeight,
+  scrollOffsetY,
+  bottomInset,
+}: ContentChangeMetrics): boolean =>
+  nextContentHeight > previousContentHeight &&
+  !shouldShowScrollToBottom({
+    contentHeight: previousContentHeight,
+    viewportHeight,
+    scrollOffsetY,
+    bottomInset,
+  });

--- a/apps/mobile/features/ai-chat/lib/message-content.ts
+++ b/apps/mobile/features/ai-chat/lib/message-content.ts
@@ -1,0 +1,96 @@
+import { ACTION_BLOCK_REGEX } from "./parse-action";
+
+export type AssistantTextSegment = {
+  readonly key: string;
+  readonly text: string;
+  readonly strong: boolean;
+};
+
+export type AssistantDisplayBlock =
+  | {
+      readonly key: string;
+      readonly type: "paragraph";
+      readonly segments: readonly AssistantTextSegment[];
+    }
+  | {
+      readonly key: string;
+      readonly type: "bullet";
+      readonly text: string;
+    };
+
+export const getPlainMessageText = (content: string): string =>
+  content.replace(ACTION_BLOCK_REGEX, "").trim();
+
+const stripInlineMarkdown = (text: string): string =>
+  text
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/(?<!\*)\*([^\s*](?:[^*]*?[^\s*])?)\*(?!\*)/g, "$1")
+    .replace(/`([^`]+)`/g, "$1");
+
+const toParagraphSegments = (text: string, blockIndex: number): readonly AssistantTextSegment[] => {
+  const matches = [...text.matchAll(/\*\*([^*]+)\*\*/g)];
+  if (matches.length === 0) {
+    return [{ key: `text-${blockIndex}-0`, text: stripInlineMarkdown(text), strong: false }];
+  }
+
+  const reduced = matches.reduce<{
+    readonly cursor: number;
+    readonly segments: readonly { readonly text: string; readonly strong: boolean }[];
+  }>(
+    (state, match) => {
+      const matchIndex = match.index ?? 0;
+      const plainPrefix = text.slice(state.cursor, matchIndex);
+      const strongText = match[1] ?? "";
+      const nextSegments = plainPrefix
+        ? [...state.segments, { text: stripInlineMarkdown(plainPrefix), strong: false }]
+        : state.segments;
+      return {
+        cursor: matchIndex + match[0].length,
+        segments: [...nextSegments, { text: stripInlineMarkdown(strongText), strong: true }],
+      };
+    },
+    { cursor: 0, segments: [] }
+  );
+
+  return [
+    ...reduced.segments,
+    { text: stripInlineMarkdown(text.slice(reduced.cursor)), strong: false },
+  ]
+    .filter((segment) => segment.text.length > 0)
+    .map((segment, segmentIndex) => ({
+      key: `${segment.strong ? "strong" : "text"}-${blockIndex}-${segmentIndex}`,
+      text: segment.text,
+      strong: segment.strong,
+    }));
+};
+
+const toDisplayBlock = (block: string, blockIndex: number): readonly AssistantDisplayBlock[] => {
+  const lines = block
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  return lines.map((line, lineIndex) => {
+    const bulletText = line.match(/^[-*]\s+(.+)$/)?.[1];
+    if (bulletText) {
+      return {
+        key: `list-${blockIndex}-${lineIndex}`,
+        type: "bullet" as const,
+        text: stripInlineMarkdown(bulletText).trim(),
+      };
+    }
+
+    return {
+      key: `paragraph-${blockIndex}-${lineIndex}`,
+      type: "paragraph" as const,
+      segments: toParagraphSegments(line, blockIndex * 100 + lineIndex),
+    };
+  });
+};
+
+export const getAssistantDisplayBlocks = (content: string): readonly AssistantDisplayBlock[] =>
+  getPlainMessageText(content)
+    .split(/\n{2,}/)
+    .map((block) => block.trim())
+    .filter(Boolean)
+    .flatMap(toDisplayBlock);

--- a/apps/mobile/features/ai-chat/lib/streaming-bubble-display.ts
+++ b/apps/mobile/features/ai-chat/lib/streaming-bubble-display.ts
@@ -1,0 +1,13 @@
+export type StreamingBubbleDisplay =
+  | { readonly phase: "waiting"; readonly label: string }
+  | { readonly phase: "streaming"; readonly content: string };
+
+export const getStreamingBubbleDisplay = (
+  content: string,
+  thinkingLabel: string
+): StreamingBubbleDisplay => {
+  const trimmedContent = content.trim();
+  return trimmedContent
+    ? { phase: "streaming", content }
+    : { phase: "waiting", label: thinkingLabel };
+};

--- a/apps/mobile/features/ai-chat/services/streaming-text-store.ts
+++ b/apps/mobile/features/ai-chat/services/streaming-text-store.ts
@@ -1,0 +1,29 @@
+export type StreamingTextStore = {
+  readonly getSnapshot: () => string;
+  readonly set: (content: string) => void;
+  readonly clear: () => void;
+  readonly subscribe: (listener: () => void) => () => void;
+};
+
+export function createStreamingTextStore(initialContent = ""): StreamingTextStore {
+  let content = initialContent;
+  const listeners = new Set<() => void>();
+
+  return {
+    getSnapshot: () => content,
+    set: (nextContent) => {
+      content = nextContent;
+      listeners.forEach((listener) => listener());
+    },
+    clear: () => {
+      content = "";
+      listeners.forEach((listener) => listener());
+    },
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}

--- a/apps/mobile/features/budget/components/BudgetListScreen.tsx
+++ b/apps/mobile/features/budget/components/BudgetListScreen.tsx
@@ -1,14 +1,16 @@
+import { FlashList, type ListRenderItemInfo } from "@shopify/flash-list";
 import { useRouter } from "expo-router";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { useOptionalUserId } from "@/features/auth/public";
 import { MonthNavigator } from "@/features/calendar/public";
 import { shouldShowNotificationPrePermissionPrompt } from "@/features/notifications/public";
 import { ScreenLayout, TAB_BAR_CLEARANCE } from "@/shared/components";
 import { Plus, Wallet } from "@/shared/components/icons";
-import { Platform, Pressable, ScrollView, StyleSheet, Text, View } from "@/shared/components/rn";
+import { Platform, Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
 import { useSubscription, useThemeColor, useTranslation } from "@/shared/hooks";
 import { captureError } from "@/shared/lib";
+import type { BudgetProgress } from "../lib/derive";
 import { nextBudgetMonth, prevBudgetMonth, useBudgetStore } from "../store";
 import { BudgetCard } from "./BudgetCard";
 import { BudgetSummaryCard } from "./BudgetSummaryCard";
@@ -22,6 +24,8 @@ function AddBudgetButton({ onPress }: { readonly onPress: () => void }) {
     </Pressable>
   );
 }
+
+const budgetKeyExtractor = (item: BudgetProgress) => item.budgetId;
 
 export function BudgetListScreen() {
   const { t } = useTranslation();
@@ -71,9 +75,9 @@ export function BudgetListScreen() {
     1
   );
 
-  const handleAddBudget = () => {
+  const handleAddBudget = useCallback(() => {
     push("/create-budget");
-  };
+  }, [push]);
 
   const handleNextMonth = useCallback(() => {
     if (!userId) return;
@@ -89,13 +93,13 @@ export function BudgetListScreen() {
     void prevBudgetMonth(db, userId);
   }, [userId]);
 
-  const handleAutoSetup = () => {
+  const handleAutoSetup = useCallback(() => {
     push("/auto-suggest-budgets");
-  };
+  }, [push]);
 
-  const handleCreateManually = () => {
+  const handleCreateManually = useCallback(() => {
     push("/create-budget");
-  };
+  }, [push]);
 
   const handleBudgetPress = useCallback(
     (budgetId: string) => {
@@ -105,6 +109,48 @@ export function BudgetListScreen() {
   );
 
   const hasBudgets = budgets.length > 0;
+  const renderBudget = useCallback(
+    ({ item }: ListRenderItemInfo<BudgetProgress>) => (
+      <BudgetCard progress={item} onPress={handleBudgetPress} />
+    ),
+    [handleBudgetPress]
+  );
+  const budgetSummary = useMemo(
+    () =>
+      hasBudgets ? (
+        <BudgetSummaryCard
+          totalBudget={summary.totalBudget}
+          totalSpent={summary.totalSpent}
+          percentUsed={summary.percentUsed}
+        />
+      ) : null,
+    [hasBudgets, summary.percentUsed, summary.totalBudget, summary.totalSpent]
+  );
+  const emptyState = useMemo(
+    () => (
+      <View style={styles.emptyState}>
+        <Wallet size={48} color={secondaryColor} />
+        <Text style={[styles.emptyTitle, { color: primaryColor }]}>{t("budgets.empty.title")}</Text>
+        <Text style={[styles.emptySubtitle, { color: secondaryColor }]}>
+          {t("budgets.empty.subtitle")}
+        </Text>
+        <View style={styles.emptyActions}>
+          <Pressable
+            style={[styles.autoSetupButton, { backgroundColor: accentGreen }]}
+            onPress={handleAutoSetup}
+          >
+            <Text style={styles.autoSetupText}>{t("budgets.empty.autoSetup")}</Text>
+          </Pressable>
+          <Pressable onPress={handleCreateManually}>
+            <Text style={[styles.createManuallyText, { color: accentGreen }]}>
+              {t("budgets.empty.createManually")}
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+    ),
+    [accentGreen, handleAutoSetup, handleCreateManually, primaryColor, secondaryColor, t]
+  );
 
   return (
     <ScreenLayout
@@ -121,56 +167,23 @@ export function BudgetListScreen() {
           onNext={handleNextMonth}
         />
 
-        <ScrollView
+        <FlashList
+          data={hasBudgets ? budgetProgress : []}
+          renderItem={renderBudget}
+          keyExtractor={budgetKeyExtractor}
+          ListHeaderComponent={budgetSummary}
+          ListEmptyComponent={emptyState}
           contentContainerStyle={[styles.scrollContent, { paddingBottom: TAB_BAR_CLEARANCE }]}
           contentInsetAdjustmentBehavior="automatic"
           showsVerticalScrollIndicator={false}
-        >
-          {hasBudgets ? (
-            <View style={styles.budgetContent}>
-              <BudgetSummaryCard
-                totalBudget={summary.totalBudget}
-                totalSpent={summary.totalSpent}
-                percentUsed={summary.percentUsed}
-              />
-
-              {budgetProgress.map((progress) => (
-                <BudgetCard
-                  key={progress.budgetId}
-                  progress={progress}
-                  onPress={handleBudgetPress}
-                />
-              ))}
-            </View>
-          ) : (
-            <View style={styles.emptyState}>
-              <Wallet size={48} color={secondaryColor} />
-              <Text style={[styles.emptyTitle, { color: primaryColor }]}>
-                {t("budgets.empty.title")}
-              </Text>
-              <Text style={[styles.emptySubtitle, { color: secondaryColor }]}>
-                {t("budgets.empty.subtitle")}
-              </Text>
-              <View style={styles.emptyActions}>
-                <Pressable
-                  style={[styles.autoSetupButton, { backgroundColor: accentGreen }]}
-                  onPress={handleAutoSetup}
-                >
-                  <Text style={styles.autoSetupText}>{t("budgets.empty.autoSetup")}</Text>
-                </Pressable>
-                <Pressable onPress={handleCreateManually}>
-                  <Text style={[styles.createManuallyText, { color: accentGreen }]}>
-                    {t("budgets.empty.createManually")}
-                  </Text>
-                </Pressable>
-              </View>
-            </View>
-          )}
-        </ScrollView>
+          ItemSeparatorComponent={BudgetItemSeparator}
+        />
       </View>
     </ScreenLayout>
   );
 }
+
+const BudgetItemSeparator = () => <View style={styles.itemSeparator} />;
 
 const styles = StyleSheet.create({
   content: {
@@ -180,8 +193,8 @@ const styles = StyleSheet.create({
   scrollContent: {
     gap: 12,
   },
-  budgetContent: {
-    gap: 12,
+  itemSeparator: {
+    height: 12,
   },
   emptyState: {
     alignItems: "center",

--- a/apps/mobile/features/transactions/components/PencilTransactionEntrySheets.tsx
+++ b/apps/mobile/features/transactions/components/PencilTransactionEntrySheets.tsx
@@ -23,7 +23,12 @@ function PickerSheetFrame({ children, onClose, testID, visible }: PickerSheetFra
     <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
       <Pressable
         testID={testID}
-        style={{ flex: 1, justifyContent: "flex-end", backgroundColor: `${modalBackdrop}40` }}
+        style={{
+          flex: 1,
+          justifyContent: "center",
+          backgroundColor: `${modalBackdrop}40`,
+          padding: 24,
+        }}
         onPress={onClose}
       >
         {children}
@@ -74,8 +79,10 @@ function SheetBody(props: { readonly children: ReactNode; readonly maxHeight?: "
       style={{
         maxHeight: props.maxHeight,
         gap: 12,
-        borderTopLeftRadius: 28,
-        borderTopRightRadius: 28,
+        width: "100%",
+        maxWidth: 480,
+        alignSelf: "center",
+        borderRadius: 24,
         backgroundColor: page,
         padding: 16,
       }}
@@ -171,8 +178,10 @@ export function TransactionDatePickerSheet(props: {
       <View
         style={{
           gap: 12,
-          borderTopLeftRadius: 28,
-          borderTopRightRadius: 28,
+          width: "100%",
+          maxWidth: 480,
+          alignSelf: "center",
+          borderRadius: 24,
           backgroundColor: card,
           padding: 16,
         }}

--- a/apps/mobile/features/transfers/components/PencilTransferEntryContent.tsx
+++ b/apps/mobile/features/transfers/components/PencilTransferEntryContent.tsx
@@ -109,14 +109,21 @@ export function usePencilTransferEntry(props: { readonly enabled?: boolean } = {
         >
           <Pressable
             testID="calendar-picker.backdrop"
-            style={{ flex: 1, justifyContent: "flex-end", backgroundColor: `${modalBackdrop}40` }}
+            style={{
+              flex: 1,
+              justifyContent: "center",
+              backgroundColor: `${modalBackdrop}40`,
+              padding: 24,
+            }}
             onPress={() => form.setShowDatePicker(false)}
           >
             <View
               style={{
                 gap: 12,
-                borderTopLeftRadius: 28,
-                borderTopRightRadius: 28,
+                width: "100%",
+                maxWidth: 480,
+                alignSelf: "center",
+                borderRadius: 24,
                 backgroundColor: card,
                 padding: 16,
               }}
@@ -157,14 +164,21 @@ export function usePencilTransferEntry(props: { readonly enabled?: boolean } = {
         >
           <Pressable
             testID="category-picker.backdrop"
-            style={{ flex: 1, justifyContent: "flex-end", backgroundColor: `${modalBackdrop}40` }}
+            style={{
+              flex: 1,
+              justifyContent: "center",
+              backgroundColor: `${modalBackdrop}40`,
+              padding: 24,
+            }}
             onPress={() => setShowCategoryPicker(false)}
           >
             <View
               style={{
                 gap: 12,
-                borderTopLeftRadius: 28,
-                borderTopRightRadius: 28,
+                width: "100%",
+                maxWidth: 480,
+                alignSelf: "center",
+                borderRadius: 24,
                 backgroundColor: page,
                 padding: 16,
               }}

--- a/apps/mobile/features/transfers/components/transfer-form/TransferForm.styles.ts
+++ b/apps/mobile/features/transfers/components/transfer-form/TransferForm.styles.ts
@@ -60,7 +60,8 @@ export const styles = StyleSheet.create({
   },
   pickerBackdrop: {
     flex: 1,
-    justifyContent: "flex-end",
+    justifyContent: "center",
+    padding: 24,
     backgroundColor: "rgba(0, 0, 0, 0.28)",
   },
   pickerHandle: {
@@ -86,8 +87,10 @@ export const styles = StyleSheet.create({
     gap: 2,
   },
   pickerSheet: {
-    borderTopLeftRadius: 28,
-    borderTopRightRadius: 28,
+    width: "100%",
+    maxWidth: 480,
+    alignSelf: "center",
+    borderRadius: 24,
     paddingHorizontal: 16,
     paddingTop: 12,
     gap: 12,

--- a/apps/mobile/shared/components/DialogRouteFrame.tsx
+++ b/apps/mobile/shared/components/DialogRouteFrame.tsx
@@ -1,0 +1,45 @@
+import { useRouter } from "expo-router";
+import type { ReactNode } from "react";
+import { Pressable, StyleSheet, View } from "@/shared/components/rn";
+import { useThemeColor } from "@/shared/hooks";
+
+type DialogRouteFrameProps = {
+  readonly children: ReactNode;
+};
+
+export function DialogRouteFrame({ children }: DialogRouteFrameProps) {
+  const router = useRouter();
+  const card = useThemeColor("card");
+  const modalBackdrop = useThemeColor("modalBackdrop");
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      style={[styles.backdrop, { backgroundColor: `${modalBackdrop}66` }]}
+      onPress={() => router.back()}
+    >
+      <View
+        style={[styles.dialog, { backgroundColor: card }]}
+        onStartShouldSetResponder={() => true}
+      >
+        {children}
+      </View>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+  },
+  dialog: {
+    width: "100%",
+    maxWidth: 560,
+    maxHeight: "88%",
+    borderRadius: 24,
+    overflow: "hidden",
+  },
+});

--- a/apps/mobile/shared/components/index.ts
+++ b/apps/mobile/shared/components/index.ts
@@ -7,6 +7,7 @@ export { FidyLogo } from "./FidyLogo";
 export { FidyNumpad } from "./FidyNumpad";
 export { GlassSurface } from "./GlassSurface";
 export { CustomTabBar } from "./navigation/CustomTabBar";
+export { DialogRouteFrame } from "./DialogRouteFrame";
 export { ProgressBar } from "./ProgressBar";
 export { HEADER_HEIGHT, ScreenLayout, TAB_BAR_CLEARANCE } from "./ScreenLayout";
 export { SettingsSection } from "./SettingsSection";

--- a/apps/mobile/shared/i18n/locales/en.ts
+++ b/apps/mobile/shared/i18n/locales/en.ts
@@ -619,6 +619,8 @@ const en = {
     noConversations: "No conversations yet",
     tapToStart: "Tap + to start a new chat",
     placeholder: "Ask about your finances...",
+    scrollToBottom: "Scroll to bottom",
+    thinking: "Fidy is thinking",
     cleanupMessage: {
       one: "%{count} expired conversation was removed",
       other: "%{count} expired conversations were removed",

--- a/apps/mobile/shared/i18n/locales/es.ts
+++ b/apps/mobile/shared/i18n/locales/es.ts
@@ -628,6 +628,8 @@ const es = {
     noConversations: "Aún no hay conversaciones",
     tapToStart: "Toca + para iniciar un nuevo chat",
     placeholder: "Pregunta sobre tus finanzas...",
+    scrollToBottom: "Ir al final",
+    thinking: "Fidy está pensando",
     cleanupMessage: {
       one: "%{count} conversación expirada fue eliminada",
       other: "%{count} conversaciones expiradas fueron eliminadas",

--- a/designs/budget-proposals/index.html
+++ b/designs/budget-proposals/index.html
@@ -1,0 +1,779 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Fidy Budget Design Proposals</title>
+    <style>
+      @import url("https://fonts.googleapis.com/css2?family=Alegreya+Sans:wght@500;700;800&family=Fraunces:opsz,wght@9..144,700;9..144,900&family=IBM+Plex+Mono:wght@500;600;700&family=Newsreader:opsz,wght@6..72,600;6..72,800&display=swap");
+
+      :root {
+        color-scheme: light;
+        --ink: #191713;
+        --muted: #756f64;
+        --paper: #f7f1e5;
+        --coal: #11110f;
+        --line: rgba(25, 23, 19, 0.16);
+        --green: #0f8d64;
+        --red: #cf3f2f;
+        --gold: #d99f26;
+        --blue: #246bce;
+        --pink: #c83773;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        background:
+          linear-gradient(90deg, rgba(17, 17, 15, 0.035) 1px, transparent 1px) 0 0 / 34px 34px,
+          linear-gradient(rgba(17, 17, 15, 0.035) 1px, transparent 1px) 0 0 / 34px 34px,
+          #eee7d8;
+        color: var(--ink);
+        font-family: "Alegreya Sans", ui-sans-serif, sans-serif;
+      }
+
+      .page {
+        width: min(1320px, calc(100vw - 32px));
+        margin: 0 auto;
+        padding: 34px 0 54px;
+      }
+
+      .intro {
+        display: grid;
+        grid-template-columns: minmax(0, 1.2fr) minmax(260px, 0.8fr);
+        gap: 30px;
+        align-items: end;
+        border-bottom: 2px solid var(--ink);
+        padding-bottom: 22px;
+        margin-bottom: 28px;
+      }
+
+      h1 {
+        margin: 0;
+        font-family: "Fraunces", Georgia, serif;
+        font-size: clamp(38px, 6vw, 82px);
+        line-height: 0.9;
+        letter-spacing: 0;
+      }
+
+      .intro p {
+        margin: 0;
+        color: var(--muted);
+        font-size: 20px;
+        line-height: 1.25;
+        max-width: 520px;
+      }
+
+      .proposals {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 22px;
+        align-items: start;
+      }
+
+      .proposal {
+        display: grid;
+        gap: 12px;
+      }
+
+      .proposal-title {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        gap: 10px;
+        border-bottom: 1px solid var(--ink);
+        padding-bottom: 8px;
+      }
+
+      .proposal-title h2 {
+        margin: 0;
+        font-family: "Newsreader", Georgia, serif;
+        font-size: 28px;
+        line-height: 1;
+      }
+
+      .proposal-title span {
+        font-family: "IBM Plex Mono", monospace;
+        font-size: 11px;
+        font-weight: 700;
+        color: var(--muted);
+        text-transform: uppercase;
+      }
+
+      .phone {
+        position: relative;
+        overflow: hidden;
+        min-height: 790px;
+        border: 2px solid var(--coal);
+        border-radius: 31px;
+        box-shadow: 0 24px 50px rgba(17, 17, 15, 0.18);
+      }
+
+      .phone::before {
+        content: "";
+        position: absolute;
+        inset: 10px 36% auto;
+        height: 5px;
+        border-radius: 99px;
+        background: currentColor;
+        opacity: 0.28;
+        z-index: 5;
+      }
+
+      .screen {
+        min-height: 790px;
+        padding: 42px 22px 24px;
+      }
+
+      .topbar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 14px;
+      }
+
+      .icon-btn {
+        width: 36px;
+        height: 36px;
+        border-radius: 999px;
+        border: 1px solid currentColor;
+        background: transparent;
+        display: grid;
+        place-items: center;
+        font: 700 19px/1 "IBM Plex Mono", monospace;
+      }
+
+      .month {
+        font-family: "IBM Plex Mono", monospace;
+        font-weight: 700;
+        font-size: 13px;
+        letter-spacing: 0;
+        text-transform: uppercase;
+      }
+
+      .money {
+        font-family: "Fraunces", Georgia, serif;
+        font-weight: 900;
+        letter-spacing: 0;
+      }
+
+      .muted {
+        color: var(--muted);
+      }
+
+      .a .screen {
+        background: #f9f0dd;
+      }
+
+      .a .hero {
+        margin: 28px -22px 0;
+        padding: 25px 22px 22px;
+        background:
+          repeating-linear-gradient(135deg, rgba(207, 63, 47, 0.08) 0 1px, transparent 1px 12px),
+          #f2d95d;
+        border-block: 2px solid var(--coal);
+      }
+
+      .a .hero-label {
+        font-family: "IBM Plex Mono", monospace;
+        font-size: 12px;
+        font-weight: 700;
+        text-transform: uppercase;
+      }
+
+      .a .hero-total {
+        margin-top: 6px;
+        font-size: 52px;
+        line-height: 0.95;
+      }
+
+      .a .hero-meta {
+        display: flex;
+        justify-content: space-between;
+        margin-top: 14px;
+        font-weight: 700;
+      }
+
+      .a .spend-track {
+        position: relative;
+        height: 34px;
+        margin-top: 16px;
+        border-block: 2px solid var(--coal);
+        background: #fff8e9;
+      }
+
+      .a .spend-track span {
+        display: block;
+        width: 62%;
+        height: 100%;
+        background: var(--green);
+      }
+
+      .a .rail {
+        margin-top: 24px;
+        border-top: 2px solid var(--coal);
+      }
+
+      .a .rail-row {
+        display: grid;
+        grid-template-columns: 44px minmax(0, 1fr) auto;
+        gap: 13px;
+        align-items: center;
+        border-bottom: 1px solid rgba(17, 17, 15, 0.25);
+        padding: 15px 0;
+      }
+
+      .a .glyph {
+        font-size: 26px;
+        line-height: 1;
+      }
+
+      .a .label {
+        font-size: 18px;
+        font-weight: 800;
+      }
+
+      .a .bar {
+        height: 7px;
+        margin-top: 7px;
+        background: rgba(17, 17, 15, 0.13);
+      }
+
+      .a .bar i {
+        display: block;
+        height: 100%;
+        background: var(--coal);
+      }
+
+      .a .pct {
+        font-family: "IBM Plex Mono", monospace;
+        font-weight: 700;
+        font-size: 13px;
+      }
+
+      .a .cta-strip {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 14px;
+        align-items: center;
+        margin: 22px -22px 0;
+        padding: 16px 22px;
+        border-block: 2px solid var(--coal);
+        background: #11110f;
+        color: #fff8e9;
+      }
+
+      .a .cta-strip strong {
+        font-size: 19px;
+      }
+
+      .b .screen {
+        color: #f4efe5;
+        background:
+          radial-gradient(circle at 50% 28%, rgba(247, 175, 49, 0.2), transparent 31%),
+          linear-gradient(180deg, #10120f, #1d2018 54%, #10120f);
+      }
+
+      .b .month {
+        color: #dfd5c1;
+      }
+
+      .b .orbital {
+        position: relative;
+        width: 286px;
+        height: 286px;
+        margin: 30px auto 22px;
+        border-radius: 50%;
+        background: conic-gradient(var(--green) 0 138deg, var(--gold) 138deg 222deg, var(--red) 222deg 260deg, #34372d 260deg);
+        box-shadow: inset 0 0 0 16px rgba(244, 239, 229, 0.08);
+      }
+
+      .b .orbital::after {
+        content: "";
+        position: absolute;
+        inset: 42px;
+        border-radius: 50%;
+        background: #10120f;
+        border: 1px solid rgba(244, 239, 229, 0.2);
+      }
+
+      .b .orbital-center {
+        position: absolute;
+        inset: 78px;
+        z-index: 1;
+        display: grid;
+        place-items: center;
+        text-align: center;
+      }
+
+      .b .orbital-center .money {
+        font-size: 39px;
+        line-height: 0.95;
+      }
+
+      .b .orbital-center span {
+        display: block;
+        margin-top: 8px;
+        color: #bdb39d;
+        font-weight: 700;
+      }
+
+      .b .tokens {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        justify-content: center;
+      }
+
+      .b .token {
+        border: 1px solid rgba(244, 239, 229, 0.3);
+        border-radius: 999px;
+        padding: 7px 11px;
+        font-family: "IBM Plex Mono", monospace;
+        font-weight: 700;
+        font-size: 11px;
+        text-transform: uppercase;
+      }
+
+      .b .allocation {
+        margin: 26px -22px 0;
+        border-top: 1px solid rgba(244, 239, 229, 0.28);
+      }
+
+      .b .allocation-row {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+        gap: 12px;
+        padding: 17px 22px;
+        border-bottom: 1px solid rgba(244, 239, 229, 0.17);
+      }
+
+      .b .allocation-row strong {
+        font-size: 19px;
+      }
+
+      .b .allocation-row small {
+        display: block;
+        margin-top: 3px;
+        color: #bdb39d;
+        font-weight: 700;
+      }
+
+      .b .amount-edit {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: "IBM Plex Mono", monospace;
+        font-weight: 700;
+      }
+
+      .b .amount-edit button {
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        border: 1px solid rgba(244, 239, 229, 0.4);
+        color: #f4efe5;
+        background: transparent;
+      }
+
+      .b .save-band {
+        margin: 24px -22px 0;
+        padding: 17px 22px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        background: #f4efe5;
+        color: #10120f;
+        font-weight: 800;
+      }
+
+      .c .screen {
+        background: #f8faf7;
+      }
+
+      .c .audit-head {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 16px;
+        margin-top: 28px;
+        padding-bottom: 20px;
+        border-bottom: 3px double var(--coal);
+      }
+
+      .c h3 {
+        margin: 0;
+        font-family: "Newsreader", Georgia, serif;
+        font-size: 43px;
+        line-height: 0.92;
+      }
+
+      .c .stamp {
+        writing-mode: vertical-rl;
+        text-orientation: mixed;
+        border-left: 2px solid var(--coal);
+        padding-left: 9px;
+        font-family: "IBM Plex Mono", monospace;
+        font-size: 11px;
+        font-weight: 700;
+        text-transform: uppercase;
+      }
+
+      .c .ledger-total {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        border-bottom: 1px solid var(--coal);
+      }
+
+      .c .metric {
+        padding: 14px 8px 13px 0;
+        border-right: 1px solid rgba(17, 17, 15, 0.18);
+      }
+
+      .c .metric:last-child {
+        border-right: 0;
+        padding-left: 10px;
+      }
+
+      .c .metric span {
+        display: block;
+        color: var(--muted);
+        font-family: "IBM Plex Mono", monospace;
+        font-size: 10px;
+        font-weight: 700;
+        text-transform: uppercase;
+      }
+
+      .c .metric strong {
+        display: block;
+        margin-top: 6px;
+        font-size: 17px;
+      }
+
+      .c .sheet {
+        margin-top: 22px;
+        border-top: 2px solid var(--coal);
+      }
+
+      .c .sheet-head,
+      .c .sheet-row {
+        display: grid;
+        grid-template-columns: 34px minmax(0, 1.1fr) 76px 58px;
+        gap: 8px;
+        align-items: center;
+      }
+
+      .c .sheet-head {
+        padding: 9px 0;
+        color: var(--muted);
+        font-family: "IBM Plex Mono", monospace;
+        font-size: 10px;
+        font-weight: 700;
+        text-transform: uppercase;
+        border-bottom: 1px solid var(--coal);
+      }
+
+      .c .sheet-row {
+        min-height: 61px;
+        border-bottom: 1px solid rgba(17, 17, 15, 0.2);
+        font-weight: 800;
+      }
+
+      .c .mini-bar {
+        height: 34px;
+        border-left: 1px solid rgba(17, 17, 15, 0.2);
+        display: flex;
+        align-items: end;
+        gap: 3px;
+        padding-left: 8px;
+      }
+
+      .c .mini-bar i {
+        width: 5px;
+        background: var(--coal);
+      }
+
+      .c .status {
+        font-family: "IBM Plex Mono", monospace;
+        font-size: 12px;
+      }
+
+      .c .status.over {
+        color: var(--red);
+      }
+
+      .c .inline-add {
+        margin-top: 22px;
+        border-top: 2px solid var(--coal);
+        border-bottom: 2px solid var(--coal);
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 12px;
+        align-items: center;
+        padding: 15px 0;
+      }
+
+      .c .inline-add strong {
+        font-size: 20px;
+      }
+
+      @media (max-width: 1060px) {
+        .proposals {
+          grid-template-columns: 1fr;
+        }
+
+        .proposal {
+          grid-template-columns: 280px minmax(320px, 410px);
+          align-items: start;
+        }
+
+        .proposal-title {
+          display: block;
+          border-bottom: 0;
+          padding-top: 22px;
+        }
+      }
+
+      @media (max-width: 720px) {
+        .intro,
+        .proposal {
+          grid-template-columns: 1fr;
+        }
+
+        .phone {
+          min-height: 740px;
+        }
+
+        .screen {
+          min-height: 740px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <section class="intro">
+        <h1>Budget screen directions</h1>
+        <p>
+          Three no-card mobile proposals for Fidy budgets. Each keeps the month switcher,
+          total budget, spent progress, category budgets, and create/edit affordances visible.
+        </p>
+      </section>
+
+      <section class="proposals" aria-label="Budget design proposals">
+        <article class="proposal">
+          <div class="proposal-title">
+            <h2>1. Market Ledger</h2>
+            <span>tactile / quick scan</span>
+          </div>
+          <div class="phone a">
+            <div class="screen">
+              <div class="topbar">
+                <button class="icon-btn" aria-label="Previous month">‹</button>
+                <div class="month">May 2026</div>
+                <button class="icon-btn" aria-label="Next month">›</button>
+              </div>
+
+              <section class="hero">
+                <div class="hero-label">Total monthly budget</div>
+                <div class="hero-total money">$2.400.000</div>
+                <div class="spend-track" aria-label="62 percent used"><span></span></div>
+                <div class="hero-meta">
+                  <span>$1.490.000 spent</span>
+                  <span>62% used</span>
+                </div>
+              </section>
+
+              <section class="rail" aria-label="Category budgets">
+                <div class="rail-row">
+                  <div class="glyph">☕</div>
+                  <div>
+                    <div class="label">Food</div>
+                    <div class="bar"><i style="width: 78%"></i></div>
+                  </div>
+                  <div class="pct">78%</div>
+                </div>
+                <div class="rail-row">
+                  <div class="glyph">🚌</div>
+                  <div>
+                    <div class="label">Transport</div>
+                    <div class="bar"><i style="width: 44%"></i></div>
+                  </div>
+                  <div class="pct">44%</div>
+                </div>
+                <div class="rail-row">
+                  <div class="glyph">🏠</div>
+                  <div>
+                    <div class="label">Home</div>
+                    <div class="bar"><i style="width: 91%"></i></div>
+                  </div>
+                  <div class="pct">91%</div>
+                </div>
+                <div class="rail-row">
+                  <div class="glyph">🎧</div>
+                  <div>
+                    <div class="label">Fun</div>
+                    <div class="bar"><i style="width: 114%; background: var(--red)"></i></div>
+                  </div>
+                  <div class="pct" style="color: var(--red)">114%</div>
+                </div>
+              </section>
+
+              <section class="cta-strip">
+                <strong>Add or copy budgets</strong>
+                <button class="icon-btn" aria-label="Add budget">+</button>
+              </section>
+            </div>
+          </div>
+        </article>
+
+        <article class="proposal">
+          <div class="proposal-title">
+            <h2>2. Allocation Dial</h2>
+            <span>editorial / focused edit</span>
+          </div>
+          <div class="phone b">
+            <div class="screen">
+              <div class="topbar">
+                <button class="icon-btn" aria-label="Previous month">‹</button>
+                <div class="month">May 2026</div>
+                <button class="icon-btn" aria-label="Next month">›</button>
+              </div>
+
+              <section class="orbital" aria-label="Budget allocation dial">
+                <div class="orbital-center">
+                  <div>
+                    <div class="money">$910k</div>
+                    <span>remaining</span>
+                  </div>
+                </div>
+              </section>
+
+              <div class="tokens" aria-label="Budget status filters">
+                <span class="token">4 active</span>
+                <span class="token">1 over</span>
+                <span class="token">17 days left</span>
+              </div>
+
+              <section class="allocation" aria-label="Editable budget allocations">
+                <div class="allocation-row">
+                  <div>
+                    <strong>Food</strong>
+                    <small>$390.000 spent of $500.000</small>
+                  </div>
+                  <div class="amount-edit"><button>-</button>$500k<button>+</button></div>
+                </div>
+                <div class="allocation-row">
+                  <div>
+                    <strong>Transport</strong>
+                    <small>$132.000 spent of $300.000</small>
+                  </div>
+                  <div class="amount-edit"><button>-</button>$300k<button>+</button></div>
+                </div>
+                <div class="allocation-row">
+                  <div>
+                    <strong>Home</strong>
+                    <small>$728.000 spent of $800.000</small>
+                  </div>
+                  <div class="amount-edit"><button>-</button>$800k<button>+</button></div>
+                </div>
+                <div class="allocation-row">
+                  <div>
+                    <strong>Fun</strong>
+                    <small>$240.000 spent of $210.000</small>
+                  </div>
+                  <div class="amount-edit"><button>-</button>$210k<button>+</button></div>
+                </div>
+              </section>
+
+              <section class="save-band">
+                <span>Save May plan</span>
+                <span>→</span>
+              </section>
+            </div>
+          </div>
+        </article>
+
+        <article class="proposal">
+          <div class="proposal-title">
+            <h2>3. Month Sheet</h2>
+            <span>dense / operational</span>
+          </div>
+          <div class="phone c">
+            <div class="screen">
+              <div class="topbar">
+                <button class="icon-btn" aria-label="Previous month">‹</button>
+                <div class="month">May 2026</div>
+                <button class="icon-btn" aria-label="Next month">›</button>
+              </div>
+
+              <section class="audit-head">
+                <h3>Budget control</h3>
+                <div class="stamp">COP · Local first</div>
+              </section>
+
+              <section class="ledger-total" aria-label="Budget totals">
+                <div class="metric">
+                  <span>Budget</span>
+                  <strong>$2.4M</strong>
+                </div>
+                <div class="metric">
+                  <span>Spent</span>
+                  <strong>$1.49M</strong>
+                </div>
+                <div class="metric">
+                  <span>Used</span>
+                  <strong>62%</strong>
+                </div>
+              </section>
+
+              <section class="sheet" aria-label="Budget table">
+                <div class="sheet-head">
+                  <span></span>
+                  <span>Category</span>
+                  <span>Limit</span>
+                  <span>Status</span>
+                </div>
+                <div class="sheet-row">
+                  <span>☕</span>
+                  <span>Food</span>
+                  <span>$500k</span>
+                  <span class="status">78%</span>
+                  <div class="mini-bar"><i style="height: 30%"></i><i style="height: 48%"></i><i style="height: 78%"></i></div>
+                </div>
+                <div class="sheet-row">
+                  <span>🚌</span>
+                  <span>Transport</span>
+                  <span>$300k</span>
+                  <span class="status">44%</span>
+                  <div class="mini-bar"><i style="height: 20%"></i><i style="height: 31%"></i><i style="height: 44%"></i></div>
+                </div>
+                <div class="sheet-row">
+                  <span>🏠</span>
+                  <span>Home</span>
+                  <span>$800k</span>
+                  <span class="status">91%</span>
+                  <div class="mini-bar"><i style="height: 66%"></i><i style="height: 74%"></i><i style="height: 91%"></i></div>
+                </div>
+                <div class="sheet-row">
+                  <span>🎧</span>
+                  <span>Fun</span>
+                  <span>$210k</span>
+                  <span class="status over">114%</span>
+                  <div class="mini-bar"><i style="height: 58%"></i><i style="height: 92%"></i><i style="height: 100%; background: var(--red)"></i></div>
+                </div>
+              </section>
+
+              <section class="inline-add">
+                <strong>New category budget</strong>
+                <button class="icon-btn" aria-label="Add budget">+</button>
+              </section>
+            </div>
+          </div>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
- virtualize suggestion lists

- improve AI chat streaming

- cover chat render helpers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished mobile chat with a floating composer, smarter auto‑scroll with a localized scroll‑to‑bottom affordance, and a “thinking” streaming bubble with animated dots and a cursor. Standardized modal routes to a centered dialog with a fade backdrop for a calmer, consistent feel.

- New Features
  - Added `ChatConversationShell` with auto‑scroll, a scroll‑to‑bottom button, and a floating composer that follows the keyboard/home indicator.
  - Streaming bubble shows a “thinking” state with animated dots; live text displays with a cursor; streaming text comes from an external store for smoother renders.
  - Assistant messages render simple markdown (bold, lists) and hide action payloads.
  - Replaced formSheet modals with `DialogRouteFrame` + `transparentModal` (`DIALOG_MODAL`) across add/edit/picker screens; centered layout, fade animation, and translucent backdrop.
  - Added i18n keys: aiChat.scrollToBottom, aiChat.thinking.

- Refactors
  - Virtualized `AccountSuggestionReviewScreen` and `BudgetListScreen` using `@shopify/flash-list`; memoized cards and stabilized callbacks.
  - Extracted chat layout, scroll, and content helpers; added tests for composer send, shell insets, scroll policy, message blocks, streaming display, and the streaming text store.
  - Centered in‑app pickers (transaction/transfer) with max width, fade backdrops, and non‑sliding dialogs.

<sup>Written for commit d3ff145d266da5ee7359b9dcfaa0dd2b426e938d. Summary will update on new commits. <a href="https://cubic.dev/pr/B4rz99/fidy/pull/482?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

