### PR TITLE
fix(mobile): standardize dialogs

### DIFF
--- a/apps/mobile/__tests__/budget/create-budget-screen.test.ts
+++ b/apps/mobile/__tests__/budget/create-budget-screen.test.ts
@@ -8,6 +8,7 @@ function readSource(relativePath: string) {
 
 const routeSource = readSource("../../app/create-budget.tsx");
 const layoutSource = readSource("../../app/_layout.tsx");
+const autoSuggestBudgetsSource = readSource("../../app/auto-suggest-budgets.tsx");
 const screenSource = readSource(
   "../../features/budget/components/create-budget/CreateBudgetScreen.tsx"
 );
@@ -30,6 +31,15 @@ test("create-budget is registered in root layout as a dialog modal", () => {
   const createBudgetBlock = layoutSource.slice(layoutSource.indexOf('name="create-budget"'));
   expect(createBudgetBlock.slice(0, 140)).toContain("DIALOG_MODAL");
   expect(layoutSource).not.toContain("formSheet");
+});
+
+test("auto-suggest budgets keeps the scroll view bounded inside the dialog", () => {
+  expect(autoSuggestBudgetsSource).toContain("style={styles.flex}");
+  expect(autoSuggestBudgetsSource).toContain(
+    "style={[styles.container, { backgroundColor: cardBg }]}"
+  );
+  expect(autoSuggestBudgetsSource).toContain("flex: { flex: 1 }");
+  expect(autoSuggestBudgetsSource).toContain("container: { flex: 1 }");
 });
 
 test("create-budget route uses the budget public route surface", () => {

--- a/apps/mobile/__tests__/calendar/add-bill-screen.test.ts
+++ b/apps/mobile/__tests__/calendar/add-bill-screen.test.ts
@@ -13,6 +13,9 @@ const formSource = readSource("../../features/calendar/components/add-bill/AddBi
 const formContentSource = readSource(
   "../../features/calendar/components/add-bill/AddBillFormContent.tsx"
 );
+const formStylesSource = readSource(
+  "../../features/calendar/components/add-bill/AddBillForm.styles.ts"
+);
 const authFormSource = readSource(
   "../../features/calendar/components/add-bill/AuthenticatedAddBillForm.tsx"
 );
@@ -33,6 +36,12 @@ test("add-bill routes through the extracted screen module", () => {
 
 test("add-bill content uses KeyboardAvoidingView for keyboard handling", () => {
   expect(formContentSource).toContain("KeyboardAvoidingView");
+});
+
+test("add-bill dialog keeps keyboard and scroll containers bounded", () => {
+  expect(formContentSource).toContain("style={styles.container}");
+  expect(formContentSource).toContain("style={[styles.container, { backgroundColor: cardBg }]}");
+  expect(formStylesSource).toContain("container: { flex: 1 }");
 });
 
 test("add-bill content has name and amount text inputs", () => {

--- a/apps/mobile/__tests__/navigation/dialog-route-frame.test.ts
+++ b/apps/mobile/__tests__/navigation/dialog-route-frame.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+
+const source = readFileSync(
+  resolve(__dirname, "../../shared/components/DialogRouteFrame.tsx"),
+  "utf-8"
+).replace(/\r\n/g, "\n");
+
+describe("DialogRouteFrame", () => {
+  test("dismisses nested dialog stacks in one navigation action", () => {
+    expect(source).toContain("router.dismiss(closeDepth)");
+    expect(source).not.toContain("setTimeout");
+    expect(source).not.toContain("closeDialogStack");
+  });
+
+  test("captures inner taps before the backdrop can dismiss", () => {
+    expect(source).toContain("onStartShouldSetResponder={() => true}");
+  });
+});

--- a/apps/mobile/__tests__/navigation/tab-layout.test.ts
+++ b/apps/mobile/__tests__/navigation/tab-layout.test.ts
@@ -73,6 +73,24 @@ describe("Tab layout", () => {
     expect(financeSource).not.toContain('t("budgets.title")');
   });
 
+  test("finance segment defaults to analytics and orders goals before calendar", () => {
+    const financeSource = readFileSync(
+      resolve(__dirname, "../../app/(tabs)/(finance)/index.tsx"),
+      "utf-8"
+    );
+
+    expect(financeSource).toContain('useState<FinanceTab>("analytics")');
+    const analyticsIndex = financeSource.indexOf('{ key: "analytics"');
+    const goalsIndex = financeSource.indexOf('{ key: "goals"');
+    const calendarIndex = financeSource.indexOf('{ key: "calendar"');
+
+    expect(analyticsIndex).toBeGreaterThanOrEqual(0);
+    expect(goalsIndex).toBeGreaterThanOrEqual(0);
+    expect(calendarIndex).toBeGreaterThanOrEqual(0);
+    expect(analyticsIndex).toBeLessThan(goalsIndex);
+    expect(goalsIndex).toBeLessThan(calendarIndex);
+  });
+
   test("does not reference MenuPanel", () => {
     expect(layoutSource).not.toContain("MenuPanel");
   });

--- a/apps/mobile/__tests__/transactions/callers.test.ts
+++ b/apps/mobile/__tests__/transactions/callers.test.ts
@@ -6,6 +6,11 @@ const editTransactionSource = readFileSync(
   resolve(__dirname, "../../app/edit-transaction.tsx"),
   "utf-8"
 ).replace(/\r\n/g, "\n");
+const reclassifyTransactionRouteSource = readFileSync(
+  resolve(__dirname, "../../app/reclassify-transaction.tsx"),
+  "utf-8"
+).replace(/\r\n/g, "\n");
+const rootLayoutSource = readFileSync(resolve(__dirname, "../../app/_layout.tsx"), "utf-8");
 
 describe("transaction callers", () => {
   test("edit screen surfaces save and delete failures before navigating away when auth/db is missing", () => {
@@ -19,7 +24,18 @@ describe("transaction callers", () => {
 
   test("edit screen reclassifies captured transactions by transaction id only", () => {
     expect(editTransactionSource).toContain('pathname: "/reclassify-transaction"');
+    expect(editTransactionSource).toContain('nestedDialog: "1"');
     expect(editTransactionSource).toContain("transactionId,");
     expect(editTransactionSource).not.toContain("processedEmailId");
+  });
+
+  test("reclassification opens as a centered dialog route", () => {
+    expect(rootLayoutSource).toContain('name="reclassify-transaction"');
+    expect(rootLayoutSource).toContain("DIALOG_MODAL");
+    expect(reclassifyTransactionRouteSource).toContain("DialogRouteFrame");
+    expect(reclassifyTransactionRouteSource).toContain('presentation="dialog"');
+    expect(reclassifyTransactionRouteSource).toContain("showBack={isNestedDialog}");
+    expect(reclassifyTransactionRouteSource).toContain("closeDepth={isNestedDialog ? 2 : 1}");
+    expect(editTransactionSource).not.toContain("onClose={back}");
   });
 });

--- a/apps/mobile/__tests__/transfers/form-layout-source.test.ts
+++ b/apps/mobile/__tests__/transfers/form-layout-source.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+
+function readSource(relativePath: string) {
+  return readFileSync(resolve(__dirname, relativePath), "utf-8");
+}
+
+const contentSource = readSource(
+  "../../features/transfers/components/transfer-form/TransferFormContent.tsx"
+);
+const stylesSource = readSource(
+  "../../features/transfers/components/transfer-form/TransferForm.styles.ts"
+);
+
+describe("transfer form dialog layout", () => {
+  test("keeps keyboard and scroll containers bounded inside dialogs", () => {
+    expect(contentSource).toContain("style={styles.container}");
+    expect(stylesSource).toContain("container: {\n    flex: 1,\n  }");
+  });
+});

--- a/apps/mobile/app/(tabs)/(finance)/index.tsx
+++ b/apps/mobile/app/(tabs)/(finance)/index.tsx
@@ -34,9 +34,9 @@ function SegmentControl({
   const secondary = useThemeColor("secondary");
 
   const tabs: readonly { key: FinanceTab; label: string }[] = [
-    { key: "calendar", label: t("calendar.title") },
-    { key: "goals", label: t("goals.title") },
     { key: "analytics", label: t("analytics.title") },
+    { key: "goals", label: t("goals.title") },
+    { key: "calendar", label: t("calendar.title") },
   ];
 
   return (
@@ -148,7 +148,7 @@ function useHeaderRight(activeTab: FinanceTab) {
 }
 
 export default function FinanceScreen() {
-  const [activeTab, setActiveTab] = useState<FinanceTab>("calendar");
+  const [activeTab, setActiveTab] = useState<FinanceTab>("analytics");
   const headerRight = useHeaderRight(activeTab);
   const pageBg = useThemeColor("page");
 

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -212,24 +212,12 @@ function RootLayout() {
             <Stack.Screen name="(tabs)" />
             {localQaAvailable ? <Stack.Screen name="qa-tools" options={iosHeaderOptions} /> : null}
             {localQaAvailable ? <Stack.Screen name="qa-open" options={iosHeaderOptions} /> : null}
-            <Stack.Screen
-              name="add-bill"
-              options={DIALOG_MODAL}
-            />
-            <Stack.Screen
-              name="day-detail"
-              options={DIALOG_MODAL}
-            />
+            <Stack.Screen name="add-bill" options={DIALOG_MODAL} />
+            <Stack.Screen name="day-detail" options={DIALOG_MODAL} />
             <Stack.Screen name="theme-picker" options={DIALOG_MODAL} />
             <Stack.Screen name="language-picker" options={DIALOG_MODAL} />
-            <Stack.Screen
-              name="delete-account"
-              options={DIALOG_MODAL}
-            />
-            <Stack.Screen
-              name="enable-notifications"
-              options={DIALOG_MODAL}
-            />
+            <Stack.Screen name="delete-account" options={DIALOG_MODAL} />
+            <Stack.Screen name="enable-notifications" options={DIALOG_MODAL} />
             <Stack.Screen name="analytics" options={iosHeaderOptions} />
             <Stack.Screen name="notifications" options={iosHeaderOptions} />
             <Stack.Screen name="search" options={iosHeaderOptions} />
@@ -250,27 +238,12 @@ function RootLayout() {
               name="link-suggested-account"
               options={{ ...DIALOG_MODAL, ...iosHeaderOptions }}
             />
-            <Stack.Screen
-              name="create-budget"
-              options={DIALOG_MODAL}
-            />
-            <Stack.Screen
-              name="auto-suggest-budgets"
-              options={DIALOG_MODAL}
-            />
+            <Stack.Screen name="create-budget" options={DIALOG_MODAL} />
+            <Stack.Screen name="auto-suggest-budgets" options={DIALOG_MODAL} />
             <Stack.Screen name="goal-detail" options={iosHeaderOptions} />
-            <Stack.Screen
-              name="create-goal"
-              options={DIALOG_MODAL}
-            />
-            <Stack.Screen
-              name="add-payment"
-              options={DIALOG_MODAL}
-            />
-            <Stack.Screen
-              name="edit-goal"
-              options={DIALOG_MODAL}
-            />
+            <Stack.Screen name="create-goal" options={DIALOG_MODAL} />
+            <Stack.Screen name="add-payment" options={DIALOG_MODAL} />
+            <Stack.Screen name="edit-goal" options={DIALOG_MODAL} />
             <Stack.Screen
               name="add-transaction"
               options={{
@@ -284,10 +257,7 @@ function RootLayout() {
             <Stack.Screen name="ai-memories" options={iosHeaderOptions} />
             <Stack.Screen name="notification-preferences" options={iosHeaderOptions} />
             <Stack.Screen name="categories" options={iosHeaderOptions} />
-            <Stack.Screen
-              name="create-category"
-              options={DIALOG_MODAL}
-            />
+            <Stack.Screen name="create-category" options={DIALOG_MODAL} />
             <Stack.Screen
               name="edit-transaction"
               options={{
@@ -296,6 +266,7 @@ function RootLayout() {
                 sheetGrabberVisible: false,
               }}
             />
+            <Stack.Screen name="reclassify-transaction" options={DIALOG_MODAL} />
             {localQaAvailable ? (
               <Stack.Screen name="qa-transfer-conflict" options={{ headerShown: false }} />
             ) : null}

--- a/apps/mobile/app/auto-suggest-budgets.tsx
+++ b/apps/mobile/app/auto-suggest-budgets.tsx
@@ -81,86 +81,88 @@ export default function AutoSuggestBudgetsScreen() {
           contentInsetAdjustmentBehavior="automatic"
           keyboardShouldPersistTaps="handled"
         >
-        <Text style={[styles.title, { color: primaryColor }]}>
-          {t("budgets.autoSuggest.title")}
-        </Text>
-        <Text style={[styles.subtitle, { color: secondaryColor }]}>
-          {t("budgets.autoSuggest.subtitle")}
-        </Text>
+          <Text style={[styles.title, { color: primaryColor }]}>
+            {t("budgets.autoSuggest.title")}
+          </Text>
+          <Text style={[styles.subtitle, { color: secondaryColor }]}>
+            {t("budgets.autoSuggest.subtitle")}
+          </Text>
 
-        <View style={styles.list}>
-          {autoSuggestions.map((suggestion) => {
-            const category = CATEGORY_MAP[suggestion.categoryId] ?? null;
-            const categoryLabel = category
-              ? getCategoryLabel(category, locale)
-              : suggestion.categoryId;
-            const isSelected = selectedIds.has(suggestion.categoryId);
+          <View style={styles.list}>
+            {autoSuggestions.map((suggestion) => {
+              const category = CATEGORY_MAP[suggestion.categoryId] ?? null;
+              const categoryLabel = category
+                ? getCategoryLabel(category, locale)
+                : suggestion.categoryId;
+              const isSelected = selectedIds.has(suggestion.categoryId);
 
-            return (
-              <View key={suggestion.categoryId} style={[styles.row, { borderColor }]}>
-                <View style={styles.rowLeft}>
-                  {category ? <Text style={{ color: category.color }}>{category.icon}</Text> : null}
-                  <View>
-                    <Text style={[styles.categoryName, { color: primaryColor }]}>
-                      {categoryLabel}
-                    </Text>
-                    <Text style={[styles.lastMonthLabel, { color: secondaryColor }]}>
-                      {formatMoney(suggestion.suggestedAmount)}{" "}
-                      {t("search.lastMonth").toLowerCase()}
-                    </Text>
+              return (
+                <View key={suggestion.categoryId} style={[styles.row, { borderColor }]}>
+                  <View style={styles.rowLeft}>
+                    {category ? (
+                      <Text style={{ color: category.color }}>{category.icon}</Text>
+                    ) : null}
+                    <View>
+                      <Text style={[styles.categoryName, { color: primaryColor }]}>
+                        {categoryLabel}
+                      </Text>
+                      <Text style={[styles.lastMonthLabel, { color: secondaryColor }]}>
+                        {formatMoney(suggestion.suggestedAmount)}{" "}
+                        {t("search.lastMonth").toLowerCase()}
+                      </Text>
+                    </View>
+                  </View>
+                  <View style={styles.rowRight}>
+                    <TextInput
+                      style={[
+                        styles.amountInput,
+                        {
+                          backgroundColor: isSelected ? pageBg : pageBg,
+                          color: isSelected ? primaryColor : secondaryColor,
+                          borderColor,
+                          opacity: isSelected ? 1 : 0.4,
+                        },
+                      ]}
+                      value={editedAmounts[suggestion.categoryId] ?? ""}
+                      onChangeText={(v) => handleAmountChange(suggestion.categoryId, v)}
+                      keyboardType="number-pad"
+                      editable={isSelected}
+                      selectTextOnFocus
+                    />
+                    <Switch
+                      value={isSelected}
+                      onValueChange={() => handleToggle(suggestion.categoryId)}
+                      trackColor={{ true: accentGreen }}
+                    />
                   </View>
                 </View>
-                <View style={styles.rowRight}>
-                  <TextInput
-                    style={[
-                      styles.amountInput,
-                      {
-                        backgroundColor: isSelected ? pageBg : pageBg,
-                        color: isSelected ? primaryColor : secondaryColor,
-                        borderColor,
-                        opacity: isSelected ? 1 : 0.4,
-                      },
-                    ]}
-                    value={editedAmounts[suggestion.categoryId] ?? ""}
-                    onChangeText={(v) => handleAmountChange(suggestion.categoryId, v)}
-                    keyboardType="number-pad"
-                    editable={isSelected}
-                    selectTextOnFocus
-                  />
-                  <Switch
-                    value={isSelected}
-                    onValueChange={() => handleToggle(suggestion.categoryId)}
-                    trackColor={{ true: accentGreen }}
-                  />
-                </View>
-              </View>
-            );
-          })}
-        </View>
+              );
+            })}
+          </View>
 
-        {autoSuggestions.length === 0 && (
-          <Text style={[styles.emptyText, { color: secondaryColor }]}>
-            {t("budgets.autoSuggest.noSuggestions")}
-          </Text>
-        )}
-
-        <View style={styles.actions}>
-          <Pressable
-            style={[
-              styles.acceptButton,
-              { backgroundColor: accentGreen, opacity: isBusy ? 0.5 : 1 },
-            ]}
-            onPress={handleAccept}
-            disabled={isBusy || ((userId == null || db == null) && selectedIds.size > 0)}
-          >
-            <Text style={styles.acceptButtonText}>{t("budgets.autoSuggest.acceptSelected")}</Text>
-          </Pressable>
-          <Pressable onPress={handleSkip}>
-            <Text style={[styles.skipText, { color: secondaryColor }]}>
-              {t("budgets.autoSuggest.skipAll")}
+          {autoSuggestions.length === 0 && (
+            <Text style={[styles.emptyText, { color: secondaryColor }]}>
+              {t("budgets.autoSuggest.noSuggestions")}
             </Text>
-          </Pressable>
-        </View>
+          )}
+
+          <View style={styles.actions}>
+            <Pressable
+              style={[
+                styles.acceptButton,
+                { backgroundColor: accentGreen, opacity: isBusy ? 0.5 : 1 },
+              ]}
+              onPress={handleAccept}
+              disabled={isBusy || ((userId == null || db == null) && selectedIds.size > 0)}
+            >
+              <Text style={styles.acceptButtonText}>{t("budgets.autoSuggest.acceptSelected")}</Text>
+            </Pressable>
+            <Pressable onPress={handleSkip}>
+              <Text style={[styles.skipText, { color: secondaryColor }]}>
+                {t("budgets.autoSuggest.skipAll")}
+              </Text>
+            </Pressable>
+          </View>
         </ScrollView>
       </KeyboardAvoidingView>
     </DialogRouteFrame>
@@ -168,12 +170,8 @@ export default function AutoSuggestBudgetsScreen() {
 }
 
 const styles = StyleSheet.create({
-  flex: {
-    flex: 1,
-  },
-  container: {
-    flex: 1,
-  },
+  flex: { flex: 1 },
+  container: { flex: 1 },
   scrollContent: {
     padding: 24,
     gap: 16,

--- a/apps/mobile/app/day-detail.tsx
+++ b/apps/mobile/app/day-detail.tsx
@@ -85,78 +85,81 @@ export default function DayDetailScreen() {
           {format(dateObj, "EEEE, PP", { locale: getDateFnsLocale(locale) })}
         </Text>
 
-      {billsForDate.length === 0 ? (
-        <View style={styles.emptyState}>
-          <Text style={[styles.emptyText, { color: secondaryColor }]}>
-            {t("bills.noBillsOnDay")}
-          </Text>
-        </View>
-      ) : (
-        <View style={styles.billList}>
-          {billsForDate.map((bill) => {
-            const billId = requireBillId(bill.id);
-            const paid = isPaymentPaid(billId);
-            return (
-              <View
-                key={billId}
-                style={[
-                  styles.billRow,
-                  {
-                    backgroundColor: paid ? accentGreenLight : pageBg,
-                    borderColor,
-                  },
-                ]}
-              >
-                <View style={styles.billInfo}>
-                  <Text style={[styles.billName, { color: primaryColor }, paid && styles.paidText]}>
-                    {bill.name}
-                  </Text>
-                  <Text style={[styles.billAmount, { color: secondaryColor }]}>
-                    {formatMoney(bill.amount)}
-                  </Text>
+        {billsForDate.length === 0 ? (
+          <View style={styles.emptyState}>
+            <Text style={[styles.emptyText, { color: secondaryColor }]}>
+              {t("bills.noBillsOnDay")}
+            </Text>
+          </View>
+        ) : (
+          <View style={styles.billList}>
+            {billsForDate.map((bill) => {
+              const billId = requireBillId(bill.id);
+              const paid = isPaymentPaid(billId);
+              return (
+                <View
+                  key={billId}
+                  style={[
+                    styles.billRow,
+                    {
+                      backgroundColor: paid ? accentGreenLight : pageBg,
+                      borderColor,
+                    },
+                  ]}
+                >
+                  <View style={styles.billInfo}>
+                    <Text
+                      style={[styles.billName, { color: primaryColor }, paid && styles.paidText]}
+                    >
+                      {bill.name}
+                    </Text>
+                    <Text style={[styles.billAmount, { color: secondaryColor }]}>
+                      {formatMoney(bill.amount)}
+                    </Text>
+                  </View>
+
+                  <View style={styles.actions}>
+                    <Pressable
+                      style={[
+                        styles.actionButton,
+                        { backgroundColor: paid ? accentGreen : peachBg },
+                      ]}
+                      onPress={() => {
+                        void handleTogglePaid(billId);
+                      }}
+                      hitSlop={8}
+                    >
+                      <Check size={16} color={paid ? "#FFFFFF" : primaryColor} />
+                    </Pressable>
+
+                    <Pressable
+                      style={[styles.actionButton, { backgroundColor: peachBg }]}
+                      onPress={() => handleEdit(billId)}
+                      hitSlop={8}
+                    >
+                      <Pencil size={16} color={primaryColor} />
+                    </Pressable>
+
+                    <Pressable
+                      style={[styles.actionButton, { backgroundColor: peachBg }]}
+                      onPress={() => handleDelete(billId, bill.name)}
+                      hitSlop={8}
+                    >
+                      <Trash2 size={16} color={accentRed} />
+                    </Pressable>
+                  </View>
                 </View>
-
-                <View style={styles.actions}>
-                  <Pressable
-                    style={[styles.actionButton, { backgroundColor: paid ? accentGreen : peachBg }]}
-                    onPress={() => {
-                      void handleTogglePaid(billId);
-                    }}
-                    hitSlop={8}
-                  >
-                    <Check size={16} color={paid ? "#FFFFFF" : primaryColor} />
-                  </Pressable>
-
-                  <Pressable
-                    style={[styles.actionButton, { backgroundColor: peachBg }]}
-                    onPress={() => handleEdit(billId)}
-                    hitSlop={8}
-                  >
-                    <Pencil size={16} color={primaryColor} />
-                  </Pressable>
-
-                  <Pressable
-                    style={[styles.actionButton, { backgroundColor: peachBg }]}
-                    onPress={() => handleDelete(billId, bill.name)}
-                    hitSlop={8}
-                  >
-                    <Trash2 size={16} color={accentRed} />
-                  </Pressable>
-                </View>
-              </View>
-            );
-          })}
-        </View>
-      )}
+              );
+            })}
+          </View>
+        )}
       </ScrollView>
     </DialogRouteFrame>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
+  container: {},
   content: {
     padding: 24,
     gap: 16,

--- a/apps/mobile/app/edit-transaction.tsx
+++ b/apps/mobile/app/edit-transaction.tsx
@@ -185,12 +185,9 @@ export default function EditTransactionScreen() {
         onDigitsChange={(digits) => setDraft({ type: "setDigits", digits })}
         onCategoryChange={(categoryId) => setDraft({ type: "update", update: { categoryId } })}
         onAccountChange={(accountId) => setDraft({ type: "update", update: { accountId } })}
-        onDescriptionChange={(description) =>
-          setDraft({ type: "update", update: { description } })
-        }
+        onDescriptionChange={(description) => setDraft({ type: "update", update: { description } })}
         onSave={handleSave}
         onDelete={handleDelete}
-        onClose={back}
         extraActionLabel={
           draft.source === "manual" ? undefined : t("transactions.convertToTransfer")
         }
@@ -201,6 +198,7 @@ export default function EditTransactionScreen() {
                 push({
                   pathname: "/reclassify-transaction",
                   params: {
+                    nestedDialog: "1",
                     transactionId,
                   },
                 })

--- a/apps/mobile/app/reclassify-transaction.tsx
+++ b/apps/mobile/app/reclassify-transaction.tsx
@@ -1,1 +1,14 @@
-export { TransferFormScreen as default } from "@/features/transfers/routes.public";
+import { useLocalSearchParams } from "expo-router";
+import { TransferFormScreen } from "@/features/transfers/routes.public";
+import { DialogRouteFrame } from "@/shared/components";
+
+export default function ReclassifyTransactionRoute() {
+  const { nestedDialog } = useLocalSearchParams<{ nestedDialog?: string | string[] }>();
+  const isNestedDialog = nestedDialog === "1";
+
+  return (
+    <DialogRouteFrame showBack={isNestedDialog} closeDepth={isNestedDialog ? 2 : 1}>
+      <TransferFormScreen presentation="dialog" />
+    </DialogRouteFrame>
+  );
+}

--- a/apps/mobile/features/budget/components/create-budget/CreateBudget.styles.ts
+++ b/apps/mobile/features/budget/components/create-budget/CreateBudget.styles.ts
@@ -20,9 +20,7 @@ export const styles = StyleSheet.create({
     flexWrap: "wrap",
     gap: 8,
   },
-  container: {
-    flex: 1,
-  },
+  container: {},
   deleteButton: {
     alignItems: "center",
     borderCurve: "continuous",

--- a/apps/mobile/features/calendar/components/add-bill/AddBillForm.styles.ts
+++ b/apps/mobile/features/calendar/components/add-bill/AddBillForm.styles.ts
@@ -1,9 +1,7 @@
 import { StyleSheet } from "@/shared/components/rn";
 
 export const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
+  container: { flex: 1 },
   content: {
     padding: 24,
     gap: 16,

--- a/apps/mobile/features/categories/components/category-sheet/CreateCategorySheet.styles.ts
+++ b/apps/mobile/features/categories/components/category-sheet/CreateCategorySheet.styles.ts
@@ -1,18 +1,12 @@
 import { StyleSheet } from "@/shared/components/rn";
 
 export const styles = StyleSheet.create({
-  container: { flex: 1 },
+  container: {},
   scrollContent: {
     paddingTop: 12,
     paddingHorizontal: 24,
     paddingBottom: 24,
     gap: 16,
-  },
-  grabBar: {
-    width: 40,
-    height: 4,
-    borderRadius: 2,
-    alignSelf: "center",
   },
   title: {
     fontFamily: "Poppins_600SemiBold",

--- a/apps/mobile/features/categories/components/category-sheet/CreateCategorySheetContent.tsx
+++ b/apps/mobile/features/categories/components/category-sheet/CreateCategorySheetContent.tsx
@@ -41,8 +41,6 @@ export function CreateCategorySheetContent({
       automaticallyAdjustKeyboardInsets
       bounces={false}
     >
-      <View style={[styles.grabBar, { backgroundColor: tertiaryColor, opacity: 0.3 }]} />
-
       <Text style={[styles.title, { color: primaryColor }]}>{t("categories.create.title")}</Text>
 
       <View style={styles.previewRow}>

--- a/apps/mobile/features/goals/components/AddPaymentSheet.tsx
+++ b/apps/mobile/features/goals/components/AddPaymentSheet.tsx
@@ -82,9 +82,6 @@ export function AddPaymentSheet() {
       contentInsetAdjustmentBehavior="automatic"
       keyboardShouldPersistTaps="handled"
     >
-      {/* Grab bar */}
-      <View style={[styles.grabBar, { backgroundColor: borderColor }]} />
-
       {/* Title */}
       <Text style={[styles.title, { color: primaryColor }]}>{t("goals.payment.title")}</Text>
 
@@ -162,7 +159,6 @@ export function AddPaymentSheet() {
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
-  grabBar: { width: 36, height: 5, borderRadius: 3, alignSelf: "center" },
   scrollContent: { padding: 24, gap: 16 },
   title: { fontFamily: "Poppins_700Bold", fontSize: 18, textAlign: "center" },
   amountSection: { alignItems: "center", paddingVertical: 8 },

--- a/apps/mobile/features/goals/components/goal-sheet/GoalSheet.styles.ts
+++ b/apps/mobile/features/goals/components/goal-sheet/GoalSheet.styles.ts
@@ -1,8 +1,7 @@
 import { StyleSheet } from "@/shared/components/rn";
 
 export const styles = StyleSheet.create({
-  container: { flex: 1 },
-  grabBar: { width: 36, height: 5, borderRadius: 3, alignSelf: "center" },
+  container: {},
   scrollContent: { padding: 24, gap: 16 },
   title: { fontFamily: "Poppins_700Bold", fontSize: 18, textAlign: "center" },
   toggleRow: { flexDirection: "row", gap: 8 },

--- a/apps/mobile/features/goals/components/goal-sheet/GoalSheetFrame.tsx
+++ b/apps/mobile/features/goals/components/goal-sheet/GoalSheetFrame.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { FidyNumpad } from "@/shared/components";
-import { ScrollView, Text, View } from "@/shared/components/rn";
+import { ScrollView, Text } from "@/shared/components/rn";
 import { useThemeColor } from "@/shared/hooks";
 import { styles } from "./GoalSheet.styles";
 
@@ -19,7 +19,6 @@ export function GoalSheetFrame({
   title,
 }: GoalSheetFrameProps) {
   const card = useThemeColor("card");
-  const borderSubtle = useThemeColor("borderSubtle");
   const primary = useThemeColor("primary");
   const { bottom } = useSafeAreaInsets();
 
@@ -30,7 +29,6 @@ export function GoalSheetFrame({
       contentInsetAdjustmentBehavior="automatic"
       keyboardShouldPersistTaps="handled"
     >
-      <View style={[styles.grabBar, { backgroundColor: borderSubtle }]} />
       <Text style={[styles.title, { color: primary }]}>{title}</Text>
       {children}
       {numpadEnabled ? <FidyNumpad onKeyPress={onKeyPress} /> : null}

--- a/apps/mobile/features/transactions/components/transaction-form/TransactionForm.styles.ts
+++ b/apps/mobile/features/transactions/components/transaction-form/TransactionForm.styles.ts
@@ -23,9 +23,7 @@ export const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 12,
   },
-  container: {
-    flex: 1,
-  },
+  container: {},
   dateChip: {
     alignItems: "center",
     borderRadius: 10,
@@ -72,7 +70,6 @@ export const styles = StyleSheet.create({
     gap: 4,
   },
   headerZone: {
-    flex: 1,
     gap: 12,
     justifyContent: "center",
     paddingHorizontal: 24,

--- a/apps/mobile/features/transactions/components/transaction-form/TransactionFormContent.tsx
+++ b/apps/mobile/features/transactions/components/transaction-form/TransactionFormContent.tsx
@@ -53,8 +53,7 @@ export function TransactionFormContent({
 
   return (
     <Pressable
-      style={styles.container}
-      className="bg-page dark:bg-page-dark"
+      style={[styles.container, { backgroundColor: cardColor }]}
       onPress={Keyboard.dismiss}
     >
       <View style={styles.headerZone}>

--- a/apps/mobile/features/transfers/components/TransferFormScreen.tsx
+++ b/apps/mobile/features/transfers/components/TransferFormScreen.tsx
@@ -1,6 +1,7 @@
 import DateTimePicker from "@react-native-community/datetimepicker";
 import { useRouter } from "expo-router";
 import { ScreenLayout } from "@/shared/components";
+import { Text, View } from "@/shared/components/rn";
 import { useCurrentDate, useTranslation } from "@/shared/hooks";
 import type { TransferFormScreenProps } from "./transfer-form/TransferForm.types";
 import { TransferFormContent } from "./transfer-form/TransferFormContent";
@@ -12,16 +13,29 @@ export function TransferFormScreen(props: TransferFormScreenProps = {}) {
   const { t } = useTranslation();
   const form = useTransferForm(props);
   const maximumDate = useCurrentDate();
+  const title = form.isReclassification ? t("transfers.reclassifyTitle") : t("transfers.title");
+  const content = (
+    <>
+      {props.presentation === "dialog" ? (
+        <View style={{ paddingHorizontal: 16, paddingTop: 16 }}>
+          <Text className="font-poppins-bold text-title text-primary dark:text-primary-dark">
+            {title}
+          </Text>
+        </View>
+      ) : null}
+      <TransferFormContent form={form} />
+    </>
+  );
 
   return (
     <>
-      <ScreenLayout
-        title={form.isReclassification ? t("transfers.reclassifyTitle") : t("transfers.title")}
-        variant="sub"
-        onBack={back}
-      >
-        <TransferFormContent form={form} />
-      </ScreenLayout>
+      {props.presentation === "dialog" ? (
+        content
+      ) : (
+        <ScreenLayout title={title} variant="sub" onBack={back}>
+          {content}
+        </ScreenLayout>
+      )}
 
       <TransferSidePicker
         visible={form.pickerTarget != null}

--- a/apps/mobile/features/transfers/components/transfer-form/TransferForm.styles.ts
+++ b/apps/mobile/features/transfers/components/transfer-form/TransferForm.styles.ts
@@ -1,6 +1,9 @@
 import { StyleSheet } from "@/shared/components/rn";
 
 export const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
   amountCard: {
     borderRadius: 18,
     paddingHorizontal: 16,

--- a/apps/mobile/features/transfers/components/transfer-form/TransferForm.types.ts
+++ b/apps/mobile/features/transfers/components/transfer-form/TransferForm.types.ts
@@ -18,6 +18,7 @@ export type TransferFormScreenProps = {
     accounts: readonly FinancialAccountRow[]
   ) => TransferFormInitialDraft | null;
   readonly onSuccessfulSave?: (destination: "needs-review" | "tabs") => Promise<void> | void;
+  readonly presentation?: "dialog" | "screen";
 };
 
 export const TRANSFER_FORM_TEST_IDS = {

--- a/apps/mobile/features/transfers/components/transfer-form/TransferFormContent.tsx
+++ b/apps/mobile/features/transfers/components/transfer-form/TransferFormContent.tsx
@@ -28,10 +28,11 @@ export function TransferFormContent(props: { readonly form: ReturnType<typeof us
 
   return (
     <KeyboardAvoidingView
-      style={{ flex: 1 }}
+      style={styles.container}
       behavior={Platform.OS === "ios" ? "padding" : undefined}
     >
       <ScrollView
+        style={styles.container}
         contentInsetAdjustmentBehavior="automatic"
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -68,7 +68,7 @@
     "expo-updates": "~55.0.22",
     "expo-web-browser": "~55.0.16",
     "i18n-js": "^4.5.3",
-    "lucide-react-native": "1.14.0",
+    "lucide-react-native": "1.16.0",
     "nativewind": "^4",
     "posthog-react-native": "4.44.0",
     "react": "19.2.0",

--- a/apps/mobile/shared/components/DialogRouteFrame.tsx
+++ b/apps/mobile/shared/components/DialogRouteFrame.tsx
@@ -1,27 +1,62 @@
 import { useRouter } from "expo-router";
 import type { ReactNode } from "react";
+import { ChevronLeft, X } from "@/shared/components/icons";
 import { Pressable, StyleSheet, View } from "@/shared/components/rn";
-import { useThemeColor } from "@/shared/hooks";
+import { useThemeColor, useTranslation } from "@/shared/hooks";
 
 type DialogRouteFrameProps = {
   readonly children: ReactNode;
+  readonly closeDepth?: number;
+  readonly showBack?: boolean;
 };
 
-export function DialogRouteFrame({ children }: DialogRouteFrameProps) {
+export function DialogRouteFrame({
+  children,
+  closeDepth = 1,
+  showBack = false,
+}: DialogRouteFrameProps) {
   const router = useRouter();
+  const { t } = useTranslation();
   const card = useThemeColor("card");
   const modalBackdrop = useThemeColor("modalBackdrop");
+  const secondary = useThemeColor("secondary");
+  const closeToOrigin = () => router.dismiss(closeDepth);
 
   return (
     <Pressable
       accessibilityRole="button"
       style={[styles.backdrop, { backgroundColor: `${modalBackdrop}66` }]}
-      onPress={() => router.back()}
+      onPress={closeToOrigin}
     >
       <View
         style={[styles.dialog, { backgroundColor: card }]}
         onStartShouldSetResponder={() => true}
+        onTouchEnd={(event) => event.stopPropagation()}
       >
+        <View style={styles.header}>
+          {showBack ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={t("common.back")}
+              hitSlop={12}
+              style={styles.headerButton}
+              onPress={() => router.dismiss()}
+            >
+              <ChevronLeft size={24} color={secondary} />
+            </Pressable>
+          ) : (
+            <View style={styles.headerButton} />
+          )}
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t("common.close")}
+            hitSlop={12}
+            style={styles.headerButton}
+            onPress={closeToOrigin}
+          >
+            <X size={22} color={secondary} />
+          </Pressable>
+        </View>
         {children}
       </View>
     </Pressable>
@@ -41,5 +76,18 @@ const styles = StyleSheet.create({
     maxHeight: "88%",
     borderRadius: 24,
     overflow: "hidden",
+  },
+  header: {
+    alignItems: "center",
+    flexDirection: "row",
+    height: 48,
+    justifyContent: "space-between",
+    paddingHorizontal: 12,
+  },
+  headerButton: {
+    alignItems: "center",
+    height: 36,
+    justifyContent: "center",
+    width: 36,
   },
 });

--- a/apps/mobile/shared/i18n/locales/en.ts
+++ b/apps/mobile/shared/i18n/locales/en.ts
@@ -6,6 +6,7 @@ const en = {
     delete: "Delete",
     confirm: "Confirm",
     dismiss: "Dismiss",
+    back: "Back",
     close: "Close",
     edit: "Edit",
     category: "Category",

--- a/apps/mobile/shared/i18n/locales/es.ts
+++ b/apps/mobile/shared/i18n/locales/es.ts
@@ -6,6 +6,7 @@ const es = {
     delete: "Eliminar",
     confirm: "Confirmar",
     dismiss: "Descartar",
+    back: "Atrás",
     close: "Cerrar",
     edit: "Editar",
     category: "Categoría",

--- a/bun.lock
+++ b/bun.lock
@@ -68,7 +68,7 @@
         "expo-updates": "~55.0.22",
         "expo-web-browser": "~55.0.16",
         "i18n-js": "^4.5.3",
-        "lucide-react-native": "1.14.0",
+        "lucide-react-native": "1.16.0",
         "nativewind": "^4",
         "posthog-react-native": "4.44.0",
         "react": "19.2.0",
@@ -1957,7 +1957,7 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
-    "lucide-react-native": ["lucide-react-native@1.14.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-native": "*", "react-native-svg": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0" } }, "sha512-FkOjd4JHIB8SplakHQjeo4RR/5peXtl+PbL+TghQqWzcQ+AKbJ/PFl5xEnerLtSQ4EIq6B9uXblY7QSyKg05WQ=="],
+    "lucide-react-native": ["lucide-react-native@1.16.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-native": "*", "react-native-svg": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0" } }, "sha512-clxA22OvrNUHB2tQQEvURN8KJ5/vbUV/6GSctU1aCoFlJmDwNrdo8xxNTG535tu7iOATZCth6R2AW1kbva+g6A=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 


### PR DESCRIPTION
- replace sheets with dialogs

- add shared dialog frame

- update finance segment order

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized mobile dialogs by replacing sheets with centered dialogs using `DialogRouteFrame`. Reclassification opens as a nested dialog with a back button and multi-depth dismiss; Finance defaults to Analytics with tabs ordered analytics → goals → calendar.

- **New Features**
  - Added `DialogRouteFrame` with header (back/close), inner-tap capture, backdrop dismiss, and multi-depth dismiss via `router.dismiss(depth)`.
  - `reclassify-transaction` is a `DIALOG_MODAL` wrapped in `DialogRouteFrame`; edit screen passes `nestedDialog=1`; `TransferFormScreen` supports `presentation="dialog"` with an inline title.
  - Finance: default tab is analytics; order is analytics → goals → calendar.

- **Refactors**
  - Replaced grab-bar sheets with dialogs across budgets, categories, goals, bills/day detail, and transfers; bounded keyboard/scroll containers in dialogs (auto-suggest budgets, add-bill, transfers).
  - Simplified styles (removed flex wrappers/grab bars); added i18n key for back (en/es); added tests for dismiss depth, inner-tap capture, and Finance ordering.
  - Bumped `lucide-react-native` to `1.16.0`.

<sup>Written for commit b1999c26b0d8b92da1e0896de7eb8e91af87dff2. Summary will update on new commits. <a href="https://cubic.dev/pr/B4rz99/fidy/pull/483?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

