### PR TITLE
feat(mobile): redesign budget view

### DIFF
--- a/apps/mobile/__tests__/budget/derive.test.ts
+++ b/apps/mobile/__tests__/budget/derive.test.ts
@@ -4,6 +4,8 @@ import {
   computeDaysLeft,
   deriveAutoSuggestBudgets,
   deriveBudgetAlerts,
+  deriveBudgetPulseCardModel,
+  deriveBudgetPulseSummaryModel,
   deriveBudgetProgress,
   deriveBudgetSummary,
 } from "@/features/budget/lib/derive";
@@ -26,6 +28,49 @@ const makeProgress = (overrides: Partial<BudgetProgress> = {}): BudgetProgress =
   isOverBudget: false,
   isNearLimit: false,
   ...overrides,
+});
+
+const translateFrom =
+  (translations: Readonly<Record<string, string>>) =>
+  (key: string, params?: Readonly<Record<string, string | number>>): string => {
+    const template = translations[key];
+    if (!template) throw new Error(`Unexpected key: ${key}`);
+    return Object.entries(params ?? {}).reduce(
+      (result, [name, value]) => result.replace(`%{${name}}`, String(value)),
+      template
+    );
+  };
+
+const nearLimitPulseProgress = makeProgress({
+  amount: 900_000 as CopAmount,
+  spent: 840_000 as CopAmount,
+  percentUsed: 93,
+  remaining: 60_000 as CopAmount,
+  isNearLimit: true,
+});
+
+const onTrackPulseProgress = makeProgress({
+  amount: 420_000 as CopAmount,
+  spent: 260_000 as CopAmount,
+  percentUsed: 62,
+  remaining: 160_000 as CopAmount,
+});
+
+const overLimitPulseProgress = makeProgress({
+  amount: 360_000 as CopAmount,
+  spent: 410_000 as CopAmount,
+  percentUsed: 114,
+  remaining: -50_000 as CopAmount,
+  isOverBudget: true,
+  isNearLimit: true,
+});
+
+const pulseCardTranslations = translateFrom({
+  "budgets.card.remaining": "Quedan %{amount}",
+  "budgets.card.over": "%{amount} sobre el presupuesto",
+  "budgets.card.status.onTrack": "Vas bien",
+  "budgets.card.status.nearLimit": "Cerca del límite",
+  "budgets.card.status.over": "Sobre el límite",
 });
 
 describe("deriveBudgetProgress", () => {
@@ -117,6 +162,82 @@ describe("deriveBudgetSummary", () => {
     expect(result.totalBudget).toBe(0);
     expect(result.totalSpent).toBe(0);
     expect(result.percentUsed).toBe(0);
+  });
+});
+
+describe("deriveBudgetPulseSummaryModel", () => {
+  it("communicates the remaining monthly amount in the hero card", () => {
+    const result = deriveBudgetPulseSummaryModel({
+      totalBudget: 2_800_000 as CopAmount,
+      totalSpent: 1_940_000 as CopAmount,
+      percentUsed: 69,
+      t: translateFrom({
+        "budgets.summary.remaining": "Te quedan %{amount} para cerrar el mes.",
+      }),
+    });
+
+    expect(result.totalBudgetLabel).toBe("$2.800.000");
+    expect(result.percentLabel).toBe("69%");
+    expect(result.guidance).toBe("Te quedan $860.000 para cerrar el mes.");
+    expect(result.remaining).toBe(860_000);
+    expect(result.isOverBudget).toBe(false);
+  });
+
+  it("uses over-budget copy when the month total is exceeded", () => {
+    const result = deriveBudgetPulseSummaryModel({
+      totalBudget: 900_000 as CopAmount,
+      totalSpent: 1_120_000 as CopAmount,
+      percentUsed: 124,
+      t: translateFrom({
+        "budgets.summary.over": "Te pasaste por %{amount} este mes.",
+      }),
+    });
+
+    expect(result.percentLabel).toBe("124%");
+    expect(result.guidance).toBe("Te pasaste por $220.000 este mes.");
+    expect(result.remaining).toBe(-220_000);
+    expect(result.isOverBudget).toBe(true);
+  });
+});
+
+describe("deriveBudgetPulseCardModel", () => {
+  it("labels on-track category budgets as default tone", () => {
+    const result = deriveBudgetPulseCardModel({
+      progress: onTrackPulseProgress,
+      t: pulseCardTranslations,
+    });
+
+    expect(result.percentLabel).toBe("62%");
+    expect(result.amountLine).toBe("$260.000 / $420.000");
+    expect(result.remainingLabel).toBe("Quedan $160.000");
+    expect(result.statusLabel).toBe("Vas bien");
+    expect(result.tone).toBe("default");
+  });
+
+  it("labels near-limit category budgets as close to the limit", () => {
+    const result = deriveBudgetPulseCardModel({
+      progress: nearLimitPulseProgress,
+      t: pulseCardTranslations,
+    });
+
+    expect(result.percentLabel).toBe("93%");
+    expect(result.amountLine).toBe("$840.000 / $900.000");
+    expect(result.remainingLabel).toBe("Quedan $60.000");
+    expect(result.statusLabel).toBe("Cerca del límite");
+    expect(result.tone).toBe("warning");
+  });
+
+  it("labels over-limit category budgets as danger tone", () => {
+    const result = deriveBudgetPulseCardModel({
+      progress: overLimitPulseProgress,
+      t: pulseCardTranslations,
+    });
+
+    expect(result.percentLabel).toBe("114%");
+    expect(result.amountLine).toBe("$410.000 / $360.000");
+    expect(result.remainingLabel).toBe("$50.000 sobre el presupuesto");
+    expect(result.statusLabel).toBe("Sobre el límite");
+    expect(result.tone).toBe("danger");
   });
 });
 

