### PR TITLE
fix(mobile): tighten react-doctor exceptions

### DIFF
--- a/react-doctor.config.json
+++ b/react-doctor.config.json
@@ -1,79 +1,67 @@
 {
   "ignore": {
     "rules": ["react-doctor/async-defer-await"],
+    "ruleReasons": {
+      "react-doctor/async-defer-await": "Current hits are async store/service state machines where the awaited setup establishes the state later guards validate. Keep this broad suppression temporary; converting these safely needs file-local review."
+    },
     "overrides": [
       {
         "files": [
-          "apps/mobile/plugins/withFidyWidget*.js",
           "plugins/withFidyWidget*.js",
-          "apps/mobile/features/budget/components/BudgetAlertBanner.tsx",
-          "features/budget/components/BudgetAlertBanner.tsx",
-          "apps/mobile/features/budget/components/UpcomingBillsSection.tsx",
           "features/budget/components/UpcomingBillsSection.tsx",
-          "apps/mobile/shared/components/ComingSoonScreen.tsx",
           "shared/components/ComingSoonScreen.tsx"
         ],
-        "rules": ["deslop/unused-file"]
+        "rules": ["deslop/unused-file"],
+        "reason": "Widget plugin files are loaded dynamically from app.config.ts, which deslop does not resolve. UpcomingBillsSection and ComingSoonScreen are parked UI components covered by source tests but not currently reachable from a route."
       },
       {
         "files": [
-          "apps/mobile/app/connected-accounts.tsx",
           "app/connected-accounts.tsx",
-          "apps/mobile/features/ai-chat/components/ChatConversationShell.tsx",
           "features/ai-chat/components/ChatConversationShell.tsx",
-          "apps/mobile/features/settings/components/NotificationPreferencesScreen.tsx",
           "features/settings/components/NotificationPreferencesScreen.tsx"
         ],
-        "rules": ["react-doctor/rn-scrollview-dynamic-padding"]
+        "rules": ["react-doctor/rn-scrollview-dynamic-padding"],
+        "reason": "These screens intentionally mirror the dynamic safe-area bottom inset into contentContainerStyle to preserve Android scroll spacing while also using contentInset for OS-level bottom offset."
       },
       {
         "files": [
-          "apps/mobile/shared/hooks/use-subscription.ts",
           "shared/hooks/use-subscription.ts",
-          "apps/mobile/shared/hooks/use-mount-effect.ts",
           "shared/hooks/use-mount-effect.ts"
         ],
-        "rules": ["react-doctor/exhaustive-deps"]
+        "rules": ["react-doctor/exhaustive-deps"],
+        "reason": "These hooks centralize deliberate dependency-array escape hatches: useSubscription lets callers provide an explicit dependency list, and useMountEffect is mount-only by contract."
       },
       {
         "files": [
-          "apps/mobile/features/email-capture/services/gmail-adapter.ts",
           "features/email-capture/services/gmail-adapter.ts"
         ],
         "rules": [
           "react-doctor/async-await-in-loop",
           "react-doctor/server-sequential-independent-await"
-        ]
+        ],
+        "reason": "Gmail message collection runs bounded batches sequentially to respect Gmail API rate limits while each batch still fetches messages in parallel."
       },
       {
         "files": [
-          "apps/mobile/features/ai-chat/services/create-ai-chat-api-service.ts",
           "features/ai-chat/services/create-ai-chat-api-service.ts",
-          "apps/mobile/features/capture-sources/services/widget-pipeline.ts",
           "features/capture-sources/services/widget-pipeline.ts",
-          "apps/mobile/features/email-capture/services/email-pipeline-service/incoming-batch.ts",
           "features/email-capture/services/email-pipeline-service/incoming-batch.ts",
-          "apps/mobile/features/email-capture/store/fetch-processing.ts",
           "features/email-capture/store/fetch-processing.ts",
-          "apps/mobile/features/email-capture/services/email-pipeline-service/retry.ts",
           "features/email-capture/services/email-pipeline-service/retry.ts",
-          "apps/mobile/features/email-capture/services/email-parse-improvement-outbox.ts",
           "features/email-capture/services/email-parse-improvement-outbox.ts",
-          "apps/mobile/shared/bootstrap/registry.ts",
           "shared/bootstrap/registry.ts",
-          "apps/mobile/shared/mutations/write-through/module.ts",
           "shared/mutations/write-through/module.ts"
         ],
-        "rules": ["react-doctor/async-await-in-loop"]
+        "rules": ["react-doctor/async-await-in-loop"],
+        "reason": "These awaits are ordered workflows: SSE reader consumption, capture dedup/cleanup, rate-limited email worker queues, ordered retry/outbox processing, bootstrap sequencing, and write-through side effects."
       },
       {
         "files": [
-          "apps/mobile/features/email-capture/services/create-email-adapter.ts",
           "features/email-capture/services/create-email-adapter.ts",
-          "apps/mobile/features/auth/store.ts",
           "features/auth/store.ts"
         ],
-        "rules": ["react-doctor/async-parallel", "react-doctor/server-sequential-independent-await"]
+        "rules": ["react-doctor/async-parallel", "react-doctor/server-sequential-independent-await"],
+        "reason": "OAuth and auth flows must preserve user-visible ordering: authorization before token exchange/profile fetch, token cleanup before remote sign-out, and local state clearing after sign-out."
       }
     ]
   }


### PR DESCRIPTION
- remove stale duplicate entries

- add suppression reasons

- fix remaining size-8 Tailwind issue


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened `react-doctor` exceptions for mobile by removing stale duplicates and adding clear reasons for the remaining suppressions. This reduces lint noise and documents intent for future cleanup.

- **Refactors**
  - Removed duplicate `apps/mobile/...` entries; kept root paths only.
  - Added `ruleReasons` for `react-doctor/async-defer-await` and per-override `reason` notes.
  - Kept only necessary file overrides and documented why for `deslop/unused-file`, `rn-scrollview-dynamic-padding`, `exhaustive-deps`, `async-await-in-loop`, `async-parallel`, and `server-sequential-independent-await`.

<sup>Written for commit 161c39f146c9e591e541475bd219c3eb7d35fe07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/B4rz99/fidy/pull/504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

