### PR TITLE
feat(mobile): redesign home screen

### DIFF
--- a/apps/mobile/__tests__/budget/store.test.ts
+++ b/apps/mobile/__tests__/budget/store.test.ts
@@ -156,6 +156,16 @@ describe("useBudgetStore", () => {
     expect(useBudgetStore.getState().isLoading).toBe(false);
   });
 
+  it("keeps loaded budget totals addressable by month", async () => {
+    mockRefreshMonth.mockResolvedValueOnce(MARCH_STALE_SNAPSHOT);
+
+    const { loadBudgetsForUser, useBudgetStore } = await initializeBudgetStore("2026-03" as Month);
+
+    await loadBudgetsForUser(mockDb, USER_ID);
+
+    expect(useBudgetStore.getState().budgetTotalByMonth["2026-03" as Month]).toBe(100000);
+  });
+
   it("clears loading when context changes without starting a newer refresh", async () => {
     const deferredSnapshot = createDeferred<BudgetMonthSnapshot>();
     mockRefreshMonth.mockReturnValueOnce(deferredSnapshot.promise);

--- a/apps/mobile/__tests__/dashboard/home-screen.test.ts
+++ b/apps/mobile/__tests__/dashboard/home-screen.test.ts
@@ -16,8 +16,14 @@ const headerSource = readSource(
 const activityFeedSource = readSource(
   "../../features/dashboard/components/home-screen/useHomeActivityFeed.ts"
 );
+const homeModelSource = readSource(
+  "../../features/dashboard/components/home-screen/useHomeScreen.ts"
+);
 const activityItemSource = readSource(
   "../../features/dashboard/components/home-screen/ActivityFeedItem.tsx"
+);
+const auroraBackgroundSource = readSource(
+  "../../features/dashboard/components/home-screen/HomeAuroraBackground.tsx"
 );
 
 test("keeps HomeScreen routed through the extracted dashboard modules", () => {
@@ -31,6 +37,8 @@ test("keeps home header actions wired through ScreenLayout", () => {
   const layoutSource = readSource("../../app/(tabs)/(index)/_layout.tsx");
 
   expect(contentSource).toContain("HomeScreenActions");
+  expect(contentSource).toContain("ProfileAvatarButton");
+  expect(contentSource).toContain("includesNativeHeader={false}");
   expect(contentSource).toContain("rightActions={headerActions}");
   expect(layoutSource).not.toContain("HomeScreenActions");
   expect(layoutSource).not.toContain("headerRight");
@@ -43,6 +51,13 @@ test("keeps the home activity feed wired to pagination and transaction mutations
   expect(activityFeedSource).toContain('pathname: "/edit-transaction"');
 });
 
+test("keeps home budget guidance scoped to the current calendar month", () => {
+  expect(homeModelSource).toContain("formatBudgetMonth(new Date())");
+  expect(homeModelSource).toContain("selectedBudgetMonth === currentBudgetMonth");
+  expect(homeModelSource).toContain("budgetTotalByMonth[currentBudgetMonth]");
+  expect(homeModelSource).not.toContain("getBudgetsForMonth");
+});
+
 test("keeps activity item rendering memo-safe for edit and delete handlers", () => {
   expect(contentSource).not.toContain("onEdit={() =>");
   expect(contentSource).not.toContain("onDelete={() =>");
@@ -50,9 +65,26 @@ test("keeps activity item rendering memo-safe for edit and delete handlers", () 
   expect(activityItemSource).toContain("onDeleteTransaction={onDeleteTransaction}");
 });
 
+test("keeps the home feed aurora background visible behind section headers and row cards", () => {
+  const dateHeaderSource = readSource("../../features/dashboard/components/DateHeader.tsx");
+
+  expect(dateHeaderSource).not.toContain("bg-page");
+  expect(dateHeaderSource).not.toContain("dark:bg-page-dark");
+  expect(activityItemSource).toContain("activityCard");
+  expect(activityItemSource).toContain("rgba(255, 255, 255, 0.58)");
+  expect(activityItemSource).toContain("rgba(28, 28, 30, 0.78)");
+});
+
+test("keeps the aurora blur mobile-friendly", () => {
+  expect(auroraBackgroundSource).toContain('stdDeviation="14"');
+  expect(auroraBackgroundSource).toContain('<G filter="url(#softAuroraBlur)">');
+  expect(auroraBackgroundSource).not.toContain('filter="url(#softAuroraBlur)"\n          opacity');
+});
+
 test("keeps the header wired to banners and analytics navigation", () => {
   expect(headerSource).toContain("<EmailConnectBanner");
   expect(headerSource).toContain("<DetectedTransactionsBanner");
+  expect(headerSource).toContain("<HomeSpendingCard");
   expect(headerSource).toContain("const db = tryGetDb(userId);");
   expect(headerSource).toContain('push("/analytics" as never)');
 });

--- a/apps/mobile/__tests__/dashboard/home-spending-card.test.ts
+++ b/apps/mobile/__tests__/dashboard/home-spending-card.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "vitest";
+import { deriveHomeSpendingCardModel } from "../../features/dashboard/components/home-screen/HomeSpendingCard";
+
+describe("home spending card model", () => {
+  test("summarizes monthly spend with budget-based daily allowance guidance", () => {
+    const model = deriveHomeSpendingCardModel({
+      balance: 2_480_000,
+      monthlyBudget: 10_000_000,
+      categorySpending: [
+        { categoryId: "food", total: 86_400 },
+        { categoryId: "health", total: 58_200 },
+        { categoryId: "transfer", total: 250_000 },
+        { categoryId: "entertainment", total: 105_300 },
+      ],
+      locale: "es",
+      now: new Date(2026, 4, 19),
+      t: (key, params) => {
+        if (key === "dashboard.dailyPaceGuidance") {
+          return `Puedes gastar hasta ${params?.amount} al día para mantenerte dentro de tu presupuesto.`;
+        }
+        throw new Error(`Unexpected key: ${key}`);
+      },
+    });
+
+    expect(model.dateLabel).toBe("martes, 19 de mayo");
+    expect(model.amountLabel).toBe("$2.480.000");
+    expect(model.guidance).toBe(
+      "Puedes gastar hasta $578.461 al día para mantenerte dentro de tu presupuesto."
+    );
+    expect(model.dailyPaceLabel).toBe("$578.461");
+    expect(model.averageLabel).toBe("$130.526");
+    expect(model.bars.map((bar) => bar.categoryId)).toEqual(["entertainment", "food", "health"]);
+  });
+
+  test("formats English dates without Spanish date glue", () => {
+    const model = deriveHomeSpendingCardModel({
+      balance: 930_000,
+      monthlyBudget: 2_000_000,
+      categorySpending: [],
+      locale: "en",
+      now: new Date(2026, 4, 19),
+      t: (_key, params) => `Spend up to ${params?.amount} per day to stay within budget.`,
+    });
+
+    expect(model.dateLabel).toBe("Tuesday, May 19");
+    expect(model.guidance).toBe("Spend up to $82.307 per day to stay within budget.");
+  });
+
+  test("falls back to current spend average when the user has no monthly budget", () => {
+    const model = deriveHomeSpendingCardModel({
+      balance: 930_000,
+      monthlyBudget: 0,
+      categorySpending: [],
+      locale: "en",
+      now: new Date(2026, 4, 19),
+      t: (key, params) => {
+        if (key === "dashboard.dailyPaceGuidance") {
+          return `Spend up to ${params?.amount} per day to stay within budget.`;
+        }
+        if (key === "dashboard.noBudgetGuidance") {
+          return `Set a monthly budget to see your daily spending limit. Current average: ${params?.amount}.`;
+        }
+        throw new Error(`Unexpected key: ${key}`);
+      },
+    });
+
+    expect(model.guidance).toBe(
+      "Set a monthly budget to see your daily spending limit. Current average: $48.947."
+    );
+    expect(model.dailyPaceLabel).toBe("$48.947");
+  });
+});

--- a/apps/mobile/__tests__/navigation/tab-layout.test.ts
+++ b/apps/mobile/__tests__/navigation/tab-layout.test.ts
@@ -31,13 +31,18 @@ describe("Tab layout", () => {
     expect(layoutSource).not.toContain('name="(menu)"');
   });
 
-  test("uses the profile avatar only on the home tab stack", () => {
+  test("keeps the profile avatar owned by the home screen content", () => {
     expect(primaryStackLayoutSources).toHaveLength(5);
     const [homeSource, aiSource, budgetSource, addSource, financeSource] =
       primaryStackLayoutSources;
+    const homeContentSource = readFileSync(
+      resolve(__dirname, "../../features/dashboard/components/home-screen/HomeScreenContent.tsx"),
+      "utf-8"
+    );
 
-    expect(homeSource).toContain("ProfileAvatarButton");
-    expect(homeSource).toContain("headerLeft");
+    expect(homeSource).not.toContain("ProfileAvatarButton");
+    expect(homeContentSource).toContain("ProfileAvatarButton");
+    expect(homeContentSource).toContain("leftAction");
     expect(aiSource).not.toContain("ProfileAvatarButton");
     expect(budgetSource).not.toContain("ProfileAvatarButton");
     expect(addSource).not.toContain("ProfileAvatarButton");
@@ -47,7 +52,7 @@ describe("Tab layout", () => {
   test("removes native header shadows from visible tab headers", () => {
     const [homeSource, , , , financeSource] = primaryStackLayoutSources;
 
-    expect(homeSource).toContain("headerShadowVisible: false");
+    expect(homeSource).toContain("headerShown: false");
     expect(financeSource).toContain("headerShadowVisible: false");
   });
 

--- a/apps/mobile/__tests__/qa/build-local-qa-seed.test.ts
+++ b/apps/mobile/__tests__/qa/build-local-qa-seed.test.ts
@@ -67,4 +67,24 @@ describe("buildLocalQaSeed", () => {
       }),
     ]);
   });
+
+  it("builds a home-activity scenario with recent activity for dashboard QA", () => {
+    const seed = buildLocalQaSeed("home-activity", now);
+
+    expect(seed.session.profile).toBe("home-activity");
+    expect(seed.session.userId).toBe("qa-local-home-activity");
+    expect(seed.financialAccounts.map((account) => account.name)).toEqual(["Cash", "Bancolombia"]);
+    expect(seed.budgets.reduce((total, budget) => total + budget.amount, 0)).toBe(10_000_000);
+    expect(seed.transactions).toHaveLength(7);
+    expect(seed.transactions.map((transaction) => transaction.categoryId)).toEqual([
+      "food",
+      "health",
+      "entertainment",
+      "home",
+      "clothing",
+      "transport",
+      "education",
+    ]);
+    expect(seed.transfers).toHaveLength(1);
+  });
 });

--- a/apps/mobile/__tests__/qa/entry-points.test.ts
+++ b/apps/mobile/__tests__/qa/entry-points.test.ts
@@ -9,6 +9,7 @@ import {
 describe("QA entry points", () => {
   it("accepts the supported local QA profiles", () => {
     expect(isLocalQaProfile("default")).toBe(true);
+    expect(isLocalQaProfile("home-activity")).toBe(true);
     expect(isLocalQaProfile("empty")).toBe(true);
     expect(isLocalQaProfile("two-accounts")).toBe(true);
     expect(isLocalQaProfile("transfer-ready")).toBe(true);
@@ -25,6 +26,7 @@ describe("QA entry points", () => {
 
   it("maps each seeded profile to its default target", () => {
     expect(getDefaultQaTarget("default")).toBe(QA_TARGETS.home);
+    expect(getDefaultQaTarget("home-activity")).toBe(QA_TARGETS.home);
     expect(getDefaultQaTarget("empty")).toBe(QA_TARGETS.onboarding);
     expect(getDefaultQaTarget("two-accounts")).toBe(QA_TARGETS.financialAccounts);
     expect(getDefaultQaTarget("transfer-ready")).toBe(QA_TARGETS.addTransfer);

--- a/apps/mobile/__tests__/qa/start-local-qa-session.test.ts
+++ b/apps/mobile/__tests__/qa/start-local-qa-session.test.ts
@@ -10,6 +10,15 @@ const mockDb = { _: "db", transaction: (fn: (tx: unknown) => unknown) => fn(mock
 const mockGetDb = vi.fn<(userId: string) => typeof mockDb>(() => mockDb);
 const mockMigrate = vi.fn<(db: unknown, config: unknown) => Promise<void>>(() => Promise.resolve());
 const mockUpsertFinancialAccount = vi.fn<(db: unknown, row: unknown) => void>();
+const mockInsertBudget = vi.fn<(db: unknown, row: unknown) => void>();
+const mockInitializeBudgetSession = vi.fn<(userId: string) => void>();
+const mockLoadBudgetsForUser = vi.fn<(db: unknown, userId: string) => Promise<void>>(() =>
+  Promise.resolve()
+);
+const mockInitializeTransactionSession = vi.fn<(userId: string) => void>();
+const mockLoadInitialTransactions = vi.fn<(db: unknown, userId: string) => Promise<void>>(() =>
+  Promise.resolve()
+);
 const mockInsertTransaction = vi.fn<(db: unknown, row: unknown) => void>();
 const mockUpsertTransfer = vi.fn<(db: unknown, row: unknown) => void>();
 const mockPersistLocalQaSession = vi.fn<(session: unknown) => Promise<void>>(() =>
@@ -27,6 +36,7 @@ const session = {
 
 const seed = {
   session,
+  budgets: [{ id: "budget-1", userId: session.userId } as never],
   financialAccounts: [{ id: "account-1", userId: session.userId } as never],
   transactions: [{ id: "txn-1", userId: session.userId } as never],
   transfers: [{ id: "transfer-1", userId: session.userId } as never],
@@ -68,6 +78,17 @@ vi.mock("@/drizzle/migrations", () => ({
 
 vi.mock("@/features/financial-accounts/lib/repository", () => ({
   upsertFinancialAccount: (db: unknown, row: unknown) => mockUpsertFinancialAccount(db, row),
+}));
+
+vi.mock("@/features/budget/public", () => ({
+  initializeBudgetSession: (userId: string) => mockInitializeBudgetSession(userId),
+  insertBudget: (db: unknown, row: unknown) => mockInsertBudget(db, row),
+  loadBudgetsForUser: (db: unknown, userId: string) => mockLoadBudgetsForUser(db, userId),
+}));
+
+vi.mock("@/features/transactions/store.public", () => ({
+  initializeTransactionSession: (userId: string) => mockInitializeTransactionSession(userId),
+  loadInitialTransactions: (db: unknown, userId: string) => mockLoadInitialTransactions(db, userId),
 }));
 
 vi.mock("@/infrastructure/local-ledger/transaction-storage", () => ({
@@ -115,8 +136,13 @@ describe("startLocalQaSession", () => {
     expect(mockGetDb).toHaveBeenCalledWith("qa-local-transfer-ready");
     expect(mockMigrate).toHaveBeenCalledOnce();
     expect(mockUpsertFinancialAccount).toHaveBeenCalledTimes(1);
+    expect(mockInsertBudget).toHaveBeenCalledTimes(1);
     expect(mockInsertTransaction).toHaveBeenCalledTimes(1);
     expect(mockUpsertTransfer).toHaveBeenCalledTimes(1);
+    expect(mockInitializeTransactionSession).toHaveBeenCalledWith("qa-local-transfer-ready");
+    expect(mockInitializeBudgetSession).toHaveBeenCalledWith("qa-local-transfer-ready");
+    expect(mockLoadInitialTransactions).toHaveBeenCalledWith(mockDb, "qa-local-transfer-ready");
+    expect(mockLoadBudgetsForUser).toHaveBeenCalledWith(mockDb, "qa-local-transfer-ready");
     expect(mockPersistLocalQaSession).toHaveBeenCalledWith(session);
     expect(result).toEqual(session);
   });

--- a/apps/mobile/__tests__/setup.ts
+++ b/apps/mobile/__tests__/setup.ts
@@ -335,12 +335,15 @@ vi.mock("react-native-svg", () => ({
   Circle: "Circle",
   Rect: "Rect",
   Path: "Path",
+  Filter: "Filter",
+  FeGaussianBlur: "FeGaussianBlur",
   G: "G",
   Text: "SvgText",
   Line: "Line",
   Polyline: "Polyline",
   Defs: "Defs",
   LinearGradient: "LinearGradient",
+  RadialGradient: "RadialGradient",
   Stop: "Stop",
 }));
 

--- a/apps/mobile/__tests__/shared/screen-layout.test.ts
+++ b/apps/mobile/__tests__/shared/screen-layout.test.ts
@@ -42,6 +42,11 @@ describe("ScreenLayout", () => {
     expect(source).toContain("iosHeaderOptions");
   });
 
+  test("does not reserve right action space for sub screens without right actions", () => {
+    expect(source).toContain("shouldRenderRightSlot");
+    expect(source).toContain('isTab ? "flex-1 flex-row justify-end" : "flex-row justify-end"');
+  });
+
   test("accepts onBack function prop", () => {
     expect(source).toMatch(/onBack\??\s*:\s*\(\)\s*=>\s*void/);
   });
@@ -54,8 +59,9 @@ describe("ScreenLayout", () => {
   });
 
   test("renders a custom iOS header for hidden-header sub screens", () => {
+    expect(source).toContain("!includesNativeHeader &&");
     expect(source).toContain(
-      "!includesNativeHeader && (!isTab || rightActions != null || onBack != null)"
+      "!isTab || leftAction != null || rightActions != null || onBack != null"
     );
   });
 

--- a/apps/mobile/app/(tabs)/(index)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/(index)/_layout.tsx
@@ -1,21 +1,5 @@
 import { Stack } from "expo-router";
-import { ProfileAvatarButton } from "@/features/settings/header.public";
-import { useColorScheme } from "@/shared/components/rn";
-import { Colors } from "@/shared/constants/theme";
 
 export default function HomeStackLayout() {
-  const theme = Colors[useColorScheme() === "dark" ? "dark" : "light"];
-
-  return (
-    <Stack
-      screenOptions={{
-        headerShown: true,
-        headerLeft: () => <ProfileAvatarButton />,
-        headerTitle: "",
-        headerShadowVisible: false,
-        headerStyle: { backgroundColor: theme.page },
-        headerTintColor: theme.primary,
-      }}
-    />
-  );
+  return <Stack screenOptions={{ headerShown: false }} />;
 }

--- a/apps/mobile/app/edit-transaction.tsx
+++ b/apps/mobile/app/edit-transaction.tsx
@@ -1,6 +1,6 @@
 import * as Haptics from "expo-haptics";
 import { useLocalSearchParams, useNavigation, useRouter } from "expo-router";
-import { useReducer, useRef, useState } from "react";
+import { useReducer, useState } from "react";
 import { useOptionalUserId } from "@/features/auth";
 import {
   type FinancialAccountRow,
@@ -71,7 +71,7 @@ export default function EditTransactionScreen() {
   const db = userId ? tryGetDb(userId) : null;
 
   const [draft, setDraft] = useReducer(updateDraft, initialDraft);
-  const loadedRef = useRef(false);
+  const [isLoaded, setIsLoaded] = useState(false);
   const [accounts, setAccounts] = useState<readonly FinancialAccountRow[]>([]);
   const transactionId =
     typeof routeTransactionId === "string" && routeTransactionId.trim().length > 0
@@ -105,7 +105,7 @@ export default function EditTransactionScreen() {
           type: tx.type,
         },
       });
-      loadedRef.current = true;
+      setIsLoaded(true);
     })();
   });
 
@@ -167,7 +167,7 @@ export default function EditTransactionScreen() {
     });
   };
 
-  if (!loadedRef.current) return null;
+  if (!isLoaded) return null;
 
   return (
     <DialogRouteFrame>

--- a/apps/mobile/features/budget/public.ts
+++ b/apps/mobile/features/budget/public.ts
@@ -29,6 +29,7 @@ export {
 export type { Budget, CreateBudgetInput } from "./schema";
 export { createBudgetSchema } from "./schema";
 export { subscribeBudgetToTransactions } from "./services/subscribe-budget-to-transactions";
+export { formatBudgetMonth } from "./store/month";
 export {
   acceptBudgetSuggestions,
   copyBudgetsForward,

--- a/apps/mobile/features/budget/store/state.ts
+++ b/apps/mobile/features/budget/store/state.ts
@@ -14,6 +14,7 @@ export type BudgetState = {
     readonly totalSpent: number;
     readonly percentUsed: number;
   };
+  readonly budgetTotalByMonth: Readonly<Partial<Record<Month, number>>>;
   readonly autoSuggestions: readonly BudgetSuggestion[];
   readonly acknowledgedAlerts: ReadonlySet<string>;
   readonly pendingAlerts: readonly BudgetAlert[];
@@ -51,6 +52,7 @@ export function createBudgetState(currentMonth: Month, activeUserId: UserId | nu
     budgets: [],
     budgetProgress: [],
     summary: { totalBudget: 0, totalSpent: 0, percentUsed: 0 },
+    budgetTotalByMonth: {},
     autoSuggestions: [],
     acknowledgedAlerts: new Set(),
     pendingAlerts: [],
@@ -70,6 +72,10 @@ function setBudgetSnapshot(set: BudgetSetState): BudgetActions["setSnapshot"] {
       budgets: snapshot.budgets as Budget[],
       budgetProgress: snapshot.budgetProgress as BudgetProgress[],
       summary: snapshot.summary,
+      budgetTotalByMonth: {
+        ...state.budgetTotalByMonth,
+        [state.currentMonth]: snapshot.summary.totalBudget,
+      },
       autoSuggestions: snapshot.autoSuggestions as BudgetSuggestion[],
       pendingAlerts: snapshot.pendingAlerts,
       pendingPermissionRequest: state.pendingPermissionRequest || snapshot.pendingPermissionRequest,

--- a/apps/mobile/features/dashboard/components/DateHeader.tsx
+++ b/apps/mobile/features/dashboard/components/DateHeader.tsx
@@ -7,7 +7,7 @@ type DateHeaderProps = {
 
 export const DateHeader = memo(function DateHeader({ label }: DateHeaderProps) {
   return (
-    <View className="bg-page px-4 py-2 dark:bg-page-dark">
+    <View className="px-4 pb-2 pt-4">
       <Text className="font-poppins-semibold text-caption uppercase tracking-widest text-secondary dark:text-secondary-dark">
         {label}
       </Text>

--- a/apps/mobile/features/dashboard/components/home-screen/ActivityFeedItem.tsx
+++ b/apps/mobile/features/dashboard/components/home-screen/ActivityFeedItem.tsx
@@ -5,7 +5,7 @@ import type { StoredTransaction } from "@/features/transactions/query.public";
 import { getTransferActivityCopy } from "@/features/transfers/display.public";
 import { CATEGORY_MAP } from "@/shared/categories";
 import { TransactionRow } from "@/shared/components";
-import { View } from "@/shared/components/rn";
+import { StyleSheet, useColorScheme, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { getCategoryLabel, getDateFnsLocale } from "@/shared/i18n";
 import { formatMoney, formatSignedMoney } from "@/shared/lib";
@@ -26,6 +26,8 @@ const TransactionActivityItem = memo(function TransactionActivityItem({
   onEditTransaction,
 }: TransactionActivityItemProps) {
   const { t, locale } = useTranslation();
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === "dark";
   const category = CATEGORY_MAP[tx.categoryId];
   const handleEdit = useCallback(() => {
     onEditTransaction(tx.id);
@@ -46,16 +48,18 @@ const TransactionActivityItem = memo(function TransactionActivityItem({
           })}
         />
       ) : null}
-      <View className="px-4">
-        <TransactionRow
-          icon={category?.icon ?? "✨"}
-          name={getTransactionDisplayName(tx, t("common.unknown"))}
-          amount={formatSignedMoney(tx.amount, tx.type)}
-          category={category ? getCategoryLabel(category, locale) : t("common.other")}
-          isPositive={tx.type === "income"}
-          onEdit={handleEdit}
-          onDelete={handleDelete}
-        />
+      <View className="px-4 py-1">
+        <View style={[styles.activityCard, isDark ? styles.activityCardDark : null]}>
+          <TransactionRow
+            icon={category?.icon ?? "✨"}
+            name={getTransactionDisplayName(tx, t("common.unknown"))}
+            amount={formatSignedMoney(tx.amount, tx.type)}
+            category={category ? getCategoryLabel(category, locale) : t("common.other")}
+            isPositive={tx.type === "income"}
+            onEdit={handleEdit}
+            onDelete={handleDelete}
+          />
+        </View>
       </View>
     </View>
   );
@@ -73,6 +77,8 @@ const TransferActivityItem = memo(function TransferActivityItem({
   showDateHeader,
 }: TransferActivityItemProps) {
   const { t, locale } = useTranslation();
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === "dark";
   const accentGreen = useThemeColor("accentGreen");
   const accentGreenLight = useThemeColor("accentGreenLight");
   const { title, route } = getTransferActivityCopy(item.transfer, accountNames, t);
@@ -89,16 +95,18 @@ const TransferActivityItem = memo(function TransferActivityItem({
           })}
         />
       ) : null}
-      <View className="px-4">
-        <TransactionRow
-          icon="↔️"
-          iconBgColor={accentGreenLight}
-          iconColor={accentGreen}
-          name={title}
-          amount={formatMoney(item.transfer.amount)}
-          category={route}
-          amountTone="neutral"
-        />
+      <View className="px-4 py-1">
+        <View style={[styles.activityCard, isDark ? styles.activityCardDark : null]}>
+          <TransactionRow
+            icon="↔️"
+            iconBgColor={accentGreenLight}
+            iconColor={accentGreen}
+            name={title}
+            amount={formatMoney(item.transfer.amount)}
+            category={route}
+            amountTone="neutral"
+          />
+        </View>
       </View>
     </View>
   );
@@ -130,3 +138,17 @@ export function ActivityFeedItem({
     <TransferActivityItem item={item} showDateHeader={showDateHeader} accountNames={accountNames} />
   );
 }
+
+const styles = StyleSheet.create({
+  activityCard: {
+    backgroundColor: "rgba(255, 255, 255, 0.58)",
+    borderColor: "rgba(26, 26, 26, 0.08)",
+    borderRadius: 8,
+    borderWidth: StyleSheet.hairlineWidth,
+    paddingHorizontal: 12,
+  },
+  activityCardDark: {
+    backgroundColor: "rgba(28, 28, 30, 0.78)",
+    borderColor: "rgba(240, 240, 240, 0.10)",
+  },
+});

--- a/apps/mobile/features/dashboard/components/home-screen/HomeAuroraBackground.tsx
+++ b/apps/mobile/features/dashboard/components/home-screen/HomeAuroraBackground.tsx
@@ -1,0 +1,125 @@
+import { memo } from "react";
+import Svg, {
+  Defs,
+  FeGaussianBlur,
+  Filter,
+  G,
+  LinearGradient,
+  Path,
+  RadialGradient,
+  Rect,
+  Stop,
+} from "react-native-svg";
+import { StyleSheet, useWindowDimensions, View } from "@/shared/components/rn";
+
+type HomeAuroraBackgroundProps = {
+  readonly isDark: boolean;
+};
+
+export const HomeAuroraBackground = memo(function HomeAuroraBackground({
+  isDark,
+}: HomeAuroraBackgroundProps) {
+  const { width, height } = useWindowDimensions();
+  const background = isDark ? "#0D0D0D" : "#FDFCF9";
+  const fadeBottom = isDark ? "#0D0D0D" : "#FDFCF9";
+  const green = isDark ? "#8BC34A" : "#7CB243";
+  const peachGlow = isDark ? "#F5E1C8" : "#E8A090";
+  const peachCore = "#E8A090";
+  const overlayOpacity = isDark ? 0.84 : 1;
+
+  return (
+    <View pointerEvents="none" style={StyleSheet.absoluteFill}>
+      <Svg
+        width={width}
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        preserveAspectRatio="none"
+      >
+        <Defs>
+          <RadialGradient id="topLeftGreen" cx="0%" cy="0%" r={isDark ? "58%" : "62%"}>
+            <Stop offset="0%" stopColor={green} stopOpacity={isDark ? 0.38 : 0.48} />
+            <Stop offset="100%" stopColor={green} stopOpacity="0" />
+          </RadialGradient>
+          <RadialGradient
+            id="topRightPeach"
+            cx="100%"
+            cy={isDark ? "18%" : "16%"}
+            r={isDark ? "62%" : "64%"}
+          >
+            <Stop offset="0%" stopColor={peachGlow} stopOpacity={isDark ? 0.3 : 0.58} />
+            <Stop offset="100%" stopColor={peachGlow} stopOpacity="0" />
+          </RadialGradient>
+          <RadialGradient id="topRightPeachCore" cx="90%" cy="20%" r="34%">
+            <Stop offset="0%" stopColor={peachCore} stopOpacity={isDark ? 0.16 : 0.3} />
+            <Stop offset="100%" stopColor={peachCore} stopOpacity="0" />
+          </RadialGradient>
+          <RadialGradient
+            id="lowerLeftPeach"
+            cx={isDark ? "10%" : "4%"}
+            cy={isDark ? "70%" : "64%"}
+            r={isDark ? "68%" : "68%"}
+          >
+            <Stop offset="0%" stopColor={peachGlow} stopOpacity={isDark ? 0.16 : 0.42} />
+            <Stop offset="100%" stopColor={peachGlow} stopOpacity="0" />
+          </RadialGradient>
+          <RadialGradient
+            id="lowerRightGreen"
+            cx="96%"
+            cy={isDark ? "86%" : "88%"}
+            r={isDark ? "68%" : "70%"}
+          >
+            <Stop offset="0%" stopColor={green} stopOpacity={isDark ? 0.16 : 0.36} />
+            <Stop offset="100%" stopColor={green} stopOpacity="0" />
+          </RadialGradient>
+          <LinearGradient id="bottomFade" x1="0" y1="0" x2="0" y2="1">
+            <Stop offset="0%" stopColor={fadeBottom} stopOpacity="0" />
+            <Stop offset="70%" stopColor={fadeBottom} stopOpacity={isDark ? 0.52 : 0.12} />
+            <Stop offset="100%" stopColor={fadeBottom} stopOpacity="1" />
+          </LinearGradient>
+          <LinearGradient id="peachBand" x1="0" y1="0" x2="1" y2="0">
+            <Stop offset="0%" stopColor={peachGlow} stopOpacity="0" />
+            <Stop offset="46%" stopColor={peachGlow} stopOpacity={isDark ? 0.28 : 0.46} />
+            <Stop offset="82%" stopColor={peachGlow} stopOpacity="0" />
+          </LinearGradient>
+          <LinearGradient id="greenBand" x1="0" y1="0" x2="1" y2="0">
+            <Stop offset="0%" stopColor={green} stopOpacity="0" />
+            <Stop offset="22%" stopColor={green} stopOpacity={isDark ? 0.3 : 0.42} />
+            <Stop offset="54%" stopColor={green} stopOpacity="0" />
+          </LinearGradient>
+          <LinearGradient id="peachCoreBand" x1="0" y1="0" x2="1" y2="0">
+            <Stop offset="0%" stopColor={peachCore} stopOpacity="0" />
+            <Stop offset="52%" stopColor={peachCore} stopOpacity={isDark ? 0.12 : 0.22} />
+            <Stop offset="72%" stopColor={peachCore} stopOpacity="0" />
+          </LinearGradient>
+          <Filter id="softAuroraBlur" x="-20%" y="-20%" width="140%" height="140%">
+            <FeGaussianBlur stdDeviation="14" />
+          </Filter>
+        </Defs>
+        <Rect width={width} height={height} fill={background} />
+        <Rect width={width} height={height} fill="url(#topLeftGreen)" />
+        <Rect width={width} height={height} fill="url(#topRightPeach)" />
+        <Rect width={width} height={height} fill="url(#topRightPeachCore)" />
+        <Rect width={width} height={height} fill="url(#lowerLeftPeach)" />
+        <Rect width={width} height={height} fill="url(#lowerRightGreen)" />
+        <G filter="url(#softAuroraBlur)">
+          <Path
+            d={`M ${-width * 0.28} ${height * 0.02} C ${width * 0.2} ${height * 0.1}, ${width * 0.46} ${height * 0.24}, ${width * 1.16} ${height * 0.04} L ${width * 1.18} ${height * 0.34} C ${width * 0.58} ${height * 0.48}, ${width * 0.1} ${height * 0.24}, ${-width * 0.28} ${height * 0.2} Z`}
+            fill="url(#greenBand)"
+            opacity={overlayOpacity}
+          />
+          <Path
+            d={`M ${-width * 0.16} ${height * 0.18} C ${width * 0.28} ${height * 0.08}, ${width * 0.58} ${height * 0.18}, ${width * 1.2} ${height * 0.42} L ${width * 1.16} ${height * 0.82} C ${width * 0.72} ${height * 0.54}, ${width * 0.2} ${height * 0.42}, ${-width * 0.18} ${height * 0.62} Z`}
+            fill="url(#peachBand)"
+            opacity={overlayOpacity}
+          />
+          <Path
+            d={`M ${-width * 0.1} ${height * 0.26} C ${width * 0.3} ${height * 0.16}, ${width * 0.62} ${height * 0.26}, ${width * 1.1} ${height * 0.18} L ${width * 1.2} ${height * 0.42} C ${width * 0.66} ${height * 0.48}, ${width * 0.34} ${height * 0.4}, ${-width * 0.18} ${height * 0.56} Z`}
+            fill="url(#peachCoreBand)"
+            opacity={isDark ? 0.7 : 0.82}
+          />
+        </G>
+        <Rect width={width} height={height} fill="url(#bottomFade)" />
+      </Svg>
+    </View>
+  );
+});

--- a/apps/mobile/features/dashboard/components/home-screen/HomeScreenContent.tsx
+++ b/apps/mobile/features/dashboard/components/home-screen/HomeScreenContent.tsx
@@ -1,10 +1,13 @@
 import { FlashList, type ListRenderItemInfo } from "@shopify/flash-list";
 import { useCallback, useMemo } from "react";
 import type { StoredActivityItem } from "@/features/activity/query.public";
+import { ProfileAvatarButton } from "@/features/settings/header.public";
 import { ScreenLayout, TAB_BAR_CLEARANCE } from "@/shared/components";
-import { Platform, StyleSheet } from "@/shared/components/rn";
+import { Platform, StyleSheet, View } from "@/shared/components/rn";
+import { useColorScheme } from "@/shared/hooks";
 import { EmptyTransactions } from "../EmptyTransactions";
 import { ActivityFeedItem } from "./ActivityFeedItem";
+import { HomeAuroraBackground } from "./HomeAuroraBackground";
 import { HomeScreenActions } from "./HomeScreenActions";
 import { HomeScreenHeader } from "./HomeScreenHeader";
 import type { HomeScreenModel } from "./useHomeScreen";
@@ -16,6 +19,9 @@ type HomeScreenContentProps = {
 const keyExtractor = (item: StoredActivityItem) => item.id;
 
 export function HomeScreenContent({ model }: HomeScreenContentProps) {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === "dark";
+  const backgroundColor = isDark ? "#0D0D0D" : "#FDFCF9";
   const renderItem = useCallback(
     ({ item }: ListRenderItemInfo<StoredActivityItem>) => (
       <ActivityFeedItem
@@ -30,8 +36,14 @@ export function HomeScreenContent({ model }: HomeScreenContentProps) {
   );
 
   const listHeader = useMemo(
-    () => <HomeScreenHeader balance={model.balance} categorySpending={model.categorySpending} />,
-    [model.balance, model.categorySpending]
+    () => (
+      <HomeScreenHeader
+        balance={model.balance}
+        categorySpending={model.categorySpending}
+        monthlyBudget={model.monthlyBudget}
+      />
+    ),
+    [model.balance, model.categorySpending, model.monthlyBudget]
   );
 
   const headerActions =
@@ -42,21 +54,30 @@ export function HomeScreenContent({ model }: HomeScreenContentProps) {
     );
 
   return (
-    <ScreenLayout title="fidy" rightActions={headerActions}>
-      <FlashList
-        data={model.activityFeed.activityPages}
-        renderItem={renderItem}
-        keyExtractor={keyExtractor}
-        onEndReached={model.activityFeed.handleEndReached}
-        onEndReachedThreshold={0.1}
-        scrollEventThrottle={16}
-        ListHeaderComponent={listHeader}
-        ListEmptyComponent={model.showEmptyTransactions ? <EmptyTransactions /> : undefined}
-        showsVerticalScrollIndicator={false}
-        contentContainerStyle={styles.listContent}
-        contentInset={{ bottom: TAB_BAR_CLEARANCE }}
-        contentInsetAdjustmentBehavior="automatic"
-      />
+    <ScreenLayout
+      title="fidy"
+      backgroundColor={backgroundColor}
+      backgroundLayer={<HomeAuroraBackground isDark={isDark} />}
+      leftAction={<ProfileAvatarButton size={36} />}
+      rightActions={headerActions}
+      includesNativeHeader={false}
+    >
+      <View className="flex-1 overflow-hidden">
+        <FlashList
+          data={model.activityFeed.activityPages}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          onEndReached={model.activityFeed.handleEndReached}
+          onEndReachedThreshold={0.1}
+          scrollEventThrottle={16}
+          ListHeaderComponent={listHeader}
+          ListEmptyComponent={model.showEmptyTransactions ? <EmptyTransactions /> : undefined}
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={styles.listContent}
+          contentInset={{ bottom: TAB_BAR_CLEARANCE }}
+          contentInsetAdjustmentBehavior="automatic"
+        />
+      </View>
     </ScreenLayout>
   );
 }

--- a/apps/mobile/features/dashboard/components/home-screen/HomeScreenHeader.tsx
+++ b/apps/mobile/features/dashboard/components/home-screen/HomeScreenHeader.tsx
@@ -3,7 +3,7 @@ import {
   AccountSuggestionsPromptBanner,
   useAccountSuggestions,
 } from "@/features/account-suggestions/routes.public";
-import { useOptionalUserId } from "@/features/auth/public";
+import { useAuthStore, useOptionalUserId } from "@/features/auth/public";
 import { DetectedTransactionsBanner } from "@/features/capture-sources/public";
 import {
   connectEmailAccount,
@@ -14,46 +14,59 @@ import { EmailConnectBanner } from "@/features/email-capture/ui.public";
 import { Platform, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
 import { AttributionReviewBanner } from "../AttributionReviewBanner";
-import { BalanceSection } from "../BalanceSection";
-import { ChartSection } from "../ChartSection";
 import { NeedsReviewBanner } from "../NeedsReviewBanner";
+import { HomeSpendingCard } from "./HomeSpendingCard";
 import type { CategorySpendingItem } from "./useHomeScreen";
 
 type HomeScreenHeaderProps = {
   readonly balance: number;
   readonly categorySpending: readonly CategorySpendingItem[];
+  readonly monthlyBudget: number;
 };
 
-export function HomeScreenHeader({ balance, categorySpending }: HomeScreenHeaderProps) {
+export function HomeScreenHeader({
+  balance,
+  categorySpending,
+  monthlyBudget,
+}: HomeScreenHeaderProps) {
   const { push } = useRouter();
   const userId = useOptionalUserId();
+  const localQaProfile = useAuthStore((state) => state.localQaSession?.profile ?? null);
   const db = userId ? tryGetDb(userId) : null;
-  const { suggestions } = useAccountSuggestions({ db, userId });
+  const showSetupBanners = localQaProfile !== "home-activity";
+  const { suggestions } = useAccountSuggestions({
+    db: showSetupBanners ? db : null,
+    userId: showSetupBanners ? userId : null,
+  });
 
   return (
     <View className="gap-4 px-4">
-      <EmailConnectBanner
-        onConnect={(provider) => {
-          if (!userId) return;
-          const db = tryGetDb(userId);
-          if (!db) return;
-          const clientId = provider === "gmail" ? getGmailClientId() : getOutlookClientId();
-          void connectEmailAccount(db, userId, provider, clientId);
-        }}
-      />
-      <NeedsReviewBanner onPress={() => push("/needs-review" as never)} />
-      <AttributionReviewBanner onPress={() => push("/attribution-review-queue" as never)} />
-      <AccountSuggestionsPromptBanner
-        count={suggestions.length}
-        onPress={() => push("/account-suggestions" as never)}
-      />
-      {Platform.OS === "ios" ? (
-        <DetectedTransactionsBanner onPress={() => push("/connected-accounts" as never)} />
+      {showSetupBanners ? (
+        <>
+          <EmailConnectBanner
+            onConnect={(provider) => {
+              if (!userId) return;
+              const db = tryGetDb(userId);
+              if (!db) return;
+              const clientId = provider === "gmail" ? getGmailClientId() : getOutlookClientId();
+              void connectEmailAccount(db, userId, provider, clientId);
+            }}
+          />
+          <NeedsReviewBanner onPress={() => push("/needs-review" as never)} />
+          <AttributionReviewBanner onPress={() => push("/attribution-review-queue" as never)} />
+          <AccountSuggestionsPromptBanner
+            count={suggestions.length}
+            onPress={() => push("/account-suggestions" as never)}
+          />
+          {Platform.OS === "ios" ? (
+            <DetectedTransactionsBanner onPress={() => push("/connected-accounts" as never)} />
+          ) : null}
+        </>
       ) : null}
-      <BalanceSection balance={balance} />
-      <ChartSection
+      <HomeSpendingCard
         categorySpending={categorySpending}
-        totalSpent={balance}
+        balance={balance}
+        monthlyBudget={monthlyBudget}
         onPress={() => push("/analytics" as never)}
       />
     </View>

--- a/apps/mobile/features/dashboard/components/home-screen/HomeSpendingCard.tsx
+++ b/apps/mobile/features/dashboard/components/home-screen/HomeSpendingCard.tsx
@@ -1,0 +1,221 @@
+import { format, getDaysInMonth } from "date-fns";
+import { CATEGORY_MAP } from "@/shared/categories";
+import { Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
+import { Colors } from "@/shared/constants/theme";
+import { useColorScheme, useTranslation } from "@/shared/hooks";
+import { getCategoryLabel, getDateFnsLocale } from "@/shared/i18n";
+import { formatMoney } from "@/shared/lib";
+import type { CategorySpendingItem } from "./useHomeScreen";
+
+type Translate = (key: string, params?: Record<string, unknown>) => string;
+
+type HomeSpendingCardModelInput = {
+  readonly balance: number;
+  readonly categorySpending: readonly CategorySpendingItem[];
+  readonly locale: string;
+  readonly monthlyBudget: number;
+  readonly now: Date;
+  readonly t: Translate;
+};
+
+type HomeCategoryBar = {
+  readonly amountLabel: string;
+  readonly categoryId: string;
+  readonly color: string;
+  readonly icon: string;
+  readonly label: string;
+  readonly percentage: number;
+};
+
+type HomeSpendingCardModel = {
+  readonly amountLabel: string;
+  readonly bars: readonly HomeCategoryBar[];
+  readonly dateLabel: string;
+  readonly guidance: string;
+  readonly dailyPaceLabel: string;
+  readonly averageLabel: string;
+};
+
+const MAX_CATEGORY_BARS = 7;
+const MIN_BAR_PERCENTAGE = 34;
+const MAX_BAR_PERCENTAGE = 100;
+
+const clampBarPercentage = (percentage: number): number =>
+  Math.max(MIN_BAR_PERCENTAGE, Math.min(MAX_BAR_PERCENTAGE, percentage));
+
+const getDateFormat = (locale: string): string =>
+  locale.startsWith("es") ? "EEEE, d 'de' MMMM" : "EEEE, MMMM d";
+
+const deriveDailyAllowance = (spent: number, monthlyBudget: number, now: Date): number => {
+  const remainingBudget = Math.max(monthlyBudget - spent, 0);
+  const remainingDaysIncludingToday = Math.max(getDaysInMonth(now) - now.getDate() + 1, 1);
+  return Math.floor(remainingBudget / remainingDaysIncludingToday);
+};
+
+const deriveAverageSpend = (spent: number, now: Date): number =>
+  Math.round(spent / Math.max(now.getDate(), 1));
+
+export function deriveHomeSpendingCardModel({
+  balance,
+  categorySpending,
+  locale,
+  monthlyBudget,
+  now,
+  t,
+}: HomeSpendingCardModelInput): HomeSpendingCardModel {
+  const dateFnsLocale = getDateFnsLocale(locale);
+  const averageSpend = deriveAverageSpend(balance, now);
+  const hasBudget = monthlyBudget > 0;
+  const dailyPace = hasBudget ? deriveDailyAllowance(balance, monthlyBudget, now) : averageSpend;
+  const visibleCategorySpending = categorySpending.filter(
+    (item) => CATEGORY_MAP[item.categoryId] != null
+  );
+  const largestCategoryTotal = Math.max(...visibleCategorySpending.map((item) => item.total), 0);
+  const bars = visibleCategorySpending
+    .slice()
+    .sort((a, b) => b.total - a.total)
+    .slice(0, MAX_CATEGORY_BARS)
+    .map((item) => {
+      const category = CATEGORY_MAP[item.categoryId];
+      return {
+        amountLabel: formatMoney(item.total),
+        categoryId: item.categoryId,
+        color: category?.color ?? Colors.chart.other,
+        icon: category?.icon ?? "✨",
+        label: category ? getCategoryLabel(category, locale) : item.categoryId,
+        percentage:
+          largestCategoryTotal === 0
+            ? MIN_BAR_PERCENTAGE
+            : clampBarPercentage((item.total / largestCategoryTotal) * 100),
+      };
+    });
+
+  return {
+    amountLabel: formatMoney(balance),
+    bars,
+    dateLabel: format(
+      now,
+      getDateFormat(locale),
+      dateFnsLocale ? { locale: dateFnsLocale } : undefined
+    ),
+    guidance: hasBudget
+      ? t("dashboard.dailyPaceGuidance", { amount: formatMoney(dailyPace) })
+      : t("dashboard.noBudgetGuidance", { amount: formatMoney(averageSpend) }),
+    dailyPaceLabel: formatMoney(dailyPace),
+    averageLabel: formatMoney(averageSpend),
+  };
+}
+
+type HomeSpendingCardProps = {
+  readonly balance: number;
+  readonly categorySpending: readonly CategorySpendingItem[];
+  readonly monthlyBudget: number;
+  readonly onPress?: () => void;
+};
+
+export function HomeSpendingCard({
+  balance,
+  categorySpending,
+  monthlyBudget,
+  onPress,
+}: HomeSpendingCardProps) {
+  const { t, locale } = useTranslation();
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === "dark";
+  const model = deriveHomeSpendingCardModel({
+    balance,
+    categorySpending,
+    locale,
+    monthlyBudget,
+    now: new Date(),
+    t,
+  });
+
+  return (
+    <Pressable
+      accessibilityRole={onPress ? "button" : undefined}
+      accessibilityLabel={t("dashboard.spendingSummary")}
+      onPress={onPress}
+      className="overflow-hidden rounded-chart"
+      style={[styles.card, isDark ? styles.cardDark : styles.cardLight]}
+    >
+      <View className="gap-4">
+        <View className="flex-row items-start justify-between gap-3">
+          <Text className="font-poppins-semibold text-label uppercase tracking-widest text-secondary dark:text-secondary-dark">
+            {t("dashboard.monthlySpend")}
+          </Text>
+          <Text className="text-right font-poppins-semibold text-caption uppercase tracking-widest text-tertiary dark:text-tertiary-dark">
+            {model.dateLabel.toLocaleUpperCase(locale)}
+          </Text>
+        </View>
+        <View className="gap-2">
+          <Text className="font-poppins-bold text-balance text-primary dark:text-primary-dark">
+            {model.amountLabel}
+          </Text>
+          <Text className="font-poppins-medium text-body text-secondary dark:text-secondary-dark">
+            {model.guidance}
+          </Text>
+        </View>
+        <View
+          className="h-28 flex-row items-end gap-2 pt-4"
+          accessibilityLabel={t("dashboard.categoryBars")}
+        >
+          {model.bars.map((bar) => (
+            <View key={bar.categoryId} className="flex-1 items-center gap-1">
+              <View
+                className="w-full items-center justify-end rounded-icon"
+                style={{
+                  height: `${bar.percentage}%`,
+                  minHeight: 24,
+                  backgroundColor: bar.color,
+                  borderTopLeftRadius: 999,
+                  borderTopRightRadius: 999,
+                  borderBottomLeftRadius: 4,
+                  borderBottomRightRadius: 4,
+                }}
+                accessible
+                accessibilityLabel={`${bar.label}, ${bar.amountLabel}`}
+              >
+                <Text className="pb-1 text-caption">{bar.icon}</Text>
+              </View>
+            </View>
+          ))}
+        </View>
+        <View className="flex-row gap-4">
+          <View className="flex-1 flex-row items-baseline gap-2">
+            <Text className="font-poppins-medium text-label text-tertiary dark:text-tertiary-dark">
+              {t("dashboard.dailyPace")}
+            </Text>
+            <Text className="font-poppins-semibold text-body text-tertiary dark:text-tertiary-dark">
+              {model.dailyPaceLabel}
+            </Text>
+          </View>
+          <View className="flex-1 flex-row items-baseline gap-2">
+            <Text className="font-poppins-medium text-label text-tertiary dark:text-tertiary-dark">
+              {t("dashboard.average")}
+            </Text>
+            <Text className="font-poppins-semibold text-body text-tertiary dark:text-tertiary-dark">
+              {model.averageLabel}
+            </Text>
+          </View>
+        </View>
+      </View>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    padding: 24,
+  },
+  cardLight: {
+    backgroundColor: "rgba(255, 255, 255, 0.62)",
+    borderColor: "rgba(26, 26, 26, 0.12)",
+    borderWidth: 1,
+  },
+  cardDark: {
+    backgroundColor: "rgba(28, 28, 30, 0.86)",
+    borderColor: "rgba(240, 240, 240, 0.12)",
+    borderWidth: 1,
+  },
+});

--- a/apps/mobile/features/dashboard/components/home-screen/useHomeScreen.ts
+++ b/apps/mobile/features/dashboard/components/home-screen/useHomeScreen.ts
@@ -1,4 +1,5 @@
 import { useOptionalUserId } from "@/features/auth/public";
+import { formatBudgetMonth, useBudgetStore } from "@/features/budget/public";
 import { useEmailCaptureStore } from "@/features/email-capture/public";
 import { useTransactionStore } from "@/features/transactions/store.public";
 import { tryGetDb } from "@/shared/db";
@@ -13,6 +14,7 @@ export type HomeScreenModel = {
   readonly activityFeed: HomeActivityFeedModel;
   readonly balance: number;
   readonly categorySpending: readonly CategorySpendingItem[];
+  readonly monthlyBudget: number;
   readonly showEmptyTransactions: boolean;
 };
 
@@ -22,12 +24,21 @@ export function useHomeScreen(): HomeScreenModel {
   const balance = useTransactionStore((state) => state.balance);
   const categorySpending = useTransactionStore((state) => state.categorySpending);
   const dataRevision = useTransactionStore((state) => state.dataRevision);
+  const currentBudgetMonth = formatBudgetMonth(new Date());
+  const selectedBudgetMonth = useBudgetStore((state) => state.currentMonth);
+  const selectedBudgetTotal = useBudgetStore((state) => state.summary.totalBudget);
+  const currentMonthBudgetTotal = useBudgetStore(
+    (state) => state.budgetTotalByMonth[currentBudgetMonth] ?? 0
+  );
   const phase = useEmailCaptureStore((state) => state.phase);
+  const monthlyBudget =
+    selectedBudgetMonth === currentBudgetMonth ? selectedBudgetTotal : currentMonthBudgetTotal;
 
   return {
     activityFeed: useHomeActivityFeed({ dataRevision, db, userId }),
     balance,
     categorySpending,
+    monthlyBudget,
     showEmptyTransactions: phase === null,
   };
 }

--- a/apps/mobile/features/qa/components/qa-tools/QaTools.constants.ts
+++ b/apps/mobile/features/qa/components/qa-tools/QaTools.constants.ts
@@ -3,6 +3,7 @@ import { getDefaultQaTarget, type LocalQaProfile, QA_TARGETS, type QaTarget } fr
 
 export const QA_PROFILES = [
   "default",
+  "home-activity",
   "empty",
   "two-accounts",
   "transfer-ready",

--- a/apps/mobile/features/qa/lib/build-local-qa-seed.ts
+++ b/apps/mobile/features/qa/lib/build-local-qa-seed.ts
@@ -1,3 +1,4 @@
+import type { BudgetRow } from "@/features/budget/public";
 import { buildDefaultFinancialAccountId } from "@/features/financial-accounts/seed.public";
 import type { FinancialAccountRow } from "@/features/financial-accounts/write.public";
 import type { TransactionRow } from "@/features/transactions/query.public";
@@ -16,15 +17,18 @@ import {
   requireUserId,
 } from "@/shared/types/assertions";
 import type { LocalQaProfile, LocalQaSession } from "../local-session";
+import { buildHomeActivityBudgets, buildHomeActivityTransactions } from "./home-activity-seed";
 
 type LocalQaSeed = {
   readonly session: LocalQaSession;
+  readonly budgets: readonly BudgetRow[];
   readonly financialAccounts: readonly FinancialAccountRow[];
   readonly transactions: readonly TransactionRow[];
   readonly transfers: readonly TransferRow[];
 };
 
 function getDisplayName(profile: LocalQaProfile): string {
+  if (profile === "home-activity") return "Local QA Home Activity";
   if (profile === "transfer-ready") return "Local QA Transfer Ready";
   if (profile === "transfer-conflict") return "Local QA Transfer Conflict";
   if (profile === "two-accounts") return "Local QA Two Accounts";
@@ -43,6 +47,14 @@ function getSessionForProfile(profile: LocalQaProfile): LocalQaSession {
     displayName,
     email: `local-qa+${profile}@fidy.dev`,
   };
+}
+
+function buildBudgets(
+  userId: LocalQaSession["userId"],
+  now: Date,
+  profile: LocalQaProfile
+): readonly BudgetRow[] {
+  return profile === "home-activity" ? buildHomeActivityBudgets(userId, now) : [];
 }
 
 function buildAccounts(
@@ -92,10 +104,14 @@ function buildTransactions(
   accounts: readonly FinancialAccountRow[],
   profile: LocalQaProfile
 ): readonly TransactionRow[] {
-  if (profile !== "transfer-ready") return [];
+  if (profile !== "transfer-ready" && profile !== "home-activity") return [];
 
   const defaultAccountId = buildDefaultFinancialAccountId(userId);
   const bankAccountId = accounts[1]?.id ?? defaultAccountId;
+
+  if (profile === "home-activity") {
+    return buildHomeActivityTransactions(userId, now, accounts);
+  }
 
   return [
     {
@@ -155,7 +171,7 @@ function buildTransfers(
   accounts: readonly FinancialAccountRow[],
   profile: LocalQaProfile
 ): readonly TransferRow[] {
-  if (profile !== "transfer-ready") return [];
+  if (profile !== "transfer-ready" && profile !== "home-activity") return [];
 
   return [
     {
@@ -181,6 +197,7 @@ export function buildLocalQaSeed(profile: LocalQaProfile, now: Date = new Date()
 
   return {
     session,
+    budgets: buildBudgets(session.userId, now, profile),
     financialAccounts,
     transactions: buildTransactions(session.userId, now, financialAccounts, profile),
     transfers: buildTransfers(session.userId, now, financialAccounts, profile),

--- a/apps/mobile/features/qa/lib/entry-points.ts
+++ b/apps/mobile/features/qa/lib/entry-points.ts
@@ -41,6 +41,14 @@ const QA_TARGET_BY_KEY: Record<QaTargetKey, QaTarget> = {
   [QA_TARGET_KEYS.profile]: QA_TARGETS.profile,
   [QA_TARGET_KEYS.qaTools]: QA_TARGETS.qaTools,
 };
+const DEFAULT_QA_TARGET_BY_PROFILE = {
+  default: QA_TARGETS.home,
+  empty: QA_TARGETS.onboarding,
+  "home-activity": QA_TARGETS.home,
+  "transfer-ready": QA_TARGETS.addTransfer,
+  "transfer-conflict": QA_TARGETS.transferConflict,
+  "two-accounts": QA_TARGETS.financialAccounts,
+} satisfies Record<LocalQaProfile, QaTarget>;
 
 export { isLocalQaProfile };
 
@@ -57,9 +65,5 @@ export function getQaTargetFromKey(key: QaTargetKey): QaTarget {
 }
 
 export function getDefaultQaTarget(profile: LocalQaProfile): QaTarget {
-  if (profile === "empty") return QA_TARGETS.onboarding;
-  if (profile === "two-accounts") return QA_TARGETS.financialAccounts;
-  if (profile === "transfer-ready") return QA_TARGETS.addTransfer;
-  if (profile === "transfer-conflict") return QA_TARGETS.transferConflict;
-  return QA_TARGETS.home;
+  return DEFAULT_QA_TARGET_BY_PROFILE[profile];
 }

--- a/apps/mobile/features/qa/lib/home-activity-seed.ts
+++ b/apps/mobile/features/qa/lib/home-activity-seed.ts
@@ -1,0 +1,163 @@
+import type { BudgetRow } from "@/features/budget/public";
+import { buildDefaultFinancialAccountId } from "@/features/financial-accounts/seed.public";
+import type { FinancialAccountRow } from "@/features/financial-accounts/write.public";
+import type { TransactionRow } from "@/features/transactions/query.public";
+import { getBuiltInCategoryId } from "@/shared/categories";
+import { generateBudgetId, generateTransactionId, toIsoDate, toIsoDateTime } from "@/shared/lib";
+import { requireCopAmount, requireMonth } from "@/shared/types/assertions";
+import type { LocalQaSession } from "../local-session";
+
+export function buildHomeActivityBudgets(
+  userId: LocalQaSession["userId"],
+  now: Date
+): readonly BudgetRow[] {
+  const month = requireMonth(toIsoDate(now).slice(0, 7));
+  const createdAt = toIsoDateTime(now);
+
+  return [
+    { categoryId: "food", amount: 2_000_000 },
+    { categoryId: "health", amount: 1_000_000 },
+    { categoryId: "entertainment", amount: 1_000_000 },
+    { categoryId: "home", amount: 2_000_000 },
+    { categoryId: "clothing", amount: 1_000_000 },
+    { categoryId: "transport", amount: 1_500_000 },
+    { categoryId: "education", amount: 1_500_000 },
+  ].map((budget) => ({
+    id: generateBudgetId(),
+    userId,
+    categoryId: getBuiltInCategoryId(budget.categoryId),
+    amount: requireCopAmount(budget.amount),
+    month,
+    createdAt,
+    updatedAt: createdAt,
+    deletedAt: null,
+  }));
+}
+
+export function buildHomeActivityTransactions(
+  userId: LocalQaSession["userId"],
+  now: Date,
+  accounts: readonly FinancialAccountRow[]
+): readonly TransactionRow[] {
+  const defaultAccountId = buildDefaultFinancialAccountId(userId);
+  const bankAccountId = accounts[1]?.id ?? defaultAccountId;
+  const today = toIsoDate(now);
+  const yesterday = toIsoDate(new Date(now.getTime() - 24 * 60 * 60 * 1000));
+  const twoDaysAgo = toIsoDate(new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000));
+  const createdAt = toIsoDateTime(now);
+
+  return [
+    {
+      id: generateTransactionId(),
+      userId,
+      type: "expense",
+      amount: requireCopAmount(86_400),
+      categoryId: getBuiltInCategoryId("food"),
+      description: "Rappi Colombia",
+      date: today,
+      accountId: defaultAccountId,
+      accountAttributionState: "confirmed",
+      createdAt,
+      updatedAt: createdAt,
+      voidedAt: null,
+      supersededAt: null,
+      source: "manual",
+    },
+    {
+      id: generateTransactionId(),
+      userId,
+      type: "expense",
+      amount: requireCopAmount(58_200),
+      categoryId: getBuiltInCategoryId("health"),
+      description: "Farmatodo Plaza",
+      date: yesterday,
+      accountId: defaultAccountId,
+      accountAttributionState: "confirmed",
+      createdAt,
+      updatedAt: createdAt,
+      voidedAt: null,
+      supersededAt: null,
+      source: "manual",
+    },
+    {
+      id: generateTransactionId(),
+      userId,
+      type: "expense",
+      amount: requireCopAmount(105_300),
+      categoryId: getBuiltInCategoryId("entertainment"),
+      description: "Cine Colombia",
+      date: yesterday,
+      accountId: bankAccountId,
+      accountAttributionState: "confirmed",
+      createdAt,
+      updatedAt: createdAt,
+      voidedAt: null,
+      supersededAt: null,
+      source: "manual",
+    },
+    {
+      id: generateTransactionId(),
+      userId,
+      type: "expense",
+      amount: requireCopAmount(42_000),
+      categoryId: getBuiltInCategoryId("home"),
+      description: "Homecenter",
+      date: yesterday,
+      accountId: bankAccountId,
+      accountAttributionState: "confirmed",
+      createdAt,
+      updatedAt: createdAt,
+      voidedAt: null,
+      supersededAt: null,
+      source: "manual",
+    },
+    {
+      id: generateTransactionId(),
+      userId,
+      type: "expense",
+      amount: requireCopAmount(92_700),
+      categoryId: getBuiltInCategoryId("clothing"),
+      description: "Arturo Calle",
+      date: twoDaysAgo,
+      accountId: bankAccountId,
+      accountAttributionState: "confirmed",
+      createdAt,
+      updatedAt: createdAt,
+      voidedAt: null,
+      supersededAt: null,
+      source: "manual",
+    },
+    {
+      id: generateTransactionId(),
+      userId,
+      type: "expense",
+      amount: requireCopAmount(38_900),
+      categoryId: getBuiltInCategoryId("transport"),
+      description: "Uber",
+      date: twoDaysAgo,
+      accountId: defaultAccountId,
+      accountAttributionState: "confirmed",
+      createdAt,
+      updatedAt: createdAt,
+      voidedAt: null,
+      supersededAt: null,
+      source: "manual",
+    },
+    {
+      id: generateTransactionId(),
+      userId,
+      type: "expense",
+      amount: requireCopAmount(74_500),
+      categoryId: getBuiltInCategoryId("education"),
+      description: "Platzi",
+      date: twoDaysAgo,
+      accountId: defaultAccountId,
+      accountAttributionState: "confirmed",
+      createdAt,
+      updatedAt: createdAt,
+      voidedAt: null,
+      supersededAt: null,
+      source: "manual",
+    },
+  ];
+}

--- a/apps/mobile/features/qa/local-session.ts
+++ b/apps/mobile/features/qa/local-session.ts
@@ -6,6 +6,7 @@ const LOCAL_QA_SESSION_KEY = "qa_local_session_v1";
 
 const LOCAL_QA_PROFILES = [
   "default",
+  "home-activity",
   "empty",
   "two-accounts",
   "transfer-ready",

--- a/apps/mobile/features/qa/start-local-qa-session.ts
+++ b/apps/mobile/features/qa/start-local-qa-session.ts
@@ -1,9 +1,18 @@
 import { migrate } from "drizzle-orm/expo-sqlite/migrator";
 import migrations from "@/drizzle/migrations";
+import {
+  initializeBudgetSession,
+  insertBudget,
+  loadBudgetsForUser,
+} from "@/features/budget/public";
 import { upsertFinancialAccount } from "@/features/financial-accounts/write.public";
 import { clearOnboardingFromStore } from "@/features/onboarding/store.public";
 import { useLocalOnboardingState } from "@/features/onboarding/store.public";
 import { useOnboardingStore } from "@/features/onboarding/store.public";
+import {
+  initializeTransactionSession,
+  loadInitialTransactions,
+} from "@/features/transactions/store.public";
 import { seedLocalLedgerRowsForQa } from "@/infrastructure/local-ledger/public";
 import { getDb, resetDbForUser } from "@/shared/db";
 import { queryClient } from "@/shared/query/client";
@@ -26,10 +35,19 @@ export async function startLocalQaSession(profile: LocalQaProfile = "default") {
   seed.financialAccounts.forEach((account) => {
     upsertFinancialAccount(db, account);
   });
+  seed.budgets.forEach((budget) => {
+    insertBudget(db, budget);
+  });
   seedLocalLedgerRowsForQa(db, {
     transactions: seed.transactions,
     transfers: seed.transfers,
   });
+  initializeTransactionSession(seed.session.userId);
+  initializeBudgetSession(seed.session.userId);
+  await Promise.all([
+    loadInitialTransactions(db, seed.session.userId),
+    loadBudgetsForUser(db, seed.session.userId),
+  ]);
 
   await persistLocalQaSession(seed.session);
 

--- a/apps/mobile/features/settings/ui.public.ts
+++ b/apps/mobile/features/settings/ui.public.ts
@@ -1,4 +1,5 @@
 export { NotificationPreferencesScreen } from "./components/NotificationPreferencesScreen";
+export { ProfileAvatarButton } from "./components/ProfileAvatarButton";
 export { PrivateBackupScreen } from "./components/PrivateBackupScreen";
 export { ProfileScreen } from "./components/ProfileScreen";
 export { SettingsScreen } from "./components/SettingsScreen";

--- a/apps/mobile/shared/components/PencilEntryScaffold.styles.ts
+++ b/apps/mobile/shared/components/PencilEntryScaffold.styles.ts
@@ -53,7 +53,7 @@ export const styles = StyleSheet.create({
     justifyContent: "center",
   },
   keyFeedback: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
     backgroundColor: "rgba(255, 255, 255, 0.42)",
     borderRadius: 14,
   },

--- a/apps/mobile/shared/components/ScreenLayout.tsx
+++ b/apps/mobile/shared/components/ScreenLayout.tsx
@@ -11,6 +11,9 @@ export const HEADER_HEIGHT = 48;
 type ScreenLayoutProps = {
   title: string;
   variant?: "tab" | "sub";
+  backgroundColor?: string;
+  backgroundLayer?: ReactNode;
+  leftAction?: ReactNode;
   rightActions?: ReactNode;
   onBack?: () => void;
   includesNativeHeader?: boolean;
@@ -20,6 +23,9 @@ type ScreenLayoutProps = {
 export function ScreenLayout({
   title,
   variant = "tab",
+  backgroundColor,
+  backgroundLayer,
+  leftAction,
   rightActions,
   onBack,
   includesNativeHeader = true,
@@ -29,9 +35,12 @@ export function ScreenLayout({
   const primaryColor = useThemeColor("primary");
   const isTab = variant === "tab";
   const customHeaderTopInset = process.env.EXPO_OS === "web" ? 0 : insets.top;
+  const shouldRenderRightSlot = rightActions != null || (isTab && leftAction != null);
+  const rightSlotClassName = isTab ? "flex-1 flex-row justify-end" : "flex-row justify-end";
   const shouldRenderCustomHeader =
     Platform.OS !== "ios" ||
-    (!includesNativeHeader && (!isTab || rightActions != null || onBack != null));
+    (!includesNativeHeader &&
+      (!isTab || leftAction != null || rightActions != null || onBack != null));
   const iosHeaderOptions = {
     title: isTab ? "" : title,
     ...(rightActions != null && {
@@ -47,12 +56,14 @@ export function ScreenLayout({
   };
 
   return (
-    <View className="flex-1 bg-page dark:bg-page-dark">
+    <View className="flex-1 bg-page dark:bg-page-dark" style={{ backgroundColor }}>
+      {backgroundLayer}
       {Platform.OS === "ios" && includesNativeHeader && <Stack.Screen options={iosHeaderOptions} />}
       {shouldRenderCustomHeader && (
         <View style={{ paddingTop: customHeaderTopInset }}>
           <View className="px-4 flex-row items-center justify-between h-12">
-            <View className="flex-row items-center" style={{ gap: 12 }}>
+            <View className="flex-1 flex-row items-center" style={{ gap: 12 }}>
+              {leftAction}
               {!isTab && onBack != null && (
                 <Pressable onPress={onBack} hitSlop={12}>
                   <ChevronLeft size={24} color={primaryColor} />
@@ -69,7 +80,18 @@ export function ScreenLayout({
                 {isTab ? "" : title}
               </Text>
             </View>
-            {rightActions}
+            {isTab && leftAction != null ? (
+              <Text
+                className="absolute left-0 right-0 text-center font-poppins-extrabold text-logo text-primary dark:text-primary-dark"
+                pointerEvents="none"
+                numberOfLines={1}
+              >
+                {title}
+              </Text>
+            ) : null}
+            {shouldRenderRightSlot ? (
+              <View className={rightSlotClassName}>{rightActions}</View>
+            ) : null}
           </View>
         </View>
       )}

--- a/apps/mobile/shared/i18n/locales/en.ts
+++ b/apps/mobile/shared/i18n/locales/en.ts
@@ -41,6 +41,14 @@ const en = {
 
   // Dashboard
   dashboard: {
+    average: "Average",
+    categoryBars: "Spending by category",
+    dailyPace: "Daily",
+    dailyPaceGuidance: "Spend up to %{amount} per day to stay within budget.",
+    monthlySpend: "Monthly spend",
+    noBudgetGuidance:
+      "Set a monthly budget to see your daily spending limit. Current average: %{amount}.",
+    spendingSummary: "Monthly spending summary",
     spentThisMonth: "Spent this month",
   },
 
@@ -821,6 +829,10 @@ const en = {
       default: {
         title: "Default",
         description: "One default cash account and onboarding complete.",
+      },
+      "home-activity": {
+        title: "Home activity",
+        description: "Recent expenses and one transfer for dashboard visual QA.",
       },
       empty: {
         title: "Empty",

--- a/apps/mobile/shared/i18n/locales/es.ts
+++ b/apps/mobile/shared/i18n/locales/es.ts
@@ -41,6 +41,15 @@ const es = {
 
   // Dashboard
   dashboard: {
+    average: "Promedio",
+    categoryBars: "Gasto por categoría",
+    dailyPace: "Diario",
+    dailyPaceGuidance:
+      "Puedes gastar hasta %{amount} al día para mantenerte dentro de tu presupuesto.",
+    monthlySpend: "Gasto del mes",
+    noBudgetGuidance:
+      "Configura un presupuesto mensual para ver tu límite diario. Promedio actual: %{amount}.",
+    spendingSummary: "Resumen del gasto mensual",
     spentThisMonth: "Gastado este mes",
   },
 
@@ -837,6 +846,10 @@ const es = {
       default: {
         title: "Predeterminado",
         description: "Una cuenta de efectivo predeterminada y onboarding completo.",
+      },
+      "home-activity": {
+        title: "Actividad de inicio",
+        description: "Gastos recientes y una transferencia para QA visual del inicio.",
       },
       empty: {
         title: "Vacío",

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "oxfmt": "0.47.0",
         "oxlint": "1.62.0",
         "oxlint-tsgolint": "0.22.1",
+        "serve-sim": "0.1.36",
         "typescript": "6.0.3",
         "xcodebuildmcp": "2.3.2",
       },
@@ -1731,6 +1732,8 @@
 
     "inline-style-prefixer": ["inline-style-prefixer@7.0.1", "", { "dependencies": { "css-in-js-utils": "^3.1.0" } }, "sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw=="],
 
+    "inspect-webkit": ["inspect-webkit@0.0.5", "", { "peerDependencies": { "typescript": "^5" }, "bin": { "inspect-webkit": "dist/cli.js" } }, "sha512-584wP/2nJO1LX74nqHP2j0tQzlK9ZTi+D0Z9qeLQjtUR/LCMXQHGX8M0vrsqBwTeGakF7q5GMFpg81nxUYlCvw=="],
+
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
 
     "interpret": ["interpret@3.1.1", "", {}, "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ=="],
@@ -2376,6 +2379,8 @@
     "send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
 
     "serialize-error": ["serialize-error@2.1.0", "", {}, "sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw=="],
+
+    "serve-sim": ["serve-sim@0.1.36", "", { "dependencies": { "inspect-webkit": "^0.0.5" }, "bin": { "serve-sim": "dist/serve-sim.js" } }, "sha512-ffF+W5q1wAeepFe7UhSIen0pB5e4Vr9NshCeyKoHDZEmShus7KxmAQPtbYmZmkcmD7TeeOvg8ML2VkIH+PKARg=="],
 
     "serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "qa:seed": "bun ./scripts/mobile-qa.ts seed",
     "qa:open": "bun ./scripts/mobile-qa.ts open",
     "qa:smoke": "bun ./scripts/mobile-qa.ts smoke",
+    "sim:serve": "bunx serve-sim --detach",
+    "sim:serve:list": "bunx serve-sim --list",
+    "sim:serve:kill": "bunx serve-sim --kill",
     "analyze:complexity:strict:update-ledger": "bun ./scripts/run-lizard-strict.ts --write-ledger",
     "analyze:file-size": "bun ./scripts/check-max-file-lines.ts",
     "mcp:xcodebuild": "xcodebuildmcp mcp",
@@ -50,6 +53,7 @@
     "oxfmt": "0.47.0",
     "oxlint": "1.62.0",
     "oxlint-tsgolint": "0.22.1",
+    "serve-sim": "0.1.36",
     "typescript": "6.0.3",
     "xcodebuildmcp": "2.3.2"
   },


### PR DESCRIPTION
- Aurora home surface
- Budget-aware spending guidance
- Home activity QA profile

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the mobile Home screen with an aurora background and a budget-aware spending card that gives daily guidance. Added a `home-activity` QA profile that seeds budgets and activity for fast visual QA.

- **New Features**
  - Aurora background with `react-native-svg` behind the feed; visible under headers and row cards; soft blur tuned for mobile.
  - Home Spending Card shows monthly spend, top-category bars, and a daily limit from the current-month budget; falls back to average; EN/ES; tap to open analytics.
  - Custom home header via `ScreenLayout` with a left `ProfileAvatarButton`; native stack header hidden; centered overlaid title.
  - `home-activity` QA profile seeds budgets, recent expenses, and a transfer; opens Home, hides setup banners, and preloads budget/transaction stores.

- **Refactors**
  - Activity rows use translucent “activityCard” containers; date headers no longer paint the page background.
  - `ScreenLayout` adds `backgroundColor`, `backgroundLayer`, and `leftAction`; renders a custom iOS header when the native one is hidden; no right slot reserved when unused.
  - Budget guidance scoped to the current calendar month via `formatBudgetMonth`; store caches `budgetTotalByMonth` for quick access.
  - Tests added for the spending card model and month caching; new dashboard i18n strings; simulator helper scripts in `package.json`.

<sup>Written for commit 1f2e423466c2afb314e3db0be3423a0a12ef9eef. Summary will update on new commits. <a href="https://cubic.dev/pr/B4rz99/fidy/pull/484?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