--- a/apps/mobile/__tests__/budget/store-state.test.ts
+++ b/apps/mobile/__tests__/budget/store-state.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { create } from "zustand";
 import { createBudgetStoreState } from "@/features/budget/store/state";
-import { requireUserId } from "@/shared/types/assertions";
+import { requireCopAmount, requireUserId } from "@/shared/types/assertions";
 import type { BudgetId, Month } from "@/shared/types/branded";
 
 const INITIAL_MONTH = "2026-03" as Month;
@@ -16,7 +16,11 @@ function applySnapshot(store: ReturnType<typeof createStore>) {
   store.getState().setSnapshot({
     budgets: [{ id: "budget-1", categoryId: "food", month: INITIAL_MONTH }] as never[],
     budgetProgress: [] as never[],
-    summary: { totalBudget: 100000, totalSpent: 25000, percentUsed: 25 },
+    summary: {
+      totalBudget: requireCopAmount(100000),
+      totalSpent: requireCopAmount(25000),
+      percentUsed: 25,
+    },
     autoSuggestions: [] as never[],
     pendingAlerts: [
       {

--- a/apps/mobile/__tests__/budget/store.test.ts
+++ b/apps/mobile/__tests__/budget/store.test.ts
@@ -7,14 +7,8 @@ import type {
 import type { Budget } from "@/features/budget/schema";
 import type * as TransactionsModule from "@/features/transactions";
 import type { AnyDb } from "@/shared/db";
-import type {
-  BudgetId,
-  CategoryId,
-  CopAmount,
-  IsoDateTime,
-  Month,
-  UserId,
-} from "@/shared/types/branded";
+import { requireCopAmount } from "@/shared/types/assertions";
+import type { BudgetId, CategoryId, IsoDateTime, Month, UserId } from "@/shared/types/branded";
 
 const USER_ID = "user-1" as UserId;
 const NOW = "2026-03-01T00:00:00.000Z" as IsoDateTime;
@@ -75,7 +69,7 @@ const makeBudget = (id: string, categoryId: CategoryId, month: Month): Budget =>
   id: id as BudgetId,
   userId: USER_ID,
   categoryId,
-  amount: 100000 as CopAmount,
+  amount: requireCopAmount(100000),
   month,
   createdAt: NOW,
   updatedAt: NOW,
@@ -85,7 +79,7 @@ const makeBudget = (id: string, categoryId: CategoryId, month: Month): Budget =>
 const EMPTY_BUDGET_REFRESH_SNAPSHOT: BudgetMonthSnapshot = {
   budgets: [makeBudget("budget-1", "food" as CategoryId, "2026-03" as Month)],
   budgetProgress: [],
-  summary: { totalBudget: 0, totalSpent: 0, percentUsed: 0 },
+  summary: { totalBudget: requireCopAmount(0), totalSpent: requireCopAmount(0), percentUsed: 0 },
   autoSuggestions: [],
   pendingAlerts: [],
   pendingPermissionRequest: false,
@@ -94,13 +88,21 @@ const EMPTY_BUDGET_REFRESH_SNAPSHOT: BudgetMonthSnapshot = {
 const MARCH_STALE_SNAPSHOT: BudgetMonthSnapshot = {
   ...EMPTY_BUDGET_REFRESH_SNAPSHOT,
   budgets: [makeBudget("budget-march", "food" as CategoryId, "2026-03" as Month)],
-  summary: { totalBudget: 100000, totalSpent: 85000, percentUsed: 85 },
+  summary: {
+    totalBudget: requireCopAmount(100000),
+    totalSpent: requireCopAmount(85000),
+    percentUsed: 85,
+  },
 };
 
 const APRIL_FRESH_SNAPSHOT: BudgetMonthSnapshot = {
   ...EMPTY_BUDGET_REFRESH_SNAPSHOT,
   budgets: [makeBudget("budget-april", "transport" as CategoryId, "2026-04" as Month)],
-  summary: { totalBudget: 120000, totalSpent: 10000, percentUsed: 8 },
+  summary: {
+    totalBudget: requireCopAmount(120000),
+    totalSpent: requireCopAmount(10000),
+    percentUsed: 8,
+  },
 };
 
 function createDeferred<T>() {
@@ -217,7 +219,7 @@ describe("useBudgetStore", () => {
     const suggestions = [
       {
         categoryId: "entertainment" as CategoryId,
-        suggestedAmount: 44000 as CopAmount,
+        suggestedAmount: requireCopAmount(44000),
       },
     ];
     mockLoadAutoSuggestions.mockReturnValue(suggestions);

--- a/apps/mobile/__tests__/shared/screen-layout.test.ts
+++ b/apps/mobile/__tests__/shared/screen-layout.test.ts
@@ -92,8 +92,6 @@ describe("ScreenLayout", () => {
   });
 
   test("supports both light and dark mode", () => {
-    expect(source).toContain("bg-page");
-    expect(source).toContain("dark:bg-page-dark");
     expect(source).toContain("useColorScheme");
     expect(source).toContain("<AppAuroraBackground");
   });

--- a/apps/mobile/__tests__/shared/screen-layout.test.ts
+++ b/apps/mobile/__tests__/shared/screen-layout.test.ts
@@ -92,6 +92,8 @@ describe("ScreenLayout", () => {
   });
 
   test("supports both light and dark mode", () => {
+    expect(source).toContain("bg-page");
+    expect(source).toContain("dark:bg-page-dark");
     expect(source).toContain("useColorScheme");
     expect(source).toContain("<AppAuroraBackground");
   });

--- a/apps/mobile/__tests__/shared/screen-layout.test.ts
+++ b/apps/mobile/__tests__/shared/screen-layout.test.ts
@@ -60,9 +60,10 @@ describe("ScreenLayout", () => {
 
   test("renders a custom iOS header for hidden-header sub screens", () => {
     expect(source).toContain("!includesNativeHeader &&");
-    expect(source).toContain(
-      "!isTab || leftAction != null || rightActions != null || onBack != null"
-    );
+    expect(source).toContain("centerAction != null");
+    expect(source).toContain("leftAction != null");
+    expect(source).toContain("rightActions != null");
+    expect(source).toContain("onBack != null");
   });
 
   test("accepts children ReactNode prop", () => {

--- a/apps/mobile/features/budget/components/BudgetCard.tsx
+++ b/apps/mobile/features/budget/components/BudgetCard.tsx
@@ -1,11 +1,9 @@
 import { memo } from "react";
 import { CATEGORY_MAP } from "@/shared/categories";
-import { ProgressBar } from "@/shared/components";
 import { Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
 import { getCategoryLabel } from "@/shared/i18n";
-import { formatMoney } from "@/shared/lib";
-import type { BudgetProgress } from "../lib/derive";
+import { deriveBudgetPulseCardModel, type BudgetProgress } from "../lib/derive";
 
 type Props = {
   readonly progress: BudgetProgress;
@@ -20,15 +18,17 @@ function BudgetCardInner({ progress, onPress }: Props) {
   const borderColor = useThemeColor("borderSubtle");
   const accentGreen = useThemeColor("accentGreen");
   const accentRed = useThemeColor("accentRed");
+  const peachLight = useThemeColor("peachLight");
 
   const category = CATEGORY_MAP[progress.categoryId] ?? null;
   const CategoryIcon = category?.icon;
   const categoryLabel = category ? getCategoryLabel(category, locale) : progress.categoryId;
-  const badgeColor = progress.isOverBudget ? accentRed : accentGreen;
-
-  const remainingText = progress.isOverBudget
-    ? t("budgets.card.over", { amount: formatMoney(Math.abs(progress.remaining)) })
-    : t("budgets.card.remaining", { amount: formatMoney(progress.remaining) });
+  const model = deriveBudgetPulseCardModel({ progress, t });
+  const badgeColor =
+    model.tone === "danger" ? accentRed : model.tone === "warning" ? peachLight : accentGreen;
+  const badgeTextColor = model.tone === "warning" ? "#3A2820" : "#0D0D0D";
+  const progressColor = model.tone === "danger" ? accentRed : accentGreen;
+  const progressWidth = `${Math.max(0, Math.min(progress.percentUsed, 100))}%` as `${number}%`;
 
   const handlePress = () => onPress(progress.budgetId);
 
@@ -40,30 +40,35 @@ function BudgetCardInner({ progress, onPress }: Props) {
       <View style={styles.header}>
         <View style={styles.categoryRow}>
           {category && CategoryIcon ? (
-            <Text style={{ color: category.color }}>{CategoryIcon}</Text>
+            <View style={[styles.emojiBubble, { backgroundColor: `${category.color}24` }]}>
+              <Text style={styles.emoji}>{CategoryIcon}</Text>
+            </View>
           ) : null}
-          <Text style={[styles.categoryName, { color: primaryColor }]}>{categoryLabel}</Text>
+          <View style={styles.categoryText}>
+            <Text style={[styles.categoryName, { color: primaryColor }]}>{categoryLabel}</Text>
+            <Text style={[styles.amountLine, { color: secondaryColor }]}>{model.amountLine}</Text>
+          </View>
         </View>
         <View style={[styles.badge, { backgroundColor: badgeColor }]}>
-          <Text style={styles.badgeText}>
-            {t("budgets.card.used", { percent: progress.percentUsed })}
-          </Text>
+          <Text style={[styles.badgeText, { color: badgeTextColor }]}>{model.percentLabel}</Text>
         </View>
       </View>
 
-      <ProgressBar percent={progress.percentUsed} />
+      <View style={[styles.progressTrack, { backgroundColor: borderColor }]}>
+        <View
+          style={[styles.progressFill, { backgroundColor: progressColor, width: progressWidth }]}
+        />
+      </View>
 
       <View style={styles.footer}>
-        <Text style={[styles.spentText, { color: secondaryColor }]}>
-          {formatMoney(progress.spent)} / {formatMoney(progress.amount)}
-        </Text>
+        <Text style={[styles.spentText, { color: secondaryColor }]}>{model.remainingLabel}</Text>
         <Text
           style={[
             styles.remainingText,
-            { color: progress.isOverBudget ? accentRed : secondaryColor },
+            { color: model.tone === "danger" ? accentRed : primaryColor },
           ]}
         >
-          {remainingText}
+          {model.statusLabel}
         </Text>
       </View>
     </Pressable>
@@ -74,10 +79,10 @@ export const BudgetCard = memo(BudgetCardInner);
 
 const styles = StyleSheet.create({
   card: {
-    borderRadius: 12,
+    borderRadius: 10,
     borderCurve: "continuous",
     borderWidth: 1,
-    padding: 16,
+    padding: 14,
     gap: 12,
   },
   header: {
@@ -86,23 +91,52 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
   },
   categoryRow: {
+    flex: 1,
     flexDirection: "row",
     alignItems: "center",
-    gap: 8,
+    gap: 10,
+    minWidth: 0,
+  },
+  emojiBubble: {
+    alignItems: "center",
+    borderRadius: 8,
+    height: 36,
+    justifyContent: "center",
+    width: 36,
+  },
+  emoji: {
+    fontSize: 18,
+  },
+  categoryText: {
+    flex: 1,
+    gap: 2,
+    minWidth: 0,
   },
   categoryName: {
     fontFamily: "Poppins_600SemiBold",
     fontSize: 14,
   },
+  amountLine: {
+    fontFamily: "Poppins_500Medium",
+    fontSize: 12,
+  },
   badge: {
-    borderRadius: 10,
-    paddingHorizontal: 8,
-    paddingVertical: 2,
+    borderRadius: 999,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
   },
   badgeText: {
-    fontFamily: "Poppins_500Medium",
+    fontFamily: "Poppins_700Bold",
     fontSize: 11,
-    color: "#FFFFFF",
+  },
+  progressTrack: {
+    borderRadius: 999,
+    height: 7,
+    overflow: "hidden",
+  },
+  progressFill: {
+    borderRadius: 999,
+    height: 7,
   },
   footer: {
     flexDirection: "row",
@@ -114,7 +148,7 @@ const styles = StyleSheet.create({
     fontSize: 12,
   },
   remainingText: {
-    fontFamily: "Poppins_500Medium",
+    fontFamily: "Poppins_700Bold",
     fontSize: 12,
   },
 });

--- a/apps/mobile/features/budget/components/BudgetHeaderMonthNavigator.tsx
+++ b/apps/mobile/features/budget/components/BudgetHeaderMonthNavigator.tsx
@@ -1,0 +1,97 @@
+import { ChevronLeft, ChevronRight } from "@/shared/components/icons";
+import { Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
+import { useThemeColor } from "@/shared/hooks";
+
+type HeaderMonthButtonProps = {
+  readonly accessibilityHint: string;
+  readonly accessibilityLabel: string;
+  readonly color: string;
+  readonly direction: "next" | "prev";
+  readonly onPress: () => void;
+};
+
+function HeaderMonthButton({
+  accessibilityHint,
+  accessibilityLabel,
+  color,
+  direction,
+  onPress,
+}: HeaderMonthButtonProps) {
+  const Icon = direction === "prev" ? ChevronLeft : ChevronRight;
+
+  return (
+    <Pressable
+      accessibilityHint={accessibilityHint}
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="button"
+      onPress={onPress}
+      hitSlop={12}
+      style={styles.headerMonthButton}
+    >
+      <Icon size={22} color={color} />
+    </Pressable>
+  );
+}
+
+type Props = {
+  readonly monthLabel: string;
+  readonly nextMonthHint: string;
+  readonly nextMonthLabel: string;
+  readonly onNext: () => void;
+  readonly onPrev: () => void;
+  readonly prevMonthHint: string;
+  readonly prevMonthLabel: string;
+};
+
+export function BudgetHeaderMonthNavigator({
+  monthLabel,
+  nextMonthHint,
+  nextMonthLabel,
+  onNext,
+  onPrev,
+  prevMonthHint,
+  prevMonthLabel,
+}: Props) {
+  const primaryColor = useThemeColor("primary");
+
+  return (
+    <View style={styles.headerMonthNavigator}>
+      <HeaderMonthButton
+        accessibilityHint={prevMonthHint}
+        accessibilityLabel={prevMonthLabel}
+        color={primaryColor}
+        direction="prev"
+        onPress={onPrev}
+      />
+      <Text style={[styles.headerMonthText, { color: primaryColor }]} numberOfLines={1}>
+        {monthLabel}
+      </Text>
+      <HeaderMonthButton
+        accessibilityHint={nextMonthHint}
+        accessibilityLabel={nextMonthLabel}
+        color={primaryColor}
+        direction="next"
+        onPress={onNext}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  headerMonthNavigator: {
+    alignItems: "center",
+    flexDirection: "row",
+    gap: 4,
+  },
+  headerMonthButton: {
+    alignItems: "center",
+    height: 36,
+    justifyContent: "center",
+    width: 32,
+  },
+  headerMonthText: {
+    fontFamily: "Poppins_700Bold",
+    fontSize: 16,
+    textAlign: "center",
+  },
+});

--- a/apps/mobile/features/budget/components/BudgetListScreen.tsx
+++ b/apps/mobile/features/budget/components/BudgetListScreen.tsx
@@ -2,24 +2,40 @@ import { FlashList, type ListRenderItemInfo } from "@shopify/flash-list";
 import { useRouter } from "expo-router";
 import { useCallback, useMemo } from "react";
 import { useOptionalUserId } from "@/features/auth/public";
-import { MonthNavigator } from "@/features/calendar/public";
+import { formatMonthYear } from "@/features/calendar/public";
 import { shouldShowNotificationPrePermissionPrompt } from "@/features/notifications/public";
 import { ScreenLayout, TAB_BAR_CLEARANCE } from "@/shared/components";
 import { Plus, Wallet } from "@/shared/components/icons";
-import { Platform, Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
+import { Pressable, StyleSheet, Text, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
 import { useSubscription, useThemeColor, useTranslation } from "@/shared/hooks";
+import { getDateFnsLocale } from "@/shared/i18n";
 import { captureError } from "@/shared/lib";
 import type { BudgetProgress } from "../lib/derive";
 import { nextBudgetMonth, prevBudgetMonth, useBudgetStore } from "../store";
 import { BudgetCard } from "./BudgetCard";
+import { BudgetHeaderMonthNavigator } from "./BudgetHeaderMonthNavigator";
 import { BudgetSummaryCard } from "./BudgetSummaryCard";
 
-function AddBudgetButton({ onPress }: { readonly onPress: () => void }) {
+function AddBudgetButton({
+  accessibilityHint,
+  accessibilityLabel,
+  onPress,
+}: {
+  readonly accessibilityHint: string;
+  readonly accessibilityLabel: string;
+  readonly onPress: () => void;
+}) {
   const primaryColor = useThemeColor("primary");
 
   return (
-    <Pressable onPress={onPress} hitSlop={12}>
+    <Pressable
+      accessibilityHint={accessibilityHint}
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="button"
+      onPress={onPress}
+      hitSlop={12}
+    >
       <Plus size={24} color={primaryColor} />
     </Pressable>
   );
@@ -28,7 +44,7 @@ function AddBudgetButton({ onPress }: { readonly onPress: () => void }) {
 const budgetKeyExtractor = (item: BudgetProgress) => item.budgetId;
 
 export function BudgetListScreen() {
-  const { t } = useTranslation();
+  const { t, locale } = useTranslation();
   const { push } = useRouter();
 
   const currentMonth = useBudgetStore((s) => s.currentMonth);
@@ -74,6 +90,7 @@ export function BudgetListScreen() {
     Number.parseInt(currentMonth.slice(5, 7), 10) - 1,
     1
   );
+  const monthLabel = formatMonthYear(monthAsDate, getDateFnsLocale(locale));
 
   const handleAddBudget = useCallback(() => {
     push("/create-budget");
@@ -154,19 +171,28 @@ export function BudgetListScreen() {
 
   return (
     <ScreenLayout
-      title={t("budgets.title")}
+      title=""
       includesNativeHeader={false}
-      rightActions={
-        Platform.OS !== "ios" ? <AddBudgetButton onPress={handleAddBudget} /> : undefined
-      }
-    >
-      <View style={styles.content}>
-        <MonthNavigator
-          currentMonth={monthAsDate}
+      centerAction={
+        <BudgetHeaderMonthNavigator
+          monthLabel={monthLabel}
+          prevMonthLabel={t("budgets.header.previousMonthLabel")}
+          prevMonthHint={t("budgets.header.previousMonthHint")}
+          nextMonthLabel={t("budgets.header.nextMonthLabel")}
+          nextMonthHint={t("budgets.header.nextMonthHint")}
           onPrev={handlePrevMonth}
           onNext={handleNextMonth}
         />
-
+      }
+      rightActions={
+        <AddBudgetButton
+          accessibilityLabel={t("budgets.header.addLabel")}
+          accessibilityHint={t("budgets.header.addHint")}
+          onPress={handleAddBudget}
+        />
+      }
+    >
+      <View style={styles.content}>
         <FlashList
           data={hasBudgets ? budgetProgress : []}
           renderItem={renderBudget}
@@ -189,12 +215,13 @@ const styles = StyleSheet.create({
   content: {
     flex: 1,
     paddingHorizontal: 16,
+    gap: 8,
   },
   scrollContent: {
-    gap: 12,
+    gap: 8,
   },
   itemSeparator: {
-    height: 12,
+    height: 8,
   },
   emptyState: {
     alignItems: "center",

--- a/apps/mobile/features/budget/components/BudgetSummaryCard.tsx
+++ b/apps/mobile/features/budget/components/BudgetSummaryCard.tsx
@@ -1,11 +1,11 @@
-import { ProgressBar } from "@/shared/components";
 import { StyleSheet, Text, View } from "@/shared/components/rn";
 import { useThemeColor, useTranslation } from "@/shared/hooks";
-import { formatMoney } from "@/shared/lib";
+import type { CopAmount } from "@/shared/types/branded";
+import { deriveBudgetPulseSummaryModel } from "../lib/derive";
 
 type Props = {
-  readonly totalBudget: number;
-  readonly totalSpent: number;
+  readonly totalBudget: CopAmount;
+  readonly totalSpent: CopAmount;
   readonly percentUsed: number;
 };
 
@@ -15,6 +15,11 @@ export function BudgetSummaryCard({ totalBudget, totalSpent, percentUsed }: Prop
   const secondaryColor = useThemeColor("secondary");
   const cardBg = useThemeColor("card");
   const borderColor = useThemeColor("borderSubtle");
+  const accentGreen = useThemeColor("accentGreen");
+  const accentRed = useThemeColor("accentRed");
+  const model = deriveBudgetPulseSummaryModel({ totalBudget, totalSpent, percentUsed, t });
+  const progressColor = model.isOverBudget ? accentRed : accentGreen;
+  const progressWidth = `${Math.max(0, Math.min(percentUsed, 100))}%` as `${number}%`;
 
   return (
     <View style={[styles.card, { backgroundColor: cardBg, borderColor }]}>
@@ -22,18 +27,18 @@ export function BudgetSummaryCard({ totalBudget, totalSpent, percentUsed }: Prop
         <Text style={[styles.label, { color: secondaryColor }]}>
           {t("budgets.summary.totalBudget")}
         </Text>
-        <Text style={[styles.amount, { color: primaryColor }]}>{formatMoney(totalBudget)}</Text>
+        <View style={[styles.percentPill, { backgroundColor: progressColor }]}>
+          <Text style={styles.percentText}>{model.percentLabel}</Text>
+        </View>
       </View>
 
-      <ProgressBar percent={percentUsed} />
+      <Text style={[styles.amount, { color: primaryColor }]}>{model.totalBudgetLabel}</Text>
+      <Text style={[styles.guidance, { color: secondaryColor }]}>{model.guidance}</Text>
 
-      <View style={styles.footer}>
-        <Text style={[styles.spentText, { color: secondaryColor }]}>
-          {formatMoney(totalSpent)} / {formatMoney(totalBudget)}
-        </Text>
-        <Text style={[styles.usedText, { color: secondaryColor }]}>
-          {t("budgets.summary.used", { percent: percentUsed })}
-        </Text>
+      <View style={[styles.progressTrack, { backgroundColor: borderColor }]}>
+        <View
+          style={[styles.progressFill, { backgroundColor: progressColor, width: progressWidth }]}
+        />
       </View>
     </View>
   );
@@ -41,10 +46,10 @@ export function BudgetSummaryCard({ totalBudget, totalSpent, percentUsed }: Prop
 
 const styles = StyleSheet.create({
   card: {
-    borderRadius: 12,
+    borderRadius: 10,
     borderCurve: "continuous",
     borderWidth: 1,
-    padding: 16,
+    padding: 18,
     gap: 12,
   },
   header: {
@@ -58,19 +63,31 @@ const styles = StyleSheet.create({
   },
   amount: {
     fontFamily: "Poppins_700Bold",
-    fontSize: 18,
+    fontSize: 34,
+    lineHeight: 40,
   },
-  footer: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-  },
-  spentText: {
+  guidance: {
     fontFamily: "Poppins_500Medium",
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  percentPill: {
+    borderRadius: 999,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+  },
+  percentText: {
+    color: "#0D0D0D",
+    fontFamily: "Poppins_700Bold",
     fontSize: 12,
   },
-  usedText: {
-    fontFamily: "Poppins_500Medium",
-    fontSize: 12,
+  progressTrack: {
+    borderRadius: 999,
+    height: 9,
+    overflow: "hidden",
+  },
+  progressFill: {
+    borderRadius: 999,
+    height: 9,
   },
 });

--- a/apps/mobile/features/budget/lib/derive.ts
+++ b/apps/mobile/features/budget/lib/derive.ts
@@ -1,4 +1,5 @@
 import { differenceInCalendarDays, endOfMonth } from "date-fns";
+import { formatMoney } from "@/shared/lib/format-money";
 import type { BudgetId, CategoryId, CopAmount, Month } from "@/shared/types/branded";
 
 export type BudgetProgress = {
@@ -52,8 +53,8 @@ export function deriveBudgetProgress(
 
 /** Pure derivation: aggregate totals across all budget progresses. */
 export function deriveBudgetSummary(progresses: readonly BudgetProgress[]): {
-  readonly totalBudget: number;
-  readonly totalSpent: number;
+  readonly totalBudget: CopAmount;
+  readonly totalSpent: CopAmount;
   readonly percentUsed: number;
 } {
   const { totalBudget, totalSpent } = progresses.reduce(
@@ -68,7 +69,81 @@ export function deriveBudgetSummary(progresses: readonly BudgetProgress[]): {
     if (totalSpent > 0) return 100;
     return 0;
   })();
-  return { totalBudget, totalSpent, percentUsed };
+  return {
+    totalBudget: totalBudget as CopAmount,
+    totalSpent: totalSpent as CopAmount,
+    percentUsed,
+  };
+}
+
+type TranslateBudgetPulse = (
+  key: string,
+  params?: Readonly<Record<string, string | number>>
+) => string;
+
+export type BudgetPulseSummaryModel = {
+  readonly totalBudgetLabel: string;
+  readonly percentLabel: string;
+  readonly guidance: string;
+  readonly remaining: CopAmount;
+  readonly isOverBudget: boolean;
+};
+
+export function deriveBudgetPulseSummaryModel(input: {
+  readonly totalBudget: CopAmount;
+  readonly totalSpent: CopAmount;
+  readonly percentUsed: number;
+  readonly t: TranslateBudgetPulse;
+}): BudgetPulseSummaryModel {
+  const remaining = (input.totalBudget - input.totalSpent) as CopAmount;
+  const amount = formatMoney(Math.abs(remaining));
+  const isOverBudget = remaining < 0;
+
+  return {
+    totalBudgetLabel: formatMoney(input.totalBudget),
+    percentLabel: `${input.percentUsed}%`,
+    guidance: input.t(isOverBudget ? "budgets.summary.over" : "budgets.summary.remaining", {
+      amount,
+    }),
+    remaining,
+    isOverBudget,
+  };
+}
+
+export type BudgetPulseCardModel = {
+  readonly amountLine: string;
+  readonly percentLabel: string;
+  readonly remainingLabel: string;
+  readonly statusLabel: string;
+  readonly tone: "default" | "warning" | "danger";
+};
+
+export function deriveBudgetPulseCardModel(input: {
+  readonly progress: BudgetProgress;
+  readonly t: TranslateBudgetPulse;
+}): BudgetPulseCardModel {
+  const { progress, t } = input;
+  const tone = (() => {
+    if (progress.isOverBudget) return "danger" as const;
+    if (progress.isNearLimit) return "warning" as const;
+    return "default" as const;
+  })();
+  const remainingAmount = formatMoney(Math.abs(progress.remaining));
+  const statusKey = (() => {
+    if (progress.isOverBudget) return "budgets.card.status.over";
+    if (progress.isNearLimit) return "budgets.card.status.nearLimit";
+    return "budgets.card.status.onTrack";
+  })();
+
+  return {
+    amountLine: `${formatMoney(progress.spent)} / ${formatMoney(progress.amount)}`,
+    percentLabel: `${progress.percentUsed}%`,
+    remainingLabel: t(progress.isOverBudget ? "budgets.card.over" : "budgets.card.remaining", {
+      amount: remainingAmount,
+    }),
+    statusLabel: t(statusKey),
+    tone,
+  };
 }
 
 /**

--- a/apps/mobile/features/budget/lib/monitoring.ts
+++ b/apps/mobile/features/budget/lib/monitoring.ts
@@ -3,7 +3,7 @@ import { getSpendingByCategoryAggregate } from "@/features/transactions/query.pu
 import type { AnyDb } from "@/shared/db/client";
 import { formatMoney, toMonth } from "@/shared/lib";
 import { assertCopAmount } from "@/shared/types/assertions";
-import type { BudgetId, CategoryId, Month, UserId } from "@/shared/types/branded";
+import type { BudgetId, CategoryId, CopAmount, Month, UserId } from "@/shared/types/branded";
 import type { Budget } from "../schema";
 import type { BudgetAlert, BudgetProgress, BudgetSuggestion } from "./derive";
 import {
@@ -25,8 +25,8 @@ export type BudgetMonthSnapshot = {
   readonly budgets: readonly Budget[];
   readonly budgetProgress: readonly BudgetProgress[];
   readonly summary: {
-    readonly totalBudget: number;
-    readonly totalSpent: number;
+    readonly totalBudget: CopAmount;
+    readonly totalSpent: CopAmount;
     readonly percentUsed: number;
   };
   readonly autoSuggestions: readonly BudgetSuggestion[];

--- a/apps/mobile/features/budget/store/state.ts
+++ b/apps/mobile/features/budget/store/state.ts
@@ -1,5 +1,6 @@
 import type { StateCreator } from "zustand";
-import type { BudgetId, Month, UserId } from "@/shared/types/branded";
+import { requireCopAmount } from "@/shared/types/assertions";
+import type { BudgetId, CopAmount, Month, UserId } from "@/shared/types/branded";
 import type { BudgetAlert, BudgetProgress, BudgetSuggestion } from "../lib/derive";
 import type { BudgetAlertState, BudgetMonthSnapshot } from "../lib/monitoring";
 import type { Budget } from "../schema";
@@ -10,11 +11,11 @@ export type BudgetState = {
   readonly budgets: readonly Budget[];
   readonly budgetProgress: readonly BudgetProgress[];
   readonly summary: {
-    readonly totalBudget: number;
-    readonly totalSpent: number;
+    readonly totalBudget: CopAmount;
+    readonly totalSpent: CopAmount;
     readonly percentUsed: number;
   };
-  readonly budgetTotalByMonth: Readonly<Partial<Record<Month, number>>>;
+  readonly budgetTotalByMonth: Readonly<Partial<Record<Month, CopAmount>>>;
   readonly autoSuggestions: readonly BudgetSuggestion[];
   readonly acknowledgedAlerts: ReadonlySet<string>;
   readonly pendingAlerts: readonly BudgetAlert[];
@@ -51,7 +52,7 @@ export function createBudgetState(currentMonth: Month, activeUserId: UserId | nu
     currentMonth,
     budgets: [],
     budgetProgress: [],
-    summary: { totalBudget: 0, totalSpent: 0, percentUsed: 0 },
+    summary: { totalBudget: requireCopAmount(0), totalSpent: requireCopAmount(0), percentUsed: 0 },
     budgetTotalByMonth: {},
     autoSuggestions: [],
     acknowledgedAlerts: new Set(),

--- a/apps/mobile/features/calendar/index.ts
+++ b/apps/mobile/features/calendar/index.ts
@@ -1,6 +1,6 @@
 export { CalendarGrid } from "./components/CalendarGrid";
 export { MonthNavigator } from "./components/MonthNavigator";
-export { getBillsForDate, getNextOccurrence } from "./lib/calendar-utils";
+export { formatMonthYear, getBillsForDate, getNextOccurrence } from "./lib/calendar-utils";
 export type { Bill, BillFrequency, BillPayment, CreateBillInput } from "./schema";
 export { billSchema, FREQUENCIES } from "./schema";
 export {

--- a/apps/mobile/shared/components/ScreenLayout.tsx
+++ b/apps/mobile/shared/components/ScreenLayout.tsx
@@ -14,6 +14,7 @@ type ScreenLayoutProps = {
   variant?: "tab" | "sub";
   backgroundColor?: string;
   backgroundLayer?: ReactNode;
+  centerAction?: ReactNode;
   leftAction?: ReactNode;
   rightActions?: ReactNode;
   onBack?: () => void;
@@ -26,6 +27,7 @@ export function ScreenLayout({
   variant = "tab",
   backgroundColor,
   backgroundLayer,
+  centerAction,
   leftAction,
   rightActions,
   onBack,
@@ -42,7 +44,11 @@ export function ScreenLayout({
   const shouldRenderCustomHeader =
     Platform.OS !== "ios" ||
     (!includesNativeHeader &&
-      (!isTab || leftAction != null || rightActions != null || onBack != null));
+      (!isTab ||
+        centerAction != null ||
+        leftAction != null ||
+        rightActions != null ||
+        onBack != null));
   const iosHeaderOptions = {
     contentStyle: { backgroundColor: "transparent" },
     headerShadowVisible: false,
@@ -87,7 +93,16 @@ export function ScreenLayout({
                 {isTab ? "" : title}
               </Text>
             </View>
-            {isTab && leftAction != null ? (
+            {isTab && centerAction != null ? (
+              <View
+                className="absolute left-16 right-16 items-center"
+                pointerEvents="box-none"
+                style={styles.centerActionSlot}
+              >
+                {centerAction}
+              </View>
+            ) : null}
+            {isTab && leftAction != null && centerAction == null ? (
               <Text
                 className="absolute left-0 right-0 text-center font-poppins-extrabold text-logo text-primary dark:text-primary-dark"
                 pointerEvents="none"
@@ -97,7 +112,9 @@ export function ScreenLayout({
               </Text>
             ) : null}
             {shouldRenderRightSlot ? (
-              <View className={rightSlotClassName}>{rightActions}</View>
+              <View className={rightSlotClassName} pointerEvents="box-none">
+                {rightActions}
+              </View>
             ) : null}
           </View>
         </View>
@@ -116,3 +133,10 @@ export function ScreenLayout({
     </View>
   );
 }
+
+const styles = {
+  // Header center content is reserved for compact controls; side actions should stay icon-sized.
+  centerActionSlot: {
+    maxWidth: "70%" as const,
+  },
+};

--- a/apps/mobile/shared/i18n/locales/en.ts
+++ b/apps/mobile/shared/i18n/locales/en.ts
@@ -326,6 +326,14 @@ const en = {
   // Budgets
   budgets: {
     title: "Budgets",
+    header: {
+      previousMonthLabel: "Previous month",
+      previousMonthHint: "Shows budgets for the previous month",
+      nextMonthLabel: "Next month",
+      nextMonthHint: "Shows budgets for the next month",
+      addLabel: "Add budget",
+      addHint: "Opens the form to create a budget",
+    },
     empty: {
       title: "No budgets yet",
       subtitle: "Set spending limits and track your money",
@@ -342,13 +350,20 @@ const en = {
       title: "Edit budget",
     },
     card: {
-      remaining: "%{amount} remaining",
+      remaining: "%{amount} left",
       over: "%{amount} over budget",
       used: "%{percent}% used",
+      status: {
+        onTrack: "On track",
+        nearLimit: "Close to limit",
+        over: "Over limit",
+      },
     },
     summary: {
       totalBudget: "Total budget",
       used: "%{percent}% used",
+      remaining: "You have %{amount} left to close the month.",
+      over: "You are %{amount} over this month.",
     },
     alerts: {
       nearLimitTitle: "Budget warning",

--- a/apps/mobile/shared/i18n/locales/es.ts
+++ b/apps/mobile/shared/i18n/locales/es.ts
@@ -334,6 +334,14 @@ const es = {
   // Presupuestos
   budgets: {
     title: "Presupuestos",
+    header: {
+      previousMonthLabel: "Mes anterior",
+      previousMonthHint: "Muestra los presupuestos del mes anterior",
+      nextMonthLabel: "Mes siguiente",
+      nextMonthHint: "Muestra los presupuestos del mes siguiente",
+      addLabel: "Agregar presupuesto",
+      addHint: "Abre el formulario para crear un presupuesto",
+    },
     empty: {
       title: "Aún no hay presupuestos",
       subtitle: "Establece límites de gasto y controla tu dinero",
@@ -350,13 +358,20 @@ const es = {
       title: "Editar presupuesto",
     },
     card: {
-      remaining: "%{amount} restante",
+      remaining: "Quedan %{amount}",
       over: "%{amount} sobre el presupuesto",
       used: "%{percent}% usado",
+      status: {
+        onTrack: "Vas bien",
+        nearLimit: "Cerca del límite",
+        over: "Sobre el límite",
+      },
     },
     summary: {
       totalBudget: "Presupuesto total",
       used: "%{percent}% usado",
+      remaining: "Te quedan %{amount} para cerrar el mes.",
+      over: "Te pasaste por %{amount} este mes.",
     },
     alerts: {
       nearLimitTitle: "Advertencia de presupuesto",


### PR DESCRIPTION
- add month pulse budget cards

- move month controls into header

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the mobile Budget screen with a new pulse summary and category cards, and moved month navigation into the header for faster switching. Applied the shared aurora background app‑wide, visible behind cards.

- **New Features**
  - Pulse summary hero: total budget label, percent pill, localized guidance (“left”/“over”), and a color‑coded progress track.
  - Pulse budget cards: emoji bubbles, spent/amount line, percent badge, status labels (“On track”, “Close to limit”, “Over limit”), and warning/over tones.
  - Header month navigation via BudgetHeaderMonthNavigator centered in ScreenLayout; uses formatMonthYear with locale and a11y labels/hints (prev/next month, add budget).
  - Added deriveBudgetPulseSummaryModel and deriveBudgetPulseCardModel with tests; updated `en`/`es` copy.

- **Refactors**
  - Replaced ProgressBar with lightweight progress tracks.
  - ScreenLayout now supports `centerAction`; BudgetListScreen uses it for the month navigator.
  - Tightened types: summary totals now `CopAmount` across state, monitoring, and tests.

<sup>Written for commit e5beeee56b00873ab1431ebdd206f453870d8f4c. Summary will update on new commits. <a href="https://cubic.dev/pr/B4rz99/fidy/pull/487?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a centered month navigator header for budgets.

* **Improvements**
  * Redesigned budget cards and summary: emoji category bubbles, percent pills, tone-based colors, clamped inline progress fills, and updated footer showing remaining/status messaging.
  * Add-budget action now always visible in list header; header spacing tightened.
  * Screen layout supports an optional centered action slot.

* **Localization**
  * Updated English and Spanish budget header and status copy.

* **Tests**
  * Expanded budget tests for pulse summary/card messaging with stricter translation checks.

* **Chores**
  * Switched budget amount fields to branded money types across state and monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/B4rz99/fidy/pull/487?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->