### PR TITLE
refactor(mobile): reuse list route shells

### DIFF
--- a/.agents/skills/mobile-qa/SKILL.md
+++ b/.agents/skills/mobile-qa/SKILL.md
@@ -29,7 +29,7 @@ Run from the repo root unless a command says otherwise.
    ```bash
    IP=$(ipconfig getifaddr en0)
    cd apps/mobile
-   CI=1 bun x expo start --dev-client --host lan --port 8081 --clear
+   bun x expo start --dev-client --host lan --port 8081 --clear
    ```
 
    Wait until Metro prints that it is waiting on `8081`, then confirm from the
@@ -88,5 +88,7 @@ Run from the repo root unless a command says otherwise.
   `bun sim:serve:kill` if ports pile up.
 - If the app shows a red dev-client screen for `127.0.0.1:8081`, fix Metro
   first. The simulator viewer is not the problem.
+- Do not set `CI=1` for manual UI QA. It can disable hot reload and make visual
+  iteration misleading.
 - Use simulator tools or direct deep links for interaction; use the browser
   stream primarily for visual QA.

--- a/apps/mobile/__tests__/budget/create-budget-screen.test.ts
+++ b/apps/mobile/__tests__/budget/create-budget-screen.test.ts
@@ -8,6 +8,7 @@ function readSource(relativePath: string) {
 
 const routeSource = readSource("../../app/create-budget.tsx");
 const layoutSource = readSource("../../app/_layout.tsx");
+const rootStackRoutesSource = readSource("../../shared/navigation/root-stack-routes.ts");
 const autoSuggestBudgetsSource = readSource("../../app/auto-suggest-budgets.tsx");
 const screenSource = readSource(
   "../../features/budget/components/create-budget/CreateBudgetScreen.tsx"
@@ -29,9 +30,10 @@ test("create-budget is registered in root layout as a full screen route", () => 
   expect(layoutSource).toContain('"create-budget"');
   expect(routeSource).not.toContain("DialogRouteFrame");
   expect(routeSource).toContain("CreateBudgetScreen");
-  const createBudgetBlock = layoutSource.slice(layoutSource.indexOf('name="create-budget"'));
-  expect(createBudgetBlock.slice(0, 140)).toContain("createBudgetRouteOptions");
-  expect(layoutSource).toContain("...fullScreenHeaderOptions");
+  expect(layoutSource).toContain('name="create-budget"');
+  expect(layoutSource).toContain("routeOptions.titled.createBudget");
+  expect(rootStackRoutesSource).toContain("createBudget");
+  expect(rootStackRoutesSource).toContain("...fullScreen");
   expect(layoutSource).not.toContain("formSheet");
 });
 

--- a/apps/mobile/__tests__/budget/create-budget-screen.test.ts
+++ b/apps/mobile/__tests__/budget/create-budget-screen.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { expect, test } from "vitest";
+import { expectTitledRouteExtendsFullScreen } from "@/__tests__/helpers/root-stack-routes";
 
 function readSource(relativePath: string) {
   return readFileSync(resolve(__dirname, relativePath), "utf-8");
@@ -33,7 +34,7 @@ test("create-budget is registered in root layout as a full screen route", () => 
   expect(layoutSource).toContain('name="create-budget"');
   expect(layoutSource).toContain("routeOptions.titled.createBudget");
   expect(rootStackRoutesSource).toContain("createBudget");
-  expect(rootStackRoutesSource).toContain("...fullScreen");
+  expectTitledRouteExtendsFullScreen(rootStackRoutesSource, "createBudget");
   expect(layoutSource).not.toContain("formSheet");
 });
 

--- a/apps/mobile/__tests__/calendar/add-bill-screen.test.ts
+++ b/apps/mobile/__tests__/calendar/add-bill-screen.test.ts
@@ -1,27 +1,39 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { expect, test } from "vitest";
+import { beforeAll, expect, test } from "vitest";
 import { expectRouteInRootStackGroup } from "@/__tests__/helpers/root-stack-routes";
 
 function readSource(relativePath: string) {
   return readFileSync(resolve(__dirname, relativePath), "utf-8");
 }
 
-const routeSource = readSource("../../app/add-bill.tsx");
-const layoutSource = readFileSync(resolve(__dirname, "../../app/_layout.tsx"), "utf-8");
-const rootStackRoutesSource = readSource("../../shared/navigation/root-stack-routes.ts");
-const screenSource = readSource("../../features/calendar/components/add-bill/AddBillScreen.tsx");
-const formSource = readSource("../../features/calendar/components/add-bill/AddBillForm.tsx");
-const formContentSource = readSource(
-  "../../features/calendar/components/add-bill/AddBillFormContent.tsx"
-);
-const formStylesSource = readSource(
-  "../../features/calendar/components/add-bill/AddBillForm.styles.ts"
-);
-const authFormSource = readSource(
-  "../../features/calendar/components/add-bill/AuthenticatedAddBillForm.tsx"
-);
-const submitSource = readSource("../../features/calendar/components/add-bill/useAddBillSubmit.ts");
+let routeSource = "";
+let layoutSource = "";
+let rootStackRoutesSource = "";
+let screenSource = "";
+let formSource = "";
+let formContentSource = "";
+let formStylesSource = "";
+let authFormSource = "";
+let submitSource = "";
+
+beforeAll(() => {
+  routeSource = readSource("../../app/add-bill.tsx");
+  layoutSource = readFileSync(resolve(__dirname, "../../app/_layout.tsx"), "utf-8");
+  rootStackRoutesSource = readSource("../../shared/navigation/root-stack-routes.ts");
+  screenSource = readSource("../../features/calendar/components/add-bill/AddBillScreen.tsx");
+  formSource = readSource("../../features/calendar/components/add-bill/AddBillForm.tsx");
+  formContentSource = readSource(
+    "../../features/calendar/components/add-bill/AddBillFormContent.tsx"
+  );
+  formStylesSource = readSource(
+    "../../features/calendar/components/add-bill/AddBillForm.styles.ts"
+  );
+  authFormSource = readSource(
+    "../../features/calendar/components/add-bill/AuthenticatedAddBillForm.tsx"
+  );
+  submitSource = readSource("../../features/calendar/components/add-bill/useAddBillSubmit.ts");
+});
 
 test("add-bill is registered in root layout as a full screen route", () => {
   expect(layoutSource).toContain("ROOT_STACK_ROUTES.fullScreen");

--- a/apps/mobile/__tests__/calendar/add-bill-screen.test.ts
+++ b/apps/mobile/__tests__/calendar/add-bill-screen.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { expect, test } from "vitest";
+import { expectRouteInRootStackGroup } from "@/__tests__/helpers/root-stack-routes";
 
 function readSource(relativePath: string) {
   return readFileSync(resolve(__dirname, relativePath), "utf-8");
@@ -27,7 +28,7 @@ test("add-bill is registered in root layout as a full screen route", () => {
   expect(routeSource).not.toContain("DialogRouteFrame");
   expect(routeSource).toContain('headerBackTitle: ""');
   expect(routeSource).toContain("headerTitle: title");
-  expect(rootStackRoutesSource).toContain('"add-bill"');
+  expectRouteInRootStackGroup(rootStackRoutesSource, "fullScreen", "add-bill");
   expect(layoutSource).toContain("ROOT_STACK_ROUTES.fullScreen.map");
   expect(layoutSource).toContain("routeOptions.fullScreen");
   expect(layoutSource).not.toContain("formSheet");

--- a/apps/mobile/__tests__/calendar/add-bill-screen.test.ts
+++ b/apps/mobile/__tests__/calendar/add-bill-screen.test.ts
@@ -8,6 +8,7 @@ function readSource(relativePath: string) {
 
 const routeSource = readSource("../../app/add-bill.tsx");
 const layoutSource = readFileSync(resolve(__dirname, "../../app/_layout.tsx"), "utf-8");
+const rootStackRoutesSource = readSource("../../shared/navigation/root-stack-routes.ts");
 const screenSource = readSource("../../features/calendar/components/add-bill/AddBillScreen.tsx");
 const formSource = readSource("../../features/calendar/components/add-bill/AddBillForm.tsx");
 const formContentSource = readSource(
@@ -22,17 +23,13 @@ const authFormSource = readSource(
 const submitSource = readSource("../../features/calendar/components/add-bill/useAddBillSubmit.ts");
 
 test("add-bill is registered in root layout as a full screen route", () => {
-  expect(layoutSource).toContain('name="add-bill"');
+  expect(layoutSource).toContain("ROOT_STACK_ROUTES.fullScreen");
   expect(routeSource).not.toContain("DialogRouteFrame");
   expect(routeSource).toContain('headerBackTitle: ""');
   expect(routeSource).toContain("headerTitle: title");
-  const addBillStart = layoutSource.indexOf('name="add-bill"');
-  const dayDetailStart = layoutSource.indexOf('name="day-detail"');
-  expect(addBillStart).toBeGreaterThan(-1);
-  expect(dayDetailStart).toBeGreaterThan(addBillStart);
-  const addBillBlock = layoutSource.slice(addBillStart, dayDetailStart);
-  expect(addBillBlock).toContain("fullScreenHeaderOptions");
-  expect(addBillBlock).not.toContain("DIALOG_MODAL");
+  expect(rootStackRoutesSource).toContain('"add-bill"');
+  expect(layoutSource).toContain("ROOT_STACK_ROUTES.fullScreen.map");
+  expect(layoutSource).toContain("routeOptions.fullScreen");
   expect(layoutSource).not.toContain("formSheet");
 });
 

--- a/apps/mobile/__tests__/calendar/calendar-screen.test.ts
+++ b/apps/mobile/__tests__/calendar/calendar-screen.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, test } from "vitest";
+import { expectRouteInRootStackGroup } from "@/__tests__/helpers/root-stack-routes";
 
 function readSource(relativePath: string) {
   return readFileSync(resolve(__dirname, relativePath), "utf-8");
@@ -42,7 +43,7 @@ describe("calendar screen", () => {
     expect(billsCalendarSource).toContain("rightActions");
     expect(billsCalendarSource).toContain('push("/add-bill")');
     expect(billsCalendarSource).toContain('accessibilityLabel={t("bills.addBill")}');
-    expect(rootStackRoutesSource).toContain('"bills-calendar"');
+    expectRouteInRootStackGroup(rootStackRoutesSource, "transparentHeader", "bills-calendar");
     expect(rootLayoutSource).toContain("ROOT_STACK_ROUTES.transparentHeader.map");
   });
 
@@ -108,7 +109,7 @@ describe("calendar screen", () => {
   });
 
   test("day detail is a full screen route so bill editing pushes normally", () => {
-    expect(rootStackRoutesSource).toContain('"day-detail"');
+    expectRouteInRootStackGroup(rootStackRoutesSource, "fullScreen", "day-detail");
     expect(rootLayoutSource).toContain("ROOT_STACK_ROUTES.fullScreen.map");
     expect(rootLayoutSource).toContain("routeOptions.fullScreen");
     expect(dayDetailSource).not.toContain("DialogRouteFrame");

--- a/apps/mobile/__tests__/calendar/calendar-screen.test.ts
+++ b/apps/mobile/__tests__/calendar/calendar-screen.test.ts
@@ -10,6 +10,7 @@ const billsCalendarSource = readSource("../../app/bills-calendar.tsx");
 const financeTabSource = readSource("../../app/(tabs)/(finance)/index.tsx");
 const dayDetailSource = readSource("../../app/day-detail.tsx");
 const rootLayoutSource = readSource("../../app/_layout.tsx");
+const rootStackRoutesSource = readSource("../../shared/navigation/root-stack-routes.ts");
 const monthBoardSource = readSource("../../features/calendar/components/CalendarMonthBoard.tsx");
 const gridSource = readSource("../../features/calendar/components/CalendarGrid.tsx");
 const dayCellSource = readSource("../../features/calendar/components/CalendarDayCell.tsx");
@@ -41,9 +42,8 @@ describe("calendar screen", () => {
     expect(billsCalendarSource).toContain("rightActions");
     expect(billsCalendarSource).toContain('push("/add-bill")');
     expect(billsCalendarSource).toContain('accessibilityLabel={t("bills.addBill")}');
-    expect(rootLayoutSource).toContain(
-      '<Stack.Screen name="bills-calendar" options={iosHeaderOptions} />'
-    );
+    expect(rootStackRoutesSource).toContain('"bills-calendar"');
+    expect(rootLayoutSource).toContain("ROOT_STACK_ROUTES.transparentHeader.map");
   });
 
   test("calendar proposal keeps the calendar, legend, and upcoming pending list without summary card", () => {
@@ -108,13 +108,9 @@ describe("calendar screen", () => {
   });
 
   test("day detail is a full screen route so bill editing pushes normally", () => {
-    const dayDetailStart = rootLayoutSource.indexOf('name="day-detail"');
-    const themePickerStart = rootLayoutSource.indexOf('name="theme-picker"');
-    expect(dayDetailStart).toBeGreaterThan(-1);
-    expect(themePickerStart).toBeGreaterThan(dayDetailStart);
-    const dayDetailBlock = rootLayoutSource.slice(dayDetailStart, themePickerStart);
-    expect(dayDetailBlock).toContain("fullScreenHeaderOptions");
-    expect(dayDetailBlock).not.toContain("DIALOG_MODAL");
+    expect(rootStackRoutesSource).toContain('"day-detail"');
+    expect(rootLayoutSource).toContain("ROOT_STACK_ROUTES.fullScreen.map");
+    expect(rootLayoutSource).toContain("routeOptions.fullScreen");
     expect(dayDetailSource).not.toContain("DialogRouteFrame");
     expect(dayDetailSource).toContain("<Stack.Screen");
     expect(dayDetailSource).toContain('router.push({ pathname: "/add-bill"');

--- a/apps/mobile/__tests__/calendar/day-detail-screen.test.ts
+++ b/apps/mobile/__tests__/calendar/day-detail-screen.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, test } from "vitest";
+import { expectRouteInRootStackGroup } from "@/__tests__/helpers/root-stack-routes";
 
 const source = readFileSync(resolve(__dirname, "../../app/day-detail.tsx"), "utf-8");
 const layoutSource = readFileSync(resolve(__dirname, "../../app/_layout.tsx"), "utf-8");
@@ -13,7 +14,7 @@ describe("day-detail screen", () => {
   test("is registered in root layout as a full screen route", () => {
     expect(layoutSource).toContain("ROOT_STACK_ROUTES.fullScreen");
     expect(source).not.toContain("DialogRouteFrame");
-    expect(rootStackRoutesSource).toContain('"day-detail"');
+    expectRouteInRootStackGroup(rootStackRoutesSource, "fullScreen", "day-detail");
     expect(layoutSource).toContain("ROOT_STACK_ROUTES.fullScreen.map");
     expect(layoutSource).toContain("routeOptions.fullScreen");
     expect(layoutSource).not.toContain("formSheet");

--- a/apps/mobile/__tests__/calendar/day-detail-screen.test.ts
+++ b/apps/mobile/__tests__/calendar/day-detail-screen.test.ts
@@ -4,18 +4,18 @@ import { describe, expect, test } from "vitest";
 
 const source = readFileSync(resolve(__dirname, "../../app/day-detail.tsx"), "utf-8");
 const layoutSource = readFileSync(resolve(__dirname, "../../app/_layout.tsx"), "utf-8");
+const rootStackRoutesSource = readFileSync(
+  resolve(__dirname, "../../shared/navigation/root-stack-routes.ts"),
+  "utf-8"
+);
 
 describe("day-detail screen", () => {
   test("is registered in root layout as a full screen route", () => {
-    expect(layoutSource).toContain('name="day-detail"');
+    expect(layoutSource).toContain("ROOT_STACK_ROUTES.fullScreen");
     expect(source).not.toContain("DialogRouteFrame");
-    const dayDetailStart = layoutSource.indexOf('name="day-detail"');
-    const themePickerStart = layoutSource.indexOf('name="theme-picker"');
-    expect(dayDetailStart).toBeGreaterThan(-1);
-    expect(themePickerStart).toBeGreaterThan(dayDetailStart);
-    const dayDetailBlock = layoutSource.slice(dayDetailStart, themePickerStart);
-    expect(dayDetailBlock).toContain("fullScreenHeaderOptions");
-    expect(dayDetailBlock).not.toContain("DIALOG_MODAL");
+    expect(rootStackRoutesSource).toContain('"day-detail"');
+    expect(layoutSource).toContain("ROOT_STACK_ROUTES.fullScreen.map");
+    expect(layoutSource).toContain("routeOptions.fullScreen");
     expect(layoutSource).not.toContain("formSheet");
   });
 

--- a/apps/mobile/__tests__/calendar/day-detail-screen.test.ts
+++ b/apps/mobile/__tests__/calendar/day-detail-screen.test.ts
@@ -1,14 +1,20 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { describe, expect, test } from "vitest";
+import { beforeAll, describe, expect, test } from "vitest";
 import { expectRouteInRootStackGroup } from "@/__tests__/helpers/root-stack-routes";
 
-const source = readFileSync(resolve(__dirname, "../../app/day-detail.tsx"), "utf-8");
-const layoutSource = readFileSync(resolve(__dirname, "../../app/_layout.tsx"), "utf-8");
-const rootStackRoutesSource = readFileSync(
-  resolve(__dirname, "../../shared/navigation/root-stack-routes.ts"),
-  "utf-8"
-);
+let source = "";
+let layoutSource = "";
+let rootStackRoutesSource = "";
+
+beforeAll(() => {
+  source = readFileSync(resolve(__dirname, "../../app/day-detail.tsx"), "utf-8");
+  layoutSource = readFileSync(resolve(__dirname, "../../app/_layout.tsx"), "utf-8");
+  rootStackRoutesSource = readFileSync(
+    resolve(__dirname, "../../shared/navigation/root-stack-routes.ts"),
+    "utf-8"
+  );
+});
 
 describe("day-detail screen", () => {
   test("is registered in root layout as a full screen route", () => {

--- a/apps/mobile/__tests__/goals/goal-sheets.test.ts
+++ b/apps/mobile/__tests__/goals/goal-sheets.test.ts
@@ -70,8 +70,8 @@ test("goals proposal keeps the empty state and goal cards wired", () => {
   expect(goalsListSource).toContain("<EmptyState");
   expect(goalsListSource).toContain("<Button");
   expect(goalsListSource).not.toContain("styles.emptyCard");
-  expect(goalsListSource).toContain("ItemSeparatorComponent={GoalItemSeparator}");
-  expect(goalsListSource).toContain("itemSeparator");
+  expect(goalsListSource).toContain("<FeedList");
+  expect(goalsListSource).toContain("itemSeparatorHeight={12}");
   expect(goalCardSource).toContain("goal.iconName");
   expect(goalCardSource).toContain("percentPill");
   expect(goalCardSource).toContain('t("goals.card.detail")');
@@ -109,13 +109,9 @@ test("create-goal opens as a full screen route, not a dialog", () => {
   expect(createGoalRouteSource).not.toContain("DialogRouteFrame");
   expect(createGoalRouteSource).toContain('headerBackTitle: ""');
   expect(createGoalRouteSource).toContain('headerTitle: t("goals.create.title")');
-  const createGoalStart = rootLayoutSource.indexOf('name="create-goal"');
-  const addPaymentStart = rootLayoutSource.indexOf('name="add-payment"');
-  expect(createGoalStart).toBeGreaterThan(-1);
-  expect(addPaymentStart).toBeGreaterThan(createGoalStart);
-  const createGoalBlock = rootLayoutSource.slice(createGoalStart, addPaymentStart);
-  expect(createGoalBlock).toContain("fullScreenHeaderOptions");
-  expect(createGoalBlock).not.toContain("DIALOG_MODAL");
+  expect(rootLayoutSource).toContain("ROOT_STACK_ROUTES.fullScreen");
+  expect(rootLayoutSource).toContain("ROOT_STACK_ROUTES.fullScreen.map");
+  expect(rootLayoutSource).toContain("routeOptions.fullScreen");
 });
 
 test("goal payment and edit open as full screen routes, not dialogs", () => {
@@ -125,18 +121,9 @@ test("goal payment and edit open as full screen routes, not dialogs", () => {
   expect(editGoalRouteSource).not.toContain("DialogRouteFrame");
   expect(editGoalRouteSource).toContain('headerBackTitle: ""');
   expect(editGoalRouteSource).toContain('headerTitle: t("goals.edit.title")');
-  const addPaymentStart = rootLayoutSource.indexOf('name="add-payment"');
-  const editGoalStart = rootLayoutSource.indexOf('name="edit-goal"');
-  const addTransactionStart = rootLayoutSource.indexOf('name="add-transaction"');
-  expect(addPaymentStart).toBeGreaterThan(-1);
-  expect(editGoalStart).toBeGreaterThan(addPaymentStart);
-  expect(addTransactionStart).toBeGreaterThan(editGoalStart);
-  const addPaymentBlock = rootLayoutSource.slice(addPaymentStart, editGoalStart);
-  const editGoalBlock = rootLayoutSource.slice(editGoalStart, addTransactionStart);
-  expect(addPaymentBlock).toContain("fullScreenHeaderOptions");
-  expect(addPaymentBlock).not.toContain("DIALOG_MODAL");
-  expect(editGoalBlock).toContain("fullScreenHeaderOptions");
-  expect(editGoalBlock).not.toContain("DIALOG_MODAL");
+  expect(rootLayoutSource).toContain("ROOT_STACK_ROUTES.fullScreen");
+  expect(rootLayoutSource).toContain("ROOT_STACK_ROUTES.fullScreen.map");
+  expect(rootLayoutSource).toContain("routeOptions.fullScreen");
 });
 
 test("create-goal full screen avoids nested card and uses debt red state", () => {

--- a/apps/mobile/__tests__/goals/goal-sheets.test.ts
+++ b/apps/mobile/__tests__/goals/goal-sheets.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { expect, test } from "vitest";
+import { expectRouteInRootStackGroup } from "@/__tests__/helpers/root-stack-routes";
 
 function readSource(relativePath: string) {
   return readFileSync(resolve(__dirname, relativePath), "utf-8");
@@ -11,6 +12,7 @@ const createGoalRouteSource = readSource("../../app/create-goal.tsx");
 const addPaymentRouteSource = readSource("../../app/add-payment.tsx");
 const editGoalRouteSource = readSource("../../app/edit-goal.tsx");
 const rootLayoutSource = readSource("../../app/_layout.tsx");
+const rootStackRoutesSource = readSource("../../shared/navigation/root-stack-routes.ts");
 const goalsListSource = readSource("../../features/goals/components/GoalsListScreen.tsx");
 const goalCardSource = readSource("../../features/goals/components/GoalCard.tsx");
 const goalDetailSource = readSource("../../features/goals/components/GoalDetail.tsx");
@@ -112,6 +114,7 @@ test("create-goal opens as a full screen route, not a dialog", () => {
   expect(rootLayoutSource).toContain("ROOT_STACK_ROUTES.fullScreen");
   expect(rootLayoutSource).toContain("ROOT_STACK_ROUTES.fullScreen.map");
   expect(rootLayoutSource).toContain("routeOptions.fullScreen");
+  expectRouteInRootStackGroup(rootStackRoutesSource, "fullScreen", "create-goal");
 });
 
 test("goal payment and edit open as full screen routes, not dialogs", () => {
@@ -124,6 +127,8 @@ test("goal payment and edit open as full screen routes, not dialogs", () => {
   expect(rootLayoutSource).toContain("ROOT_STACK_ROUTES.fullScreen");
   expect(rootLayoutSource).toContain("ROOT_STACK_ROUTES.fullScreen.map");
   expect(rootLayoutSource).toContain("routeOptions.fullScreen");
+  expectRouteInRootStackGroup(rootStackRoutesSource, "fullScreen", "add-payment");
+  expectRouteInRootStackGroup(rootStackRoutesSource, "fullScreen", "edit-goal");
 });
 
 test("create-goal full screen avoids nested card and uses debt red state", () => {

--- a/apps/mobile/__tests__/goals/goal-sheets.test.ts
+++ b/apps/mobile/__tests__/goals/goal-sheets.test.ts
@@ -1,39 +1,61 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { expect, test } from "vitest";
+import { beforeAll, expect, test } from "vitest";
 import { expectRouteInRootStackGroup } from "@/__tests__/helpers/root-stack-routes";
 
 function readSource(relativePath: string) {
   return readFileSync(resolve(__dirname, relativePath), "utf-8");
 }
 
-const createSheetSource = readSource("../../features/goals/components/GoalCreateScreen.tsx");
-const createGoalRouteSource = readSource("../../app/create-goal.tsx");
-const addPaymentRouteSource = readSource("../../app/add-payment.tsx");
-const editGoalRouteSource = readSource("../../app/edit-goal.tsx");
-const rootLayoutSource = readSource("../../app/_layout.tsx");
-const rootStackRoutesSource = readSource("../../shared/navigation/root-stack-routes.ts");
-const goalsListSource = readSource("../../features/goals/components/GoalsListScreen.tsx");
-const goalCardSource = readSource("../../features/goals/components/GoalCard.tsx");
-const goalDetailSource = readSource("../../features/goals/components/GoalDetail.tsx");
-const addPaymentSource = readSource("../../features/goals/components/AddPaymentScreen.tsx");
-const editSheetSource = readSource("../../features/goals/components/GoalEditScreen.tsx");
-const editLoadedSource = readSource(
-  "../../features/goals/components/goal-form/GoalEditScreenLoaded.tsx"
-);
-const formSource = readSource("../../features/goals/components/goal-form/GoalForm.tsx");
-const frameSource = readSource("../../features/goals/components/goal-form/GoalFormFrame.tsx");
-const stylesSource = readSource("../../features/goals/components/goal-form/GoalForm.styles.ts");
-const numpadFormScreenSource = readSource("../../shared/components/NumpadFormScreen.tsx");
-const typeToggleSource = readSource("../../features/goals/components/goal-form/GoalTypeToggle.tsx");
-const dateFieldSource = readSource("../../features/goals/components/goal-form/GoalDateField.tsx");
-const formHookSource = readSource("../../features/goals/components/goal-form/useGoalForm.ts");
-const createActionsSource = readSource(
-  "../../features/goals/components/goal-form/useGoalCreateActions.ts"
-);
-const editActionsSource = readSource(
-  "../../features/goals/components/goal-form/useGoalEditActions.ts"
-);
+let createSheetSource = "";
+let createGoalRouteSource = "";
+let addPaymentRouteSource = "";
+let editGoalRouteSource = "";
+let rootLayoutSource = "";
+let rootStackRoutesSource = "";
+let goalsListSource = "";
+let goalCardSource = "";
+let goalDetailSource = "";
+let addPaymentSource = "";
+let editSheetSource = "";
+let editLoadedSource = "";
+let formSource = "";
+let frameSource = "";
+let stylesSource = "";
+let numpadFormScreenSource = "";
+let typeToggleSource = "";
+let dateFieldSource = "";
+let formHookSource = "";
+let createActionsSource = "";
+let editActionsSource = "";
+
+beforeAll(() => {
+  createSheetSource = readSource("../../features/goals/components/GoalCreateScreen.tsx");
+  createGoalRouteSource = readSource("../../app/create-goal.tsx");
+  addPaymentRouteSource = readSource("../../app/add-payment.tsx");
+  editGoalRouteSource = readSource("../../app/edit-goal.tsx");
+  rootLayoutSource = readSource("../../app/_layout.tsx");
+  rootStackRoutesSource = readSource("../../shared/navigation/root-stack-routes.ts");
+  goalsListSource = readSource("../../features/goals/components/GoalsListScreen.tsx");
+  goalCardSource = readSource("../../features/goals/components/GoalCard.tsx");
+  goalDetailSource = readSource("../../features/goals/components/GoalDetail.tsx");
+  addPaymentSource = readSource("../../features/goals/components/AddPaymentScreen.tsx");
+  editSheetSource = readSource("../../features/goals/components/GoalEditScreen.tsx");
+  editLoadedSource = readSource(
+    "../../features/goals/components/goal-form/GoalEditScreenLoaded.tsx"
+  );
+  formSource = readSource("../../features/goals/components/goal-form/GoalForm.tsx");
+  frameSource = readSource("../../features/goals/components/goal-form/GoalFormFrame.tsx");
+  stylesSource = readSource("../../features/goals/components/goal-form/GoalForm.styles.ts");
+  numpadFormScreenSource = readSource("../../shared/components/NumpadFormScreen.tsx");
+  typeToggleSource = readSource("../../features/goals/components/goal-form/GoalTypeToggle.tsx");
+  dateFieldSource = readSource("../../features/goals/components/goal-form/GoalDateField.tsx");
+  formHookSource = readSource("../../features/goals/components/goal-form/useGoalForm.ts");
+  createActionsSource = readSource(
+    "../../features/goals/components/goal-form/useGoalCreateActions.ts"
+  );
+  editActionsSource = readSource("../../features/goals/components/goal-form/useGoalEditActions.ts");
+});
 
 test("keeps the create-goal sheet wired to the shared form without projection copy", () => {
   expect(createSheetSource).toContain("<GoalForm");

--- a/apps/mobile/__tests__/helpers/root-stack-routes.ts
+++ b/apps/mobile/__tests__/helpers/root-stack-routes.ts
@@ -1,0 +1,13 @@
+import { expect } from "vitest";
+
+export function expectRouteInRootStackGroup(source: string, groupName: string, routeName: string) {
+  const groupMatch = new RegExp(`${groupName}:\\s*\\[([\\s\\S]*?)\\]`).exec(source);
+
+  expect(groupMatch?.[1]).toContain(`"${routeName}"`);
+}
+
+export function expectTitledRouteExtendsFullScreen(source: string, routeKey: string) {
+  const routeMatch = new RegExp(`${routeKey}:\\s*\\{([\\s\\S]*?)\\}`).exec(source);
+
+  expect(routeMatch?.[1]).toContain("...fullScreen");
+}

--- a/apps/mobile/__tests__/helpers/root-stack-routes.ts
+++ b/apps/mobile/__tests__/helpers/root-stack-routes.ts
@@ -1,13 +1,19 @@
 import { expect } from "vitest";
 
+function escapeRegexLiteral(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 export function expectRouteInRootStackGroup(source: string, groupName: string, routeName: string) {
-  const groupMatch = new RegExp(`${groupName}:\\s*\\[([\\s\\S]*?)\\]`).exec(source);
+  const escapedGroupName = escapeRegexLiteral(groupName);
+  const groupMatch = new RegExp(`${escapedGroupName}:\\s*\\[([\\s\\S]*?)\\]`).exec(source);
 
   expect(groupMatch?.[1]).toContain(`"${routeName}"`);
 }
 
 export function expectTitledRouteExtendsFullScreen(source: string, routeKey: string) {
-  const routeMatch = new RegExp(`${routeKey}:\\s*\\{([\\s\\S]*?)\\}`).exec(source);
+  const escapedRouteKey = escapeRegexLiteral(routeKey);
+  const routeMatch = new RegExp(`${escapedRouteKey}:\\s*\\{([\\s\\S]*?)\\}`).exec(source);
 
   expect(routeMatch?.[1]).toContain("...fullScreen");
 }

--- a/apps/mobile/__tests__/navigation/root-layout-headers.test.ts
+++ b/apps/mobile/__tests__/navigation/root-layout-headers.test.ts
@@ -1,18 +1,24 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { describe, expect, test } from "vitest";
+import { beforeAll, describe, expect, test } from "vitest";
 import { expectRouteInRootStackGroup } from "@/__tests__/helpers/root-stack-routes";
 
 describe("Root layout native headers", () => {
-  const source = readFileSync(resolve(__dirname, "../../app/_layout.tsx"), "utf-8");
-  const routeOptionsSource = readFileSync(
-    resolve(__dirname, "../../shared/components/route-options.ts"),
-    "utf-8"
-  );
-  const rootStackRoutesSource = readFileSync(
-    resolve(__dirname, "../../shared/navigation/root-stack-routes.ts"),
-    "utf-8"
-  );
+  let source = "";
+  let routeOptionsSource = "";
+  let rootStackRoutesSource = "";
+
+  beforeAll(() => {
+    source = readFileSync(resolve(__dirname, "../../app/_layout.tsx"), "utf-8");
+    routeOptionsSource = readFileSync(
+      resolve(__dirname, "../../shared/components/route-options.ts"),
+      "utf-8"
+    );
+    rootStackRoutesSource = readFileSync(
+      resolve(__dirname, "../../shared/navigation/root-stack-routes.ts"),
+      "utf-8"
+    );
+  });
 
   test("default screenOptions hides headers", () => {
     expect(source).toContain("screenOptions={{ headerShown: false }}");

--- a/apps/mobile/__tests__/navigation/root-layout-headers.test.ts
+++ b/apps/mobile/__tests__/navigation/root-layout-headers.test.ts
@@ -8,6 +8,10 @@ describe("Root layout native headers", () => {
     resolve(__dirname, "../../shared/components/route-options.ts"),
     "utf-8"
   );
+  const rootStackRoutesSource = readFileSync(
+    resolve(__dirname, "../../shared/navigation/root-stack-routes.ts"),
+    "utf-8"
+  );
 
   test("default screenOptions hides headers", () => {
     expect(source).toContain("screenOptions={{ headerShown: false }}");
@@ -15,19 +19,18 @@ describe("Root layout native headers", () => {
 
   test("detail screens enable native headers on iOS with aurora-safe chrome", () => {
     for (const screen of ["search", "connected-accounts", "profile"]) {
-      expect(source).toContain(`"${screen}"`);
-      const screenStart = source.indexOf(`name="${screen}"`);
-      const screenBlock = source.slice(screenStart, source.indexOf("/>", screenStart));
-      expect(screenBlock).not.toContain("headerTransparent");
+      expect(rootStackRoutesSource).toContain(`"${screen}"`);
     }
+    expect(source).toContain("ROOT_STACK_ROUTES.transparentHeader.map");
+    expect(source).toContain("routeOptions.transparentHeader");
     expect(routeOptionsSource).toContain('headerShown: Platform.OS === "ios"');
     expect(routeOptionsSource).toContain('headerStyle: { backgroundColor: "transparent" }');
     expect(routeOptionsSource).toContain("headerTransparent: true");
-    expect(source).toContain("createTransparentHeaderRouteOptions(theme)");
+    expect(rootStackRoutesSource).toContain("createTransparentHeaderRouteOptions(theme)");
   });
 
   test("dialog modal routes use shared dialog route options without sheet detents", () => {
-    expect(source).toContain("dialogRouteOptions");
+    expect(rootStackRoutesSource).toContain("dialogRouteOptions");
     expect(routeOptionsSource).toContain('presentation: "transparentModal"');
     expect(routeOptionsSource).toContain('animation: "fade"');
     expect(routeOptionsSource).toContain('contentStyle: { backgroundColor: "transparent" }');
@@ -36,28 +39,26 @@ describe("Root layout native headers", () => {
   });
 
   test("promoted full-screen routes keep native headers on every platform", () => {
-    expect(source).toContain("createFullScreenRouteOptions(theme)");
+    expect(rootStackRoutesSource).toContain("createFullScreenRouteOptions(theme)");
     expect(routeOptionsSource).toContain("headerShown: true");
     expect(routeOptionsSource).toContain('headerTransparent: Platform.OS === "ios"');
     expect(routeOptionsSource).toContain(
       'headerStyle: { backgroundColor: Platform.OS === "ios" ? "transparent" : theme.page }'
     );
-    expect(source).toContain('name="add-bill"');
-    const addBillStart = source.indexOf('name="add-bill"');
-    const dayDetailStart = source.indexOf('name="day-detail"');
-    expect(addBillStart).toBeGreaterThan(-1);
-    expect(dayDetailStart).toBeGreaterThan(addBillStart);
-    const addBillBlock = source.slice(addBillStart, dayDetailStart);
-    expect(addBillBlock).toContain("fullScreenHeaderOptions");
-    expect(addBillBlock).not.toContain("DIALOG_MODAL");
+    expect(rootStackRoutesSource).toContain('"add-bill"');
+    expect(rootStackRoutesSource).toContain('"day-detail"');
+    expect(source).toContain("ROOT_STACK_ROUTES.fullScreen.map");
+    expect(source).toContain("routeOptions.fullScreen");
   });
 
   test("bills-calendar uses iosHeaderOptions to enable iOS-only native header", () => {
-    expect(source).toContain('<Stack.Screen name="bills-calendar" options={iosHeaderOptions} />');
+    expect(rootStackRoutesSource).toContain('"bills-calendar"');
+    expect(source).toContain("ROOT_STACK_ROUTES.transparentHeader.map");
+    expect(source).toContain("routeOptions.transparentHeader");
   });
 
   test("ScreenLayout full-screen routes avoid Android native header duplication", () => {
-    expect(source).toContain("createScreenLayoutRouteOptions(theme)");
+    expect(rootStackRoutesSource).toContain("createScreenLayoutRouteOptions(theme)");
     expect(routeOptionsSource).toContain("createScreenLayoutRouteOptions");
     expect(routeOptionsSource).toContain('headerShown: Platform.OS === "ios"');
 
@@ -66,9 +67,9 @@ describe("Root layout native headers", () => {
       "link-suggested-account",
       "reclassify-transaction",
     ]) {
-      expect(source).toContain(
-        `<Stack.Screen name="${screen}" options={screenLayoutRouteOptions} />`
-      );
+      expect(rootStackRoutesSource).toContain(`"${screen}"`);
     }
+    expect(source).toContain("ROOT_STACK_ROUTES.screenLayout.map");
+    expect(source).toContain("routeOptions.screenLayout");
   });
 });

--- a/apps/mobile/__tests__/navigation/root-layout-headers.test.ts
+++ b/apps/mobile/__tests__/navigation/root-layout-headers.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, test } from "vitest";
+import { expectRouteInRootStackGroup } from "@/__tests__/helpers/root-stack-routes";
 
 describe("Root layout native headers", () => {
   const source = readFileSync(resolve(__dirname, "../../app/_layout.tsx"), "utf-8");
@@ -19,7 +20,7 @@ describe("Root layout native headers", () => {
 
   test("detail screens enable native headers on iOS with aurora-safe chrome", () => {
     for (const screen of ["search", "connected-accounts", "profile"]) {
-      expect(rootStackRoutesSource).toContain(`"${screen}"`);
+      expectRouteInRootStackGroup(rootStackRoutesSource, "transparentHeader", screen);
     }
     expect(source).toContain("ROOT_STACK_ROUTES.transparentHeader.map");
     expect(source).toContain("routeOptions.transparentHeader");
@@ -45,14 +46,14 @@ describe("Root layout native headers", () => {
     expect(routeOptionsSource).toContain(
       'headerStyle: { backgroundColor: Platform.OS === "ios" ? "transparent" : theme.page }'
     );
-    expect(rootStackRoutesSource).toContain('"add-bill"');
-    expect(rootStackRoutesSource).toContain('"day-detail"');
+    expectRouteInRootStackGroup(rootStackRoutesSource, "fullScreen", "add-bill");
+    expectRouteInRootStackGroup(rootStackRoutesSource, "fullScreen", "day-detail");
     expect(source).toContain("ROOT_STACK_ROUTES.fullScreen.map");
     expect(source).toContain("routeOptions.fullScreen");
   });
 
   test("bills-calendar uses iosHeaderOptions to enable iOS-only native header", () => {
-    expect(rootStackRoutesSource).toContain('"bills-calendar"');
+    expectRouteInRootStackGroup(rootStackRoutesSource, "transparentHeader", "bills-calendar");
     expect(source).toContain("ROOT_STACK_ROUTES.transparentHeader.map");
     expect(source).toContain("routeOptions.transparentHeader");
   });
@@ -67,7 +68,7 @@ describe("Root layout native headers", () => {
       "link-suggested-account",
       "reclassify-transaction",
     ]) {
-      expect(rootStackRoutesSource).toContain(`"${screen}"`);
+      expectRouteInRootStackGroup(rootStackRoutesSource, "screenLayout", screen);
     }
     expect(source).toContain("ROOT_STACK_ROUTES.screenLayout.map");
     expect(source).toContain("routeOptions.screenLayout");

--- a/apps/mobile/__tests__/navigation/root-layout-local-qa.test.ts
+++ b/apps/mobile/__tests__/navigation/root-layout-local-qa.test.ts
@@ -1,13 +1,19 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { describe, expect, test } from "vitest";
+import { beforeAll, describe, expect, test } from "vitest";
+import { expectRouteInRootStackGroup } from "@/__tests__/helpers/root-stack-routes";
 
 describe("Root layout local QA gating", () => {
-  const source = readFileSync(resolve(__dirname, "../../app/_layout.tsx"), "utf-8");
-  const rootStackRoutesSource = readFileSync(
-    resolve(__dirname, "../../shared/navigation/root-stack-routes.ts"),
-    "utf-8"
-  );
+  let source = "";
+  let rootStackRoutesSource = "";
+
+  beforeAll(() => {
+    source = readFileSync(resolve(__dirname, "../../app/_layout.tsx"), "utf-8");
+    rootStackRoutesSource = readFileSync(
+      resolve(__dirname, "../../shared/navigation/root-stack-routes.ts"),
+      "utf-8"
+    );
+  });
 
   test("disables remote capture hooks when remote effects are off", () => {
     expect(source).toContain("enableRemoteEffects && onboardingComplete ? userId : null");
@@ -19,7 +25,7 @@ describe("Root layout local QA gating", () => {
 
   test("allows QA launcher routes to bypass the normal auth redirect", () => {
     expect(source).toContain('topSegment === "qa-open"');
-    expect(rootStackRoutesSource).toContain('"qa-open"');
+    expectRouteInRootStackGroup(rootStackRoutesSource, "localQaTransparentHeader", "qa-open");
   });
 
   test("installs the QA runtime and renders the QA status banner from the root boundary", () => {

--- a/apps/mobile/__tests__/navigation/root-layout-local-qa.test.ts
+++ b/apps/mobile/__tests__/navigation/root-layout-local-qa.test.ts
@@ -4,6 +4,10 @@ import { describe, expect, test } from "vitest";
 
 describe("Root layout local QA gating", () => {
   const source = readFileSync(resolve(__dirname, "../../app/_layout.tsx"), "utf-8");
+  const rootStackRoutesSource = readFileSync(
+    resolve(__dirname, "../../shared/navigation/root-stack-routes.ts"),
+    "utf-8"
+  );
 
   test("disables remote capture hooks when remote effects are off", () => {
     expect(source).toContain("enableRemoteEffects && onboardingComplete ? userId : null");
@@ -15,7 +19,7 @@ describe("Root layout local QA gating", () => {
 
   test("allows QA launcher routes to bypass the normal auth redirect", () => {
     expect(source).toContain('topSegment === "qa-open"');
-    expect(source).toContain('name="qa-open"');
+    expect(rootStackRoutesSource).toContain('"qa-open"');
   });
 
   test("installs the QA runtime and renders the QA status banner from the root boundary", () => {

--- a/apps/mobile/__tests__/navigation/root-layout-query-provider.test.ts
+++ b/apps/mobile/__tests__/navigation/root-layout-query-provider.test.ts
@@ -4,6 +4,10 @@ import { describe, expect, test } from "vitest";
 
 describe("Root layout query provider", () => {
   const source = readFileSync(resolve(__dirname, "../../app/_layout.tsx"), "utf-8");
+  const rootStackRoutesSource = readFileSync(
+    resolve(__dirname, "../../shared/navigation/root-stack-routes.ts"),
+    "utf-8"
+  );
 
   test("wraps the app tree in QueryProvider", () => {
     expect(source).toContain('import { QueryProvider } from "@/shared/query"');
@@ -21,8 +25,12 @@ describe("Root layout query provider", () => {
   });
 
   test("keeps the existing root Stack screen declarations", () => {
-    for (const screen of ["(auth)", "(tabs)", "add-bill", "delete-account", "analytics"]) {
+    for (const screen of ["(auth)", "(tabs)"]) {
       expect(source).toContain(`"${screen}"`);
+    }
+
+    for (const screen of ["add-bill", "delete-account", "analytics"]) {
+      expect(rootStackRoutesSource).toContain(`"${screen}"`);
     }
   });
 

--- a/apps/mobile/__tests__/navigation/root-layout-query-provider.test.ts
+++ b/apps/mobile/__tests__/navigation/root-layout-query-provider.test.ts
@@ -1,13 +1,18 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { describe, expect, test } from "vitest";
+import { beforeAll, describe, expect, test } from "vitest";
 
 describe("Root layout query provider", () => {
-  const source = readFileSync(resolve(__dirname, "../../app/_layout.tsx"), "utf-8");
-  const rootStackRoutesSource = readFileSync(
-    resolve(__dirname, "../../shared/navigation/root-stack-routes.ts"),
-    "utf-8"
-  );
+  let source = "";
+  let rootStackRoutesSource = "";
+
+  beforeAll(() => {
+    source = readFileSync(resolve(__dirname, "../../app/_layout.tsx"), "utf-8");
+    rootStackRoutesSource = readFileSync(
+      resolve(__dirname, "../../shared/navigation/root-stack-routes.ts"),
+      "utf-8"
+    );
+  });
 
   test("wraps the app tree in QueryProvider", () => {
     expect(source).toContain('import { QueryProvider } from "@/shared/query"');

--- a/apps/mobile/__tests__/search/search-screen.test.ts
+++ b/apps/mobile/__tests__/search/search-screen.test.ts
@@ -23,8 +23,8 @@ const baseHookSource = readSource(
 const resultsListSource = readSource(
   "../../features/search/components/search-screen/SearchResultsList.tsx"
 );
-const listHeaderSource = readSource(
-  "../../features/search/components/search-screen/SearchListHeader.tsx"
+const filterControlsSource = readSource(
+  "../../features/search/components/search-screen/SearchFilterControls.tsx"
 );
 const summarySource = readSource("../../features/search/components/ResultsSummary.tsx");
 const transactionItemSource = readSource(
@@ -62,15 +62,17 @@ test("keeps search initialization wired to initial route filters and bootstrap s
 
 test("keeps content and results rendering wired to the extracted list modules", () => {
   expect(contentSource).toContain("<SearchResultsList");
-  expect(resultsListSource).toContain("<SearchListHeader");
+  expect(resultsListSource).toContain("<SearchFilterControls");
   expect(resultsListSource).toContain("<SearchTransactionItem");
+  expect(resultsListSource).toContain("<FeedList");
 });
 
 test("keeps the transaction search redesign surfaces wired into the screen", () => {
   expect(contentSource).toContain('variant="sub"');
   expect(contentSource).not.toContain("<SearchInputBar");
   expect(inputBarSource).toContain("placeholder={placeholder}");
-  expect(listHeaderSource).toContain("<SearchInputBar");
+  expect(filterControlsSource).toContain("<SearchInputBar");
+  expect(filterControlsSource).toContain("<FilterChipRow");
   expect(resultsListSource).toContain("handleTextChange={handleTextChange}");
   expect(controlsSource).not.toContain("previousCategoryCount > 0");
   expect(controlsSource).not.toContain("panel.setActivePanel(null)");

--- a/apps/mobile/__tests__/shared/ui-kit.test.tsx
+++ b/apps/mobile/__tests__/shared/ui-kit.test.tsx
@@ -612,6 +612,22 @@ describe("shared UI kit", () => {
     expect(source).not.toContain("Pressable");
   });
 
+  it("keeps repeated feed screens on the shared FeedList primitive", () => {
+    const files = [
+      "../../features/budget/components/BudgetListScreen.tsx",
+      "../../features/goals/components/GoalsListScreen.tsx",
+      "../../features/ai-chat/components/ConversationList.tsx",
+      "../../features/search/components/search-screen/SearchResultsList.tsx",
+    ];
+
+    files.forEach((file) => {
+      const source = readFileSync(resolve(__dirname, file), "utf-8");
+
+      expectSharedComponentImport(source, "FeedList");
+      expect(source).toContain("<FeedList");
+    });
+  });
+
   it("keeps remaining list empty states and CTAs on shared primitives", () => {
     const budgetListSource = readFileSync(
       resolve(__dirname, "../../features/budget/components/BudgetListScreen.tsx"),

--- a/apps/mobile/__tests__/transactions/callers.test.ts
+++ b/apps/mobile/__tests__/transactions/callers.test.ts
@@ -14,6 +14,10 @@ const rootLayoutSource = readFileSync(resolve(__dirname, "../../app/_layout.tsx"
   /\r\n/g,
   "\n"
 );
+const rootStackRoutesSource = readFileSync(
+  resolve(__dirname, "../../shared/navigation/root-stack-routes.ts"),
+  "utf-8"
+).replace(/\r\n/g, "\n");
 
 describe("transaction callers", () => {
   test("edit screen surfaces save and delete failures before navigating away when auth/db is missing", () => {
@@ -32,13 +36,9 @@ describe("transaction callers", () => {
   });
 
   test("reclassification opens as a full screen transfer route", () => {
-    expect(rootLayoutSource).toContain('name="reclassify-transaction"');
-    const routeStart = rootLayoutSource.indexOf('name="reclassify-transaction"');
-    const routeBlock = rootLayoutSource.slice(
-      routeStart,
-      rootLayoutSource.indexOf("/>", routeStart)
-    );
-    expect(routeBlock).toContain("screenLayoutRouteOptions");
+    expect(rootStackRoutesSource).toContain('"reclassify-transaction"');
+    expect(rootLayoutSource).toContain("ROOT_STACK_ROUTES.screenLayout.map");
+    expect(rootLayoutSource).toContain("routeOptions.screenLayout");
     expect(reclassifyTransactionRouteSource).not.toContain("DialogRouteFrame");
     expect(reclassifyTransactionRouteSource).toContain("TransferFormScreen");
   });

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -30,15 +30,7 @@ import {
 import { isLocalQaAvailable, useQaDevtoolsRuntime } from "@/features/qa/hooks.public";
 import { QaStatusBanner } from "@/features/qa/ui.public";
 import { useSettingsStore } from "@/features/settings/hooks.public";
-import {
-  AppToastHost,
-  createFullScreenRouteOptions,
-  createEntryRouteOptions,
-  createScreenLayoutRouteOptions,
-  createTransparentHeaderRouteOptions,
-  dialogRouteOptions,
-  ErrorFallback,
-} from "@/shared/components";
+import { AppToastHost, ErrorFallback } from "@/shared/components";
 import { useColorScheme } from "@/shared/components/rn";
 import { Colors } from "@/shared/constants/theme";
 import { type AnyDb, getDb } from "@/shared/db";
@@ -51,6 +43,10 @@ import {
   setSentryUser,
   wrapWithSentry,
 } from "@/shared/lib";
+import {
+  createRootStackRouteOptions,
+  ROOT_STACK_ROUTES,
+} from "@/shared/navigation/root-stack-routes";
 import { QueryProvider } from "@/shared/query";
 import type { UserId } from "@/shared/types/branded";
 import migrations from "../drizzle/migrations";
@@ -213,18 +209,7 @@ export function RootLayout() {
   }
 
   const db = userId ? getDb(userId) : null;
-  const iosHeaderOptions = createTransparentHeaderRouteOptions(theme);
-  const fullScreenHeaderOptions = createFullScreenRouteOptions(theme);
-  const createBudgetRouteOptions = {
-    ...fullScreenHeaderOptions,
-    title: t("budgets.create.title"),
-  };
-  const autoSuggestBudgetsRouteOptions = {
-    ...fullScreenHeaderOptions,
-    title: t("budgets.autoSuggest.title"),
-  };
-  const screenLayoutRouteOptions = createScreenLayoutRouteOptions(theme);
-  const entryRouteOptions = createEntryRouteOptions();
+  const routeOptions = createRootStackRouteOptions(theme, t);
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
@@ -233,42 +218,36 @@ export function RootLayout() {
           <Stack screenOptions={{ headerShown: false }}>
             <Stack.Screen name="(auth)" />
             <Stack.Screen name="(tabs)" />
-            {localQaAvailable ? <Stack.Screen name="qa-tools" options={iosHeaderOptions} /> : null}
-            {localQaAvailable ? <Stack.Screen name="qa-open" options={iosHeaderOptions} /> : null}
-            <Stack.Screen name="add-bill" options={fullScreenHeaderOptions} />
-            <Stack.Screen name="day-detail" options={fullScreenHeaderOptions} />
-            <Stack.Screen name="theme-picker" options={dialogRouteOptions} />
-            <Stack.Screen name="language-picker" options={dialogRouteOptions} />
-            <Stack.Screen name="delete-account" options={dialogRouteOptions} />
-            <Stack.Screen name="enable-notifications" options={dialogRouteOptions} />
-            <Stack.Screen name="analytics" options={iosHeaderOptions} />
-            <Stack.Screen name="notifications" options={iosHeaderOptions} />
-            <Stack.Screen name="search" options={iosHeaderOptions} />
-            <Stack.Screen name="connected-accounts" options={iosHeaderOptions} />
-            <Stack.Screen name="account-suggestions" options={iosHeaderOptions} />
-            <Stack.Screen name="create-financial-account" options={iosHeaderOptions} />
-            <Stack.Screen name="financial-accounts" options={iosHeaderOptions} />
-            <Stack.Screen name="financial-account-details" options={iosHeaderOptions} />
-            <Stack.Screen name="financial-account-form" options={iosHeaderOptions} />
-            <Stack.Screen name="profile" options={iosHeaderOptions} />
-            <Stack.Screen name="settings" options={iosHeaderOptions} />
-            {__DEV__ ? <Stack.Screen name="design-system" options={iosHeaderOptions} /> : null}
-            <Stack.Screen name="financial-account-identifier" options={screenLayoutRouteOptions} />
-            <Stack.Screen name="link-suggested-account" options={screenLayoutRouteOptions} />
-            <Stack.Screen name="create-budget" options={createBudgetRouteOptions} />
-            <Stack.Screen name="auto-suggest-budgets" options={autoSuggestBudgetsRouteOptions} />
-            <Stack.Screen name="goal-detail" options={fullScreenHeaderOptions} />
-            <Stack.Screen name="create-goal" options={fullScreenHeaderOptions} />
-            <Stack.Screen name="add-payment" options={fullScreenHeaderOptions} />
-            <Stack.Screen name="edit-goal" options={fullScreenHeaderOptions} />
-            <Stack.Screen name="add-transaction" options={entryRouteOptions} />
-            <Stack.Screen name="add-transfer" options={entryRouteOptions} />
-            <Stack.Screen name="bills-calendar" options={iosHeaderOptions} />
-            <Stack.Screen name="notification-preferences" options={iosHeaderOptions} />
-            <Stack.Screen name="categories" options={iosHeaderOptions} />
-            <Stack.Screen name="create-category" options={fullScreenHeaderOptions} />
-            <Stack.Screen name="edit-transaction" options={entryRouteOptions} />
-            <Stack.Screen name="reclassify-transaction" options={screenLayoutRouteOptions} />
+            {localQaAvailable
+              ? ROOT_STACK_ROUTES.localQaTransparentHeader.map((name) => (
+                  <Stack.Screen key={name} name={name} options={routeOptions.transparentHeader} />
+                ))
+              : null}
+            {ROOT_STACK_ROUTES.fullScreen.map((name) => (
+              <Stack.Screen key={name} name={name} options={routeOptions.fullScreen} />
+            ))}
+            {ROOT_STACK_ROUTES.dialog.map((name) => (
+              <Stack.Screen key={name} name={name} options={routeOptions.dialog} />
+            ))}
+            {ROOT_STACK_ROUTES.transparentHeader.map((name) => (
+              <Stack.Screen key={name} name={name} options={routeOptions.transparentHeader} />
+            ))}
+            {__DEV__
+              ? ROOT_STACK_ROUTES.devOnlyTransparentHeader.map((name) => (
+                  <Stack.Screen key={name} name={name} options={routeOptions.transparentHeader} />
+                ))
+              : null}
+            {ROOT_STACK_ROUTES.screenLayout.map((name) => (
+              <Stack.Screen key={name} name={name} options={routeOptions.screenLayout} />
+            ))}
+            <Stack.Screen name="create-budget" options={routeOptions.titled.createBudget} />
+            <Stack.Screen
+              name="auto-suggest-budgets"
+              options={routeOptions.titled.autoSuggestBudgets}
+            />
+            {ROOT_STACK_ROUTES.entry.map((name) => (
+              <Stack.Screen key={name} name={name} options={routeOptions.entry} />
+            ))}
             {localQaAvailable ? (
               <Stack.Screen name="qa-transfer-conflict" options={{ headerShown: false }} />
             ) : null}

--- a/apps/mobile/features/ai-chat/components/ConversationList.tsx
+++ b/apps/mobile/features/ai-chat/components/ConversationList.tsx
@@ -1,8 +1,7 @@
-import { FlashList } from "@shopify/flash-list";
 import { format } from "date-fns";
 import { memo, useCallback, useMemo } from "react";
 import { useOptionalUserId } from "@/features/auth/public";
-import { Card, ScreenLayout, TAB_BAR_CLEARANCE } from "@/shared/components";
+import { Card, FeedList, ScreenLayout, TAB_BAR_CLEARANCE } from "@/shared/components";
 import { MessageSquare, Trash2, X } from "@/shared/components/icons";
 import { Platform, Pressable, Text, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
@@ -21,8 +20,6 @@ type ConversationListProps = {
   readonly onSelectSession: (id: ChatSessionId) => void;
   readonly onNewChat: () => void;
 };
-
-const ItemSeparator = () => <View style={{ height: 10 }} />;
 
 const sessionKeyExtractor = (item: ChatSessionListItem) =>
   item.type === "date" ? item.id : item.session.id;
@@ -136,18 +133,17 @@ export function ConversationList({ onSelectSession, onNewChat }: ConversationLis
       includesNativeHeader={false}
       rightActions={<NewChatButton onPress={onNewChat} />}
     >
-      <FlashList
+      <FeedList
         data={groupedSessions}
         renderItem={renderItem}
         keyExtractor={sessionKeyExtractor}
-        contentInsetAdjustmentBehavior="automatic"
         contentContainerStyle={{
           paddingBottom: 0,
           paddingHorizontal: 16,
         }}
         contentInset={{ bottom: TAB_BAR_CLEARANCE }}
-        ItemSeparatorComponent={ItemSeparator}
-        ListHeaderComponent={
+        itemSeparatorHeight={10}
+        header={
           <View style={{ paddingHorizontal: 4, paddingTop: 20, paddingBottom: 18, gap: 12 }}>
             <Text className="font-poppins-medium text-body" style={{ color: supportTextColor }}>
               {t("aiChat.conversationsSubtitle")}
@@ -176,7 +172,7 @@ export function ConversationList({ onSelectSession, onNewChat }: ConversationLis
             ) : null}
           </View>
         }
-        ListFooterComponent={AndroidTabBarSpacer}
+        footer={<AndroidTabBarSpacer />}
       />
     </ScreenLayout>
   );

--- a/apps/mobile/features/budget/components/BudgetListScreen.tsx
+++ b/apps/mobile/features/budget/components/BudgetListScreen.tsx
@@ -1,10 +1,10 @@
-import { FlashList, type ListRenderItemInfo } from "@shopify/flash-list";
+import type { ListRenderItemInfo } from "@shopify/flash-list";
 import { useRouter } from "expo-router";
 import { useCallback, useMemo } from "react";
 import { useOptionalUserId } from "@/features/auth/public";
 import { formatMonthYear } from "@/features/calendar/public";
 import { shouldShowNotificationPrePermissionPrompt } from "@/features/notifications/public";
-import { Button, EmptyState, ScreenLayout, TAB_BAR_CLEARANCE } from "@/shared/components";
+import { Button, EmptyState, FeedList, ScreenLayout, TAB_BAR_CLEARANCE } from "@/shared/components";
 import { Plus, Wallet } from "@/shared/components/icons";
 import { Pressable, StyleSheet, View } from "@/shared/components/rn";
 import { tryGetDb } from "@/shared/db";
@@ -210,39 +210,30 @@ export function BudgetListScreen() {
         />
       }
     >
-      <View style={styles.content}>
-        <FlashList
-          data={hasBudgets ? budgetProgress : []}
-          renderItem={renderBudget}
-          keyExtractor={budgetKeyExtractor}
-          ListHeaderComponent={budgetSummary}
-          ListEmptyComponent={emptyState}
-          contentContainerStyle={[styles.scrollContent, { paddingBottom: TAB_BAR_CLEARANCE }]}
-          contentInsetAdjustmentBehavior="automatic"
-          showsVerticalScrollIndicator={false}
-          ItemSeparatorComponent={BudgetItemSeparator}
-        />
-      </View>
+      <FeedList
+        data={hasBudgets ? budgetProgress : []}
+        renderItem={renderBudget}
+        keyExtractor={budgetKeyExtractor}
+        header={budgetSummary}
+        empty={emptyState}
+        containerStyle={styles.content}
+        contentContainerStyle={[styles.scrollContent, { paddingBottom: TAB_BAR_CLEARANCE }]}
+        itemSeparatorHeight={8}
+      />
     </ScreenLayout>
   );
 }
-
-const BudgetItemSeparator = () => <View style={styles.itemSeparator} />;
 
 const styles = StyleSheet.create({
   content: {
     flex: 1,
     paddingHorizontal: 16,
-    gap: 8,
   },
   scrollContent: {
     gap: 8,
   },
   headerContent: {
     gap: 8,
-  },
-  itemSeparator: {
-    height: 8,
   },
   addButton: {
     width: 36,

--- a/apps/mobile/features/goals/components/GoalsListScreen.tsx
+++ b/apps/mobile/features/goals/components/GoalsListScreen.tsx
@@ -1,10 +1,10 @@
-import { FlashList } from "@shopify/flash-list";
 import { useRouter } from "expo-router";
 import { useCallback } from "react";
 import { useOptionalUserId } from "@/features/auth/public";
 import {
   Button,
   EmptyState,
+  FeedList,
   IconActionButton,
   ScreenLayout,
   TAB_BAR_CLEARANCE,
@@ -121,21 +121,17 @@ export function GoalsListScreen() {
       {!hasGoals && !isLoading ? (
         <GoalsEmpty onCreateGoal={handleCreateGoal} />
       ) : (
-        <FlashList
+        <FeedList
           data={goals}
           renderItem={renderItem}
           keyExtractor={keyExtractor}
           contentContainerStyle={[styles.listContent, { paddingBottom: TAB_BAR_CLEARANCE }]}
-          showsVerticalScrollIndicator={false}
-          contentInsetAdjustmentBehavior="automatic"
-          ItemSeparatorComponent={GoalItemSeparator}
+          itemSeparatorHeight={12}
         />
       )}
     </ScreenLayout>
   );
 }
-
-const GoalItemSeparator = () => <View style={styles.itemSeparator} />;
 
 // ---------------------------------------------------------------------------
 // Styles
@@ -144,8 +140,5 @@ const GoalItemSeparator = () => <View style={styles.itemSeparator} />;
 const styles = StyleSheet.create({
   listContent: {
     padding: 16,
-  },
-  itemSeparator: {
-    height: 12,
   },
 });

--- a/apps/mobile/features/search/components/search-screen/SearchFilterControls.tsx
+++ b/apps/mobile/features/search/components/search-screen/SearchFilterControls.tsx
@@ -4,7 +4,7 @@ import { ResultsSummary } from "../ResultsSummary";
 import { SearchInputBar } from "./SearchInputBar";
 import type { SearchScreenViewModel } from "./SearchScreen.types";
 
-type SearchListHeaderProps = Pick<
+type SearchFilterControlsProps = Pick<
   SearchScreenViewModel,
   | "activePanel"
   | "filterPanel"
@@ -23,7 +23,7 @@ type SearchListHeaderProps = Pick<
   readonly placeholder: string;
 };
 
-export function SearchListHeader({
+export function SearchFilterControls({
   activePanel,
   filterPanel,
   filters,
@@ -38,7 +38,7 @@ export function SearchListHeader({
   secondary,
   showSummary,
   summary,
-}: SearchListHeaderProps) {
+}: SearchFilterControlsProps) {
   return (
     <>
       <SearchInputBar

--- a/apps/mobile/features/search/components/search-screen/SearchResultsList.tsx
+++ b/apps/mobile/features/search/components/search-screen/SearchResultsList.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useMemo } from "react";
-import { TAB_BAR_CLEARANCE } from "@/shared/components";
-import { FlatList, StyleSheet } from "@/shared/components/rn";
+import { FeedList, TAB_BAR_CLEARANCE } from "@/shared/components";
+import { StyleSheet } from "@/shared/components/rn";
 import { toIsoDate } from "@/shared/lib";
 import { hasActiveFilters } from "../../lib/filters";
 import type { SearchResult } from "../../lib/types";
 import { SearchEmptyState } from "../SearchEmptyState";
-import { SearchListHeader } from "./SearchListHeader";
+import { SearchFilterControls } from "./SearchFilterControls";
 import type { SearchScreenViewModel } from "./SearchScreen.types";
 import { SearchTransactionItem } from "./SearchTransactionItem";
 
@@ -74,15 +74,15 @@ export function SearchResultsList({
   );
 
   return (
-    <FlatList
+    <FeedList
       key={hasFilters ? "filtered-results" : "unfiltered-results"}
       data={results}
       renderItem={renderItem}
       keyExtractor={keyExtractor}
       onEndReached={handleEndReached}
       onEndReachedThreshold={0.3}
-      ListHeaderComponent={
-        <SearchListHeader
+      header={
+        <SearchFilterControls
           activePanel={activePanel}
           filterPanel={filterPanel}
           filters={filters}
@@ -99,11 +99,7 @@ export function SearchResultsList({
           summary={summary}
         />
       }
-      ListEmptyComponent={
-        hasFilters ? <SearchEmptyState onClearFilters={handleClearAll} /> : undefined
-      }
-      showsVerticalScrollIndicator={false}
-      contentInsetAdjustmentBehavior="automatic"
+      empty={hasFilters ? <SearchEmptyState onClearFilters={handleClearAll} /> : undefined}
       contentContainerStyle={styles.listContent}
     />
   );

--- a/apps/mobile/shared/components/FeedList.tsx
+++ b/apps/mobile/shared/components/FeedList.tsx
@@ -1,0 +1,67 @@
+import { FlashList, type FlashListProps } from "@shopify/flash-list";
+import { StyleSheet, View, type StyleProp, type ViewStyle } from "@/shared/components/rn";
+
+type FeedListProps<TItem> = Omit<
+  FlashListProps<TItem>,
+  | "contentContainerStyle"
+  | "contentInsetAdjustmentBehavior"
+  | "data"
+  | "ItemSeparatorComponent"
+  | "ListEmptyComponent"
+  | "ListFooterComponent"
+  | "ListHeaderComponent"
+  | "renderItem"
+  | "showsVerticalScrollIndicator"
+> & {
+  readonly containerStyle?: StyleProp<ViewStyle>;
+  readonly contentContainerStyle?: FlashListProps<TItem>["contentContainerStyle"];
+  readonly data: readonly TItem[];
+  readonly empty?: FlashListProps<TItem>["ListEmptyComponent"];
+  readonly footer?: FlashListProps<TItem>["ListFooterComponent"];
+  readonly header?: FlashListProps<TItem>["ListHeaderComponent"];
+  readonly itemSeparatorHeight?: number;
+  readonly renderItem: NonNullable<FlashListProps<TItem>["renderItem"]>;
+  readonly showsVerticalScrollIndicator?: boolean;
+};
+
+function createSeparator(height: number) {
+  return function FeedListSeparator() {
+    return <View style={{ height }} />;
+  };
+}
+
+export function FeedList<TItem>({
+  containerStyle,
+  contentContainerStyle,
+  empty,
+  footer,
+  header,
+  itemSeparatorHeight,
+  showsVerticalScrollIndicator = false,
+  ...listProps
+}: FeedListProps<TItem>) {
+  const list = (
+    <FlashList
+      {...listProps}
+      contentContainerStyle={contentContainerStyle}
+      contentInsetAdjustmentBehavior="automatic"
+      showsVerticalScrollIndicator={showsVerticalScrollIndicator}
+      ItemSeparatorComponent={
+        itemSeparatorHeight != null ? createSeparator(itemSeparatorHeight) : undefined
+      }
+      ListEmptyComponent={empty}
+      ListFooterComponent={footer}
+      ListHeaderComponent={header}
+    />
+  );
+
+  return containerStyle ? <View style={[styles.container, containerStyle]}>{list}</View> : list;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});
+
+export type { FeedListProps };

--- a/apps/mobile/shared/components/FeedList.tsx
+++ b/apps/mobile/shared/components/FeedList.tsx
@@ -1,4 +1,5 @@
 import { FlashList, type FlashListProps } from "@shopify/flash-list";
+import { useMemo } from "react";
 import { StyleSheet, View, type StyleProp, type ViewStyle } from "@/shared/components/rn";
 
 type FeedListProps<TItem> = Omit<
@@ -40,15 +41,18 @@ export function FeedList<TItem>({
   showsVerticalScrollIndicator = false,
   ...listProps
 }: FeedListProps<TItem>) {
+  const separator = useMemo(
+    () => (itemSeparatorHeight != null ? createSeparator(itemSeparatorHeight) : undefined),
+    [itemSeparatorHeight]
+  );
+
   const list = (
     <FlashList
       {...listProps}
       contentContainerStyle={contentContainerStyle}
       contentInsetAdjustmentBehavior="automatic"
       showsVerticalScrollIndicator={showsVerticalScrollIndicator}
-      ItemSeparatorComponent={
-        itemSeparatorHeight != null ? createSeparator(itemSeparatorHeight) : undefined
-      }
+      ItemSeparatorComponent={separator}
       ListEmptyComponent={empty}
       ListFooterComponent={footer}
       ListHeaderComponent={header}

--- a/apps/mobile/shared/components/index.ts
+++ b/apps/mobile/shared/components/index.ts
@@ -9,6 +9,8 @@ export { ChoiceTray } from "./ChoiceTray";
 export { DialogCancelButton, DialogFrame, DialogPanel, DialogTitle } from "./DialogFrame";
 export { EmptyState } from "./EmptyState";
 export { ErrorFallback } from "./ErrorFallback";
+export { FeedList } from "./FeedList";
+export type { FeedListProps } from "./FeedList";
 export { FieldButton } from "./FieldButton";
 export type { FieldButtonProps } from "./FieldButton";
 export { FidyLogo } from "./FidyLogo";

--- a/apps/mobile/shared/navigation/root-stack-routes.ts
+++ b/apps/mobile/shared/navigation/root-stack-routes.ts
@@ -6,10 +6,7 @@ import {
   dialogRouteOptions,
 } from "@/shared/components";
 
-type RootRouteTheme = {
-  readonly page: string;
-  readonly primary: string;
-};
+type RootRouteTheme = Parameters<typeof createFullScreenRouteOptions>[0];
 
 type Translate = (key: string) => string;
 

--- a/apps/mobile/shared/navigation/root-stack-routes.ts
+++ b/apps/mobile/shared/navigation/root-stack-routes.ts
@@ -1,0 +1,73 @@
+import {
+  createEntryRouteOptions,
+  createFullScreenRouteOptions,
+  createScreenLayoutRouteOptions,
+  createTransparentHeaderRouteOptions,
+  dialogRouteOptions,
+} from "@/shared/components";
+
+type RootRouteTheme = {
+  readonly page: string;
+  readonly primary: string;
+};
+
+type Translate = (key: string) => string;
+
+export const ROOT_STACK_ROUTES = {
+  devOnlyTransparentHeader: ["design-system"],
+  dialog: ["theme-picker", "language-picker", "delete-account", "enable-notifications"],
+  entry: ["add-transaction", "add-transfer", "edit-transaction"],
+  fullScreen: [
+    "add-bill",
+    "day-detail",
+    "goal-detail",
+    "create-goal",
+    "add-payment",
+    "edit-goal",
+    "create-category",
+  ],
+  localQaTransparentHeader: ["qa-tools", "qa-open"],
+  screenLayout: [
+    "financial-account-identifier",
+    "link-suggested-account",
+    "reclassify-transaction",
+  ],
+  transparentHeader: [
+    "analytics",
+    "notifications",
+    "search",
+    "connected-accounts",
+    "account-suggestions",
+    "create-financial-account",
+    "financial-accounts",
+    "financial-account-details",
+    "financial-account-form",
+    "profile",
+    "settings",
+    "bills-calendar",
+    "notification-preferences",
+    "categories",
+  ],
+} as const;
+
+export function createRootStackRouteOptions(theme: RootRouteTheme, t: Translate) {
+  const fullScreen = createFullScreenRouteOptions(theme);
+
+  return {
+    dialog: dialogRouteOptions,
+    entry: createEntryRouteOptions(),
+    fullScreen,
+    screenLayout: createScreenLayoutRouteOptions(theme),
+    transparentHeader: createTransparentHeaderRouteOptions(theme),
+    titled: {
+      autoSuggestBudgets: {
+        ...fullScreen,
+        title: t("budgets.autoSuggest.title"),
+      },
+      createBudget: {
+        ...fullScreen,
+        title: t("budgets.create.title"),
+      },
+    },
+  } as const;
+}


### PR DESCRIPTION
- Add shared FeedList

- Extract search filter controls

- Group root stack route options

- Remove CI from mobile QA skill

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors mobile list screens to a shared `FeedList` and centralizes root stack routes with `ROOT_STACK_ROUTES` and `createRootStackRouteOptions` for consistent headers and less duplication. Tightens tests and QA docs with route-group assertions, deferred setup, and more stable checks.

- **Refactors**
  - Added `FeedList` to standardize `FlashList` usage (header/footer/empty/separators) with stable `itemSeparatorHeight`; adopted in Budget, Goals, AI Chat conversations, and Search (migrated from `FlatList`/custom separators).
  - Renamed `SearchListHeader` to `SearchFilterControls` and composed `SearchResultsList` with `FeedList`.
  - Centralized route config in `ROOT_STACK_ROUTES` with `createRootStackRouteOptions(theme, t)`; `_layout` now maps groups for transparent headers, full screen, dialog, screen layout, entry, dev-only/local QA, and titled budget routes.

- **Tests/QA**
  - Added `expectRouteInRootStackGroup` and `expectTitledRouteExtendsFullScreen` helpers with escaped regex; tests read from the extracted route config and move file reads to `beforeAll` for stability.
  - Updated navigation tests to assert mapped groups and `routeOptions.*` wiring.
  - Removed `CI=1` from manual mobile QA to keep hot reload working.

<sup>Written for commit 195ac5c823a83d6d4dfbcef03bef39c1b6265f04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/B4rz99/fidy/pull/508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a typed FeedList component for consistent list rendering across the app.

* **Refactor**
  * Centralized root navigation configuration and route groups.
  * Migrated multiple screens to FeedList for uniform spacing, headers, and empty states.
  * Replaced the previous search header with a clearer filter-controls component.

* **Tests**
  * Updated test suites to verify navigation wiring and the new list/filter integrations using centralized route definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->